### PR TITLE
Fix the 'show acl table' format issue

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -7,6 +7,7 @@ import os.path
 import json
 import argparse
 import tabulate
+from natsort import natsorted
 
 import openconfig_acl
 import pyangbind.lib.pybindJSON as pybindJSON
@@ -384,7 +385,7 @@ class AclLoader(object):
             if not val["ports"]:
                 data.append([key, val["type"], "", val["policy_desc"]])
             else:
-                ports = sorted(val["ports"], )
+                ports = natsorted(val["ports"].split(","),)
                 data.append([key, val["type"], ports[0], val["policy_desc"]])
 
                 if len(ports) > 1:


### PR DESCRIPTION
Old output:
Command: acl-loader show table 
Name        Type    Ports    Description
----------  ------  -------  -------------
dataacl     L3      ,        dataacl
                    ,
                    ,
                    ,
                    1
                    1
                    1
                    6
                    7
                    8
                    8
                    9
                    E
                    E
                    E
                    E
                    E
                    e
                    e
                    e
                    e
                    e
...

New output:
$ show acl table
Command: acl-loader show table 
Name        Type    Ports       Description

dataacl     L3      Ethernet8   dataacl
                    Ethernet9
                    Ethernet16
                    Ethernet17
                    Ethernet18
