### PR TITLE
[scripts/portstat]: Cached counters file per system instead of per user

### DIFF
--- a/scripts/portstat
+++ b/scripts/portstat
@@ -21,6 +21,7 @@ import time
 from collections import namedtuple, OrderedDict
 from natsort import natsorted
 from tabulate import tabulate
+from fcntl import flock, LOCK_EX, LOCK_NB
 
 
 PORT_RATE = 40
@@ -62,6 +63,8 @@ PORT_STATUS_VALUE_DOWN = 'DOWN'
 PORT_STATE_UP = 'U'
 PORT_STATE_DOWN = 'D'
 PORT_STATE_DISABLED = 'X'
+CACHED_STATS_FILE_HIDDEN = ".__CaChEd_StAtS__"
+ERR_PER_DEN = 13
 
 class Portstat(object):
     def __init__(self):
@@ -340,11 +343,11 @@ Examples:
     print_all = args.all
 
     if tag_name is not None:
-        cnstat_file = uid + "-" + tag_name
+        cnstat_file = CACHED_STATS_FILE_HIDDEN + tag_name
     else:
-        cnstat_file = uid
+        cnstat_file = CACHED_STATS_FILE_HIDDEN
 
-    cnstat_dir = "/tmp/portstat-" + uid
+    cnstat_dir = "/tmp/portstat"
     cnstat_fqn_file = cnstat_dir + "/" + cnstat_file
 
     if delete_all_stats:
@@ -388,8 +391,22 @@ Examples:
 
 
     if save_fresh_stats:
+        if uid is not '0':
+            print("Permission Denied, Please run as root/sudo")
+            sys.exit(ERR_PER_DEN);
         try:
-            pickle.dump(cnstat_dict, open(cnstat_fqn_file, 'w'))
+            cnstat_fqn_fd = open(cnstat_fqn_file, 'w')
+            try:
+                # do not block forever, allow user to try again
+                flock(cnstat_fqn_fd, LOCK_EX|LOCK_NB)
+            except IOError as e:
+                print("Counters are being cleared by others, Try again")
+                cnstat_fqn_fd.close()
+                sys.exit(e.errno)
+
+            pickle.dump(cnstat_dict, cnstat_fqn_fd)
+            cnstat_fqn_fd.close()
+
         except IOError as e:
             sys.exit(e.errno)
         else:


### PR DESCRIPTION
[scripts/portstat]: Cached file is not per system, it is stored per user as of today, which does not allow users to have a global view of counters

Signed-off-by: pchaudhary@linkedin.com

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
1.) Made cached counter file per system instead of per user.  Tag files can be used to have different view of stats, if needed.
2.) Allow only root to run "clear counters", because it is changing system stats view.
3.) Add synchronization for file writing. Today cached file may get corrupted if 2 portstat processes are writing in file simultaneously. 

**- How I did it**
1.) Create hidden file with system file format name for cached counters. This name format will indicate user, to not change the file, via manual editing.
2.) Allow only root to run "clear counters" or "portstat -c"
3.) Use flock for synchronization to avoid write by multiple process. Other options considered were a.) linux pidfile, linux lockfile b.) Posix IPCs.
    --flock is less costly system call and also provide stable synchronization.
    Note: ideally we can take shared flock for file read operation as well, so that portstat does not read the file when it is being written. As of now this change is not done, because it is easily recoverable.
File Modified:
   [scripts/portstat]

**- How to verify it**
1.) only root should be able to clear counters. 

admin@lnos-x1-a-asw01:~$ clear counters
Permission Denied

admin@lnos-x1-a-asw01:~$ sudo clear counters
Cleared counters

2.) Observe file and time stamp

admin@lnos-x1-a-asw01:~$ ls -la /tmp/portstat/
total 20
drwxrwxrwx 2 admin admin  4096 May 16 15:37 .
drwxrwxrwt 8 root  root   4096 May 16 17:22 ..
-rw-r--r-- 1 root  root  11528 May 16 17:22 .CaChEd_StAtS

admin@lnos-x1-a-asw01:~$ date
Wed May 16 17:23:01 UTC 2018

3.) Run command as root user and observe new timestamp

root@lnos-x1-a-asw01:/home/admin# clear counters
Cleared counters

root@lnos-x1-a-asw01:/home/admin# ls -la /tmp/portstat/
total 20
drwxrwxrwx 2 admin admin  4096 May 16 15:37 .
drwxrwxrwt 8 root  root   4096 May 16 17:23 ..
-rw-r--r-- 1 root  root  11535 May 16 17:23 .CaChEd_StAtS
root@lnos-x1-a-asw01:/home/admin# date
Wed May 16 17:23:36 UTC 2018


4. ) Dir permission should be root + exe by all
admin@lnos-x1-a-asw01:~$ ls -l /tmp/
total 64
prw-r--r-- 1 root  root      0 May 16 17:34 479.tmp
-rw-r--r-- 1 root  root      8 May 16 15:14 dhcp_graph_url
drwxr-xr-x 2 admin admin  4096 May 16 17:33 portstat<<<<<<<<<<<<<<<<<<<<<<<<<<
-rw-r--r-- 1 admin admin 54488 May 16 15:33 python-sonic-utilities_1.2-1_all.deb

5.) File permission should be rw by root and read by all.

root@lnos-x1-a-asw01:/home/admin# ls -la /tmp/portstat/
total 20
drwxrwxrwx 2 admin admin  4096 May 16 15:37 .
drwxrwxrwt 8 root  root   4096 May 16 17:24 ..
-rw-r--r-- 1 root  root  11535 May 16 17:23 .CaChEd_StAtS

6.) Try portstat
admin@lnos-x1-a-asw01:~$ sudo portstat -c
Cleared counters

7.)counters with cached file
admin@lnos-x1-a-asw01:~$ portstat 

Ethernet114        D        0  0.00 B/s      0.00%         0         0         0        0  0.00 B/s      0.00%         0         0         0
Ethernet116        U        1  9.13 B/s      0.00%         0         0         0        1  9.24 B/s      0.00%         0         0         0
Ethernet118        D        0  0.00 B/s      0.00%         0         0         0        0  0.00 B/s      0.00%         0         0         0
Ethernet120        D        0  0.00 B/s      0.00%         0         0         0        0  0.00 B/s      0.00%         0         0         0
Ethernet122        D        0  0.00 B/s      0.00%         0         0         0        0  0.00 B/s      0.00%         0         0         0
Ethernet124        U        1  9.13 B/s      0.00%         0         0         0        1  9.24 B/s      0.00%         0         0         0
Ethernet126        U        1  9.13 B/s      0.00%         0         0         0        1  9.24 B/s      0.00%         0         0         0

9.) Check synchronisation, run "portstat -c" in loop, user root
admin@lnos-x1-a-asw01:~$ cat portstat_loop.sh 
for i in {1..5000} 
do
    portstat -c
    echo $i
done

Noticed file lock:<<<<<
Cleared counters
1400
File is locked, Try again
1401
File is locked, Try again
1402
File is locked, Try again
1403
Cleared counters
1404
**- Previous command output (if the output of a command-line utility has changed)**
As per field 3
**- New command output (if the output of a command-line utility has changed)**
As per field 3
-->

