### PR TITLE
Warm reboot: Add support for docker upgrade

### DIFF
--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -377,11 +377,11 @@ def upgrade_docker(container_name, url, cleanup_image, enforce_check, tag):
 
         cmd = "docker exec -it " + container_name + " orchagent_restart_check" + skipPendingTaskCheck
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
-        result = proc.stdout.read().rstrip()
-        if result != "RESTARTCHECK succeeded":
+        (out, err) = proc.communicate()
+        if proc.returncode != 0:
             if enforce_check:
                 click.echo("Orchagent is not in clean state, check syslog and try later")
-                sys.exit(1)
+                sys.exit(proc.returncode)
             else:
                 click.echo("Orchagent is not in clean state, upgrading it anyway")
         else:

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -147,6 +147,20 @@ def remove_image(image):
         run_command('grub-set-default --boot-directory=' + HOST_PATH + ' 0')
         click.echo('Image removed')
 
+# TODO: Embed tag name info into docker image meta data at build time,
+# and extract tag name from docker image file.
+def get_docker_tag_name(image):
+    # Try to get tag name from label metadata
+    cmd = "docker inspect  --format '{{.ContainerConfig.Labels.Tag}}' " + image
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+    (out, err) = proc.communicate()
+    if proc.returncode != 0:
+        return "unknown"
+    tag = out.rstrip()
+    if tag == "<no value>":
+        return "unknown"
+    return tag
+
 # Callback for confirmation prompt. Aborts if user enters "n"
 def abort_if_false(ctx, param, value):
     if not value:
@@ -321,61 +335,85 @@ def cleanup():
 @cli.command()
 @click.option('-y', '--yes', is_flag=True, callback=abort_if_false,
         expose_value=False, prompt='New docker image will be installed, continue?')
-@click.option('--cleanup_image', is_flag=True, help="Clean up old docker images")
-@click.argument('container_name', metavar='<container_name>', required=True, type=click.Choice(["swss", "snmp", "lldp"]))
-@click.argument('tag', metavar='<tag>', required=True, type=click.STRING)
+@click.option('--cleanup_image', is_flag=True, help="Clean up old docker image")
+@click.option('--enforce_check', is_flag=True, help="Enforce pending task check for docker upgrade")
+@click.option('--tag', type=str, help="Tag for the new docker image")
+@click.argument('container_name', metavar='<container_name>', required=True,
+    type=click.Choice(["swss", "snmp", "lldp", "bgp", "pmon", "dhcp_relay", "telemetry", "teamd"]))
 @click.argument('url')
-def upgrade_docker(cleanup_image, container_name, tag, url):
+def upgrade_docker(container_name, url, cleanup_image, enforce_check, tag):
     """ Upgrade docker image from local binary or URL"""
 
-    # example images: docker-lldp-sv2:latest
+    # example image: docker-lldp-sv2:latest
     cmd = "docker inspect --format '{{.Config.Image}}' " + container_name
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
-    images = proc.stdout.read().rstrip()
+    (out, err) = proc.communicate()
+    if proc.returncode != 0:
+        sys.exit(proc.returncode)
+    image_latest = out.rstrip()
 
     # example image_name: docker-lldp-sv2
-    cmd = "echo " + images + " | cut -d ':' -f 1"
+    cmd = "echo " + image_latest + " | cut -d ':' -f 1"
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
     image_name = proc.stdout.read().rstrip()
 
-    # example image_id: 7ed919240fb9
-    cmd = "docker images --format '{{.ID}}' " + image_name
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
-    image_id = proc.stdout.read()
-
-
     DEFAULT_IMAGE_PATH = os.path.join("/tmp/", image_name)
-
     if url.startswith('http://') or url.startswith('https://'):
         click.echo('Downloading image...')
