### PR TITLE
[config] Store ConfigDB init indicator boolean value as 1/0 in Redis …

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -159,7 +159,7 @@ def reload(filename):
     client.flushdb()
     command = "{} -j {} --write-to-db".format(SONIC_CFGGEN_PATH, filename)
     run_command(command, display_cmd=True)
-    client.set(config_db.INIT_INDICATOR, True)
+    client.set(config_db.INIT_INDICATOR, 1)
     _restart_services()
 
 @cli.command()
@@ -200,7 +200,7 @@ def load_minigraph():
     else:
         command = "{} -m --write-to-db".format(SONIC_CFGGEN_PATH)
     run_command(command, display_cmd=True)
-    client.set(config_db.INIT_INDICATOR, True)
+    client.set(config_db.INIT_INDICATOR, 1)
     if os.path.isfile('/etc/sonic/acl.json'):
         run_command("acl-loader update full /etc/sonic/acl.json", display_cmd=True)
     #FIXME: After config DB daemon is implemented, we'll no longer need to restart every service.


### PR DESCRIPTION
- Redis has no concept of a boolean datatype, and stores everything as strings. However, the redis-py Python API converts Python booleans into strings of text representations of the Python booleans (`True` and  `False`). However, other languages, such as C++ use all-lowercase `true` and `false`. Therefore, it is best to store boolean values in Redis in a language-agnostic way that makes sense when retrieved using any language (`1` and `0`).