### PR TITLE
Exposing config-check logic to CLI

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -189,12 +189,28 @@ def save(filename):
     run_command(command, display_cmd=True)
 
 @cli.command()
+@click.argument('filename', default='/etc/sonic/config_db.json', type=click.Path(exists=True))
+def check(filename):
+    """Verifies that the configuration in the json file is correct."""
+
+    command = "{} -j {} --check-json".format(SONIC_CFGGEN_PATH, filename)
+    run_command(command, display_cmd=True)
+    print "Valid configuration found in " + filename + " file"
+
+@cli.command()
 @click.option('-y', '--yes', is_flag=True)
 @click.argument('filename', default='/etc/sonic/config_db.json', type=click.Path(exists=True))
 def load(filename, yes):
     """Import a previous saved config DB dump file."""
+
     if not yes:
         click.confirm('Load config from the file %s?' % filename, abort=True)
+
+    # Validating passed json configuration file
+    command = "{} -j {} --check-json".format(SONIC_CFGGEN_PATH, filename)
+    run_command(command, display_cmd=True)
+
+    # Proceeding to load changes into DB
     command = "{} -j {} --write-to-db".format(SONIC_CFGGEN_PATH, filename)
     run_command(command, display_cmd=True)
 
@@ -205,6 +221,11 @@ def reload(filename, yes):
     """Clear current configuration and import a previous saved config DB dump file."""
     if not yes:
         click.confirm('Clear current config and reload config from the file %s?' % filename, abort=True)
+
+    # Validating passed json configuration file
+    command = "{} -j {} --check-json".format(SONIC_CFGGEN_PATH, filename)
+    run_command(command, display_cmd=True)
+
     #Stop services before config push
     _stop_services()
     config_db = ConfigDBConnector()


### PR DESCRIPTION
I'm simply extending the new config verification logic to our current CLI commands so that a config-check is implicitly done whenever user executes 'config load/reload' commands. See some examples below...

As part of this PR i'm also adding a new CLI command to allow users to explicitly validate their json-file configuration.

<-- Running 'config load' with invalid configuration:

    admin@lnos-x1-a-csw02:~$ sudo config load ~/config_db.json
    Reload all config? [y/N]: y
    Running command: sonic-cfggen -j /home/admin/config_db.json --check-json
    DEVICE_NEIGHBOR port Ethernet5 not found in PORT table.

    Invalid configuration detected. No configuration changes processed. Exiting...

<-- Running 'config reload' with invalid configuration:

    admin@lnos-x1-a-csw02:~$ sudo config reload ~/config_db.json
    Clear current and reload all config? [y/N]: y
    Running command: sonic-cfggen -j /home/admin/config_db.json --check-json
    DEVICE_NEIGHBOR port Ethernet5 not found in PORT table.

    Invalid configuration detected. No configuration changes processed. Exiting...

<-- Running 'config check' with invalid configuration:

    admin@lnos-x1-a-csw02:~$ sudo config check ~/config_db.json
    Running command: sonic-cfggen -j /home/admin/config_db.json --check-json
    DEVICE_NEIGHBOR port Ethernet5 not found in PORT table.

    Invalid configuration detected. No configuration changes processed. Exiting...

<-- Running 'config check' with valid configuration:

    admin@lnos-x1-a-csw02:~$ sudo config check /etc/sonic/config_db.json
    Running command: sonic-cfggen -j /etc/sonic/config_db.json --check-json
    Valid configuration found in /etc/sonic/config_db.json file

Signed-off-by: Rodny Molina <rmolina@linkedin.com>
