### PR TITLE
[acl-loader] Prevent from hanging if run by non-root user

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -80,7 +80,7 @@ class AclLoader(object):
         self.sessions_db_info = {}
         self.configdb = ConfigDBConnector()
         self.configdb.connect()
-        self.appdb = SonicV2Connector()
+        self.appdb = SonicV2Connector(host="127.0.0.1")
         self.appdb.connect(self.appdb.APPL_DB)
 
         self.read_tables_info()


### PR DESCRIPTION
- If `acl-loader` was run by a non-root user, it would just hang indefinitely in the call to `SonicV2Connector()`.

- NOTE: We may want to exit if run by a non-root user and add "acl-loader show *` to /etc/sudoers as we have done for other CLI utils which have both show and config functionality.