### PR TITLE
add fast-reboot support for nephos platform by stop kernel modules

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -63,6 +63,12 @@ then
   systemctl stop "$service_name"
 fi
 
+# Stop kernel modules for Nephos platform
+if [ "$sonic_asic_type" = 'nephos' ];
+then
+  systemctl stop nps-modules-`uname -r`.service
+fi
+
 # Wait until all buffers synced with disk
 sync
 sleep 1

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -64,7 +64,7 @@ then
 fi
 
 # Stop kernel modules for Nephos platform
-if [ "$sonic_asic_type" = 'nephos' ];
+if [[ "$sonic_asic_type" = 'nephos' ]];
 then
   systemctl stop nps-modules-`uname -r`.service
 fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
add fast-reboot support for nephos platform 
**- How I did it**
Stop kernel modules for Nephos platform
**- How to verify it**
Passed test.
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

