### PR TITLE
[fast-reboot]: Dump default routes from APPL_DB table before fast-reboot

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -26,10 +26,14 @@ sonic_asic_type=$(sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)
 # Load kernel into the memory
 /sbin/kexec -l "$KERNEL_IMAGE" --initrd="$INITRD" --append="$BOOT_OPTIONS"
 
-# Dump the ARP and FDB tables to files
+# Dump the ARP and FDB tables to files also as default routes for both IPv4 and IPv6
 /usr/bin/fast-reboot-dump.py
 docker cp /tmp/fdb.json swss:/
 docker cp /tmp/arp.json swss:/
+if [ -e /tmp/default_routes.json ]
+then
+  docker cp /tmp/default_routes.json swss:/
+fi
 
 # Kill bgpd to enable graceful restart of BGP
 docker exec -ti bgp killall -9 watchquagga


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Dump default routes (both IPv4 and IPv6) from APPL db right before fast reboot restart.

**- How I did it**
Change fast-reboot-dump.py script

**- How to verify it**
Run sudo /usr/bin/fast-reboot-dump.py and you'll find /tmp/default-routes.json file with valid output.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

