### PR TITLE
Enabling debug/undebug feature for quagga/frr

### DIFF
--- a/debug/debug_frr.py
+++ b/debug/debug_frr.py
@@ -1,0 +1,124 @@
+import click
+from debug.main import *
+
+
+###############################################################################
+#
+# 'debug bgp' cli stanza
+#
+###############################################################################
+
+
+@cli.group(cls=AliasedGroup, default_if_no_args=False)
+def bgp():
+    """debug bgp events """
+    pass
+
+@bgp.command()
+def as4():
+    """debug bgp AS4 actions """
+    command = 'sudo vtysh -c "debug bgp as4"'
+    run_command(command)
+
+@bgp.command()
+def bestpath():
+    """debug bgp bestpath """
+    command = 'sudo vtysh -c "debug bgp bestpath"'
+    run_command(command)
+
+@bgp.command()
+def keepalives():
+    """debug bgp keepalives """
+    command = 'sudo vtysh -c "debug bgp keepalives"'
+    run_command(command)
+
+@bgp.command()
+def neighborEvents():
+    """debug bgp neighbor events """
+    command = 'sudo vtysh -c "debug bgp neighbor-events"'
+    run_command(command)
+
+@bgp.command()
+def nht():
+    """debug bgp nexthop tracking events """
+    command = 'sudo vtysh -c "debug bgp nht"'
+    run_command(command)
+
+@bgp.command()
+def updateGroups():
+    """debug bgp update-group events """
+    command = 'sudo vtysh -c "debug bgp update-groups"'
+    run_command(command)
+
+@bgp.command()
+def updates():
+    """debug bgp updates """
+    command = 'sudo vtysh -c "debug bgp updates"'
+    run_command(command)
+
+@bgp.command()
+def zebra():
+    """debug bgp zebra messages """
+    command = 'sudo vtysh -c "debug bgp zebra"'
+    run_command(command)
+
+
+###############################################################################
+#
+# 'debug zebra' cli stanza
+#
+###############################################################################
+
+
+@cli.group(cls=AliasedGroup, default_if_no_args=False)
+def zebra():
+    """debug zebra events """
+    pass
+
+@zebra.command()
+def events():
+    """debug zebra events """
+    command = 'sudo vtysh -c "debug zebra events"'
+    run_command(command)
+
+@zebra.command()
+def fpm():
+    """debug zebra fpm events """
+    command = 'sudo vtysh -c "debug zebra fpm"'
+    run_command(command)
+
+@zebra.command()
+def kernel():
+    """debug zebra's kernel-interface events """
+    command = 'sudo vtysh -c "debug zebra kernel"'
+    run_command(command)
+
+@zebra.command()
+def mpls():
+    """debug zebra MPLS events """
+    command = 'sudo vtysh -c "debug zebra mpls"'
+    run_command(command)
+
+@zebra.command()
+def nht():
+    """debug zebra next-hop-tracking events """
+    command = 'sudo vtysh -c "debug zebra nht"'
+    run_command(command)
+
+@zebra.command()
+def packet():
+    """debug zebra packets """
+    command = 'sudo vtysh -c "debug zebra packet"'
+    run_command(command)
+
+@zebra.command()
+def pseudowires():
+    """debug zebra pseudowire events """
+    command = 'sudo vtysh -c "debug zebra pseudowires"'
+    run_command(command)
+
+@zebra.command()
+def rib():
+    """debug zebra RIB events """
+    command = 'sudo vtysh -c "debug zebra rib"'
+    run_command(command)

