### PR TITLE
Add 'sudo' to required calls

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -270,22 +270,25 @@ def syseeprom():
 def logging():
     pass
 
-# Default 'lldp' command (called if no subcommands or their aliases were passed)
+# Default 'logging' command (called if no subcommands or their aliases were passed)
 @logging.command(default=True)
 @click.argument('process', required=False)
-@click.option('--tail', required=False, default=10)
-@click.option('--follow', required=False)
-def default(process, tail, follow):
+@click.option('-l', '--lines')
+@click.option('-f', '--follow', is_flag=True)
+def default(process, lines, follow):
     """Show system log"""
-    if process is not None:
-        command = "grep {} /var/log/syslog".format(process)
-        if tail is not None:
-            command += "| tail -{}".format(tail)
-        elif follow is not None:
-            command += "| tail -f"
-        run_command(command)
+    if follow:
+        run_command("sudo tail -f /var/log/syslog")
     else:
-        run_command("cat /var/log/syslog", pager=True)
+        command = "sudo cat /var/log/syslog"
+
+        if process is not None:
+            command += " | grep '{}'".format(process)
+
+        if lines is not None:
+            command += " | tail -{}".format(lines)
+
+        run_command(command, pager=True)
 
 
 #

--- a/show/main.py
+++ b/show/main.py
@@ -259,7 +259,7 @@ def summary():
 @platform.command()
 def syseeprom():
     """Show system EEPROM information"""
-    run_command("decode-syseeprom")
+    run_command("sudo decode-syseeprom")
 
 
 #


### PR DESCRIPTION
- Now calling `decode-syseeprom`, `cat /var/log/syslog` and `tail -f /var/log/syslog` using sudo.
- Minor refactoring of `show logging`:
  - Changed option from `--tail` to `--lines`
  - Made `--follow` option into a boolean flag that takes no argument
  - Added abbreviated `-l` and `-f` options

TODO: Add  `decode-syseeprom`, `cat /var/log/syslog` and `tail -f /var/log/syslog` to /etc/sudoers in sonic-buildimage repo when updating this submodule.