-        urllib.urlretrieve(url, DEFAULT_IMAGE_PATH, reporthook)
+        try:
+            urllib.urlretrieve(url, DEFAULT_IMAGE_PATH, reporthook)
+        except Exception, e:
+            click.echo("Download error", e)
+            return
         image_path = DEFAULT_IMAGE_PATH
     else:
         image_path = os.path.join("./", url)
 
     # make sure orchagent is in clean state if swss is to be upgraded
     if container_name == "swss":
-        cmd = "docker exec -it " + container_name + " orchagent_restart_check"
+        skipPendingTaskCheck = " -s"
+        if enforce_check:
+            skipPendingTaskCheck = ""
+
+        cmd = "docker exec -it " + container_name + " orchagent_restart_check" + skipPendingTaskCheck
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
         result = proc.stdout.read().rstrip()
         if result != "RESTARTCHECK succeeded":
-            click.echo("Orchagent is not in clean state, check syslog and try later")
-            sys.exit(1)
+            if enforce_check:
+                click.echo("Orchagent is not in clean state, check syslog and try later")
+                sys.exit(1)
+            else:
+                click.echo("Orchagent is not in clean state, upgrading it anyway")
         else:
             click.echo("Orchagent is in clean state and frozen for warm upgrade")
 
     run_command("systemctl stop %s" % container_name)
-    run_command("docker rm  %s" % container_name)
-    run_command("docker rmi  %s" % images)
+    run_command("docker rm  %s " % container_name)
+    run_command("docker rmi  %s " % image_latest)
     run_command("docker load < %s" % image_path)
+    if tag == None:
+        # example image: docker-lldp-sv2:latest
+        tag = get_docker_tag_name(image_latest)
     run_command("docker tag %s:latest %s:%s" % (image_name, image_name, tag))
     run_command("systemctl restart %s" % container_name)
+
     # Clean up old docker images
     if cleanup_image:
-        image_id = image_id.splitlines()
-        image_id = set(image_id)
-        for id in image_id:
-            run_command("docker rmi -f %s" % id)
+        # All images id under the image name
+        cmd = "docker images --format '{{.ID}}' " + image_name
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+        image_id_all = proc.stdout.read()
+        image_id_all = image_id_all.splitlines()
+        image_id_all = set(image_id_all)
+
+        # this is image_id for image with "latest" tag
+        cmd = "docker images --format '{{.ID}}' " + image_latest
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+        image_id_latest = proc.stdout.read().rstrip()
+
+        for id in image_id_all:
+            if id != image_id_latest:
+                run_command("docker rmi -f %s" % id)
 
     run_command("sleep 5") # wait 5 seconds for application to sync
     click.echo('Done')

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -339,7 +339,7 @@ def upgrade_docker(cleanup_image, container_name, tag, url):
     image_name = proc.stdout.read().rstrip()
 
     # example image_id: 7ed919240fb9
-    cmd = "docker images  --format '{{.ID}}' " +  image_name
+    cmd = "docker images --format '{{.ID}}' " + image_name
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
     image_id = proc.stdout.read()
 
@@ -355,7 +355,7 @@ def upgrade_docker(cleanup_image, container_name, tag, url):
 
     # make sure orchagent is in clean state if swss is to be upgraded
     if container_name == "swss":
-        cmd = "docker exec -it " +  container_name + " orchagent_restart_check"
+        cmd = "docker exec -it " + container_name + " orchagent_restart_check"
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
         result = proc.stdout.read().rstrip()
         if result != "RESTARTCHECK succeeded":

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -151,7 +151,7 @@ def remove_image(image):
 # and extract tag name from docker image file.
 def get_docker_tag_name(image):
     # Try to get tag name from label metadata
-    cmd = "docker inspect  --format '{{.ContainerConfig.Labels.Tag}}' " + image
+    cmd = "docker inspect --format '{{.ContainerConfig.Labels.Tag}}' " + image
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
     (out, err) = proc.communicate()
     if proc.returncode != 0:
@@ -388,8 +388,8 @@ def upgrade_docker(container_name, url, cleanup_image, enforce_check, tag):
             click.echo("Orchagent is in clean state and frozen for warm upgrade")
 
     run_command("systemctl stop %s" % container_name)