--- a/debug/debug_quagga.py
+++ b/debug/debug_quagga.py
@@ -1,0 +1,100 @@
+import click
+from debug.main import *
+
+
+###############################################################################
+#
+# 'debug bgp' cli stanza
+#
+###############################################################################
+
+
+@cli.group(cls=AliasedGroup, default_if_no_args=False)
+def bgp():
+    """debug bgp events """
+    pass
+
+@bgp.command()
+def as4():
+    """debug bgp AS4 actions """
+    command = 'sudo vtysh -c "debug bgp as4"'
+    run_command(command)
+
+@bgp.command()
+def events():
+    """debug bgp events """
+    command = 'sudo vtysh -c "debug bgp events"'
+    run_command(command)
+
+@bgp.command()
+def filters():
+    """debug bgp filters """
+    command = 'sudo vtysh -c "debug bgp filters"'
+    run_command(command)
+
+@bgp.command()
+def fsm():
+    """debug bgp fsm """
+    command = 'sudo vtysh -c "debug bgp fsm"'
+    run_command(command)
+
+@bgp.command()
+def keepalives():
+    """debug bgp keepalives """
+    command = 'sudo vtysh -c "debug bgp keepalives"'
+    run_command(command)
+
+@bgp.command()
+def updates():
+    """debug bgp updates """
+    command = 'sudo vtysh -c "debug bgp updates"'
+    run_command(command)
+
+@bgp.command()
+def zebra():
+    """debug bgp zebra messages """
+    command = 'sudo vtysh -c "debug bgp zebra"'
+    run_command(command)
+
+
+###############################################################################
+#
+# 'debug zebra' cli stanza
+#
+###############################################################################
+
+
+@cli.group(cls=AliasedGroup, default_if_no_args=False)
+def zebra():
+    """debug zebra events """
+    pass
+
+@zebra.command()
+def events():
+    """debug zebra events """
+    command = 'sudo vtysh -c "debug zebra events"'
+    run_command(command)
+
+@zebra.command()
+def fpm():
+    """debug zebra fpm events """
+    command = 'sudo vtysh -c "debug zebra fpm"'
+    run_command(command)
+
+@zebra.command()
+def kernel():
+    """debug zebra's kernel-interface events """
+    command = 'sudo vtysh -c "debug zebra kernel"'
+    run_command(command)
+
+@zebra.command()
+def packet():
+    """debug zebra packets """
+    command = 'sudo vtysh -c "debug zebra packet"'
+    run_command(command)
+
+@zebra.command()
+def rib():
+    """debug zebra RIB events """
+    command = 'sudo vtysh -c "debug zebra rib"'
+    run_command(command)

--- a/debug/main.py
+++ b/debug/main.py
@@ -79,6 +79,31 @@ class AliasedGroup(DefaultGroup):
         ctx.fail('Too many matches: %s' % ', '.join(sorted(matches)))
 
 
+# To be enhanced. Routing-stack information should be collected from a global
+# location (configdb?), so that we prevent the continous execution of this
+# bash oneliner. To be revisited once routing-stack info is tracked somewhere.
+def get_routing_stack():
+    command = "sudo docker ps | grep bgp | awk '{print$2}' | cut -d'-' -f3 | cut -d':' -f1"
+
+    try:
+        proc = subprocess.Popen(command,
+                                stdout=subprocess.PIPE,
+                                shell=True,
+                                stderr=subprocess.STDOUT)
+        stdout = proc.communicate()[0]
+        proc.wait()
+        result = stdout.rstrip('\n')
+
+    except OSError, e:
+        raise OSError("Cannot detect routing-stack")
+
+    return (result)
+
+
+# Global Routing-Stack variable
+routing_stack = get_routing_stack()
+
+
 def run_command(command, pager=False):
     if pager is True:
         click.echo(click.style("Command: ", fg='cyan') + click.style(command, fg='green'))
@@ -102,31 +127,33 @@ def cli():
     """SONiC command line - 'debug' command"""
     pass
 
+@cli.command()
+def enable():
+    """enable debugging for routing events """
+    command = 'sudo vtysh -c "configure terminal" -c "log syslog debugging"'
+    run_command(command)
+
+@cli.command()
+def disable():
+    """disable debugging for routing events """
+    command = 'sudo vtysh -c "configure terminal" -c "no log syslog debugging"'
+    run_command(command)
+
 #
-# 'bgp' group ###
+# Inserting 'debug' functionality into cli's parse-chain.
+# Debugging commands are determined by the routing-stack being elected.
 #
+if routing_stack == "quagga":
+    from .debug_quagga import bgp
+    cli.add_command(bgp)
+    from .debug_quagga import zebra
+    cli.add_command(zebra)
+elif routing_stack == "frr":
+    from .debug_frr import bgp
+    cli.add_command(bgp)
+    from .debug_frr import zebra
+    cli.add_command(zebra)
 
