### PR TITLE
Add support to reload mgmt conf file and minigraph

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -83,6 +83,14 @@ def _switch_bgp_session_status(ipaddr_or_hostname, status, verbose):
         raise click.Abort
     _switch_bgp_session_status_by_addr(ipaddress, status, verbose)
 
+def _change_hostname(hostname):
+    current_hostname = os.uname()[1]
+    if current_hostname != hostname:
+        run_command('echo {} > /etc/hostname'.format(hostname), display_cmd=True)
+        run_command('hostname -F /etc/hostname', display_cmd=True)
+        run_command('sed -i "/\s{}$/d" /etc/hosts'.format(current_hostname), display_cmd=True)
+        run_command('echo "127.0.0.1 {}" >> /etc/hosts'.format(hostname), display_cmd=True)
+
 # Callback for confirmation prompt. Aborts if user enters "n"
 def _abort_if_false(ctx, param, value):
     if not value:
@@ -118,11 +126,14 @@ def load(filename):
                 expose_value=False, prompt='Reload mgmt config?')
 @click.argument('filename', default='/etc/sonic/device_desc.xml', type=click.Path(exists=True))
 def load_mgmt_config(filename):
-    """Reconfigure mgmt interface based on device description file."""
+    """Reconfigure hostname and mgmt interface based on device description file."""
     command = "{} -M {} --write-to-db".format(SONIC_CFGGEN_PATH, filename)
     run_command(command, display_cmd=True)
-    #FIXME: After config DB daemon for mgmt interface is implemented, we'll no longer need to manually config mgmt interface here
-    mgmt_conf = parse_device_desc_xml(filename)['minigraph_mgmt_interface']
+    #FIXME: After config DB daemon for hostname and mgmt interface is implemented, we'll no longer need to do manual configuration here
+    config_data = parse_device_desc_xml(filename)
+    hostname = config_data['minigraph_hostname']
+    _change_hostname(hostname)
+    mgmt_conf = config_data['minigraph_mgmt_interface']
     command = "ifconfig eth0 {} netmask {}".format(str(mgmt_conf['addr']), str(mgmt_conf['mask']))
     run_command(command, display_cmd=True)
     command = "[ -f /var/run/dhclient.eth0.pid ] && kill `cat /var/run/dhclient.eth0.pid` && rm -f /var/run/dhclient.eth0.pid"
@@ -135,6 +146,11 @@ def load_minigraph():
     """Reconfigure based on minigraph."""
     command = "{} -m --write-to-db".format(SONIC_CFGGEN_PATH)
     run_command(command, display_cmd=True)
+    command = "{} -m -v minigraph_hostname".format(SONIC_CFGGEN_PATH)
+    p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
+    p.wait()
+    hostname = p.communicate()[0].strip()
+    _change_hostname(hostname)
     #FIXME: After config DB daemon is implemented, we'll no longer need to restart every service.
     run_command("service interfaces-config restart", display_cmd=True)
     run_command("service ntp-config restart", display_cmd=True)


### PR DESCRIPTION
`config load_mgmt_config [FILENAME]` to reconfigure mgmt interface based on device description file.
`config load_minigraph` to reload config from `/etc/sonic/minigraph.xml`