### PR TITLE
Adapt to new minigraph_parser schema

### DIFF
--- a/scripts/teamshow
+++ b/scripts/teamshow
@@ -49,7 +49,7 @@ class Teamshow(object):
         minigraph_path = '/etc/sonic/minigraph.xml'
         machine_info = get_machine_info()
         platform_info = get_platform_info(machine_info)
-        self.teams = parse_xml(minigraph_path, platform = platform_info)['minigraph_portchannels'].keys();
+        self.teams = parse_xml(minigraph_path, platform = platform_info)['PORTCHANNEL'].keys();
 
     def get_portchannel_status(self, port_channel_name):
         """

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -28,7 +28,7 @@ PLATFORM_SPECIFIC_CLASS_NAME = "SfpUtil"
 PLATFORM_ROOT_PATH = '/usr/share/sonic/device'
 SONIC_CFGGEN_PATH = '/usr/local/bin/sonic-cfggen'
 MINIGRAPH_PATH = '/etc/sonic/minigraph.xml'
-HWSKU_KEY = 'minigraph_hwsku'
+HWSKU_KEY = "DEVICE_METADATA['localhost']['hwsku']"
 PLATFORM_KEY = 'platform'
 
 # Global platform-specific sfputil class instance

--- a/show/main.py
+++ b/show/main.py
@@ -275,7 +275,7 @@ def summary():
 
     PLATFORM_TEMPLATE_FILE = "/tmp/cli_platform_{0}.j2".format(username)
     PLATFORM_TEMPLATE_CONTENTS = "Platform: {{ platform }}\n" \
-                                 "HwSKU: {{ minigraph_hwsku }}\n" \
+                                 "HwSKU: {{ DEVICE_METADATA['localhost']['hwsku'] }}\n" \
                                  "ASIC: {{ asic_type }}"
 
     # Create a temporary Jinja2 template file to use with sonic-cfggen
@@ -283,7 +283,7 @@ def summary():
     f.write(PLATFORM_TEMPLATE_CONTENTS)
     f.close()
 
-    command = "sonic-cfggen -m /etc/sonic/minigraph.xml -y /etc/sonic/sonic_version.yml -t {0}".format(PLATFORM_TEMPLATE_FILE)
+    command = "sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t {0}".format(PLATFORM_TEMPLATE_FILE)
     p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
     click.echo(p.stdout.read())
 


### PR DESCRIPTION
Fix issues that `config load_minigraph`, `config load_mgmt_desc`, `teamshow`, `sfputil show`, and `show platform su` not working correctly after https://github.com/Azure/sonic-buildimage/pull/942