### PR TITLE
Fix teamshow issues due to dependencies on minigraph

### DIFF
--- a/scripts/teamshow
+++ b/scripts/teamshow
@@ -46,10 +46,8 @@ class Teamshow(object):
         """
             Get the portchannel names from minigraph.
         """
-        minigraph_path = '/etc/sonic/minigraph.xml'
-        machine_info = get_machine_info()
-        platform_info = get_platform_info(machine_info)
-        self.teams = parse_xml(minigraph_path, platform = platform_info)['PORTCHANNEL'].keys();
+        team_keys = self.db.keys(self.db.APPL_DB, PORT_CHANNEL_TABLE_PREFIX+"*")
+        self.teams = [key[len(PORT_CHANNEL_TABLE_PREFIX):] for key in team_keys]
 
     def get_portchannel_status(self, port_channel_name):
         """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Remove the dependencies on minigraph for certain commands.
**- How I did it**
Use configDB values instead.
**- How to verify it**
show interfaces portchannel
**- Previous command output (if the output of a command-line utility has changed)**
root@switch1:/home/admin# show interfaces portchannel
Command: teamshow
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available, S - selected, D - deselected
  No.  Team Dev       Protocol     Ports
-----  -------------  -----------  ---------------------------

root@switch1:/home/admin#

no portchannel displayed, because no configuration in minigraph but in config_db.json
**- New command output (if the output of a command-line utility has changed)**
root@switch1:/home/admin# show interfaces portchannel
Command: teamshow
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available, S - selected, D - deselected
  No.  Team Dev       Protocol     Ports
-----  -------------  -----------  ---------------------------
   01  PortChannel01  LACP(A)(Dw)  Ethernet11(D) Ethernet12(D)
   02  PortChannel02  LACP(A)(Dw)  Ethernet14(D) Ethernet13(D)

root@switch1:/home/admin#
-->

