### PR TITLE
 [generate_dump]: fix a saidump file copy bug

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -290,7 +290,7 @@ main() {
     if [[ $platform == *"mlnx"* ]]; then
         local sai_dump_filename="/tmp/sai_sdk_dump_$(date +"%m_%d_%Y_%I_%M_%p")"
         docker exec -it syncd saisdkdump -f $sai_dump_filename
-        docker cp syncd:$sai_dump_filename /tmp/
+        docker exec syncd tar Ccf $(dirname $sai_dump_filename) - $(basename $sai_dump_filename) | tar Cxf /tmp/ -
         save_file $sai_dump_filename sai_sdk_dump true
     fi
 


### PR DESCRIPTION
**- What I did**

  fix a bug that not able to copy saidump file from the syncd container

**- How I did it**

the saidump file is generated to the /tmp folder of syncd container,
"docker cp" command is not applicable to tmpfs, need to use other
way to copy this file from the tmpfs of syncd to the host.

please refer to "docker cp" command description:
[https://docs.docker.com/engine/reference/commandline/cp/](url)

**- How to verify it**

use "show techsupport" to check, the saidump file can be found under /tmp folder of the switch.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**


