### PR TITLE
Add fast-reboot

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -8,7 +8,7 @@ then
 fi
 
 # Unload previous kernel if any loaded
-if [ "x`cat /sys/kernel/kexec_loaded`y" = "x1y" ]
+if [ $(cat /sys/kernel/kexec_loaded) -eq 1 ]
 then
   /sbin/kexec -u
 fi
@@ -16,7 +16,7 @@ fi
 # Kernel and initrd image
 KERNEL_IMAGE="/vmlinuz"
 INITRD="/initrd.img"
-BOOT_OPTIONS="`cat /proc/cmdline`"
+BOOT_OPTIONS=$(cat /proc/cmdline)
 
 case "$BOOT_OPTIONS" in
   *fast-reboot*)
@@ -35,11 +35,8 @@ systemctl stop docker.service
 
 # Wait until all buffers synced with disk
 sync
-sleep 1
+sleep 3
 sync
-sleep 1
-sync
-sleep 1
 
 # Reboot
 reboot

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Check root privileges
+if [ "$EUID" -ne 0 ]
+then
+  echo "Please run as root"
+  exit
+fi
+
+# Unload previous kernel if any loaded
+if [ "x`cat /sys/kernel/kexec_loaded`y" = "x1y" ]
+then
+  /sbin/kexec -u
+fi
+
+# Kernel and initrd image
+KERNEL_IMAGE="/vmlinuz"
+INITRD="/initrd.img"
+BOOT_OPTIONS="`cat /proc/cmdline`"
+
+case "$BOOT_OPTIONS" in
+  *fast-reboot*)
+    # it's already there
+    ;;
+  *)
+    BOOT_OPTIONS="$BOOT_OPTIONS fast-reboot"
+    ;;
+esac
+
+# Load kernel into memory
+/sbin/kexec -l "$KERNEL_IMAGE" --initrd="$INITRD" --append="$BOOT_OPTIONS"
+
+# Stop docker container engine. Otherwise will have broken docker storage
+systemctl stop docker.service
+
+# Wait until all buffers synced with disk
+sync
+sleep 1
+sync
+sleep 1
+sync
+sleep 1
+
+# Reboot
+reboot

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         'scripts/boot_part',
         'scripts/coredump-compress',
         'scripts/decode-syseeprom',
+        'scripts/fast-reboot',
         'scripts/generate_dump',
         'scripts/portstat',
         'scripts/sfputil',


### PR DESCRIPTION
Add fast-reboot utility to reboot SONiC box using kexec-tools.
Add fast-reboot to kernel parameters to indicate that kernel was loaded after fast reboot