### PR TITLE
Add empty case

### DIFF
--- a/scripts/teamshow
+++ b/scripts/teamshow
@@ -49,7 +49,7 @@ class Teamshow(object):
         """
         team_keys = self.db.keys(self.db.CONFIG_DB, PORT_CHANNEL_CFG_TABLE_PREFIX+"*")
         if team_keys == None:
-                return
+            return
         self.teams = [key[len(PORT_CHANNEL_CFG_TABLE_PREFIX):] for key in team_keys]
 
     def get_portchannel_status(self, port_channel_name):

--- a/scripts/teamshow
+++ b/scripts/teamshow
@@ -49,7 +49,6 @@ class Teamshow(object):
         """
         team_keys = self.db.keys(self.db.CONFIG_DB, PORT_CHANNEL_CFG_TABLE_PREFIX+"*")
         if team_keys == None:
-                #print "None"
                 return
         self.teams = [key[len(PORT_CHANNEL_CFG_TABLE_PREFIX):] for key in team_keys]
 

--- a/scripts/teamshow
+++ b/scripts/teamshow
@@ -48,6 +48,9 @@ class Teamshow(object):
             Get the portchannel names from database.
         """
         team_keys = self.db.keys(self.db.CONFIG_DB, PORT_CHANNEL_CFG_TABLE_PREFIX+"*")
+        if team_keys == None:
+                #print "None"
+                return
         self.teams = [key[len(PORT_CHANNEL_CFG_TABLE_PREFIX):] for key in team_keys]
 
     def get_portchannel_status(self, port_channel_name):


### PR DESCRIPTION
**- What I did**
 - Handle the case when there is no port channel in the device

**- How I did it** 
 - Check when the team_keys == None, return the function instead of continue to assign a none object to the team

**- How to verify it**
 - Run teamshow when there is no port channel in the device

**- Previous command output (if the output of a command-line utility has changed)**

'NoneType' object is not iterable

**- New command output (if the output of a command-line utility has changed)**

Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available, S - selected, D - deselected
No.    Team Dev    Protocol    Ports
-----  ----------  ----------  -------


