### PR TITLE
[show] Add and rename 'show interfaces transceiver' subcommands (eeprom, lpmode, presence)

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -231,10 +231,14 @@ def transceiver():
 
 @transceiver.command()
 @click.argument('interfacename', required=False)
-def basic(interfacename):
-    """Show basic interface transceiver information"""
+@click.option('-d', '--dom', 'dump_dom', is_flag=True, help="Also display Digital Optical Monitoring (DOM) data")
+def eeprom(interfacename, dump_dom):
+    """Show interface transceiver EEPROM information"""
 
     command = "sudo sfputil show eeprom"
+
+    if dump_dom:
+        command += " --dom"
 
     if interfacename is not None:
         command += " -p {}".format(interfacename)
@@ -244,10 +248,22 @@ def basic(interfacename):
 
 @transceiver.command()
 @click.argument('interfacename', required=False)
-def details(interfacename):
-    """Show interface transceiver details (Digital Optical Monitoring)"""
+def lpmode(interfacename):
+    """Show interface transceiver low-power mode status"""
 
-    command = "sudo sfputil show eeprom --dom"
+    command = "sudo sfputil show lpmode"
+
+    if interfacename is not None:
+        command += " -p {}".format(interfacename)
+
+    run_command(command)
+
+@transceiver.command()
+@click.argument('interfacename', required=False)
+def presence(interfacename):
+    """Show interface transceiver presence"""
+
+    command = "sudo sfputil show presence"
 
     if interfacename is not None:
         command += " -p {}".format(interfacename)


### PR DESCRIPTION
**- What I did**

- Remove `show interfaces transceiver basic` and `show interfaces transceiver details` and combine the functionality into `show interfaces transceiver eeprom [-d/--dom]`

- Add `show interfaces transceiver lpmode` and `show interfaces transceiver presence` commands to give `show` command access to new sfputil functionality

**- Previous command output (if the output of a command-line utility has changed)**

```
admin@sonic:~$ show interfaces transceiver basic Ethernet0
Command: sudo sfputil show eeprom -p Ethernet0
Ethernet0: SFP EEPROM detected
        Connector: No separable connector
        Encoding: Unspecified
        Extended Identifier: Unknown
        Extended RateSelect Compliance: QSFP+ Rate Select Version 1
        Identifier: QSFP+
        Length Cable Assembly(m): 1
        Specification compliance:
                10/40G Ethernet Compliance Code: 40GBASE-CR4
                Fibre Channel Speed: 1200 Mbytes/Sec
                Fibre Channel link length/Transmitter Technology: Electrical inter-enclosure (EL)
                Fibre Channel transmission media: Twin Axial Pair (TW)
        Vendor Date Code(YYYY-MM-DD Lot): 2015-11-03 
        Vendor Name: Molex Inc.
        Vendor OUI: 00-09-3a
        Vendor PN: 1110401104
        Vendor Rev: 
        Vendor SN: 530736557
```

```
admin@sonic:~$ show interfaces transceiver details Ethernet0     
Command: sudo sfputil show eeprom --dom -p Ethernet0
Ethernet0: SFP EEPROM detected
        Connector: No separable connector
        Encoding: Unspecified
        Extended Identifier: Unknown
        Extended RateSelect Compliance: QSFP+ Rate Select Version 1
        Identifier: QSFP+
        Length Cable Assembly(m): 1
        Specification compliance:
                10/40G Ethernet Compliance Code: 40GBASE-CR4
                Fibre Channel Speed: 1200 Mbytes/Sec
                Fibre Channel link length/Transmitter Technology: Electrical inter-enclosure (EL)
                Fibre Channel transmission media: Twin Axial Pair (TW)
        Vendor Date Code(YYYY-MM-DD Lot): 2015-11-03 
        Vendor Name: Molex Inc.
        Vendor OUI: 00-09-3a
        Vendor PN: 1110401104
        Vendor Rev: 
        Vendor SN: 530736557
        ChannelMonitorValues:
                RX1Power: -infdBm
                RX2Power: -infdBm
                RX3Power: -infdBm
                RX4Power: -infdBm
                TX1Bias: 0.0000mA
                TX2Bias: 0.0000mA
                TX3Bias: 0.0000mA
                TX4Bias: 0.0000mA
        ModuleMonitorValues:
                Temperature: 1.5039C
                Vcc: 0.0000Volts
```

**- New command output (if the output of a command-line utility has changed)**
```
admin@sonic:~$ show interfaces transceiver basic Ethernet0
Usage: show interfaces transceiver [OPTIONS] COMMAND [ARGS]...

Error: No such command "basic".
```

