### PR TITLE
Update fast-reboot script to boot next selected image

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -15,9 +15,10 @@ then
 fi
 
 # Kernel and initrd image
-KERNEL_IMAGE="/vmlinuz"
-INITRD="/initrd.img"
-BOOT_OPTIONS=$(cat /proc/cmdline)
+NEXT_SONIC_IMAGE=$(sonic_installer list | grep "Next: " | cut -d ' ' -f 2)
+BOOT_OPTIONS=$(cat /host/grub/grub.cfg | sed "/$NEXT_SONIC_IMAGE'/,/}/"'!'"g" | grep linux)
+KERNEL_IMAGE="/host$(echo $BOOT_OPTIONS | cut -d ' ' -f 2)"
+INITRD=$(echo $KERNEL_IMAGE | sed 's/vmlinuz/initrd.img/g')
 
 case "$BOOT_OPTIONS" in
   *fast-reboot*)
@@ -67,4 +68,5 @@ sleep 1
 sync
 
 # Reboot
+echo "Rebooting to $NEXT_SONIC_IMAGE..."
 reboot

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -16,9 +16,9 @@ fi
 
 # Kernel and initrd image
 NEXT_SONIC_IMAGE=$(sonic_installer list | grep "Next: " | cut -d ' ' -f 2)
-BOOT_OPTIONS=$(cat /host/grub/grub.cfg | sed "/$NEXT_SONIC_IMAGE'/,/}/"'!'"g" | grep linux)
-KERNEL_IMAGE="/host$(echo $BOOT_OPTIONS | cut -d ' ' -f 2)"
-BOOT_OPTIONS="$(echo $BOOT_OPTIONS | sed -e 's/\s*linux\s*/BOOT_IMAGE=/') fast-reboot"
+KERNEL_OPTIONS=$(cat /host/grub/grub.cfg | sed "/$NEXT_SONIC_IMAGE'/,/}/"'!'"g" | grep linux)
+KERNEL_IMAGE="/host$(echo $KERNEL_OPTIONS | cut -d ' ' -f 2)"
+BOOT_OPTIONS="$(echo $KERNEL_OPTIONS | sed -e 's/\s*linux\s*/BOOT_IMAGE=/') fast-reboot"
 INITRD=$(echo $KERNEL_IMAGE | sed 's/vmlinuz/initrd.img/g')
 
 sonic_asic_type=$(sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -18,16 +18,8 @@ fi
 NEXT_SONIC_IMAGE=$(sonic_installer list | grep "Next: " | cut -d ' ' -f 2)
 BOOT_OPTIONS=$(cat /host/grub/grub.cfg | sed "/$NEXT_SONIC_IMAGE'/,/}/"'!'"g" | grep linux)
 KERNEL_IMAGE="/host$(echo $BOOT_OPTIONS | cut -d ' ' -f 2)"
+BOOT_OPTIONS="$(echo $BOOT_OPTIONS | sed -e 's/\s*linux\s*/BOOT_IMAGE=/') fast-reboot"
 INITRD=$(echo $KERNEL_IMAGE | sed 's/vmlinuz/initrd.img/g')
-
-case "$BOOT_OPTIONS" in
-  *fast-reboot*)
-    # it's already there
-    ;;
-  *)
-    BOOT_OPTIONS="$BOOT_OPTIONS fast-reboot"
-    ;;
-esac
 
 sonic_asic_type=$(sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)
 


### PR DESCRIPTION
**- What I did**
Updated fast-reboot script to boot image which would boot after regular reboot

**- How I did it**
When deciding which kernel to kexec script now checks what is actually scheduled to boot in GRUB

**- How to verify it**
Install new image using SONiC-to-SONiC method (not from ONIE) and execute fast-reboot.
Make sure newly installed version booted

**- Description for the changelog**