### PR TITLE
[Fast-reboot]: Find correct opennsl module name before stopping the module

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -55,7 +55,8 @@ systemctl stop docker.service
 # Stop opennsl modules for Broadcom platform
 if [ "$sonic_asic_type" = 'broadcom' ];
 then
- systemctl stop opennsl-modules-3.16.0-4-amd64.service
+  service_name=$(systemctl list-units --plain --no-pager --no-legend --type=service | grep opennsl | cut -f 1 -d' ')
+  systemctl stop "$service_name"
 fi
 
 # Wait until all buffers synced with disk


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Get correct name for the Broadcom opennsl service before stopping it

**- How I did it**
Check list of systemctl services

**- How to verify it**
Check the console when you doing fast-reboot procedure for output from systemctl

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