-    run_command("docker rm  %s " % container_name)
-    run_command("docker rmi  %s " % image_latest)
+    run_command("docker rm %s " % container_name)
+    run_command("docker rmi %s " % image_latest)
     run_command("docker load < %s" % image_path)
     if tag == None:
         # example image: docker-lldp-sv2:latest


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**- What I did**
Add sonic_installer upgrade_docker command to support docker upgrade

**- How I did it**

**- How to verify it**

***sonic_installer upgrade_docker*** 
```
root@sonic:~# sonic_installer  upgrade_docker  --help
Usage: sonic_installer upgrade_docker [OPTIONS] <container_name> URL

  Upgrade docker image from local binary or URL

Options:
  -y, --yes
  --cleanup_image  Clean up old docker image
  --enforce_check  Enforce pending task check for docker upgrade
  --tag TEXT       Tag for the new docker image
  --help           Show this message and exit.
root@sonic:~# 
```

***Before docker upgrade***
```
root@sonic:~# docker images
REPOSITORY                 TAG                                   IMAGE ID            CREATED             SIZE
docker-orchagent-brcm      latest                                c5f3705e554d        7 hours ago         368.2 MB
docker-orchagent-brcm      test_02                               c5f3705e554d        7 hours ago         368.2 MB
docker-snmp-sv2            latest                                57ad52ea394d        3 weeks ago         373.4 MB
docker-snmp-sv2            warm-reboot.0-dirty-20180823.192608   57ad52ea394d        3 weeks ago         373.4 MB
docker-fpm-quagga          latest                                c68b681610b1        3 weeks ago         380.6 MB
docker-fpm-quagga          warm-reboot.0-dirty-20180823.192608   c68b681610b1        3 weeks ago         380.6 MB
docker-lldp-sv2            latest                                8ecc6ab3e0b7        3 weeks ago         332.4 MB
docker-lldp-sv2            warm-reboot.0-dirty-20180823.192608   8ecc6ab3e0b7        3 weeks ago         332.4 MB
docker-platform-monitor    latest                                e3fea372c435        3 weeks ago         335.7 MB
docker-platform-monitor    warm-reboot.0-dirty-20180823.192608   e3fea372c435        3 weeks ago         335.7 MB
docker-syncd-brcm          latest                                dd8cec44739a        3 weeks ago         410.5 MB
docker-syncd-brcm          warm-reboot.0-dirty-20180823.192608   dd8cec44739a        3 weeks ago         410.5 MB
docker-database            latest                                12f8549a03d0        3 weeks ago         298.5 MB
docker-database            warm-reboot.0-dirty-20180823.192608   12f8549a03d0        3 weeks ago         298.5 MB
docker-sonic-telemetry     latest                                4ee9aeaebcb5        3 weeks ago         324.8 MB
docker-sonic-telemetry     warm-reboot.0-dirty-20180823.192608   4ee9aeaebcb5        3 weeks ago         324.8 MB
docker-dhcp-relay          latest                                1f81836482bf        3 weeks ago         301.6 MB
docker-dhcp-relay          warm-reboot.0-dirty-20180823.192608   1f81836482bf        3 weeks ago         301.6 MB
docker-router-advertiser   latest                                48e9b8ac32b0        3 weeks ago         296.1 MB
docker-router-advertiser   warm-reboot.0-dirty-20180823.192608   48e9b8ac32b0        3 weeks ago         296.1 MB
docker-teamd               latest                                27d6fb7bec52        3 weeks ago         362.3 MB
docker-teamd               warm-reboot.0-dirty-20180823.192608   27d6fb7bec52        3 weeks ago         362.3 MB
root@sonic:~# 
```

