### PR TITLE
[reboot] While rebooting device, execute platform specific reboot tool when available

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -59,6 +59,6 @@ sync
 sleep 1
 sync
 
-# Reboot
+# Reboot: explicity call Linux native reboot under sbin
 echo "Rebooting to $NEXT_SONIC_IMAGE..."
-reboot
+/sbin/reboot

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -1,0 +1,25 @@
+#! /bin/bash
+
+function stop_sonic_services()
+{
+    echo "Stopping sonic services..."
+    systemctl stop swss
+    systemctl stop teamd
+    systemctl stop bgp
+    systemctl stop lldp
+}
+
+# Obtain our platform as we will mount directories with these names in each docker
+PLATFORM=`sonic-cfggen -v platform`
+
+DEVPATH="/usr/share/sonic/device"
+REBOOT="platform_reboot"
+
+if [ -x ${DEVPATH}/${PLATFORM}/${REBOOT} ]; then
+    stop_sonic_services
+    echo "Rebooting with platform ${PLATFORM} specific tool ..."
+    ${DEVPATH}/${PLATFORM}/${REBOOT}
+    exit 0
+fi
+
+/sbin/reboot $@

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -18,6 +18,7 @@ REBOOT="platform_reboot"
 if [ -x ${DEVPATH}/${PLATFORM}/${REBOOT} ]; then
     stop_sonic_services
     sync
+    sleep 3
     echo "Rebooting with platform ${PLATFORM} specific tool ..."
     ${DEVPATH}/${PLATFORM}/${REBOOT}
     exit 0

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -17,6 +17,7 @@ REBOOT="platform_reboot"
 
 if [ -x ${DEVPATH}/${PLATFORM}/${REBOOT} ]; then
     stop_sonic_services
+    sync
     echo "Rebooting with platform ${PLATFORM} specific tool ..."
     ${DEVPATH}/${PLATFORM}/${REBOOT}
     exit 0

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -7,6 +7,7 @@ function stop_sonic_services()
     systemctl stop teamd
     systemctl stop bgp
     systemctl stop lldp
+    systemctl stop snmp
 }
 
 # Obtain our platform as we will mount directories with these names in each docker

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         'scripts/port2alias',
         'scripts/portconfig',
         'scripts/portstat',
+        'scripts/reboot',
         'scripts/teamshow'
     ],
     data_files=[


### PR DESCRIPTION
**- What I did**
Reboot device with platform specific tool when available.

**- How I did it**
- Added a script under /usr/bin/reboot, this script will be executed when reboot is invoked without absolute path.
- The script checks if <device path>/platform_reboot tool is available and executable. If so, use this tool to reboot device.
- Update fast-reboot to call native Linux reboot with absolute path.

**- How to verify it**
- Executed the script on device with platform_reboot available, and the tool was called.
- Executed the script on device without platform_reboot tool or not with execution permission, Linux native reboot was called.

