### PR TITLE
[sonic_install] sync filesystem after file copy is done

### DIFF
--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -189,9 +189,11 @@ def install(url):
         os.chmod(image_path, stat.S_IXUSR)
         run_command(image_path)
         run_command('grub-set-default --boot-directory=' + HOST_PATH + ' 0')
-    run_command("sync")
     run_command("rm -rf /host/old_config")
     run_command("cp -r /etc/sonic /host/old_config")
+
+    # sync filesystem, keep at last step.
+    run_command("sync")
     click.echo('Done')
 
 

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -194,6 +194,7 @@ def install(url):
 
     # sync filesystem, keep at last step.
     run_command("sync")
+    run_command("sleep 3") # wait 3 seconds after sync
     click.echo('Done')
 
 


### PR DESCRIPTION
**- What I did**
sync file system after all copies and installations are done.

**- How to verify it**
With platform specific reboot tool power cycling devices, it is highly repeatable that some file would be missing after sonic_install.

The fix is verified under the same circumstances.

The issue turns out not related to this sync. But putting the sync at the end of the execution list by itself is a good practice anyways.