```
admin@sonic:~$ show interfaces transceiver details Ethernet0
Usage: show interfaces transceiver [OPTIONS] COMMAND [ARGS]...

Error: No such command "details".
```


```
admin@sonic:~$ show interfaces transceiver eeprom Ethernet0
Command: sudo sfputil show eeprom -p Ethernet0
Ethernet0: SFP EEPROM detected
        Connector: No separable connector
        Encoding: Unspecified
        Extended Identifier: Unknown
        Extended RateSelect Compliance: QSFP+ Rate Select Version 1
        Identifier: QSFP+
        Length Cable Assembly(m): 1
        Specification compliance:
                10/40G Ethernet Compliance Code: 40GBASE-CR4
                Fibre Channel Speed: 1200 Mbytes/Sec
                Fibre Channel link length/Transmitter Technology: Electrical inter-enclosure (EL)
                Fibre Channel transmission media: Twin Axial Pair (TW)
        Vendor Date Code(YYYY-MM-DD Lot): 2016-05-08 
        Vendor Name: Molex Inc.
        Vendor OUI: 00-09-3a
        Vendor PN: 1110401054
        Vendor Rev: 
        Vendor SN: 612930553
```

```
admin@sonic:~$ show interfaces transceiver eeprom Ethernet0 --dom
Command: sudo sfputil show eeprom --dom -p Ethernet0
Ethernet0: SFP EEPROM detected
        Connector: No separable connector
        Encoding: Unspecified
        Extended Identifier: Unknown
        Extended RateSelect Compliance: QSFP+ Rate Select Version 1
        Identifier: QSFP+
        Length Cable Assembly(m): 1
        Specification compliance:
                10/40G Ethernet Compliance Code: 40GBASE-CR4
                Fibre Channel Speed: 1200 Mbytes/Sec
                Fibre Channel link length/Transmitter Technology: Electrical inter-enclosure (EL)
                Fibre Channel transmission media: Twin Axial Pair (TW)
        Vendor Date Code(YYYY-MM-DD Lot): 2016-05-08 
        Vendor Name: Molex Inc.
        Vendor OUI: 00-09-3a
        Vendor PN: 1110401054
        Vendor Rev: 
        Vendor SN: 612930553
        ChannelMonitorValues:
                RX1Power: -infdBm
                RX2Power: -infdBm
                RX3Power: -infdBm
                RX4Power: -infdBm
                TX1Bias: 0.0000mA
                TX2Bias: 0.0000mA
                TX3Bias: 0.0000mA
                TX4Bias: 0.0000mA
        ModuleMonitorValues:
                Temperature: 1.5039C
                Vcc: 0.0000Volts
```

```
admin@sonic:~$ show interfaces transceiver lpmode      
Command: sudo sfputil show lpmode
Port         Low-power Mode
-----------  ----------------
Ethernet0    On
Ethernet4    On
Ethernet8    On
Ethernet12   On
Ethernet16   On
Ethernet20   On
Ethernet24   On
Ethernet28   On
Ethernet32   On
Ethernet36   On
Ethernet40   On
Ethernet44   On
Ethernet48   On
Ethernet52   On
Ethernet56   On
Ethernet60   On
Ethernet64   On
Ethernet68   On
Ethernet72   On
Ethernet76   On
Ethernet80   On
Ethernet84   On
Ethernet88   On
Ethernet92   On
Ethernet96   On
Ethernet100  On
Ethernet104  On
Ethernet108  On
Ethernet112  On
Ethernet116  On
Ethernet120  On
Ethernet124  On
```

```
admin@sonic:~$ show interfaces transceiver presence
Command: sudo sfputil show presence
Port         Presence
-----------  ----------
Ethernet0    Present
Ethernet4    Present
Ethernet8    Present
Ethernet12   Present
Ethernet16   Present
Ethernet20   Present
Ethernet24   Present
Ethernet28   Present
Ethernet32   Present
Ethernet36   Present
Ethernet40   Present
Ethernet44   Present
Ethernet48   Present
Ethernet52   Present
Ethernet56   Present
Ethernet60   Present
Ethernet64   Present
Ethernet68   Present
Ethernet72   Present
Ethernet76   Present
Ethernet80   Present
Ethernet84   Present
Ethernet88   Present
Ethernet92   Present
Ethernet96   Present
Ethernet100  Present
Ethernet104  Present
Ethernet108  Present
Ethernet112  Present
Ethernet116  Present
Ethernet120  Present
Ethernet124  Present
```