### PR TITLE
[reboot] reduce stop service to only stop syncd

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -2,12 +2,9 @@
 
 function stop_sonic_services()
 {
-    echo "Stopping sonic services..."
-    systemctl stop swss
-    systemctl stop teamd
-    systemctl stop bgp
-    systemctl stop lldp
-    systemctl stop snmp
+    echo "Stopping syncd..."
+    docker exec -it syncd /usr/bin/syncd_request_shutdown --cold > /dev/null
+    sleep 3
 }
 
 # Obtain our platform as we will mount directories with these names in each docker


### PR DESCRIPTION
**- What I did**
When the service dockers are in some rare failure situations, stopping
service might get stuck. To make sure reboot always move ahead, we
could request syncd to stop, wait some time, then proceed with reboot.

**- How to verify it**
I executed a few hundreds of reboots with the new script on my dut.
