### PR TITLE
[decode-syseeprom]: Fix caching

### DIFF
--- a/scripts/decode-syseeprom
+++ b/scripts/decode-syseeprom
@@ -26,7 +26,8 @@ PLATFORM_KEY = 'platform'
 
 PLATFORM_ROOT = '/usr/share/sonic/device'
 
-cache_root = '/var/cache/ssw/decode-syseeprom'
+CACHE_ROOT = '/var/cache/sonic/decode-syseeprom'
+CACHE_FILE = 'syseeprom_cache'
 
 # Returns platform and HW SKU
 def get_platform():
@@ -98,21 +99,22 @@ def run(target, opts, args):
         sys.stderr.write("Device is not ready: " + status + "\n")
         exit(0)
 
-    if not os.path.exists(cache_root):
+    if not os.path.exists(CACHE_ROOT):
         try:
-            os.makedirs(cache_root)
+            os.makedirs(CACHE_ROOT)
         except:
             pass
     if opts.init:
-        for file in glob.glob(os.path.join(cache_root, '*')):
+        for file in glob.glob(os.path.join(CACHE_ROOT, '*')):
             os.remove(file)
 
     #
     # only the eeprom classes that inherit from eeprom_base
     # support caching. Others will work normally
     #
+    print repr(opts)
     try:
-        target.set_cache_name(os.path.join(cache_root, opts.target))
+        target.set_cache_name(os.path.join(CACHE_ROOT, CACHE_FILE))
     except:
         pass
 

--- a/scripts/decode-syseeprom
+++ b/scripts/decode-syseeprom
@@ -112,7 +112,6 @@ def run(target, opts, args):
     # only the eeprom classes that inherit from eeprom_base
     # support caching. Others will work normally
     #
-    print repr(opts)
     try:
         target.set_cache_name(os.path.join(CACHE_ROOT, CACHE_FILE))
     except:


### PR DESCRIPTION
- `opts.target` did not exist, so a cache file was never specified. Now specifying cache file name explicitly.
- Also changed cache file path from `/var/cache/ssw/` to `/var/cache/sonic/`
- Resolves https://github.com/Azure/sonic-utilities/issues/137