### PR TITLE
[installer]: remove old_config before backup

### DIFF
--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -190,6 +190,7 @@ def install(url):
         run_command(image_path)
         run_command('grub-set-default --boot-directory=' + HOST_PATH + ' 0')
     run_command("sync")
+    run_command("rm -rf /host/old_config")
     run_command("cp -r /etc/sonic /host/old_config")
     click.echo('Done')
 


### PR DESCRIPTION
if /host/old_config exists, the copy command will copy sonic directory
into /host/old_config