### PR TITLE
[reboot] update reboot script to retrieve platform with new format

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -11,7 +11,7 @@ function stop_sonic_services()
 }
 
 # Obtain our platform as we will mount directories with these names in each docker
-PLATFORM=`sonic-cfggen -H -v DEVICE_METADATA.hwsku.platform`
+PLATFORM=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
 
 DEVPATH="/usr/share/sonic/device"
 REBOOT="platform_reboot"


### PR DESCRIPTION
**- What I did**
sonic-cfggen has changed its information format. Particularly, platform is no longer under hwsku, instead, it is under localhost now.

**- How to verify it**
Tested reboot on dut. without the change, there is an error; with the change, there is no error.

