### PR TITLE
Fixed the confirm prompt to be before stop service

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -203,10 +203,10 @@ def load(filename, yes):
 @click.argument('filename', default='/etc/sonic/config_db.json', type=click.Path(exists=True))
 def reload(filename, yes):
     """Clear current configuration and import a previous saved config DB dump file."""
-    #Stop services before config push
-    _stop_services()
     if not yes:
         click.confirm('Clear current config and reload config from the file %s?' % filename, abort=True)
+    #Stop services before config push
+    _stop_services()
     config_db = ConfigDBConnector()
     config_db.connect()
     client = config_db.redis_clients[config_db.CONFIG_DB]


### PR DESCRIPTION
**- What I did**
Modified the confirmation prompt to be before stop services

**- How I did it**
Changed the order

**- How to verify it**
Do `sudo config reload`

**- Previous command output (if the output of a command-line utility has changed)**
```
#sudo config reload 
Running command: service dhcp_relay stop
Running command: service swss stop
Running command: service snmp stop
Running command: service lldp stop
Running command: service pmon stop
Running command: service bgp stop
Running command: service teamd stop
Clear current config and reload config from the file /etc/sonic/config_db.json? [y/N]

```
**- New command output (if the output of a command-line utility has changed)**
```
#sudo config reload 
Clear current config and reload config from the file /etc/sonic/config_db.json? [y/N]
```
-->

