### PR TITLE
[psuutil]: Shorten the help message to display it fully

### DIFF
--- a/psuutil/main.py
+++ b/psuutil/main.py
@@ -149,7 +149,7 @@ def version():
 # 'numpsus' subcommand
 @cli.command()
 def numpsus():
-    "Display the number of supported PSU in the device"
+    """Display number of supported PSUs on device"""
     click.echo(str(platform_psuutil.get_num_psus()))
 
 # 'status' subcommand


### PR DESCRIPTION
Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>

it seems that the number of characters to be displayed is limited.

previous output:
```
Usage: psuutil [OPTIONS] COMMAND [ARGS]...                 
                                                           
  psuutil - Command line utility for providing PSU status  
                                                           
Options:                                                   
  --help  Show this message and exit.                      
                                                           
Commands:                                                  
  numpsus  Display the number of supported PSU in the...   
  status   Display PSU status                              
  version  Display version info                            
```

current output:
```
Usage: psuutil [OPTIONS] COMMAND [ARGS]...                
                                                          
  psuutil - Command line utility for providing PSU status 
                                                          
Options:                                                  
  --help  Show this message and exit.                     
                                                          
Commands:                                                 
  numpsus  Display number of supported PSUs on device  
  status   Display PSU status                             
  version  Display version info                           
```
