### PR TITLE
queuestats support "all" type and fix queue index bug

### DIFF
--- a/scripts/queuestat
+++ b/scripts/queuestat
@@ -35,9 +35,10 @@ STATUS_INVALID = 'INVALID'
 
 QUEUE_TYPE_MC = 'MC'
 QUEUE_TYPE_UC = 'UC'
+QUEUE_TYPE_ALL = 'ALL'
 SAI_QUEUE_TYPE_MULTICAST = "SAI_QUEUE_TYPE_MULTICAST"
 SAI_QUEUE_TYPE_UNICAST = "SAI_QUEUE_TYPE_UNICAST"
- 
+SAI_QUEUE_TYPE_ALL = "SAI_QUEUE_TYPE_ALL"
 
 COUNTER_TABLE_PREFIX = "COUNTERS:"
 COUNTERS_PORT_NAME_MAP = "COUNTERS_PORT_NAME_MAP"
@@ -110,6 +111,8 @@ class Queuestat(object):
                     return QUEUE_TYPE_MC
                 elif queue_type == SAI_QUEUE_TYPE_UNICAST:
                     return QUEUE_TYPE_UC
+                elif queue_type == SAI_QUEUE_TYPE_ALL:
+                    return QUEUE_TYPE_ALL
                 else:
                     print "Queue Type is invalid:", table_id, queue_type
                     sys.exit(1)
@@ -147,8 +150,7 @@ class Queuestat(object):
         for key, data in cnstat_dict.iteritems():
             if key == 'time':
                 continue
-            index = int(data.queueindex) % (queue_count / 2)
-            table.append((port, data.queuetype + str(index),
+            table.append((port, data.queuetype + str(data.queueindex),
                         data.totalpacket, data.totalbytes,
                         data.droppacket, data.dropbytes))
 
@@ -179,16 +181,14 @@ class Queuestat(object):
             if key in cnstat_old_dict:
                 old_cntr = cnstat_old_dict.get(key)
 
-            index = int(cntr.queueindex) % (queue_count / 2)
-
             if old_cntr is not None:
-                table.append((port, cntr.queuetype + str(index),
+                table.append((port, cntr.queuetype + str(data.queueindex),
                             ns_diff(cntr.totalpacket, old_cntr.totalpacket),
                             ns_diff(cntr.totalbytes, old_cntr.totalbytes),
                             ns_diff(cntr.droppacket, old_cntr.droppacket),
                             ns_diff(cntr.dropbytes, old_cntr.dropbytes)))
             else:
-                table.append((port, cntr.queuetype + str(index),
+                table.append((port, cntr.queuetype + str(data.queueindex),
                         cntr.totalpacket, cntr.totalbytes,
                         cntr.droppacket, cntr.dropbytes))
 

--- a/scripts/queuestat
+++ b/scripts/queuestat
@@ -182,13 +182,13 @@ class Queuestat(object):
                 old_cntr = cnstat_old_dict.get(key)
 
             if old_cntr is not None:
-                table.append((port, cntr.queuetype + str(data.queueindex),
+                table.append((port, cntr.queuetype + str(cntr.queueindex),
                             ns_diff(cntr.totalpacket, old_cntr.totalpacket),
                             ns_diff(cntr.totalbytes, old_cntr.totalbytes),
                             ns_diff(cntr.droppacket, old_cntr.droppacket),
                             ns_diff(cntr.dropbytes, old_cntr.dropbytes)))
             else:
-                table.append((port, cntr.queuetype + str(data.queueindex),
+                table.append((port, cntr.queuetype + str(cntr.queueindex),
                         cntr.totalpacket, cntr.totalbytes,
                         cntr.droppacket, cntr.dropbytes))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
support "SAI_QUEUE_TYPE_ALL"  type of queue display
fix queue index display bug
**- How I did it**
support "SAI_QUEUE_TYPE_ALL"  type of queue display
fix queue index display bug, should get queue index from data.queueindex, which is queried from db
**- How to verify it**
show queue counters
**- Previous command output (if the output of a command-line utility has changed)**
root@switch1:/home/admin# show queue counters 
     Port    TxQ    Counter/pkts    Counter/bytes    Drop/pkts    Drop/bytes
---------  -----  --------------  ---------------  -----------  ------------
Ethernet1    UC0               0                0            0             0
Ethernet1    UC1               0                0            0             0
Ethernet1    UC2               0                0            0             0
Ethernet1    UC3               0                0            0             0
Ethernet1    UC4               0                0            0             0
Ethernet1    UC5               0                0            0             0
Ethernet1    UC0               0                0            0             0
Ethernet1    UC1               0                0            0             0
Ethernet1    MC2               0                0            0             0
Ethernet1    MC3               0                0            0             0
Ethernet1    MC4               0                0            0             0
Ethernet1 MC5 0 0 0 0

**- New command output (if the output of a command-line utility has changed)**
root@switch1:/home/admin# show queue counters Ethernet1
Command: queuestat -p Ethernet1
     Port    TxQ    Counter/pkts    Counter/bytes    Drop/pkts    Drop/bytes
---------  -----  --------------  ---------------  -----------  ------------
Ethernet1    UC0               0                0            0             0
Ethernet1    UC1               0                0            0             0
Ethernet1    UC2               0                0            0             0
Ethernet1    UC3               0                0            0             0
Ethernet1    UC4               0                0            0             0
Ethernet1    UC5               0                0            0             0
Ethernet1    UC6               0                0            0             0
Ethernet1    UC7             106            23728            0             0
Ethernet1    MC0               0                0            0             0
Ethernet1    MC1               0                0            0             0
Ethernet1    MC2               0                0            0             0
Ethernet1    MC3               0                0            0             0


root@switch1:/home/admin# 

root@switch1:/home/admin# show queue counters Ethernet1
Command: queuestat -p Ethernet1
     Port    TxQ    Counter/pkts    Counter/bytes    Drop/pkts    Drop/bytes
---------  -----  --------------  ---------------  -----------  ------------
Ethernet1   ALL0               0                0            0             0
Ethernet1   ALL1               0                0            0             0
Ethernet1   ALL2               0                0            0             0
Ethernet1   ALL3               0                0            0             0
Ethernet1   ALL4               0                0            0             0
Ethernet1   ALL5               0                0            0             0
Ethernet1   ALL6               0                0            0             0
Ethernet1   ALL7               7              859            0             0


root@switch1:/home/admin#
-->

