### PR TITLE
[sonic-utilities/scripts] Fixing FP ports issue

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -1,5 +1,12 @@
 #! /bin/bash
 
+# Check root privileges
+if [[ "$EUID" -ne 0 ]]
+then
+  echo "Please run as root" >&2
+  exit 1
+fi
+
 function stop_sonic_services()
 {
     echo "Stopping syncd..."
@@ -13,8 +20,10 @@ PLATFORM=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
 DEVPATH="/usr/share/sonic/device"
 REBOOT="platform_reboot"
 
+# Stop syncd gracefully.
+stop_sonic_services
+
 if [ -x ${DEVPATH}/${PLATFORM}/${REBOOT} ]; then
-    stop_sonic_services
     sync
     sleep 3
     echo "Rebooting with platform ${PLATFORM} specific tool ..."


### PR DESCRIPTION
This commit fixes the Front Panel Ports not coming up during
cold reboot and traffic being sent at line rate. The root cause
was the PCIe bus error which was caused because of the host
side not doing a gracefull shutdown calling bcm_shutdown and
soc_shutdown. The fix will call the gracefull shutdown of syncd
during reboot which in turns calls the bcm_shutdown and soc_shutdown.
Additionally added the check to make sure the script will run only when
it has root privileges otherwise it will quit.

Verified the fix by running traffic at line rate 40G from Ixia and
rebooted using script multiple times and traffic was successfully
forwarded after every reboot.

Signed-off-by: Harish Venkatraman <Harish_Venkatraman@dell.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

