### PR TITLE
[counterpoll]: init cli support to change counter polling configuration

### DIFF
--- a/counterpoll/main.py
+++ b/counterpoll/main.py
@@ -1,0 +1,59 @@
+#! /usr/bin/python -u
+
+import click
+import swsssdk
+from tabulate import tabulate
+
+@click.group()
+def cli():
+    """ SONiC Static Counter Poll configurations """
+
+# Queue counter commands
+@cli.group()
+def queue():
+    """ Queue counter commands """
+
+@queue.command()
+@click.argument('poll_interval', type=click.IntRange(100, 30000))
+def interval(poll_interval):
+    """ Set queue counter query interval """
+    configdb = swsssdk.ConfigDBConnector()
+    configdb.connect()
+    queue_info = {}
+    if poll_interval is not None:
+        queue_info['POLL_INTERVAL'] = poll_interval
+    configdb.mod_entry("FLEX_COUNTER_TABLE", "QUEUE", queue_info)
+
+# Port counter commands
+@cli.group()
+def port():
+    """ Queue counter commands """
+
+@port.command()
+@click.argument('poll_interval', type=click.IntRange(100, 30000))
+def interval(poll_interval):
+    """ Set queue counter query interval """
+    configdb = swsssdk.ConfigDBConnector()
+    configdb.connect()
+    port_info = {}
+    if poll_interval is not None:
+        port_info['POLL_INTERVAL'] = poll_interval
+    configdb.mod_entry("FLEX_COUNTER_TABLE", "test", port_info)
+
+@cli.command()
+def show():
+    """ Show the counter configuration """
+    configdb = swsssdk.ConfigDBConnector()
+    configdb.connect()
+    queue_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'QUEUE')
+    port_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'PORT')
+    
+    header = ("Type", "Interval")
+    data = []
+    if queue_info:
+        data.append(["QUEUE_STAT", queue_info["POLL_INTERVAL"]])
+    if port_info:
+        data.append(["PORT_STAT", port_info["POLL_INTERVAL"]])
+
+    print tabulate(data, headers=header, tablefmt="simple", missingval="")
+

--- a/data/etc/bash_completion.d/counterpoll
+++ b/data/etc/bash_completion.d/counterpoll
@@ -1,0 +1,8 @@
+_counterpoll_completion() {
+    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
+                   COMP_CWORD=$COMP_CWORD \
+                   _COUNTERPOLL_COMPLETE=complete $1 ) )
+    return 0
+}
+
+complete -F _counterpoll_completion -o default counterpoll;

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         'acl_loader',
         'clear',
         'config',
+        'counterpoll',
         'crm',
         'debug',
         'pfcwd',
@@ -63,6 +64,7 @@ setup(
         'console_scripts': [
             'acl-loader = acl_loader.main:cli',
             'config = config.main:cli',
+            'counterpoll = counterpoll.main:cli',
             'crm = crm.main:cli',
             'debug = debug.main:cli',
             'pfcwd = pfcwd.main:cli',


### PR DESCRIPTION
Signed-off-by: Sihui Han <sihan@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Provides CLI command to change counter polling interval. In future, add command to enable/disable specific counter query
**- How I did it**
Add counterpoll queue interval <value> and counterpoll port interval <value> to make the change
Add counterpoll show to display current counterpoll configuration.
 
**- How to verify it**
Tested on DUT
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**
```
admin@SONiC# counterpoll show  
Type          Interval                               
----------  ----------                               
QUEUE_STAT       10000                               
PORT_STAT        10000                               
root@str-s6000-acs-13:/home/admin#       
```            
-->

