### PR TITLE
Reuse updategraph service to load minigraph in cli

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -224,23 +224,9 @@ def load_mgmt_config(filename):
                 expose_value=False, prompt='Reload config from minigraph?')
 def load_minigraph():
     """Reconfigure based on minigraph."""
-    config_db = ConfigDBConnector()
-    config_db.connect()
-    client = config_db.redis_clients[config_db.CONFIG_DB]
-    client.flushdb()
-    if os.path.isfile('/etc/sonic/init_cfg.json'):
-        command = "{} -H -m -j /etc/sonic/init_cfg.json --write-to-db".format(SONIC_CFGGEN_PATH)
-    else:
-        command = "{} -H -m --write-to-db".format(SONIC_CFGGEN_PATH)
-    run_command(command, display_cmd=True)
-    client.set(config_db.INIT_INDICATOR, 1)
-    run_command('pfcwd start_default', display_cmd=True)
-    if os.path.isfile('/etc/sonic/acl.json'):
-        run_command("acl-loader update full /etc/sonic/acl.json", display_cmd=True)
-    run_command("config qos reload", display_cmd=True)
-    #FIXME: After config DB daemon is implemented, we'll no longer need to restart every service.
-    _restart_services()
-    print "Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`."
+    run_command('sed -i "/enabled=/d" /etc/sonic/updategraph.conf', display_cmd=True)
+    run_command('echo enabled=reload_only /etc/sonic/updategraph.conf', display_cmd=True)
+    run_command('service updategraph restart', display_cmd=True)
 
 #
 # 'qos' group


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
As new `updategraph` service in https://github.com/Azure/sonic-buildimage/pull/1452 support reloading minigraph, reuse the logic in CLI to avoid explicitly restart depending service in CLI code. 

