### PR TITLE
[generate_dump]: Enhance the generate_dump debugging script

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -13,6 +13,7 @@ LN=ln
 GZIP=gzip
 CP=cp
 MV=mv
+GREP=grep
 V=
 NOOP=false
 DO_COMPRESS=true
@@ -255,8 +256,12 @@ main() {
     save_cmd "show version" "version"
     save_cmd "show platform summary" "platform.summary"
     save_cmd "show platform syseeprom" "platform.syseeprom"
+    save_cmd "cat /host/machine.conf" "machine.conf"
 
     save_cmd "sensors" "sensors"
+    save_cmd "show platform psustatus" "platform.psustatus"
+    save_cmd "lspci -vvv -xx" "lspci"
+    save_cmd "lsusb -v" "lsusb"
 
     save_cmd "sysctl -a" "sysctl"
     save_ip "link" "link"
@@ -270,6 +275,11 @@ main() {
     save_vtysh "show ip bgp" "bgp.table" true
     save_bgp_neighbor
 
+    save_cmd "show interface status" "interface.status"
+    save_cmd "show interface counters" "interface.counters"
+    save_cmd "show interface transceiver presence" "interface.xcvrs.presence"
+    save_cmd "show interface transceiver eeprom --dom" "interface.xcvrs.eeprom"
+
     save_cmd "lldpctl" "lldpctl"
 
     save_cmd "ps aux" "ps.aux"
@@ -279,19 +289,36 @@ main() {
     save_cmd "vmstat -s" "vmstat.s"
     save_cmd "mount" "mount"
     save_cmd "df" "df"
+    save_cmd "dmesg" "dmesg"
 
     save_redis "0" "APP_DB"
     save_redis "1" "ASIC_DB"
     save_redis "2" "COUNTERS_DB"
 
+    save_cmd "docker ps -a" "docker.ps"
+    save_cmd "docker top pmon" "docker.pmon"
+
     save_cmd "docker exec -it syncd saidump" "saidump"
-    
+
     local platform="$(/usr/local/bin/sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)"
     if [[ $platform == *"mlnx"* ]]; then
         local sai_dump_filename="/tmp/sai_sdk_dump_$(date +"%m_%d_%Y_%I_%M_%p")"
         docker exec -it syncd saisdkdump -f $sai_dump_filename
         docker exec syncd tar Ccf $(dirname $sai_dump_filename) - $(basename $sai_dump_filename) | tar Cxf /tmp/ -
         save_file $sai_dump_filename sai_sdk_dump true
+    fi
+
+    local asic="$(/usr/local/bin/sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)"
+    if [ "$asic" = "broadcom" ]; then
+        save_cmd "bcmcmd -t5 version" "broadcom.version"
+        save_cmd "bcmcmd -t5 soc" "broadcom.soc"
+        save_cmd "bcmcmd -t5 ps" "broadcom.ps"
+    fi
+
+    if $GREP -qi "aboot_platform=.*arista" /host/machine.conf; then
+        save_cmd "cat /proc/scd" "scd"
+        save_cmd "arista syseeprom" "arista.syseeprom"
+        save_cmd "arista dump" "arista.dump"
     fi
 
     $RM $V -rf $TARDIR


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Added additional debugging information to the generate_dump script including
 - USB and PCI devices
 - Transceiver status and eeprom data
 - Interface status and counters
 - ASIC specific data
 - Arista specific info

**- How I did it**
Added additional commands to the generate_dump script. 
The ASIC version is determined using sonic_cfggen to parse the sonic_version YAML file. 
The Arista platform check is done by grepping /host/machine.conf as the Arista bootloader (Aboot) populates this file.

**- How to verify it**
admin@gd381:~$ show techsupport
...
/var/dump/sonic_dump_gd381_20180625_174535.tar.gz

admin@gd381:~$ tar -xzf /var/dump/sonic_dump_gd381_20180625_174720.tar.gz -C ~/

admin@gd381:~$ ls -l ~/sonic_dump_gd381_20180625_174720/dump
total 2620
-rw-r--r-- 1 admin admin  33533 Jun 25 17:47 APP_DB.json
-rw-r--r-- 1 admin admin 820099 Jun 25 17:47 ASIC_DB.json
-rw-r--r-- 1 admin admin 774247 Jun 25 17:47 COUNTERS_DB.json
**-rw-r--r-- 1 admin admin   6065 Jun 25 17:47 arista.dump
-rw-r--r-- 1 admin admin     69 Jun 25 17:47 arista.syseeprom**
-rw-r--r-- 1 admin admin      0 Jun 25 17:47 bgp.neighbors
-rw-r--r-- 1 admin admin      0 Jun 25 17:47 bgp.summary
-rw-r--r-- 1 admin admin     49 Jun 25 17:47 bgp.table.gz
**-rw-r--r-- 1 admin admin   6821 Jun 25 17:47 broadcom.ps
-rw-r--r-- 1 admin admin   1872 Jun 25 17:47 broadcom.soc
-rw-r--r-- 1 admin admin    781 Jun 25 17:47 broadcom.version**
-rw-r--r-- 1 admin admin    495 Jun 25 17:47 df
**-rw-r--r-- 1 admin admin 104858 Jun 25 17:47 dmesg
-rw-r--r-- 1 admin admin    992 Jun 25 17:47 docker.pmon
-rw-r--r-- 1 admin admin   1596 Jun 25 17:47 docker.ps**
-rw-r--r-- 1 admin admin    230 Jun 25 17:47 free
**-rw-r--r-- 1 admin admin   9588 Jun 25 17:47 interface.counters
-rw-r--r-- 1 admin admin   5168 Jun 25 17:47 interface.status
-rw-r--r-- 1 admin admin  20875 Jun 25 17:47 interface.xcvrs.eeprom
-rw-r--r-- 1 admin admin   1609 Jun 25 17:47 interface.xcvrs.presence**
-rw-r--r-- 1 admin admin  15122 Jun 25 17:47 ip.addr
-rw-r--r-- 1 admin admin  11883 Jun 25 17:47 ip.link
-rw-r--r-- 1 admin admin    270 Jun 25 17:47 ip.neigh
-rw-r--r-- 1 admin admin   8397 Jun 25 17:47 ip.route
-rw-r--r-- 1 admin admin    275 Jun 25 17:47 ip.rule
-rw-r--r-- 1 admin admin   6042 Jun 25 17:47 lldpctl
**-rw-r--r-- 1 admin admin  99323 Jun 25 17:47 lspci
-rw-r--r-- 1 admin admin  16524 Jun 25 17:47 lsusb
-rw-r--r-- 1 admin admin    193 Jun 25 17:47 machine.conf**
-rw-r--r-- 1 admin admin   2091 Jun 25 17:47 mount
**-rw-r--r-- 1 admin admin     54 Jun 25 17:47 platform.psustatus**
-rw-r--r-- 1 admin admin     77 Jun 25 17:47 platform.summary
-rw-r--r-- 1 admin admin     86 Jun 25 17:47 platform.syseeprom
-rw-r--r-- 1 admin admin  17560 Jun 25 17:47 ps.aux
-rw-r--r-- 1 admin admin 263865 Jun 25 17:47 saidump
**-rw-r--r-- 1 admin admin   1174 Jun 25 17:47 scd**
-rw-r--r-- 1 admin admin   2517 Jun 25 17:47 sensors
-rw-r--r-- 1 admin admin 316214 Jun 25 17:47 sysctl
-rw-r--r-- 1 admin admin   1810 Jun 25 17:47 version
-rw-r--r-- 1 admin admin    573 Jun 25 17:47 vmstat
-rw-r--r-- 1 admin admin  10765 Jun 25 17:47 vmstat.m
-rw-r--r-- 1 admin admin    764 Jun 25 17:47 vmstat.s

**- Previous command output (if the output of a command-line utility has changed)**
N/A

**- New command output (if the output of a command-line utility has changed)**
N/A