### PR TITLE
Reorder dependencies to fix wheel build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,8 @@ setup(
         ]
     },
     install_requires=[
-        'click',
         'click-default-group',
+        'click',
         'natsort',
         'tabulate',
         'swsssdk'


### PR DESCRIPTION
- Dependencies listed in `install_requires` are installed in reverse order, so `click-default-group` must precede `click`