### PR TITLE
CLI support for Layer 2 MAC/FDB show 

### DIFF
--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -123,10 +123,7 @@ class FdbShow(object):
             return 0
 
         keys = [r[pos] for r in self.bridge_mac_list]
-        try:
-            return keys.index(key_value)
-        except ValueError as e:
-            print e.message
+        return keys.index(key_value)
 
 
     def display(self, vlan, port):

--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -1,0 +1,192 @@
+#!/usr/bin/python
+"""
+    Script to show MAC/FDB entries learnt in Hardware
+    
+    usage: fdbshow [-p PORT] [-v VLAN]
+    optional arguments:
+      -p,  --port              FDB learned on specific port: Ethernet0
+      -v,  --vlan              FDB learned on specific Vlan: 1000
+  
+    Example of the output:
+    admin@str~$ fdbshow
+      No.    Vlan  MacAddress         Port
+    -----  ------  -----------------  ----------
+        0    1000  7C:FE:90:80:9F:05  Ethernet20
+        1    1000  7C:FE:90:80:9F:10  Ethernet40
+        2    1000  7C:FE:90:80:9F:01  Ethernet4
+        3    1000  7C:FE:90:80:9F:02  Ethernet8
+
+    admin@str:~$ fdbshow -p Ethernet4
+      No.    Vlan  MacAddress         Port
+    -----  ------  -----------------  ---------
+        0    1000  7C:FE:90:80:9F:01  Ethernet4
+
+    admin@str:~$ fdbshow -v 1001
+    1001 is not in list
+
+"""
+
+import swsssdk
+import argparse
+import json
+import sys
+
+from tabulate import tabulate
+from natsort import natsorted
+
+class FdbShow(object):
+
+    HEADER = ['No.', 'Vlan', 'MacAddress', 'Port']
+    FDB_COUNT = 0
+
+    def __init__(self):
+        super(FdbShow,self).__init__()
+        self.db = swsssdk.SonicV2Connector(host="127.0.0.1")
+        self.get_interface_oid_map()
+        self.get_bridge_port_oid_map()
+        self.fetch_fdb_data()
+        return
+
+    
+    def get_interface_oid_map(self):
+        """
+            Get the Interface names from Counters DB
+        """
+        self.db.connect('COUNTERS_DB')
+        self.if_name_map = self.db.get_all('COUNTERS_DB', 'COUNTERS_PORT_NAME_MAP', blocking=True)
+        self.if_oid_map = {sai_oid: if_name for if_name, sai_oid in self.if_name_map.items()}
+
+
+    def get_bridge_port_oid_map(self):
+        """
+            Get the Bridge port names from ASIC DB
+        """
+        self.db.connect(self.db.ASIC_DB)
+        self.if_br_oid_map = {} 
+        br_port_str = self.db.keys('ASIC_DB', "ASIC_STATE:SAI_OBJECT_TYPE_BRIDGE_PORT:*")
+        if not br_port_str:
+            return
+        
+        offset = len("ASIC_STATE:SAI_OBJECT_TYPE_BRIDGE_PORT:")
+        oid_pfx = len("oid:0x")
+        for s in br_port_str:
+            br_port_id = s[(offset + oid_pfx):]
+            ent = self.db.get_all('ASIC_DB', s, blocking=True)
+            port_id = ent[b"SAI_BRIDGE_PORT_ATTR_PORT_ID"][oid_pfx:]
+            self.if_br_oid_map[br_port_id] = port_id 
+
+
+    def fetch_fdb_data(self):
+        """
+            Fetch FDB entries from ASIC DB. 
+            FDB entries are sorted on "VlanID" and stored as a list of tuples
+        """
+        self.db.connect(self.db.ASIC_DB)
+        self.bridge_mac_list = []
+        
+        fdb_str = self.db.keys('ASIC_DB', "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY:*")
+        if not fdb_str:
+            return
+
+        oid_pfx = len("oid:0x")
+        for s in fdb_str:
+            fdb_entry = s.decode()
+            try:
+                fdb = json.loads(fdb_entry .split(":", 2)[-1])
+            except ValueError as e: 
+                print e.message
+                continue
+           
+            ent = self.db.get_all('ASIC_DB', s, blocking=True)
+            br_port_id = ent[b"SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID"][oid_pfx:]
+            try:
+                port_id = self.if_br_oid_map[br_port_id]
+                if_name = self.if_oid_map[port_id]
+            except KeyError as e:
+                continue
+            
+            self.bridge_mac_list.append((int(fdb["vlan"]),) + (fdb["mac"],) + (if_name,))
+
+        self.bridge_mac_list.sort(key = lambda x: x[0])
+        return
+    
+    
+    def get_iter_index(self, key_value=0, pos=0):
+        """
+            Get the starting index of matched entry
+        """
+        if pos == 0:
+            self.bridge_mac_list.sort(key = lambda x: x[pos])
+        keys = [r[pos] for r in self.bridge_mac_list]
+        try:
+            return keys.index(key_value)
+        except IndexError as e:
+            print e.message
+
+
+    def display_specific(self, port, vlan):
+        """
+            Display the FDB entries for specified vlan/port.
+        """
+        output = []
+
+        if vlan is not None and port is None:
+            vlan = int(vlan)
+            s_index = self.get_iter_index(vlan)
+            fdb_list = [fdb for fdb in self.bridge_mac_list[s_index:] if fdb[0] == vlan]
+
+        elif vlan is None and port is not None:
+            self.bridge_mac_list = natsorted(self.bridge_mac_list, key = lambda x: x[2])
+            s_index = self.get_iter_index(port, 2)
+            fdb_list = [fdb for fdb in self.bridge_mac_list[s_index:] if fdb[2] == port]
+
+        else:
+            vlan = int(vlan)
+            s_index = self.get_iter_index(vlan)
+            fdb_list = [fdb for fdb in self.bridge_mac_list[s_index:]
+                        if fdb[0] == vlan and fdb[2] == port]
+
+        for fdb in fdb_list:
+            output.append([self.FDB_COUNT, fdb[0], fdb[1], fdb[2]])
+            self.FDB_COUNT += 1
+
+        print tabulate(output, self.HEADER)
+        print "Total number of entries {0} ".format(self.FDB_COUNT)
+
+
+    def display_summary(self):
+        """
+            Display the FDB summary. 
+            @todo: - PortChannel support
+        """
+        output = []
+        self.bridge_mac_list.sort(key = lambda x: x[0])
+        for fdb in self.bridge_mac_list:
+            output.append([self.FDB_COUNT, fdb[0], fdb[1], fdb[2]])
+            self.FDB_COUNT += 1
+            
+        print tabulate(output, self.HEADER)
+        print "Total number of entries {0} ".format(self.FDB_COUNT)
+        
+        
+def main():
+    
+    parser = argparse.ArgumentParser(description='Display ASIC FDB entries',
+                                     formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument('-p', '--port', type=str, help='FDB learned on specific port: Ethernet0', default=None)
+    parser.add_argument('-v', '--vlan', type=str, help='FDB learned on specific Vlan: 1001', default=None)
+    args = parser.parse_args()
+
+    try:
+        fdb = FdbShow()
+        if args.port is None and args.vlan is None:
+            fdb.display_summary()
+        else:
+            fdb.display_specific(args.port, args.vlan)
+        
+    except Exception as e:
+        print e.message
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -31,6 +31,7 @@ import argparse
 import json
 import sys
 
+from swsssdk import port_util
 from tabulate import tabulate
 from natsort import natsorted
 
@@ -42,39 +43,11 @@ class FdbShow(object):
     def __init__(self):
         super(FdbShow,self).__init__()
         self.db = swsssdk.SonicV2Connector(host="127.0.0.1")
-        self.get_interface_oid_map()
-        self.get_bridge_port_oid_map()
+        self.if_name_map, \
+        self.if_oid_map = port_util.get_interface_oid_map(self.db)
+        self.if_br_oid_map = port_util.get_bridge_port_map(self.db)
         self.fetch_fdb_data()
         return
-
-    
-    def get_interface_oid_map(self):
-        """
-            Get the Interface names from Counters DB
-        """
-        self.db.connect('COUNTERS_DB')
-        self.if_name_map = self.db.get_all('COUNTERS_DB', 'COUNTERS_PORT_NAME_MAP', blocking=True)
-        self.if_oid_map = {sai_oid: if_name for if_name, sai_oid in self.if_name_map.items()}
-
-
-    def get_bridge_port_oid_map(self):
-        """
-            Get the Bridge port names from ASIC DB
-        """
-        self.db.connect(self.db.ASIC_DB)
-        self.if_br_oid_map = {} 
-        br_port_str = self.db.keys('ASIC_DB', "ASIC_STATE:SAI_OBJECT_TYPE_BRIDGE_PORT:*")
-        if not br_port_str:
-            return
-        
-        offset = len("ASIC_STATE:SAI_OBJECT_TYPE_BRIDGE_PORT:")
-        oid_pfx = len("oid:0x")
-        for s in br_port_str:
-            br_port_id = s[(offset + oid_pfx):]
-            ent = self.db.get_all('ASIC_DB', s, blocking=True)
-            port_id = ent[b"SAI_BRIDGE_PORT_ATTR_PORT_ID"][oid_pfx:]
-            self.if_br_oid_map[br_port_id] = port_id 
-
 
     def fetch_fdb_data(self):
         """

--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -134,7 +134,7 @@ class FdbShow(object):
         output = []
         args = {vlan, port}
 
-        if len(args) == 1:
+        if len(args) == 1 and None in args:
             """
             Display the FDB summary.
             """

--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -11,16 +11,16 @@
     admin@str~$ fdbshow
       No.    Vlan  MacAddress         Port
     -----  ------  -----------------  ----------
-        0    1000  7C:FE:90:80:9F:05  Ethernet20
-        1    1000  7C:FE:90:80:9F:10  Ethernet40
-        2    1000  7C:FE:90:80:9F:01  Ethernet4
-        3    1000  7C:FE:90:80:9F:02  Ethernet8
-
+        1    1000  7C:FE:90:80:9F:05  Ethernet20
+        2    1000  7C:FE:90:80:9F:10  Ethernet40
+        3    1000  7C:FE:90:80:9F:01  Ethernet4
+        4    1000  7C:FE:90:80:9F:02  Ethernet8
+    Total number of entries 4
     admin@str:~$ fdbshow -p Ethernet4
       No.    Vlan  MacAddress         Port
     -----  ------  -----------------  ---------
-        0    1000  7C:FE:90:80:9F:01  Ethernet4
-
+        1    1000  7C:FE:90:80:9F:01  Ethernet4
+    Total number of entries 1
     admin@str:~$ fdbshow -v 1001
     1001 is not in list
 
@@ -147,8 +147,8 @@ class FdbShow(object):
                         if fdb[0] == vlan and fdb[2] == port]
 
         for fdb in fdb_list:
-            output.append([self.FDB_COUNT, fdb[0], fdb[1], fdb[2]])
             self.FDB_COUNT += 1
+            output.append([self.FDB_COUNT, fdb[0], fdb[1], fdb[2]])
 
         print tabulate(output, self.HEADER)
         print "Total number of entries {0} ".format(self.FDB_COUNT)
@@ -162,8 +162,8 @@ class FdbShow(object):
         output = []
         self.bridge_mac_list.sort(key = lambda x: x[0])
         for fdb in self.bridge_mac_list:
-            output.append([self.FDB_COUNT, fdb[0], fdb[1], fdb[2]])
             self.FDB_COUNT += 1
+            output.append([self.FDB_COUNT, fdb[0], fdb[1], fdb[2]])
             
         print tabulate(output, self.HEADER)
         print "Total number of entries {0} ".format(self.FDB_COUNT)

--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -27,10 +27,10 @@
 """
 import argparse
 import json
-import swsssdk
 import sys
 
 from natsort import natsorted
+from swsssdk import SonicV2Connector, port_util
 from tabulate import tabulate
 
 class FdbShow(object):
@@ -40,10 +40,10 @@ class FdbShow(object):
 
     def __init__(self):
         super(FdbShow,self).__init__()
-        self.db = swsssdk.SonicV2Connector(host="127.0.0.1")
+        self.db = SonicV2Connector(host="127.0.0.1")
         self.if_name_map, \
-        self.if_oid_map = swsssdk.port_util.get_interface_oid_map(self.db)
-        self.if_br_oid_map = swsssdk.port_util.get_bridge_port_map(self.db)
+        self.if_oid_map = port_util.get_interface_oid_map(self.db)
+        self.if_br_oid_map = port_util.get_bridge_port_map(self.db)
         self.fetch_fdb_data()
         return
 
@@ -62,10 +62,8 @@ class FdbShow(object):
         oid_pfx = len("oid:0x")
         for s in fdb_str:
             fdb_entry = s.decode()
-            try:
-                fdb = json.loads(fdb_entry .split(":", 2)[-1])
-            except ValueError as e: 
-                print e.message
+            fdb = json.loads(fdb_entry .split(":", 2)[-1])
+            if not fdb:
                 continue
            
             ent = self.db.get_all('ASIC_DB', s, blocking=True)
@@ -74,10 +72,12 @@ class FdbShow(object):
                 port_id = self.if_br_oid_map[br_port_id]
                 if_name = self.if_oid_map[port_id]
             except KeyError as e:
+                print e.message
                 continue
             
             self.bridge_mac_list.append((int(fdb["vlan"]),) + (fdb["mac"],) + (if_name,))
 
+        self.bridge_mac_list.sort(key = lambda x: x[0])
         return
     
     
@@ -85,9 +85,7 @@ class FdbShow(object):
         """
             Get the starting index of matched entry
         """
-        if pos == 0:
-            self.bridge_mac_list.sort(key = lambda x: x[pos])
-        else:
+        if pos != 0:
             self.bridge_mac_list = natsorted(self.bridge_mac_list, key = lambda x: x[pos])
 
         if key_value == 0:
@@ -103,32 +101,18 @@ class FdbShow(object):
             @todo: - PortChannel support
         """
         output = []
-        args = {vlan, port}
 
-        if len(args) == 1 and None in args:
-            """
-            Display the FDB summary.
-            """
-            s_index = self.get_iter_index()
-            fdb_list = self.bridge_mac_list[s_index:]
-        elif None not in args:
+        if vlan is not None:
             vlan = int(vlan)
             s_index = self.get_iter_index(vlan)
-            fdb_list = [fdb for fdb in self.bridge_mac_list[s_index:]
-                        if fdb[0] == vlan and fdb[2] == port]
-        else:
-            #Placeholder added for MAC as None
-            arg_list = [vlan, None, port]
-            m_index = [idx for idx, val in enumerate(arg_list) if val != None][0]
-            if m_index == 0:
-                arg_list[m_index] = int(arg_list[m_index])
+            self.bridge_mac_list = [fdb for fdb in self.bridge_mac_list[s_index:]
+                                    if fdb[0] == vlan]
+        if port is not None:
+            s_index = self.get_iter_index(port, 2)
+            self.bridge_mac_list = [fdb for fdb in self.bridge_mac_list[s_index:]
+                                    if fdb[2] == port]
 
-            s_index = self.get_iter_index(arg_list[m_index], m_index)
-            fdb_list = self.bridge_mac_list[s_index:]
-            fdb_list = [fdb for fdb in self.bridge_mac_list[s_index:]
-                        if fdb[m_index] == arg_list[m_index]]
-
-        for fdb in fdb_list:
+        for fdb in self.bridge_mac_list:
             self.FDB_COUNT += 1
             output.append([self.FDB_COUNT, fdb[0], fdb[1], fdb[2]])
 

--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -107,7 +107,6 @@ class FdbShow(object):
             
             self.bridge_mac_list.append((int(fdb["vlan"]),) + (fdb["mac"],) + (if_name,))
 
-        self.bridge_mac_list.sort(key = lambda x: x[0])
         return
     
     
@@ -117,34 +116,49 @@ class FdbShow(object):
         """
         if pos == 0:
             self.bridge_mac_list.sort(key = lambda x: x[pos])
+        else:
+            self.bridge_mac_list = natsorted(self.bridge_mac_list, key = lambda x: x[pos])
+
+        if key_value == 0:
+            return 0
+
         keys = [r[pos] for r in self.bridge_mac_list]
         try:
             return keys.index(key_value)
-        except IndexError as e:
+        except ValueError as e:
             print e.message
 
 
-    def display_specific(self, port, vlan):
+    def display(self, vlan, port):
         """
             Display the FDB entries for specified vlan/port.
+            @todo: - PortChannel support
         """
         output = []
+        args = {vlan, port}
 
-        if vlan is not None and port is None:
-            vlan = int(vlan)
-            s_index = self.get_iter_index(vlan)
-            fdb_list = [fdb for fdb in self.bridge_mac_list[s_index:] if fdb[0] == vlan]
-
-        elif vlan is None and port is not None:
-            self.bridge_mac_list = natsorted(self.bridge_mac_list, key = lambda x: x[2])
-            s_index = self.get_iter_index(port, 2)
-            fdb_list = [fdb for fdb in self.bridge_mac_list[s_index:] if fdb[2] == port]
-
-        else:
+        if len(args) == 1:
+            """
+            Display the FDB summary.
+            """
+            s_index = self.get_iter_index()
+            fdb_list = self.bridge_mac_list[s_index:]
+        elif None not in args:
             vlan = int(vlan)
             s_index = self.get_iter_index(vlan)
             fdb_list = [fdb for fdb in self.bridge_mac_list[s_index:]
                         if fdb[0] == vlan and fdb[2] == port]
+        else:
+            #Placeholder added for MAC as None
+            arg_list = [vlan, None, port]
+            m_index = [idx for idx, val in enumerate(arg_list) if val != None][0]
+            if m_index == 0:
+                arg_list[m_index] = int(arg_list[m_index])
+
+            s_index = self.get_iter_index(arg_list[m_index], m_index)
+            fdb_list = self.bridge_mac_list[s_index:]
+            fdb_list = [fdb for fdb in self.bridge_mac_list[s_index:]
+                        if fdb[m_index] == arg_list[m_index]]
 
         for fdb in fdb_list:
             self.FDB_COUNT += 1
@@ -154,21 +168,6 @@ class FdbShow(object):
         print "Total number of entries {0} ".format(self.FDB_COUNT)
 
 
-    def display_summary(self):
-        """
-            Display the FDB summary. 
-            @todo: - PortChannel support
-        """
-        output = []
-        self.bridge_mac_list.sort(key = lambda x: x[0])
-        for fdb in self.bridge_mac_list:
-            self.FDB_COUNT += 1
-            output.append([self.FDB_COUNT, fdb[0], fdb[1], fdb[2]])
-            
-        print tabulate(output, self.HEADER)
-        print "Total number of entries {0} ".format(self.FDB_COUNT)
-        
-        
 def main():
     
     parser = argparse.ArgumentParser(description='Display ASIC FDB entries',
@@ -179,11 +178,7 @@ def main():
 
     try:
         fdb = FdbShow()
-        if args.port is None and args.vlan is None:
-            fdb.display_summary()
-        else:
-            fdb.display_specific(args.port, args.vlan)
-        
+        fdb.display(args.vlan, args.port)
     except Exception as e:
         print e.message
         sys.exit(1)

--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -59,22 +59,21 @@ class FdbShow(object):
         if not fdb_str:
             return
 
+        if self.if_br_oid_map is None:
+            return
+
         oid_pfx = len("oid:0x")
         for s in fdb_str:
             fdb_entry = s.decode()
             fdb = json.loads(fdb_entry .split(":", 2)[-1])
             if not fdb:
                 continue
-           
+
             ent = self.db.get_all('ASIC_DB', s, blocking=True)
             br_port_id = ent[b"SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID"][oid_pfx:]
-            try:
-                port_id = self.if_br_oid_map[br_port_id]
-                if_name = self.if_oid_map[port_id]
-            except KeyError as e:
-                print e.message
-                continue
-            
+            port_id = self.if_br_oid_map[br_port_id]
+            if_name = self.if_oid_map[port_id]
+
             self.bridge_mac_list.append((int(fdb["vlan"]),) + (fdb["mac"],) + (if_name,))
 
         self.bridge_mac_list.sort(key = lambda x: x[0])

--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -25,15 +25,13 @@
     1001 is not in list
 
 """
-
-import swsssdk
 import argparse
 import json
+import swsssdk
 import sys
 
-from swsssdk import port_util
-from tabulate import tabulate
 from natsort import natsorted
+from tabulate import tabulate
 
 class FdbShow(object):
 
@@ -44,8 +42,8 @@ class FdbShow(object):
         super(FdbShow,self).__init__()
         self.db = swsssdk.SonicV2Connector(host="127.0.0.1")
         self.if_name_map, \
-        self.if_oid_map = port_util.get_interface_oid_map(self.db)
-        self.if_br_oid_map = port_util.get_bridge_port_map(self.db)
+        self.if_oid_map = swsssdk.port_util.get_interface_oid_map(self.db)
+        self.if_br_oid_map = swsssdk.port_util.get_bridge_port_map(self.db)
         self.fetch_fdb_data()
         return
 

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         'scripts/dropcheck',
         'scripts/fast-reboot',
         'scripts/fast-reboot-dump.py',
+        'scripts/fdbshow',
         'scripts/generate_dump',
         'scripts/lldpshow',
         'scripts/portstat',

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,8 @@ setup(
         'click',
         'click-default-group',
         'natsort',
-        'tabulate'
+        'tabulate',
+        'swsssdk'
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/show/main.py
+++ b/show/main.py
@@ -226,6 +226,25 @@ def sfp(interfacename):
 
     run_command(cmd)
 
+#
+# 'mac' command ("show mac ...")
+#
+
+@cli.command()
+@click.option('-v', '--vlan')
+@click.option('-p', '--port')
+def mac(vlan, port):
+    """Show MAC (FDB) entries"""
+
+    command = "fdbshow"
+
+    if vlan is not None:
+        command += " -v {}".format(vlan)
+
+    if port is not None:
+        command += " -p {}".format(port)
+
+    run_command(command)
 
 #
 # 'ip' group ("show ip ...")


### PR DESCRIPTION
Support to show Layer 2 MAC entries learnt in Hardware.  The entries can also be shown per Port/Vlan 

    usage: fdbshow [-p PORT] [-v VLAN]
    optional arguments:
      -p,  --port              FDB learned on specific port: Ethernet0
      -v,  --vlan              FDB learned on specific Vlan: 1000
  
    Example of the output:
    admin@str~$ fdbshow
      No.    Vlan  MacAddress         Port
    -----  ------  -----------------  ----------
        1    1000  7C:FE:90:80:9F:05  Ethernet20
        2    1000  7C:FE:90:80:9F:10  Ethernet40
        3    1000  7C:FE:90:80:9F:01  Ethernet4
        4    1000  7C:FE:90:80:9F:02  Ethernet8
    Total number of entries 4
