### PR TITLE
[data/etc/bash_completion.d/sonic-clear] Issue: clear tab completion …

### DIFF
--- a/data/etc/bash_completion.d/sonic-clear
+++ b/data/etc/bash_completion.d/sonic-clear
@@ -1,8 +1,9 @@
-_clear_completion() {
+_sonic_clear_completion() {
     COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
                    COMP_CWORD=$COMP_CWORD \
-                   _CLEAR_COMPLETE=complete $1 ) )
+                   _SONIC_CLEAR_COMPLETE=complete sonic-clear ) )
     return 0
 }
 
-complete -F _clear_completion -o default clear;
+complete -F _sonic_clear_completion -o default sonic-clear;
+complete -F _sonic_clear_completion clear;


### PR DESCRIPTION
Issue:
a.) clear tab completion shows garbage value
b.) sonic-clear tab completion does not show correct options
$ clear ^[[3;J^[[H^[[2J
$ sonic-clear
acl-loader       crm              debug            grub             insserv          psuutil          show             sonic_installer  valgrind         
config           debconf          docker           initramfs-tools  pfcwd            sfputil          sonic-clear      undebug  

Changes :
1.) Have bash_completion function for sonic-clear command instead of clear command.
2.) Use the same completion function for clear[/usr/bin/clear] as well.
3.) Change name of _clear_completion to _sonic_clear_completion.
4.) Replace $1 with "sonic-clear" in _sonic_clear_completion, so that it can be reused for clear.

Signed-off-by: Praveen Chaudhary <pchaudhary@linkedin.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Fixed issue: clear tab completion shows garbage value
$ clear TAB-TAB     ---->    $ clear ^[[3;J^[[H^[[2J

**- How I did it**
Changes :
1.) Have bash_completion function for sonic-clear command instead of clear command.
2.) Use the same completion function for clear[/usr/bin/clear] as well.
3.) Change name of _clear_completion to _sonic_clear_completion.
4.) Replace $1 with "sonic-clear" in _sonic_clear_completion, so that it can be reused for clear.

**- How to verify it**
Tests:
1.) clear [Enter]
Clears Screen

2.) clear <TAB><TAB>
$ clear 
arp       bgp       counters  fdb       ip        ipv6 

3.) clear a<TAB>
$ clear a
arp

4.) clear counters
$ clear counters 
Permission Denied, Please run as root/sudo

5.) clear arp
$ clear arp
fe80::2a6f:7fff:feba:1cff dev eth0 lladdr 28:6f:7f:ba:1c:ff router used 259/319/70 probes 0 STALE
172.25.11.1 dev eth0 lladdr 28:6f:7f:ba:1c:ff ref 1 used 66/0/65 probes 1 REACHABLE

Round 1, deleting 2 entries
Flush is complete after 1 round

6.) $ sonic-clear 
arp       bgp       counters  fdb       ip        ipv6  

7.) which clear
/usr/local/bin/clear
**- Previous command output (if the output of a command-line utility has changed)**
$ clear ^[[3;J^[[H^[[2J

$ sonic-clear 

acl-loader       crm              debug            grub             insserv          psuutil          show             sonic_installer  valgrind         
config           debconf          docker           initramfs-tools  pfcwd            sfputil          sonic-clear      undebug  
**- New command output (if the output of a command-line utility has changed)**
As per section 3.
-->

