### PR TITLE
[aclshow]: Skip rules with 0 count and sort the output

### DIFF
--- a/scripts/aclshow
+++ b/scripts/aclshow
@@ -18,14 +18,16 @@ optional arguments:
 """
 
 from __future__ import print_function
-import subprocess
-import re
-import sys
-import os
-from tabulate import tabulate
+
 import argparse
 import json
+import os
+import re
+import subprocess
 import swsssdk
+import sys
+
+from tabulate import tabulate
 
 ### temp file to save counter positions when doing clear counter action.
 ### if we could have a SAI command to clear counters will be better, so no need to maintain
@@ -198,7 +200,7 @@ class AclStat(object):
 
     def get_counter_value(self, key, type):
         """
-        return the counter value or the difference comparing with the saved value
+        return the counter value or the difference comparing with the saved value in string format
         """
         if not self.acl_counters[key]:
             return 'N/A'
@@ -206,13 +208,13 @@ class AclStat(object):
         if key in self.saved_acl_counters:
             new_value = int(self.acl_counters[key][type]) - int(self.saved_acl_counters[key][type])
             if new_value > 0:
-                return new_value
+                return str(new_value)
 
-        return self.acl_counters[key][type]
+        return str(self.acl_counters[key][type])
 
     def display_acl_stat(self):
         """
-        print out acl rules and counters
+        print out ACL rules and counters
         """
         def get_action(rule):
             for action in ['packet_action', 'mirror_action']:
@@ -223,6 +225,9 @@ class AclStat(object):
         header = ACL_HEADER
         aclstat = []
         for rule_key in self.acl_rules.keys():
+            if self.get_counter_value(rule_key, 'packets') == '0' or \
+                    self.get_counter_value(rule_key, 'packets') == 'N/A':
+                continue
             rule = self.acl_rules[rule_key]
             ports = self.acl_tables[rule_key[0]]['ports']
             line = [rule_key[1], rule['table'],
@@ -233,6 +238,8 @@ class AclStat(object):
                     self.get_counter_value(rule_key, 'bytes')]
             aclstat.append(line)
 
+        # sort the list with table name first and then descending priority
+        aclstat.sort(key=lambda x: (x[1], -int(x[3])))
         print(tabulate(aclstat, header))
 
     def display_acl_details(self):


### PR DESCRIPTION
- Without -d or --details option, simplify the output by skipping the rules
  that doesn't match any packets till now.
- Sort the output by sorting using table name first and then descending priority.