### PR TITLE
Remove 'broken pipe' workaround for Click

### DIFF
--- a/connect/main.py
+++ b/connect/main.py
@@ -91,18 +91,8 @@ def run_command(command, display_cmd=False):
         output = proc.stdout.readline()
         if output == "" and proc.poll() is not None:
             break
-        if output:
-            try:
-                click.echo(output.rstrip('\n'))
-            except IOError as e:
-                # In our version of Click (v6.6), click.echo() and click.echo_via_pager() do not properly handle
-                # SIGPIPE, and if a pipe is broken before all output is processed (e.g., pipe output to 'head'),
-                # it will result in a stack trace. This is apparently fixed upstream, but for now, we silently
-                # ignore SIGPIPE here.
-                if e.errno == errno.EPIPE:
-                    sys.exit(0)
-                else:
-                    raise
+        elif output:
+            click.echo(output.rstrip('\n'))
 
     rc = proc.poll()
     if rc != 0:

--- a/show/main.py
+++ b/show/main.py
@@ -123,17 +123,7 @@ def run_command(command, display_cmd=False):
         if output == "" and proc.poll() is not None:
             break
         if output:
-            try:
-                click.echo(output.rstrip('\n'))
-            except IOError as e:
-                # In our version of Click (v6.6), click.echo() and click.echo_via_pager() do not properly handle
-                # SIGPIPE, and if a pipe is broken before all output is processed (e.g., pipe output to 'head'),
-                # it will result in a stack trace. This is apparently fixed upstream, but for now, we silently
-                # ignore SIGPIPE here.
-                if e.errno == errno.EPIPE:
-                    sys.exit(0)
-                else:
-                    raise
+            click.echo(output.rstrip('\n'))
 
     rc = proc.poll()
     if rc != 0:


### PR DESCRIPTION
Now that we have upgraded our version of Click to 6.7-4 in https://github.com/Azure/sonic-buildimage/commit/f04f0704f70fcd0f114563d3d567b9f2cc9b1ee5, we no longer need to work around the Click "broken pipe" issue, as it was fixed here: https://github.com/pallets/click/commit/e850c58571272e24d7169172c0f8086c2f88b5ef