### PR TITLE
Fix/enhance the messages when user do "config load" or "config reload" with file

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -180,22 +180,24 @@ def save(filename):
     run_command(command, display_cmd=True)
 
 @cli.command()
-@click.option('-y', '--yes', is_flag=True, callback=_abort_if_false,
-                expose_value=False, prompt='Reload all config?')
+@click.option('-y', '--yes', is_flag=True)
 @click.argument('filename', default='/etc/sonic/config_db.json', type=click.Path(exists=True))
-def load(filename):
+def load(filename, yes):
     """Import a previous saved config DB dump file."""
+    if not yes:
+        click.confirm('Load config from the file %s?' % filename, abort=True)
     command = "{} -j {} --write-to-db".format(SONIC_CFGGEN_PATH, filename)
     run_command(command, display_cmd=True)
 
 @cli.command()
-@click.option('-y', '--yes', is_flag=True, callback=_abort_if_false,
-                expose_value=False, prompt='Clear current and reload all config?')
+@click.option('-y', '--yes', is_flag=True)
 @click.argument('filename', default='/etc/sonic/config_db.json', type=click.Path(exists=True))
-def reload(filename):
+def reload(filename, yes):
     """Clear current configuration and import a previous saved config DB dump file."""
     #Stop services before config push
     _stop_services()
+    if not yes:
+        click.confirm('Clear current config and reload config from the file %s?' % filename, abort=True)
     config_db = ConfigDBConnector()
     config_db.connect()
     client = config_db.redis_clients[config_db.CONFIG_DB]


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Fix/enhance the messages when user do
"config load a.json" or "config reload b.json"

**- How I did it**
Print the specific file to be loaded rather than "all config" of previous code.

**- How to verify it**
See command below.

**- Previous command output (if the output of a command-line utility has changed)**
$ sudo config load vlan.json 
Reload all config? [y/N]:y
Running command: sonic-cfggen -j vlan.json --write-to-db


$ sudo config load vlan.json -y
Running command: sonic-cfggen -j vlan.json --write-to-db


$ sudo config reload 
Clear current and reload all config? [y/N]: y
Running command: sonic-cfggen -j /etc/sonic/config_db.json --write-to-db
Running command: service hostname-config restart
Running command: service interfaces-config restart
Running command: service ntp-config restart
Running command: service rsyslog-config restart
Running command: service swss restart
Running command: service bgp restart
Running command: service teamd restart
Running command: service pmon restart
Running command: service lldp restart
Running command: service snmp restart
Running command: service dhcp_relay restart

**- New command output (if the output of a command-line utility has changed)**

$ sudo config load vlan.json 
Load config from the file vlan.json? [y/N]:y
Running command: sonic-cfggen -j vlan.json --write-to-db


$ sudo config load vlan.json -y
Running command: sonic-cfggen -j vlan.json --write-to-db


$ sudo config reload
Clear current config and reload config from the file /etc/sonic/config_db.json? [y/N]:y
Running command: sonic-cfggen -j /etc/sonic/config_db.json --write-to-db
Running command: service hostname-config restart
Running command: service interfaces-config restart
Running command: service ntp-config restart
Running command: service rsyslog-config restart
Running command: service swss restart
Running command: service bgp restart
Running command: service teamd restart
Running command: service pmon restart
Running command: service lldp restart
Running command: service snmp restart
Running command: service dhcp_relay restart

-->

