### PR TITLE
fix aclshow -d not showing ACL table issue

### DIFF
--- a/scripts/aclshow
+++ b/scripts/aclshow
@@ -220,6 +220,9 @@ class AclStat(object):
         def adj_len(text, mlen):
             return text + "." * (mlen - len(text))
 
+        if not self.acl_tables:
+            return
+
         # determine max len of the table and rule properties
         onetable = self.acl_tables.itervalues().next()
         tlen = len(onetable.keys()[0])
@@ -227,11 +230,14 @@ class AclStat(object):
             if len(property) > tlen:
                 tlen = len(property)
 
-        onerule = self.acl_rules.itervalues().next()
-        rlen = len(onerule.keys()[0])
-        for property in onerule.keys() + [PACKETS_COUNTER, BYTES_COUNTER]:
-            if len(property) > rlen:
-                rlen = len(property)
+        if not self.acl_rules:
+            rlen = 0
+        else:
+            onerule = self.acl_rules.itervalues().next()
+            rlen = len(onerule.keys()[0])
+            for property in onerule.keys() + [PACKETS_COUNTER, BYTES_COUNTER]:
+                if len(property) > rlen:
+                    rlen = len(property)
 
         mlen = max(rlen, tlen) + 1
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Fix the "aclshow -d" not showing ACL table if no rules were added

**- How I did it**
Check corner cases.

**- How to verify it**
Verify the scenario is fixed.

**- Previous command output (if the output of a command-line utility has changed)**
empty.

**- New command output (if the output of a command-line utility has changed)**
```
ACL Table: dataacl
==================
Property      Value
------------  ----------------------------------------------------
type........  L3
policy_desc.  dataacl
ports.......  Ethernet8,Ethernet9,Ethernet16,Ethernet17,Ethernet18 
-->
```