-@cli.group(cls=AliasedGroup, default_if_no_args=True)
-def bgp():
-    """debug bgp on """
-    pass
-
-@bgp.command(default=True)
-def default():
-    command = 'sudo vtysh -c "debug bgp"'
-    run_command(command)
-
-@bgp.command()
-def events():
-    """debug bgp events on """
-    command = 'sudo vtysh -c "debug bgp events"'
-    run_command(command)
-
-@bgp.command()
-def updates():
-    """debug bgp events on """
-    command = 'sudo vtysh -c "debug bgp updates"'
-    run_command(command)
 
 if __name__ == '__main__':
     cli()

--- a/undebug/undebug_frr.py
+++ b/undebug/undebug_frr.py
@@ -1,0 +1,124 @@
+import click
+from debug.main import *
+
+
+###############################################################################
+#
+# 'undebug bgp' cli stanza
+#
+###############################################################################
+
+
+@cli.group(cls=AliasedGroup, default_if_no_args=False)
+def bgp():
+    """undebug bgp events """
+    pass
+
+@bgp.command()
+def as4():
+    """undebug bgp AS4 actions """
+    command = 'sudo vtysh -c "no debug bgp as4"'
+    run_command(command)
+
+@bgp.command()
+def bestpath():
+    """undebug bgp bestpath """
+    command = 'sudo vtysh -c "no debug bgp bestpath"'
+    run_command(command)
+
+@bgp.command()
+def keepalives():
+    """undebug bgp keepalives """
+    command = 'sudo vtysh -c "no debug bgp keepalives"'
+    run_command(command)
+
+@bgp.command()
+def neighborEvents():
+    """undebug bgp neighbor events """
+    command = 'sudo vtysh -c "no debug bgp neighbor-events"'
+    run_command(command)
+
+@bgp.command()
+def nht():
+    """undebug bgp nexthop tracking events """
+    command = 'sudo vtysh -c "no debug bgp nht"'
+    run_command(command)
+
+@bgp.command()
+def updateGroups():
+    """undebug bgp update-group events """
+    command = 'sudo vtysh -c "no debug bgp update-groups"'
+    run_command(command)
+
+@bgp.command()
+def updates():
+    """undebug bgp updates """
+    command = 'sudo vtysh -c "no debug bgp updates"'
+    run_command(command)
+
+@bgp.command()
+def zebra():
+    """undebug bgp zebra messages """
+    command = 'sudo vtysh -c "no debug bgp zebra"'
+    run_command(command)
+
+
+###############################################################################
+#
+# 'undebug zebra' cli stanza
+#
+###############################################################################
+
+
+@cli.group(cls=AliasedGroup, default_if_no_args=False)
+def zebra():
+    """undebug zebra events """
+    pass
+
+@zebra.command()
+def events():
+    """undebug zebra events """
+    command = 'sudo vtysh -c "no debug zebra events"'
+    run_command(command)
+
+@zebra.command()
+def fpm():
+    """undebug zebra fpm events """
+    command = 'sudo vtysh -c "no debug zebra fpm"'
+    run_command(command)
+
+@zebra.command()
+def kernel():
+    """undebug zebra's kernel-interface events """
+    command = 'sudo vtysh -c "no debug zebra kernel"'
+    run_command(command)
+
+@zebra.command()
+def mpls():
+    """undebug zebra MPLS events """
+    command = 'sudo vtysh -c "no debug zebra mpls"'
+    run_command(command)
+
+@zebra.command()
+def nht():
+    """undebug zebra next-hop-tracking events """
+    command = 'sudo vtysh -c "no debug zebra nht"'
+    run_command(command)
+
+@zebra.command()
+def packet():
+    """undebug zebra packets """
+    command = 'sudo vtysh -c "no debug zebra packet"'
+    run_command(command)
+
+@zebra.command()
+def pseudowires():
+    """undebug zebra pseudowire events """
+    command = 'sudo vtysh -c "no debug zebra pseudowires"'
+    run_command(command)
+
+@zebra.command()
+def rib():
+    """undebug zebra RIB events """
+    command = 'sudo vtysh -c "no debug zebra rib"'
+    run_command(command)

