### PR TITLE
[config] Add new command line to support mellanox sniffer

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -10,6 +10,7 @@ from swsssdk import ConfigDBConnector
 from minigraph import parse_device_desc_xml
 
 import aaa
+import mlnx
 
 SONIC_CFGGEN_PATH = "sonic-cfggen"
 MINIGRAPH_PATH = "/etc/sonic/minigraph.xml"
@@ -532,6 +533,16 @@ def ecn(profile, rmax, rmin, ymax, ymin, gmax, gmin, verbose):
     if gmin is not None: command += " -gmin %d" % gmin
     if verbose: command += " -vv"
     run_command(command, display_cmd=verbose)
+
+
+#
+# 'platform' group
+#
+@cli.group()
+def platform():
+    """Platform-related configuration tasks"""
+platform.add_command(mlnx.mlnx)
+
 
 if __name__ == '__main__':
     cli()

--- a/config/mlnx.py
+++ b/config/mlnx.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python
+#
+# main.py
+#
+# Specific command-line utility for Mellanox platform
+#
+
+try:
+    import sys
+    import os
+    import subprocess
+    import click
+    import imp
+    import syslog
+    import types
+    import traceback
+    import time
+    from tabulate import tabulate
+except ImportError as e:
+    raise ImportError("%s - required module not found" % str(e))
+
+VERSION = '1.0'
+
+SNIFFER_SYSLOG_IDENTIFIER = "sniffer"
+
+# Mellanox platform name
+MLNX_PLATFORM_NAME = 'mellanox'
+
+# sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type
+PLATFORM_ROOT_PATH = '/usr/share/sonic/device'
+SONIC_CFGGEN_PATH = '/usr/local/bin/sonic-cfggen'
+SONIC_VERSION_PATH = '/etc/sonic/sonic_version.yml'
+ASIC_TYPE_KEY = 'asic_type'
+
+# SDK sniffer env variable
+ENV_VARIABLE_SX_SNIFFER = 'SX_SNIFFER_ENABLE'
+ENV_VARIABLE_SX_SNIFFER_TARGET = 'SX_SNIFFER_TARGET'
+
+# SDK sniffer file path and name
+SDK_SNIFFER_TARGET_PATH = '/var/log/mellanox/sniffer/'
+SDK_SNIFFER_FILENAME_PREFIX = 'sx_sdk_sniffer_'
+SDK_SNIFFER_FILENAME_EXT = '.pcap'
+
+# commands to manipulate syncd container and swss service
+COMMAND_STOP_SYNCD = 'docker stop syncd'
+COMMAND_RM_SYNCD = 'docker rm syncd'
+COMMAND_CREATE_SYNCD = '/usr/bin/syncd.sh start'
+COMMAND_RESTART_SWSS = 'service swss restart'
+
+# global variable SDK_SNIFFER_TARGET_FILE_NAME
+SDK_SNIFFER_TARGET_FILE_NAME = ''
+
+
+# ========================== Syslog wrappers ==========================
+def log_info(msg, syslog_identifier, also_print_to_console=False):
+    syslog.openlog(syslog_identifier)
+    syslog.syslog(syslog.LOG_INFO, msg)
+    syslog.closelog()
+
+    if also_print_to_console:
+        print msg
+
+
+def log_warning(msg, syslog_identifier, also_print_to_console=False):
+    syslog.openlog(syslog_identifier)
+    syslog.syslog(syslog.LOG_WARNING, msg)
+    syslog.closelog()
+
+    if also_print_to_console:
+        print msg
+
+
+def log_error(msg, syslog_identifier, also_print_to_console=False):
+    syslog.openlog(syslog_identifier)
+    syslog.syslog(syslog.LOG_ERR, msg)
+    syslog.closelog()
+
+    if also_print_to_console:
+        print msg
+
+
+# run command
+def run_command(command, pager=False):
+
+    env = {}
+    env.update(os.environ)
+
+    if pager is True:
+        click.echo(click.style("Command: ", fg='cyan') + click.style(command, fg='green'))
+        p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, env=env)
+        click.echo_via_pager(p.stdout.read())
+    else:
+        click.echo(click.style("Command: ", fg='cyan') + click.style(command, fg='green'))
+        p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, env=env)
+        click.echo(p.stdout.read())
+
+
+# Get asic type with command "sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type"
+def get_asic_type():
+    try:
+        proc = subprocess.Popen([SONIC_CFGGEN_PATH, '-y', SONIC_VERSION_PATH, '-v', ASIC_TYPE_KEY],
+                                stdout=subprocess.PIPE,
+                                shell=False,
+                                stderr=subprocess.STDOUT)
+        stdout = proc.communicate()[0]
+        proc.wait()
+        asic_type = stdout.rstrip('\n')
+    except OSError, e:
+        raise OSError("Cannot detect platform asic type, %s" % str(e))
+
+    return asic_type
+
+
+# verify if the platform is with Mellanox asic.
+def verify_asic_type():
+    asic_type = get_asic_type()
+    return cmp(asic_type, MLNX_PLATFORM_NAME)
+
+
+# generate sniffer target file name include a time stamp.
+def generate_file_name(prm=False, sdk=False):
+    time_stamp = time.strftime("%Y%m%d%H%M%S")
+    if sdk is True:
+        file_name = SDK_SNIFFER_FILENAME_PREFIX + time_stamp + SDK_SNIFFER_FILENAME_EXT
+        global SDK_SNIFFER_TARGET_FILE_NAME
+        SDK_SNIFFER_TARGET_FILE_NAME = file_name
+    elif prm is True:
+        # place holders for 'sniff prm enable/disable' and 'sniffer all enable/disable'
+        pass
+    else:
+        file_name = ''
+
+    return file_name
+
+
+# Set necessary environment variables for sniffers
+def set_environment_variable(sdk=False, prm=False, all=False, set=False):
+    if set is True:
+        if sdk is True:
+            os.environ[ENV_VARIABLE_SX_SNIFFER] = "1"
+
+            target_filename = generate_file_name(sdk=True)
+            os.environ[ENV_VARIABLE_SX_SNIFFER_TARGET] = SDK_SNIFFER_TARGET_PATH + target_filename
+        elif prm is True:
+            # place holder for prm sniffer
+            pass
+
+        elif all is True:
+            # place holder for all sniffer
+            pass
+
+        else:
+            pass
+    else:
+        if sdk is True:
+            os.environ[ENV_VARIABLE_SX_SNIFFER] = "0"
+            os.environ[ENV_VARIABLE_SX_SNIFFER_TARGET] = ''
+        elif prm is True:
+            # place holder for prm sniffer
+            pass
+
+        elif all is True:
+            # place holder for all sniffer
+            pass
+
+        else:
+            pass
+
+
+# run command 'docker stop syncd' to stop the syncd docker container
+def stop_syncd_container():
+    try:
+        run_command(COMMAND_STOP_SYNCD)
+    except OSError, e:
+        log_error("Can not stop syncd container, %s" % str(e), SNIFFER_SYSLOG_IDENTIFIER, True)
+        return 1
+    return 0
+
+
+# run command 'docker rm syncd' to remove the syncd docker container
+def remove_syncd_container():
+    try:
+        run_command(COMMAND_RM_SYNCD)
+    except OSError, e:
+        log_error("Can not remove syncd container, %s" % str(e), SNIFFER_SYSLOG_IDENTIFIER, True)
+        return 1
+    return 0
+
+
+# run command '/usr/bin/syncd.sh start' to create the syncd container
+def re_create_syncd_container():
+    try:
+        run_command(COMMAND_CREATE_SYNCD)
+    except OSError, e:
+        log_error("Not able to recreate syncd container, %s" % str(e), SNIFFER_SYSLOG_IDENTIFIER, True)
+        return 1
+    return 0
+
+
+# restart the swss service with command 'service swss restart'
+def restart_swss():
+    try:
+        run_command(COMMAND_RESTART_SWSS)
+    except OSError, e:
+        log_error("Not able to restart swss service, %s" % str(e), SNIFFER_SYSLOG_IDENTIFIER, True)
+        return 1
+    return 0
+
+
+# ==================== CLI commands and groups ====================
+
+# Callback for confirmation prompt. Aborts if user enters "n"
+def _abort_if_false(ctx, param, value):
+    if not value:
+        ctx.abort()
+
+
+# 'mlnx' group
+@click.group()
+def mlnx():
+    """Mellanox platform specific configuration tasks"""
+    # check the platform info, this command only work on Mellanox platform
+    err = verify_asic_type()
+    if err != 0:
+        print "This command only supported on Mellanox platform"
+        sys.exit(2)
+
+
+# 'sniffer' group
+@mlnx.group()
+def sniffer():
+    """sniffer - Utility for managing Mellanox SDK/PRM sniffer"""
+    pass
+
+
+# 'sdk' subgroup
+@sniffer.group()
+def sdk():
+    """SDK Sniffer - Command Line to enable/disable SDK sniffer"""
+    pass
+
+
+# 'sniffer sdk enable' command
+@sdk.command('enable')
+@click.option('-y', '--yes', is_flag=True, callback=_abort_if_false, expose_value=False,
+              prompt='To enable SDK sniffer swss service will be restarted, continue?')
+def enable_sdk_sniffer():
+    """Enable SDK Sniffer"""
+    print "Enable SDK sniffer"
+
+    err = stop_syncd_container()
+    if err is not 0:
+        return
+
+    err = remove_syncd_container()
+    if err is not 0:
+        return
+
+    set_environment_variable(sdk=True, set=True)
+
+    err = re_create_syncd_container()
+    if err is not 0:
+        return
+
+    err = restart_swss()
+    if err is not 0:
+        return
+
+    full_file_path = SDK_SNIFFER_TARGET_PATH + SDK_SNIFFER_TARGET_FILE_NAME
+
+    print 'sdk sniffer recording to file %s.' % full_file_path
+
+
+# 'sniffer sdk disable' command
+@sdk.command('disable')
+@click.option('-y', '--yes', is_flag=True, callback=_abort_if_false, expose_value=False,
+              prompt='To disable SDK sniffer swss service will be restarted, continue?')
+def disable_sdk_sniffer():
+    """Disable SDK Sniffer"""
+    print "Disable SDK sniffer"
+
+    err = stop_syncd_container()
+    if err is not 0:
+        return
+
+    err = remove_syncd_container()
+    if err is not 0:
+        return
+
+    set_environment_variable(sdk=True)
+
+    err = re_create_syncd_container()
+    if err is not 0:
+        return
+
+    err = restart_swss()
+    if err is not 0:
+        return
+
+    print "SDK sniffer disabled"
+
+
+# place holders for 'sniff prm enable/disable' and 'sniffer all enable/disable'
+'''
+@cli.group()
+def prm():
+    """PRM Sniffer - Command Line to enable/disable PRM sniffer"""
+    pass
+
+
+@prm.command('enable')
+def enable_prm_sniffer():
+    """Enable SDK sniffer"""
+    pass
+
+
+@prm.command('disable')
+def disable_prm_sniffer():
+    """Disable PRM sniffer"""
+    pass
+
+
+@cli.group()
+def all():
+    """ALL SNIFFERS - Command line to enable/disable PRM and SDK sniffer"""
+    pass
+
+
+@all.command('enable')
+def enable_all_sniffer():
+    """Enable PRM and SDK sniffers"""
+    pass
+
+
+@all.command('disable')
+def disable_all_sniffer():
+    """Disable PRM and SDK sniffers"""
+    pass
+'''
+
+if __name__ == '__main__':
+    mlnx()


### PR DESCRIPTION
	modified:   config/main.py
	new file:   config/mlnx.py

Signed-off-by:  Kebo Liu kebol@mellanox.com

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Add new command line for Mellanox SDK sniffers
**- How I did it**
 Add new cli group "platform" under "config" command.
 "mlnx" subgroup of "platform" group is for Mellanox platform specific CLI
Add command "config platform mlnx sniffer sdk enable" to enable sdk sniffer
Add command "config platform mlnx sniffer sdk disable" to disable sdk sniffer 
**- How to verify it**
On Mellanox platform can issue these command to enable and disable sdk sniffer.
**- Previous command output (if the output of a command-line utility has changed)**
please refer to design doc [https://github.com/Azure/SONiC/wiki/Mellanox-SDK-and-PRM-Sniffer-Utility-CLI-Design-for-SONiC](url)
**- New command output (if the output of a command-line utility has changed)**
please refer to design doc [https://github.com/Azure/SONiC/wiki/Mellanox-SDK-and-PRM-Sniffer-Utility-CLI-Design-for-SONiC](url)

 This PR needs [sonic-buildimage#1551](https://github.com/Azure/sonic-buildimage/pull/1551) merged first.