***docker upgrade***
```
root@sonic:~# 
root@sonic:~# sonic_installer upgrade_docker  --enforce_check  --cleanup_image swss ./docker-orchagent-brcm_test_02.gz --tag=test_02
New docker image will be installed, continue? [y/N]: y
Orchagent is in clean state and frozen for warm upgrade
Command: systemctl stop swss

Command: docker rm  swss 
swss

Command: docker rmi  docker-orchagent-brcm:latest 
Untagged: docker-orchagent-brcm:latest

Command: docker load < ././docker-orchagent-brcm_test_02.gz

Command: docker tag docker-orchagent-brcm:latest docker-orchagent-brcm:test_02

Command: systemctl restart swss

Command: sleep 5

Done
root@sonic:~# docker images
REPOSITORY                 TAG                                   IMAGE ID            CREATED             SIZE
docker-orchagent-brcm      latest                                c5f3705e554d        7 hours ago         368.2 MB
docker-orchagent-brcm      test_02                               c5f3705e554d        7 hours ago         368.2 MB
docker-snmp-sv2            latest                                57ad52ea394d        3 weeks ago         373.4 MB
docker-snmp-sv2            warm-reboot.0-dirty-20180823.192608   57ad52ea394d        3 weeks ago         373.4 MB
docker-fpm-quagga          latest                                c68b681610b1        3 weeks ago         380.6 MB
docker-fpm-quagga          warm-reboot.0-dirty-20180823.192608   c68b681610b1        3 weeks ago         380.6 MB
docker-lldp-sv2            latest                                8ecc6ab3e0b7        3 weeks ago         332.4 MB
docker-lldp-sv2            warm-reboot.0-dirty-20180823.192608   8ecc6ab3e0b7        3 weeks ago         332.4 MB
docker-platform-monitor    latest                                e3fea372c435        3 weeks ago         335.7 MB
docker-platform-monitor    warm-reboot.0-dirty-20180823.192608   e3fea372c435        3 weeks ago         335.7 MB
docker-syncd-brcm          latest                                dd8cec44739a        3 weeks ago         410.5 MB
docker-syncd-brcm          warm-reboot.0-dirty-20180823.192608   dd8cec44739a        3 weeks ago         410.5 MB
docker-database            latest                                12f8549a03d0        3 weeks ago         298.5 MB
docker-database            warm-reboot.0-dirty-20180823.192608   12f8549a03d0        3 weeks ago         298.5 MB
docker-sonic-telemetry     latest                                4ee9aeaebcb5        3 weeks ago         324.8 MB
docker-sonic-telemetry     warm-reboot.0-dirty-20180823.192608   4ee9aeaebcb5        3 weeks ago         324.8 MB
docker-dhcp-relay          latest                                1f81836482bf        3 weeks ago         301.6 MB
docker-dhcp-relay          warm-reboot.0-dirty-20180823.192608   1f81836482bf        3 weeks ago         301.6 MB
docker-router-advertiser   latest                                48e9b8ac32b0        3 weeks ago         296.1 MB
docker-router-advertiser   warm-reboot.0-dirty-20180823.192608   48e9b8ac32b0        3 weeks ago         296.1 MB
docker-teamd               latest                                27d6fb7bec52        3 weeks ago         362.3 MB
docker-teamd               warm-reboot.0-dirty-20180823.192608   27d6fb7bec52        3 weeks ago         362.3 MB
root@sonic:~# 
root@sonic:~# sonic_installer upgrade_docker  --enforce_check  --cleanup_image swss ./docker-orchagent-brcm_test_02.gz              
New docker image will be installed, continue? [y/N]: y
Orchagent is in clean state and frozen for warm upgrade
Command: systemctl stop swss

Command: docker rm  swss 
swss

Command: docker rmi  docker-orchagent-brcm:latest 
Untagged: docker-orchagent-brcm:latest

Command: docker load < ././docker-orchagent-brcm_test_02.gz

Command: docker tag docker-orchagent-brcm:latest docker-orchagent-brcm:unknown

Command: systemctl restart swss

Command: sleep 5

Done
root@sonic:~# docker images
REPOSITORY                 TAG                                   IMAGE ID            CREATED             SIZE
docker-orchagent-brcm      latest                                c5f3705e554d        7 hours ago         368.2 MB
docker-orchagent-brcm      test_02                               c5f3705e554d        7 hours ago         368.2 MB
docker-orchagent-brcm      unknown                               c5f3705e554d        7 hours ago         368.2 MB
docker-snmp-sv2            latest                                57ad52ea394d        3 weeks ago         373.4 MB
docker-snmp-sv2            warm-reboot.0-dirty-20180823.192608   57ad52ea394d        3 weeks ago         373.4 MB
docker-fpm-quagga          latest                                c68b681610b1        3 weeks ago         380.6 MB
docker-fpm-quagga          warm-reboot.0-dirty-20180823.192608   c68b681610b1        3 weeks ago         380.6 MB
docker-lldp-sv2            latest                                8ecc6ab3e0b7        3 weeks ago         332.4 MB
docker-lldp-sv2            warm-reboot.0-dirty-20180823.192608   8ecc6ab3e0b7        3 weeks ago         332.4 MB
docker-platform-monitor    latest                                e3fea372c435        3 weeks ago         335.7 MB
docker-platform-monitor    warm-reboot.0-dirty-20180823.192608   e3fea372c435        3 weeks ago         335.7 MB
docker-syncd-brcm          latest                                dd8cec44739a        3 weeks ago         410.5 MB
docker-syncd-brcm          warm-reboot.0-dirty-20180823.192608   dd8cec44739a        3 weeks ago         410.5 MB
docker-database            latest                                12f8549a03d0        3 weeks ago         298.5 MB
docker-database            warm-reboot.0-dirty-20180823.192608   12f8549a03d0        3 weeks ago         298.5 MB
docker-sonic-telemetry     latest                                4ee9aeaebcb5        3 weeks ago         324.8 MB
docker-sonic-telemetry     warm-reboot.0-dirty-20180823.192608   4ee9aeaebcb5        3 weeks ago         324.8 MB
docker-dhcp-relay          latest                                1f81836482bf        3 weeks ago         301.6 MB
docker-dhcp-relay          warm-reboot.0-dirty-20180823.192608   1f81836482bf        3 weeks ago         301.6 MB
docker-router-advertiser   latest                                48e9b8ac32b0        3 weeks ago         296.1 MB
docker-router-advertiser   warm-reboot.0-dirty-20180823.192608   48e9b8ac32b0        3 weeks ago         296.1 MB
docker-teamd               latest                                27d6fb7bec52        3 weeks ago         362.3 MB
docker-teamd               warm-reboot.0-dirty-20180823.192608   27d6fb7bec52        3 weeks ago         362.3 MB
root@sonic:~# 
root@sonic:~# sonic_installer upgrade_docker  --enforce_check  --cleanup_image swss ./docker-orchagent-brcm_test_01.gz --tag=test_01
New docker image will be installed, continue? [y/N]: y
Orchagent is in clean state and frozen for warm upgrade
Command: systemctl stop swss

Command: docker rm  swss 
swss

Command: docker rmi  docker-orchagent-brcm:latest 
Untagged: docker-orchagent-brcm:latest

Command: docker load < ././docker-orchagent-brcm_test_01.gz

Command: docker tag docker-orchagent-brcm:latest docker-orchagent-brcm:test_01

Command: systemctl restart swss

Command: docker rmi -f c5f3705e554d
Untagged: docker-orchagent-brcm:test_02
Untagged: docker-orchagent-brcm:unknown
Deleted: sha256:c5f3705e554df1f8cab6eefc048364a1838706d6b6d21a69e72ac2b33c5d5799
Deleted: sha256:e116c136985f1faaa2881f6ca2604e92d5ce12ad3eb7ea7078d1a12d060c6512

Command: sleep 5

Done
root@sonic:~# 
```


**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**