--- a/undebug/undebug_quagga.py
+++ b/undebug/undebug_quagga.py
@@ -1,0 +1,100 @@
+import click
+from undebug.main import *
+
+
+###############################################################################
+#
+# 'undebug bgp' cli stanza
+#
+###############################################################################
+
+
+@cli.group(cls=AliasedGroup, default_if_no_args=False)
+def bgp():
+    """undebug bgp events """
+    pass
+
+@bgp.command()
+def as4():
+    """undebug bgp AS4 actions """
+    command = 'sudo vtysh -c "no debug bgp as4"'
+    run_command(command)
+
+@bgp.command()
+def events():
+    """undebug bgp events """
+    command = 'sudo vtysh -c "no debug bgp events"'
+    run_command(command)
+
+@bgp.command()
+def filters():
+    """undebug bgp filters """
+    command = 'sudo vtysh -c "no debug bgp filters"'
+    run_command(command)
+
+@bgp.command()
+def fsm():
+    """undebug bgp fsm """
+    command = 'sudo vtysh -c "no debug bgp fsm"'
+    run_command(command)
+
+@bgp.command()
+def keepalives():
+    """undebug bgp keepalives """
+    command = 'sudo vtysh -c "no debug bgp keepalives"'
+    run_command(command)
+
+@bgp.command()
+def updates():
+    """undebug bgp updates """
+    command = 'sudo vtysh -c "no debug bgp updates"'
+    run_command(command)
+
+@bgp.command()
+def zebra():
+    """undebug bgp zebra messages """
+    command = 'sudo vtysh -c "no debug bgp zebra"'
+    run_command(command)
+
+
+###############################################################################
+#
+# 'undebug zebra' cli stanza
+#
+###############################################################################
+
+
+@cli.group(cls=AliasedGroup, default_if_no_args=False)
+def zebra():
+    """undebug zebra events """
+    pass
+
+@zebra.command()
+def events():
+    """undebug zebra events """
+    command = 'sudo vtysh -c "no debug zebra events"'
+    run_command(command)
+
+@zebra.command()
+def fpm():
+    """undebug zebra fpm events """
+    command = 'sudo vtysh -c "no debug zebra fpm"'
+    run_command(command)
+
+@zebra.command()
+def kernel():
+    """undebug zebra's kernel-interface events """
+    command = 'sudo vtysh -c "no debug zebra kernel"'
+    run_command(command)
+
+@zebra.command()
+def packet():
+    """undebug zebra packets """
+    command = 'sudo vtysh -c "no debug zebra packet"'
+    run_command(command)
+
+@zebra.command()
+def rib():
+    """undebug zebra RIB events """
+    command = 'sudo vtysh -c "no debug zebra rib"'
+    run_command(command)


### PR DESCRIPTION
With this PR I'm taking care of the following issues:

     * Fixed debug/undebug cli commands for bgp and zebra processes.
     * Added a new cli command to activate/deactivate the generation of debuging info.
     * Added two separated command structures for Quagga and FRR routing-stacks -- notice that they don't fully match.

New debug/undebug stanzas now look like this (Quagga example below):

```
    admin@lnos-x1-a-csw01:~$ debug ?
    Usage: debug [OPTIONS] COMMAND [ARGS]...

      SONiC command line - 'debug' command

    Options:
      -?, -h, --help  Show this message and exit.

    Commands:
      bgp      debug bgp events
      disable  disable debugging for routing events
      enable   enable debugging for routing events
      zebra    debug bgp events

    admin@lnos-x1-a-csw01:~$ debug bgp ?
    Usage: debug bgp [OPTIONS] COMMAND [ARGS]...

      debug bgp events

    Options:
      -?, -h, --help  Show this message and exit.

    Commands:
      as4         debug bgp AS4 actions
      events      debug bgp events
      filters     debug bgp filters
      fsm         debug bgp fsm
      keepalives  debug bgp keepalives
      updates     debug bgp updates
      zebra       debug bgp zebra messages

    admin@lnos-x1-a-csw01:~$ debug zebra ?
    Usage: debug zebra [OPTIONS] COMMAND [ARGS]...

      debug bgp events

    Options:
      -?, -h, --help  Show this message and exit.

    Commands:
      events  debug zebra events
      fpm     debug zebra fpm events
      kernel  debug zebra's kernel-interface events
      packet  debug zebra packets
      rib     debug zebra RIB events
```
