### PR TITLE
Remove explicit dependency on swsssdk

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,7 @@ setup(
         'click-default-group',
         'click',
         'natsort',
-        'tabulate',
-        'swsssdk'
+        'tabulate'
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
- The swsssdk package is installed as a wheel. If we compile sonic-utilities as a wheel, it will locate the swsssdk package dependency. However, if we compile sonic-utilities as a Debian package, it will look for a swsssdk Debian package, fail to find it, and the installation will fail.

- For now, we remove this explicit dependency in order to revert back to building sonic-utilities as a Debian package until we find a better solution, as we should specify all dependencies to ensure proper builds in case something goes wrong with the swsssdk installation.