### PR TITLE
Stop services before pushing new config during "load_minigraph"

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -151,17 +151,7 @@ def _stop_services():
     run_command("service pmon stop", display_cmd=True)
 
 def _restart_services():
-    run_command("service hostname-config restart", display_cmd=True)
-    run_command("service interfaces-config restart", display_cmd=True)
-    run_command("service ntp-config restart", display_cmd=True)
-    run_command("service rsyslog-config restart", display_cmd=True)
-    run_command("service swss restart", display_cmd=True)
-    run_command("service bgp restart", display_cmd=True)
-    run_command("service teamd restart", display_cmd=True)
-    run_command("service pmon restart", display_cmd=True)
-    run_command("service lldp restart", display_cmd=True)
-    run_command("service snmp restart", display_cmd=True)
-    run_command("service dhcp_relay restart", display_cmd=True)
+    run_command("service updategraph restart", display_cmd=True)
 
 # This is our main entrypoint - the main 'config' command
 @click.group()

--- a/config/main.py
+++ b/config/main.py
@@ -141,6 +141,15 @@ def _abort_if_false(ctx, param, value):
     if not value:
         ctx.abort()
 
+def _stop_services():
+    run_command("service dhcp_relay stop", display_cmd=True)
+    run_command("service snmp stop", display_cmd=True)
+    run_command("service lldp stop", display_cmd=True)
+    run_command("service bgp stop", display_cmd=True)
+    run_command("service swss stop", display_cmd=True)
+    run_command("service teamd stop", display_cmd=True)
+    run_command("service pmon stop", display_cmd=True)
+
 def _restart_services():
     run_command("service hostname-config restart", display_cmd=True)
     run_command("service interfaces-config restart", display_cmd=True)
@@ -225,6 +234,9 @@ def load_mgmt_config(filename):
                 expose_value=False, prompt='Reload config from minigraph?')
 def load_minigraph():
     """Reconfigure based on minigraph."""
+    #Stop services before config push
+    _stop_services()
+
     config_db = ConfigDBConnector()
     config_db.connect()
     client = config_db.redis_clients[config_db.CONFIG_DB]

--- a/config/main.py
+++ b/config/main.py
@@ -143,15 +143,25 @@ def _abort_if_false(ctx, param, value):
 
 def _stop_services():
     run_command("service dhcp_relay stop", display_cmd=True)
+    run_command("service swss stop", display_cmd=True)
     run_command("service snmp stop", display_cmd=True)
     run_command("service lldp stop", display_cmd=True)
-    run_command("service bgp stop", display_cmd=True)
-    run_command("service swss stop", display_cmd=True)
-    run_command("service teamd stop", display_cmd=True)
     run_command("service pmon stop", display_cmd=True)
+    run_command("service bgp stop", display_cmd=True)
+    run_command("service teamd stop", display_cmd=True)
 
 def _restart_services():
-    run_command("service updategraph restart", display_cmd=True)
+    run_command("service hostname-config restart", display_cmd=True)
+    run_command("service interfaces-config restart", display_cmd=True)
+    run_command("service ntp-config restart", display_cmd=True)
+    run_command("service rsyslog-config restart", display_cmd=True)
+    run_command("service swss restart", display_cmd=True)
+    run_command("service bgp restart", display_cmd=True)
+    run_command("service teamd restart", display_cmd=True)
+    run_command("service pmon restart", display_cmd=True)
+    run_command("service lldp restart", display_cmd=True)
+    run_command("service snmp restart", display_cmd=True)
+    run_command("service dhcp_relay restart", display_cmd=True)
 
 # This is our main entrypoint - the main 'config' command
 @click.group()

--- a/config/main.py
+++ b/config/main.py
@@ -196,6 +196,8 @@ def load(filename):
 @click.argument('filename', default='/etc/sonic/config_db.json', type=click.Path(exists=True))
 def reload(filename):
     """Clear current configuration and import a previous saved config DB dump file."""
+    #Stop services before config push
+    _stop_services()
     config_db = ConfigDBConnector()
     config_db.connect()
     client = config_db.redis_clients[config_db.CONFIG_DB]


### PR DESCRIPTION
**- What I did**
During `load_minigraph`, stop sonic services before pushing new config. Previously (without stopping services), _orchagent_ crash was consistently observed while loading minigraph resulting in generating false-alarms. By stopping the services, the crash was _not_ observed
`
Apr 25 18:23:08.736428 str-a7060cx-acs-10 INFO supervisord 2018-04-25 18:23:03,100 INFO exited: orchagent (terminated by SIGABRT (core dumped); not expected`

**- How I did it**
Modified config python script

**- How to verify it**
Execute `sudo config load_minigraph -y` and check syslogs for `not expected` process exit

**- Previous command output (if the output of a command-line utility has changed)**
```
admin$ sudo config load_minigraph -y
Running command: sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --write-to-db
Running command: pfcwd start_default
Running command: acl-loader update full /etc/sonic/acl.json
Running command: config qos reload
Running command: sonic-cfggen -m -t /usr/share/sonic/device/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/buffers.json.j2 >/tmp/buffers.json
Running command: sonic-cfggen -j /tmp/buffers.json --write-to-db
Running command: sonic-cfggen -j /usr/share/sonic/device/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/qos.json --write-to-db

Running command: service hostname-config restart
Running command: service interfaces-config restart
Running command: service ntp-config restart
Running command: service rsyslog-config restart
Running command: service swss restart
Running command: service bgp restart
Running command: service teamd restart
Running command: service pmon restart
Running command: service lldp restart
Running command: service snmp restart
Running command: service dhcp_relay restart

```
**- New command output (if the output of a command-line utility has changed)**
```
admin$ sudo config load_minigraph -y
Running command: service dhcp_relay stop
Running command: service snmp stop
Running command: service lldp stop
Running command: service bgp stop
Running command: service swss stop
Running command: service teamd stop
Running command: service pmon stop
Running command: sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --write-to-db
Running command: pfcwd start_default
Running command: acl-loader update full /etc/sonic/acl.json
Running command: config qos reload
Running command: sonic-cfggen -m -t /usr/share/sonic/device/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/buffers.json.j2 >/tmp/buffers.json
Running command: sonic-cfggen -j /tmp/buffers.json --write-to-db
Running command: sonic-cfggen -j /usr/share/sonic/device/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/qos.json --write-to-db

Running command: service hostname-config restart
Running command: service interfaces-config restart
Running command: service ntp-config restart
Running command: service rsyslog-config restart
Running command: service swss restart
Running command: service bgp restart
Running command: service teamd restart
Running command: service pmon restart
Running command: service lldp restart
Running command: service snmp restart
Running command: service dhcp_relay restart
```


