### PR TITLE
[reboot scripts] remove -t option in docker exec commands

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -41,8 +41,8 @@ mkdir -p /host/fast-reboot
 /usr/bin/fast-reboot-dump.py -t /host/fast-reboot
 
 # Kill bgpd to start the bgp graceful restart procedure
-docker exec -ti bgp killall -9 zebra
-docker exec -ti bgp killall -9 bgpd
+docker exec -i bgp killall -9 zebra
+docker exec -i bgp killall -9 bgpd
 
 # Kill lldp, otherwise it sends informotion about reboot
 docker kill lldp > /dev/null
@@ -54,7 +54,7 @@ docker kill teamd > /dev/null
 if [[ "$sonic_asic_type" = 'broadcom' ]];
 then
     # Gracefully stop syncd
-    docker exec -ti syncd /usr/bin/syncd_request_shutdown --cold > /dev/null
+    docker exec -i syncd /usr/bin/syncd_request_shutdown --cold > /dev/null
 
     # Check that syncd was stopped
     while docker top syncd | grep -q /usr/bin/syncd

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -3,7 +3,7 @@
 function stop_sonic_services()
 {
     echo "Stopping syncd..."
-    docker exec -it syncd /usr/bin/syncd_request_shutdown --cold > /dev/null
+    docker exec -i syncd /usr/bin/syncd_request_shutdown --cold > /dev/null
     sleep 3
 }
 


### PR DESCRIPTION
**- What I did**
When the command is called by ssh execution, there is no shell. With
-t option these docker commands will fail.

ssh execution: e.g. ssh admin@dut "sudo /usr/bin/fast-reboot"

**- How to verify it**
ssh admin@dut "sudo /usr/bin/fast-reboot"
ssh admin@dut "sudo /sur/bin/reboot"
