### PR TITLE
[show] Enhance/fix 'show ip/ipv6 bgp neighbors ...' commands

### DIFF
--- a/show/bgp_quagga_v4.py
+++ b/show/bgp_quagga_v4.py
@@ -25,11 +25,19 @@ def summary():
 # 'neighbors' subcommand ("show ip bgp neighbors")
 @bgp.command()
 @click.argument('ipaddress', required=False)
-def neighbors(ipaddress):
+@click.argument('info_type', type=click.Choice(['routes', 'advertised-routes', 'received-routes']), required=False)
+def neighbors(ipaddress, info_type):
     """Show IP (IPv4) BGP neighbors"""
 
+    command = 'sudo vtysh -c "show ip bgp neighbor'
+
     if ipaddress is not None:
-        command = 'sudo vtysh -c "show ip bgp neighbor {} "'.format(ipaddress)
-        run_command(command)
-    else:
-        run_command('sudo vtysh -c "show ip bgp neighbor"')
+        command += ' {}'.format(ipaddress)
+
+        # info_type is only valid if ipaddress is specified
+        if info_type is not None:
+            command += ' {}'.format(info_type)
+
+    command += '"'
+
+    run_command(command)

--- a/show/bgp_quagga_v6.py
+++ b/show/bgp_quagga_v6.py
@@ -25,7 +25,8 @@ def summary():
 # 'neighbors' subcommand ("show ipv6 bgp neighbors")
 @bgp.command()
 @click.argument('ipaddress', required=True)
-def neighbors(ipaddress):
+@click.argument('info_type', type=click.Choice(['routes', 'advertised-routes', 'received-routes']), required=True)
+def neighbors(ipaddress, info_type):
     """Show IPv6 BGP neighbors"""
-    command = 'sudo vtysh -c "show ipv6 bgp neighbor {} "'.format(ipaddress)
+    command = 'sudo vtysh -c "show ipv6 bgp neighbor {} {}"'.format(ipaddress, info_type)
     run_command(command)


### PR DESCRIPTION
- Add support for 'routes', 'advertised-routes', 'received-routes' options in both `show ip bgp neighbors` and `show ipv6 bgp neighbors`. Require the options as well as the neighbor IP address in the latter (ipv6), as the corresponding quagga vtysh command also requires them.