### PR TITLE
[portstat]: Show port speed accordingly

### DIFF
--- a/scripts/portstat
+++ b/scripts/portstat
@@ -27,10 +27,11 @@ PORT_RATE = 40
 
 NStats = namedtuple("NStats", "rx_ok, rx_err, rx_drop, rx_ovr, tx_ok,\
                     tx_err, tx_drop, tx_ovr, rx_byt, tx_byt")
-header_all = ['Iface', 'ADMIN', 'OPER', 'RX_OK', 'RX_BPS', 'RX_PPS', 'RX_UTIL', 'RX_ERR', 'RX_DRP', 'RX_OVR',
+
+header_all = ['IFACE', 'ADMIN', 'OPER', 'SPEED', 'RX_OK', 'RX_BPS', 'RX_PPS', 'RX_UTIL', 'RX_ERR', 'RX_DRP', 'RX_OVR',
           'TX_OK', 'TX_BPS', 'Tx_PPS', 'TX_UTIL', 'TX_ERR', 'TX_DRP', 'TX_OVR']
 
-header = ['Iface', 'ADMIN', 'OPER', 'RX_OK', 'RX_BPS', 'RX_UTIL', 'RX_ERR', 'RX_DRP', 'RX_OVR',
+header = ['IFACE', 'ADMIN', 'OPER', 'SPEED', 'RX_OK', 'RX_BPS', 'RX_UTIL', 'RX_ERR', 'RX_DRP', 'RX_OVR',
           'TX_OK', 'TX_BPS', 'TX_UTIL', 'TX_ERR', 'TX_DRP', 'TX_OVR']
 
 counter_bucket_dict = {
@@ -53,6 +54,7 @@ COUNTERS_PORT_NAME_MAP = "COUNTERS_PORT_NAME_MAP"
 PORT_STATUS_TABLE_PREFIX = "PORT_TABLE:"
 PORT_OPER_STATUS_FIELD = "oper_status"
 PORT_ADMIN_STATUS_FIELD = "admin_status"
+PORT_SPEED_FIELD = "speed"
 
 class Portstat(object):
     def __init__(self):
@@ -165,13 +167,19 @@ class Portstat(object):
                 continue
 
             if print_all:
-                table.append((key, self.get_port_status(key, PORT_ADMIN_STATUS_FIELD), self.get_port_status(key, PORT_OPER_STATUS_FIELD),
+                table.append((key,
+                              self.get_port_status(key, PORT_ADMIN_STATUS_FIELD),
+                              self.get_port_status(key, PORT_OPER_STATUS_FIELD),
+                              self.get_port_status(key, PORT_SPEED_FIELD),
                               data.rx_ok, "N/A", "N/A", "N/A", data.rx_err,
                               data.rx_drop, data.rx_ovr,
                               data.tx_ok, "N/A", "N/A", "N/A", data.tx_err,
                               data.tx_drop, data.tx_ovr))
             else:
-                table.append((key, self.get_port_status(key, PORT_ADMIN_STATUS_FIELD), self.get_port_status(key, PORT_OPER_STATUS_FIELD),
+                table.append((key,
+                              self.get_port_status(key, PORT_ADMIN_STATUS_FIELD),
+                              self.get_port_status(key, PORT_OPER_STATUS_FIELD),
+                              self.get_port_status(key, PORT_SPEED_FIELD),
                               data.rx_ok, "N/A", "N/A", data.rx_err,
                               data.rx_drop, data.rx_ovr,
                               data.tx_ok, "N/A", "N/A", data.tx_err,


### PR DESCRIPTION
This pull request depends on https://github.com/Azure/sonic-swss/pull/287/files. After that pull request is merged, we could add port speed value column in the current `port_config.ini` files and display the speed via this script.