### PR TITLE
[counterpoll]: output default value when not configured

### DIFF
--- a/counterpoll/main.py
+++ b/counterpoll/main.py
@@ -84,12 +84,12 @@ def show():
     queue_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'QUEUE')
     port_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'PORT')
     
-    header = ("Type", "Interval", "Status")
+    header = ("Type", "Interval (in ms)", "Status")
     data = []
     if queue_info:
-        data.append(["QUEUE_STAT", queue_info["POLL_INTERVAL"], queue_info["FLEX_COUNTER_STATUS"]])
+        data.append(["QUEUE_STAT", queue_info["POLL_INTERVAL"] if 'POLL_INTERVAL' in queue_info else 'default (10000)', queue_info["FLEX_COUNTER_STATUS"] if 'FLEX_COUNTER_STATUS' in queue_info else 'disable' ])
     if port_info:
-        data.append(["PORT_STAT", port_info["POLL_INTERVAL"], port_info["FLEX_COUNTER_STATUS"]])
+        data.append(["PORT_STAT", port_info["POLL_INTERVAL"] if 'POLL_INTERVAL' in port_info else 'default (1000)', port_info["FLEX_COUNTER_STATUS"] if 'FLEX_COUNTER_STATUS' in port_info else 'disable'])
 
     print tabulate(data, headers=header, tablefmt="simple", missingval="")
 


### PR DESCRIPTION
Signed-off-by: Sihui Han <sihan@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Output default value when not configured
**- How I did it**

**- How to verify it**
Tested on DUT
**- Previous command output (if the output of a command-line utility has changed)**
fail to show when not configured before.
**- New command output (if the output of a command-line utility has changed)**
admin@sonic:/home/admin# counterpoll show
Type        Interval (in ms)    Status
----------  ------------------  --------
QUEUE_STAT  default (10000)     enable
PORT_STAT   1000                enable
-->

