### PR TITLE
[show]: If rotated syslog.1 file exists, concatenate output of syslog.1 and syslog

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -493,7 +493,10 @@ def logging(process, lines, follow):
     if follow:
         run_command("sudo tail -f /var/log/syslog")
     else:
-        command = "sudo cat /var/log/syslog"
+        if os.path.isfile("/var/log/syslog.1"):
+            command = "sudo cat /var/log/syslog.1 /var/log/syslog"
+        else:
+            command = "sudo cat /var/log/syslog"
 
         if process is not None:
             command += " | grep '{}'".format(process)


### PR DESCRIPTION
In the case /var/log/syslog was recently rotated, `show logging` could potentially display no or very few log messages. WIth this PR, if /var/log/syslog.1 exists, we will display the contents of /var/log/syslog.1 followed by the contents of /var/log/syslog, thus ensuring `show logging` always displays a reasonable amount of recent log messages.