### PR TITLE
sonic_installer onie get_next_image() may return wrong index due to wrong re search text

### DIFF
--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -105,7 +105,7 @@ def get_next_image():
         if m:
             next_image_index = int(m.group(1))
         else:
-            m = re.search("saved_entry(\d+)", grubenv)
+            m = re.search("saved_entry=(\d+)", grubenv)
             if m:
                 next_image_index = int(m.group(1))
             else:


### PR DESCRIPTION
sonic_installer list return wrong next image index, if no next_boot set and default entry is 1.

**- What I did**

To make sure `sudo sonic_installer list` shows the right list.

**- How I did it**

Just correct the right re search text.

**- How to verify it**

Check all three grubenv conditions.

* Default

```
a@sonic:~$  cat /host/grub/grubenv 
# GRUB Environment Block
saved_entry=0
#########################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################a@sonic:~$ 
```


After set next boot:

```
a@tswitch-questone2:~$ cat /host/grub/grubenv 
# GRUB Environment Block
saved_entry=0
next_entry=1
############################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################a@tswitch-questone2:~$ 
a@tswitch-questone2:~$ 
```

* startup after set_next_boot reboot

```
a@tswitch-questone2:~$ cat /host/grub/grubenv 
# GRUB Environment Block
saved_entry=0
next_entry=
#############################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################a@tswitch-questone2:~$ 
a@tswitch-questone2:~$ 

```


