### PR TITLE
[config and sonic-installer] Support bgp admin state preserving

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1,5 +1,6 @@
 #!/usr/sbin/env python
 
+import sys
 import os
 import click
 import json
@@ -118,7 +119,10 @@ def neighbor(ipaddr_or_hostname):
 
     command = "vtysh -c 'configure terminal' -c 'router bgp {}' -c 'neighbor {} shutdown'".format(bgp_asn, ipaddress)
     run_command(command)
-
+    command = 'sed -i "/^\s*{}:/d" /etc/sonic/bgp_admin.yml'.format(ipaddress)
+    run_command(command)
+    command = 'echo "  {}: off" >> /etc/sonic/bgp_admin.yml'.format(ipaddress)
+    run_command(command)
 
 @bgp.group()
 def startup():
@@ -144,6 +148,10 @@ def neighbor(ipaddr_or_hostname):
         raise click.Abort
 
     command = "vtysh -c 'configure terminal' -c 'router bgp {}' -c 'no neighbor {} shutdown'".format(bgp_asn, ipaddress)
+    run_command(command)
+    command = 'sed -i "/^\s*{}:/d" /etc/sonic/bgp_admin.yml'.format(ipaddress)
+    run_command(command)
+    command = 'echo "  {}: on" >> /etc/sonic/bgp_admin.yml'.format(ipaddress)
     run_command(command)
 
 

--- a/config/main.py
+++ b/config/main.py
@@ -119,8 +119,10 @@ def neighbor(ipaddr_or_hostname):
 
     command = "vtysh -c 'configure terminal' -c 'router bgp {}' -c 'neighbor {} shutdown'".format(bgp_asn, ipaddress)
     run_command(command)
+    # Remove existing item in bgp_admin.yml about the admin state of this neighbor
     command = 'sed -i "/^\s*{}:/d" /etc/sonic/bgp_admin.yml'.format(ipaddress)
     run_command(command)
+    # and add a new line mark it as off
     command = 'echo "  {}: off" >> /etc/sonic/bgp_admin.yml'.format(ipaddress)
     run_command(command)
 
@@ -149,8 +151,10 @@ def neighbor(ipaddr_or_hostname):
 
     command = "vtysh -c 'configure terminal' -c 'router bgp {}' -c 'no neighbor {} shutdown'".format(bgp_asn, ipaddress)
     run_command(command)
+    # Remove existing item in bgp_admin.yml about the admin state of this neighbor
     command = 'sed -i "/^\s*{}:/d" /etc/sonic/bgp_admin.yml'.format(ipaddress)
     run_command(command)
+    # and add a new line mark it as on
     command = 'echo "  {}: on" >> /etc/sonic/bgp_admin.yml'.format(ipaddress)
     run_command(command)
 

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -154,7 +154,7 @@ def install(url):
     else:
         os.chmod(image_path, stat.S_IXUSR)
         run_command(image_path)
-        run_command("cp /etc/sonic/minigraph.xml /host/")
+        run_command("cp -r /etc/sonic /host/old_config")
         run_command('grub-set-default --boot-directory=' + HOST_PATH + ' 0')
     click.echo('Done')
 


### PR DESCRIPTION
BGP admin state will be recorded when calling `config bgp neighbor shutdown` and `config bgp neighbor startup`. Those states will be preserved upon bgp service restart and firmware version upgrade.