### PR TITLE
 Add support for reboot cause and 'show reboot-cause' command for display

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -1,12 +1,5 @@
 #! /bin/bash
 
-# Check root privileges
-if [[ "$EUID" -ne 0 ]]
-then
-  echo "Please run as root" >&2
-  exit 1
-fi
-
 function stop_sonic_services()
 {
     echo "Stopping syncd..."
@@ -14,21 +7,27 @@ function stop_sonic_services()
     sleep 3
 }
 
-# Obtain our platform as we will mount directories with these names in each docker
-PLATFORM=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
 
+# Exit if not superuser
+if [[ "$EUID" -ne 0 ]]; then
+    echo "Please run as root" >&2
+    exit 1
+fi
+
+PLATFORM=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
 DEVPATH="/usr/share/sonic/device"
-REBOOT="platform_reboot"
+PLAT_REBOOT="platform_reboot"
 
 # Stop syncd gracefully.
 stop_sonic_services
 
-if [ -x ${DEVPATH}/${PLATFORM}/${REBOOT} ]; then
+if [ -x ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT} ]; then
     sync
     sleep 3
     echo "Rebooting with platform ${PLATFORM} specific tool ..."
-    ${DEVPATH}/${PLATFORM}/${REBOOT}
+    ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT}
     exit 0
 fi
 
+# If no platform-specific reboot tool, just call /sbin/reboot
 /sbin/reboot $@

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -31,7 +31,11 @@ sleep 3
 if [ -x ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT} ]; then
     echo "Rebooting with platform ${PLATFORM} specific tool ..."
     exec ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT}
+else
+    # If no platform-specific reboot tool, just run /sbin/reboot
+    exec /sbin/reboot $@
 fi
 
-# If no platform-specific reboot tool, just run /sbin/reboot
-exec /sbin/reboot $@
+# Should never reach here
+echo "Reboot failed!" >&2
+exit 1

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -14,20 +14,24 @@ if [[ "$EUID" -ne 0 ]]; then
     exit 1
 fi
 
-PLATFORM=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
+REBOOT_USER=$(logname)
+REBOOT_TIME=$(date)
+PLATFORM=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
 DEVPATH="/usr/share/sonic/device"
 PLAT_REBOOT="platform_reboot"
+REBOOT_CAUSE_FILE="/var/cache/sonic/reboot-cause.txt"
 
-# Stop syncd gracefully.
+# Stop SONiC services gracefully.
 stop_sonic_services
 
+echo "User issued reboot command [User: ${REBOOT_USER}, Time: ${REBOOT_TIME}]" > ${REBOOT_CAUSE_FILE}
+sync
+sleep 3
+
 if [ -x ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT} ]; then
-    sync
-    sleep 3
     echo "Rebooting with platform ${PLATFORM} specific tool ..."
-    ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT}
-    exit 0
+    exec ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT}
 fi
 
-# If no platform-specific reboot tool, just call /sbin/reboot
-/sbin/reboot $@
+# If no platform-specific reboot tool, just run /sbin/reboot
+exec /sbin/reboot $@

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -1,5 +1,12 @@
 #! /bin/bash
 
+REBOOT_USER=$(logname)
+REBOOT_TIME=$(date)
+PLATFORM=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
+DEVPATH="/usr/share/sonic/device"
+PLAT_REBOOT="platform_reboot"
+REBOOT_CAUSE_FILE="/var/cache/sonic/reboot-cause.txt"
+
 function stop_sonic_services()
 {
     echo "Stopping syncd..."
@@ -10,21 +17,17 @@ function stop_sonic_services()
 
 # Exit if not superuser
 if [[ "$EUID" -ne 0 ]]; then
-    echo "Please run as root" >&2
+    echo "This command must be run as root" >&2
     exit 1
 fi
-
-REBOOT_USER=$(logname)
-REBOOT_TIME=$(date)
-PLATFORM=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
-DEVPATH="/usr/share/sonic/device"
-PLAT_REBOOT="platform_reboot"
-REBOOT_CAUSE_FILE="/var/cache/sonic/reboot-cause.txt"
 
 # Stop SONiC services gracefully.
 stop_sonic_services
 
-echo "User issued reboot command [User: ${REBOOT_USER}, Time: ${REBOOT_TIME}]" > ${REBOOT_CAUSE_FILE}
+# Update the reboot cause file to reflect that user issued 'reboot' command
+# Upon next boot, the contents of this file will be used to determine the
+# cause of the previous reboot
+echo "User issued 'reboot' command [User: ${REBOOT_USER}, Time: ${REBOOT_TIME}]" > ${REBOOT_CAUSE_FILE}
 sync
 sleep 3
 

--- a/show/main.py
+++ b/show/main.py
@@ -1064,6 +1064,8 @@ def ecn():
 def reboot_cause():
     """Show cause of most recent reboot"""
     PREVIOUS_REBOOT_CAUSE_FILE = "/var/cache/sonic/previous-reboot-cause.txt"
+
+    # File should always be created at boot, but check just in case it's not
     if not os.path.isfile(PREVIOUS_REBOOT_CAUSE_FILE):
         click.echo("Unable to determine cause of previous reboot\n")
     else:

--- a/show/main.py
+++ b/show/main.py
@@ -1065,7 +1065,10 @@ def reboot_cause():
     """Show cause of most recent reboot"""
     PREVIOUS_REBOOT_CAUSE_FILE = "/var/cache/sonic/previous-reboot-cause.txt"
 
-    # File should always be created at boot, but check just in case it's not
+    # At boot time, PREVIOUS_REBOOT_CAUSE_FILE is generated based on
+    # the contents of the 'reboot cause' file as it was left when the device
+    # went down for reboot. This file should always be created at boot,
+    # but check first just in case it's not present.
     if not os.path.isfile(PREVIOUS_REBOOT_CAUSE_FILE):
         click.echo("Unable to determine cause of previous reboot\n")
     else:

--- a/show/main.py
+++ b/show/main.py
@@ -1057,5 +1057,19 @@ def ecn():
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
     click.echo(proc.stdout.read())
 
+#
+# 'reboot-cause' command ("show reboot-cause")
+#
+@cli.command('reboot-cause')
+def reboot_cause():
+    """Show cause of most recent reboot"""
+    PREVIOUS_REBOOT_CAUSE_FILE = "/var/cache/sonic/previous-reboot-cause.txt"
+    if not os.path.isfile(PREVIOUS_REBOOT_CAUSE_FILE):
+        click.echo("Unable to determine cause of previous reboot\n")
+    else:
+        cmd = "cat {}".format(PREVIOUS_REBOOT_CAUSE_FILE)
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+        click.echo(proc.stdout.read())
+
 if __name__ == '__main__':
     cli()


### PR DESCRIPTION
Example output:

```
admin@sonic:~$ show reboot-cause 
User issued reboot command [User: admin, Time: Sat Jun 23 01:30:43 UTC 2018]
```

```
admin@sonic:~$ show reboot-cause 
Unexpected reboot
```
