### PR TITLE
Add fast-reboot support for Aboot based images

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -16,9 +16,18 @@ fi
 
 # Kernel and initrd image
 NEXT_SONIC_IMAGE=$(sonic_installer list | grep "Next: " | cut -d ' ' -f 2)
-KERNEL_OPTIONS=$(cat /host/grub/grub.cfg | sed "/$NEXT_SONIC_IMAGE'/,/}/"'!'"g" | grep linux)
-KERNEL_IMAGE="/host$(echo $KERNEL_OPTIONS | cut -d ' ' -f 2)"
-BOOT_OPTIONS="$(echo $KERNEL_OPTIONS | sed -e 's/\s*linux\s*/BOOT_IMAGE=/') fast-reboot"
+if grep -q aboot_platform= /host/machine.conf; then
+    IMAGE_PATH="/host/image-${NEXT_SONIC_IMAGE#SONiC-OS-}"
+    KERNEL_IMAGE="$(ls $IMAGE_PATH/boot/vmlinuz-*)"
+    BOOT_OPTIONS="$(cat "$IMAGE_PATH/kernel-cmdline" | tr '\n' ' ') fast-reboot"
+elif grep -q onie_platform= /host/machine.conf; then
+    KERNEL_OPTIONS=$(cat /host/grub/grub.cfg | sed "/$NEXT_SONIC_IMAGE'/,/}/"'!'"g" | grep linux)
+    KERNEL_IMAGE="/host$(echo $KERNEL_OPTIONS | cut -d ' ' -f 2)"
+    BOOT_OPTIONS="$(echo $KERNEL_OPTIONS | sed -e 's/\s*linux\s*/BOOT_IMAGE=/') fast-reboot"
+else
+    echo "Unknown bootloader. fast-reboot is not supported."
+    exit 1
+fi
 INITRD=$(echo $KERNEL_IMAGE | sed 's/vmlinuz/initrd.img/g')
 
 sonic_asic_type=$(sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

ru** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**

Added support of fast-reboot for Arista platform by adding support of Aboot in fast-reboot.
Also changed sonic_installer to use `install=y` instead of `sonic_upgrade=1`.
The boot0 will stay backward compatible with previous `sonic_installer` versions.

**- How to verify it**

Running `sonic_installer install` and then `fast-reboot` should show kexec working.
It is assumed that all ONIE based platform define onie_platform= in /host/machine.conf.

