### PR TITLE
Get Vlan Id from SAI Vlan Object if bvid present

### DIFF
--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -76,10 +76,10 @@ class FdbShow(object):
             port_id = self.if_br_oid_map[br_port_id]
             if_name = self.if_oid_map[port_id]
             if 'vlan' in fdb:
-                self.bridge_mac_list.append((int(fdb["vlan"]),) + (fdb["mac"],) + (if_name,))
+                vlan_id = fdb["vlan"]
             elif 'bvid' in fdb:
                 vlan_id = port_util.get_vlan_id_from_bvid(self.db, fdb["bvid"])
-                self.bridge_mac_list.append((int(vlan_id),) + (fdb["mac"],) + (if_name,))
+            self.bridge_mac_list.append((int(vlan_id),) + (fdb["mac"],) + (if_name,))
 
         self.bridge_mac_list.sort(key = lambda x: x[0])
         return

--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -75,8 +75,11 @@ class FdbShow(object):
                 continue
             port_id = self.if_br_oid_map[br_port_id]
             if_name = self.if_oid_map[port_id]
-
-            self.bridge_mac_list.append((int(fdb["vlan"]),) + (fdb["mac"],) + (if_name,))
+            if 'vlan' in fdb:
+                self.bridge_mac_list.append((int(fdb["vlan"]),) + (fdb["mac"],) + (if_name,))
+            elif 'bvid' in fdb:
+                vlan_id = port_util.get_vlan_id_from_bvid(self.db, fdb["bvid"])
+                self.bridge_mac_list.append((int(vlan_id),) + (fdb["mac"],) + (if_name,))
 
         self.bridge_mac_list.sort(key = lambda x: x[0])
         return


### PR DESCRIPTION
**- What I did**
Get Vlan Id from SAI_OBJECT_TYPE_VLAN if _bvid_ is present in fdb entry. 

**- How I did it**

**- How to verify it**
Execute fdbshow and it must display the entires

**- Command output**
```
$ fdbshow 
  No.    Vlan  MacAddress         Port
-----  ------  -----------------  ----------
    1    1000  24:8A:07:4C:F5:03  Ethernet12
    2    1000  24:8A:07:4C:F5:18  Ethernet96
    3    1000  24:8A:07:4C:F5:16  Ethernet88
    4    1000  24:8A:07:4C:F5:09  Ethernet36
    5    1000  24:8A:07:4C:F5:15  Ethernet84
```

-->

