### PR TITLE
[Fast-reboot]: Refactor fast-reboot script. Store the dumps in /host

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Check root privileges
-if [ "$EUID" -ne 0 ]
+if [[ "$EUID" -ne 0 ]]
 then
   echo "Please run as root"
   exit
@@ -9,7 +9,7 @@ fi
 
 
 # Unload the previously loaded kernel if any loaded
-if [ "$(cat /sys/kernel/kexec_loaded)" -eq 1 ]
+if [[ "$(cat /sys/kernel/kexec_loaded)" -eq 1 ]]
 then
   /sbin/kexec -u
 fi
@@ -27,33 +27,28 @@ sonic_asic_type=$(sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)
 /sbin/kexec -l "$KERNEL_IMAGE" --initrd="$INITRD" --append="$BOOT_OPTIONS"
 
 # Dump the ARP and FDB tables to files also as default routes for both IPv4 and IPv6
-/usr/bin/fast-reboot-dump.py
-docker cp /tmp/fdb.json swss:/
-docker cp /tmp/arp.json swss:/
-if [ -e /tmp/default_routes.json ]
-then
-  docker cp /tmp/default_routes.json swss:/
-fi
+# into /host/fast-reboot
+mkdir -p /host/fast-reboot
+/usr/bin/fast-reboot-dump.py /host/fast-reboot
 
-# Kill bgpd to enable graceful restart of BGP
-docker exec -ti bgp killall -9 watchquagga
+# Kill bgpd to start the bgp graceful restart procedure
 docker exec -ti bgp killall -9 zebra
 docker exec -ti bgp killall -9 bgpd
 
 # Kill lldp, otherwise it sends informotion about reboot
-docker kill lldp
+docker kill lldp > /dev/null
 
 # Kill teamd, otherwise it gets down all LAGs
-docker kill teamd
+docker kill teamd > /dev/null
 
-# Kill other containers to make reboot faster
-docker ps -qa | xargs docker kill
+# Kill other containers to make the reboot faster
+docker ps -q | xargs docker kill > /dev/null
 
 # Stop the docker container engine. Otherwise we will have a broken docker storage
 systemctl stop docker.service
 
 # Stop opennsl modules for Broadcom platform
-if [ "$sonic_asic_type" = 'broadcom' ];
+if [[ "$sonic_asic_type" = 'broadcom' ]];
 then
   service_name=$(systemctl list-units --plain --no-pager --no-legend --type=service | grep opennsl | cut -f 1 -d' ')
   systemctl stop "$service_name"

--- a/scripts/fast-reboot-dump.py
+++ b/scripts/fast-reboot-dump.py
@@ -4,6 +4,7 @@ import swsssdk
 import json
 import socket
 import struct
+import sys
 import os
 from fcntl import ioctl
 import binascii
@@ -244,18 +245,17 @@ def generate_default_route_entries(filename):
 
     db.close(db.APPL_DB)
 
-    if len(default_routes_output) > 0:
-        with open(filename, 'w') as fp:
-            json.dump(default_routes_output, fp, indent=2, separators=(',', ': '))
-    else:
-        if os.path.isfile(filename):
-            os.unlink(filename)
+    with open(filename, 'w') as fp:
+        json.dump(default_routes_output, fp, indent=2, separators=(',', ': '))
 
 
 def main():
-    all_available_macs, map_mac_ip_per_vlan = generate_fdb_entries('/tmp/fdb.json')
-    arp_entries = generate_arp_entries('/tmp/arp.json', all_available_macs)
-    generate_default_route_entries('/tmp/default_routes.json')
+    root_dir = '/tmp'
+    if len(sys.argv) > 1 and os.path.isdir(sys.argv[1]):
+        root_dir = sys.argv[1]
+    all_available_macs, map_mac_ip_per_vlan = generate_fdb_entries(root_dir + '/fdb.json')
+    arp_entries = generate_arp_entries(root_dir + '/arp.json', all_available_macs)
+    generate_default_route_entries(root_dir + '/default_routes.json')
     garp_send(arp_entries, map_mac_ip_per_vlan)
 
     return


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
1. Refactor fast-reboot script
2. Store the dumps in /host directory to better work with NOS-SONiC updates

**- How I did it**
Modify fast-reboot and fast-reboot.py to better serve our needs

**- How to verify it**
1. Run mkdir your_dir; sudo /usr/bin/fast-reboot-dump.py your_dir to find the dumps in your_dir
2. Run sudo fast-reboot to find the fast-reboot working

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

