### PR TITLE
[show/main.py]: New Sonic CLI Command "show ndp" to show IPV6 Neighbours

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -169,6 +169,21 @@ def arp(ipaddress, verbose):
 
     run_command(cmd, display_cmd=verbose)
 
+#
+# 'ndp' command ("show ndp")
+#
+
+@cli.command()
+@click.argument('ip6address', required=False)
+@click.option('--verbose', is_flag=True, help="Enable verbose output")
+def ndp(ip6address):
+    """Show IPv6 Neighbour table"""
+    cmd = "/bin/ip -6 neigh show"
+
+    if ip6address is not None:
+        cmd += ' {}'.format(ip6address)
+
+    run_command(cmd, display_cmd=verbose)
 
 #
 # 'interfaces' group ("show interfaces ...")


### PR DESCRIPTION
1.) Added "show ndp" to show ipv6 neighbours.
This calls "/bin/ip -6 neigh show"

Signed-off-by: pchaudhary@linkedin.com

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
With this commit, New Sonic CLI Command "show ndp" is added to show IPV6 Neighbours. These IPv6 neighbour are learned via Neighbour Discovery Protocol(NDP).

Since Sonic CLI does not have a strict command parser as of now, this command will dump first argument to kernel except:
a.) if help argument is used i.e. "-?, -h, --help"
b.) or if more than one args are used i.e show ndp fe80::2e0:ecff:fe3c:a0a fe80::1

**- How I did it**
Added new python cli.command which calls "/bin/ip -6 neigh show"

**- How to verify it**
[Tests Done:]
admin@lnos-x1-a-csw05:~$ show ndp
Command: /bin/ip -6 neigh show
fe80::2e0:ecff:fe3c:a0a dev eth0 lladdr 00:e0:ec:3c:0a:0a STALE
fe80::2e0:ecff:fe3b:d8b8 dev eth0 lladdr 00:e0:ec:3b:d8:b8 STALE
fe80::2e0:ecff:fe3b:d9be dev eth0 lladdr 00:e0:ec:3b:d9:be STALE
fe80::2a6f:7fff:feba:1cff dev eth0 lladdr 28:6f:7f:ba:1c:ff router STALE
fe80::2e0:ecff:fe3c:a16 dev eth0 lladdr 00:e0:ec:3c:0a:16 STALE


admin@lnos-x1-a-csw05:~$ show ndp fe80::2e0:ecff:fe3c:a0a
Command: /bin/ip -6 neigh show fe80::2e0:ecff:fe3c:a0a
fe80::2e0:ecff:fe3c:a0a dev eth0 lladdr 00:e0:ec:3c:0a:0a STALE


admin@lnos-x1-a-csw05:~$ show ndp ?                    
Command: /bin/ip -6 neigh show ?
Error: an inet prefix is expected rather than "?".


admin@lnos-x1-a-csw05:~$ show ndp garbage
Command: /bin/ip -6 neigh show garbage
Error: an inet prefix is expected rather than "garbage".


admin@lnos-x1-a-csw05:~$ show ndp -?   
Usage: show ndp [OPTIONS] [IP6ADDRESS]

Show IP6 Neighbour table

Options:
  -?, -h, --help  Show this message and exit.


admin@lnos-x1-a-csw05:~$ show ndp -h
Usage: show ndp [OPTIONS] [IP6ADDRESS]

Show IP6 Neighbour table

Options:
  -?, -h, --help  Show this message and exit.


admin@lnos-x1-a-csw05:~$ show ndp fe80::2e0:ecff:fe3c:a0a fe80::1
Usage: show ndp [OPTIONS] [IP6ADDRESS]

Error: Got unexpected extra argument (fe80::1)

**- Previous command output (if the output of a command-line utility has changed)**
This command was not present before.
**- New command output (if the output of a command-line utility has changed)**
admin@lnos-x1-a-csw05:~$ show ndp
Command: /bin/ip -6 neigh show
fe80::2e0:ecff:fe3c:a0a dev eth0 lladdr 00:e0:ec:3c:0a:0a STALE
fe80::2e0:ecff:fe3b:d8b8 dev eth0 lladdr 00:e0:ec:3b:d8:b8 STALE
fe80::2e0:ecff:fe3b:d9be dev eth0 lladdr 00:e0:ec:3b:d9:be STALE
fe80::2a6f:7fff:feba:1cff dev eth0 lladdr 28:6f:7f:ba:1c:ff router STALE
fe80::2e0:ecff:fe3c:a16 dev eth0 lladdr 00:e0:ec:3c:0a:16 STALE


admin@lnos-x1-a-csw05:~$ show ndp fe80::2e0:ecff:fe3c:a0a
Command: /bin/ip -6 neigh show fe80::2e0:ecff:fe3c:a0a
fe80::2e0:ecff:fe3c:a0a dev eth0 lladdr 00:e0:ec:3c:0a:0a STALE


-->

