### PR TITLE
[generate_dump]: Skip the sparse file /var/log/lastlog

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -306,6 +306,10 @@ main() {
 
     # gzip up all log files individually before placing them in the incremental tarball
     for file in $(find -L /var/log -type f); do
+        # ignore the sparse file lastlog
+        if [ "$file" = "/var/log/lastlog" ]; then
+            continue
+        fi
         # don't gzip already-gzipped log files :)
         if [ -z "${file##*.gz}" ]; then
             save_file $file log false


### PR DESCRIPTION
This sparse file is HUGE and without ignoring this file, it will take
forever to gzip this file and ultimately causing the script to hang.