### PR TITLE
Fixed parser logic to handle non mandatory TLV.

### DIFF
--- a/scripts/lldpshow
+++ b/scripts/lldpshow
@@ -77,7 +77,11 @@ class Lldpshow(object):
                 chassis = intf.find('chassis')
                 capabs = chassis.findall('capability')
                 capab = self.parse_cap(capabs)
-                self.lldpsum[l_intf]['r_name'] = chassis.find('name').text
+                rmt_name = chassis.find('name')
+                if rmt_name is not None:
+                    self.lldpsum[l_intf]['r_name'] = rmt_name.text
+                else:
+                    self.lldpsum[l_intf]['r_name'] = ''
                 remote_port = intf.find('port')
                 self.lldpsum[l_intf]['r_portid'] = remote_port.find('id').text
                 rmt_desc = remote_port.find('descr')


### PR DESCRIPTION
**Summary**:
Fixed parser logic to handle non mandatory TLV.

From WIKI:
Each LLDP frame starts with the following mandatory TLVs: Chassis ID, Port ID, and Time-to-Live.
The mandatory TLVs are followed by any number of optional TLVs. The frame ends with a special TLV,
named end of LLDPDU in which both the type and length fields are 0.

**Log**:
admin@sonic:~$ show lldp table
'NoneType' object has no attribute 'text'