### PR TITLE
[config bgp] Convert user input ipv6 addr to lower case before comparing

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -77,8 +77,8 @@ def _change_bgp_session_status(ipaddr_or_hostname, status, verbose):
     """
     ip_addrs = []
 
-    # Convert the IP address to lowercase because IPv6 addresses will be stored
-    # in ConfigDB with all lowercase alphabet characters during minigraph parsing
+    # If we were passed an IP address, convert it to lowercase because IPv6 addresses were
+    # stored in ConfigDB with all lowercase alphabet characters during minigraph parsing
     if _is_neighbor_ipaddress(ipaddr_or_hostname.lower()):
         ip_addrs.append(ipaddr_or_hostname.lower())
     else:

--- a/config/main.py
+++ b/config/main.py
@@ -39,10 +39,7 @@ def _is_neighbor_ipaddress(ipaddress):
     """
     config_db = ConfigDBConnector()
     config_db.connect()
-
-    # Convert the IP address to uppercase because IPv6 addresses are stored
-    # in ConfigDB with all uppercase alphabet characters
-    entry = config_db.get_entry('BGP_NEIGHBOR', ipaddress.upper())
+    entry = config_db.get_entry('BGP_NEIGHBOR', ipaddress)
     return True if entry else False
 
 def _get_all_neighbor_ipaddresses():
@@ -73,16 +70,17 @@ def _change_bgp_session_status_by_addr(ipaddress, status, verbose):
     config_db = ConfigDBConnector()
     config_db.connect()
 
-    # Convert the IP address to uppercase because IPv6 addresses are stored
-    # in ConfigDB with all uppercase alphabet characters
-    config_db.mod_entry('bgp_neighbor', ipaddress.upper(), {'admin_status': status})
+    config_db.mod_entry('bgp_neighbor', ipaddress, {'admin_status': status})
 
 def _change_bgp_session_status(ipaddr_or_hostname, status, verbose):
     """Start up or shut down BGP session by IP address or hostname
     """
     ip_addrs = []
-    if _is_neighbor_ipaddress(ipaddr_or_hostname):
-        ip_addrs.append(ipaddr_or_hostname)
+
+    # Convert the IP address to lowercase because IPv6 addresses will be stored
+    # in ConfigDB with all lowercase alphabet characters during minigraph parsing
+    if _is_neighbor_ipaddress(ipaddr_or_hostname.lower()):
+        ip_addrs.append(ipaddr_or_hostname.lower())
     else:
         # If <ipaddr_or_hostname> is not the IP address of a neighbor, check to see if it's a hostname
         ip_addrs = _get_neighbor_ipaddress_list_by_hostname(ipaddr_or_hostname)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
1. Do case conversion only for user input but not for keys queried from configDB. 
1. Use lower case instead of upper case.
We will make a change in minigraph parser as well to make sure all bgp session ipv6 addresses are written into configDB in lower case.
