### PR TITLE
[pcmping]: Add pcmping tool to get portchannel member packet loss state

### DIFF
--- a/scripts/pcmping
+++ b/scripts/pcmping
@@ -46,7 +46,7 @@ def receive(my_socket, timeout, exp_pkt, exp_socket, time_sent):
 def create_decap_packet(interface, dst_out, dst_in, sockets, exp_socket, max_iter):
     dscp = 16
     tos = dscp << 2
-    tcp_hdr    = TCP(sport=1234, dport=80, flags="S", chksum=0)
+    tcp_hdr = TCP(sport=1234, dport=80, flags="S", chksum=0)
     for x in range(1, max_iter):
         print "---------- Attempting to create decap packet that goes through %s, iteration: %d ---------" % (interface, x)
         ip_src = socket.inet_ntoa(struct.pack('>I', random.randint(1, 0xffffffff)))
@@ -107,6 +107,10 @@ def create_socket(interface, portchannel):
         sys.exit(1)
     return sockets, exp_socket
 
+def print_statistics(interface, total_count, recv_count):
+    print "\n--- %s ping statistics ---" % interface
+    print ("%d packets transmitted, %d received, %0.2f%% packet loss" % (total_count, recv_count, (total_count-recv_count)*1.0/total_count*100))
+
 def main():
     parser  = argparse.ArgumentParser(description='Check portchannel member link state',
                                       version='1.0.0',
@@ -156,11 +160,8 @@ def main():
                 break;
             time.sleep(1)
     except KeyboardInterrupt:
-        print "\n--- %s ping statistics ---" % interface
-        print ("%d packets transmitted, %d received, %0.2f%% packet loss" % (total_count, recv_count, (total_count-recv_count)*1.0/total_count*100))
-        return 
-    print "\n--- %s ping statistics ---" % interface
-    print ("%d packets transmitted, %d received, %0.2f%% packet loss" % (total_count, recv_count, (total_count-recv_count)*1.0/total_count*100))
-
+        print_statistics(interface, total_count, recv_count)
+        return
+    print_statistics(interface, total_count, recv_count)
 if __name__ == '__main__':
     main()

--- a/scripts/pcmping
+++ b/scripts/pcmping
@@ -18,6 +18,7 @@ RCV_SIZE = 20480
 RCV_TIMEOUT = 10000
 SELECT_TIMEOUT = 2
 PROBE_PACKET_LEN = 9000
+DHCP_DEFAULT = 0
 
 def receive(my_socket, timeout, exp_pkt, time_sent):
     timeLeft = timeout
@@ -42,7 +43,7 @@ def receive(my_socket, timeout, exp_pkt, time_sent):
             return False, delay, None
         
 def find_probe_packet(interface, dst_out, dst_in, sockets, exp_socket, max_iter):
-    dscp = random.randint(0, 32)
+    dscp = DHCP_DEFAULT
     tos = dscp << 2
     src_out = dst_in
     decap_valid = False

--- a/scripts/pcmping
+++ b/scripts/pcmping
@@ -1,0 +1,166 @@
+#!/usr/bin/env python
+
+"""
+    Portchannel member ping: get portchannel member packet loss state.
+
+"""
+
+from scapy.all import *
+import argparse
+import random
+import socket
+import select
+import time
+import ipaddr as ipaddress
+import sys
+import swsssdk
+
+RCV_SIZE_DEFAULT = 4096
+RCV_TIMEOUT = 10000
+DEFAULT_PACKET_LEN = 100
+SELECT_TIMEOUT = 2
+
+def receive(my_socket, timeout, exp_pkt, exp_socket, time_sent):
+    timeLeft = timeout
+    delay = 0
+    while True:
+        startedSelect = time.time()
+        whatReady = select.select(my_socket, [], [], timeLeft)
+        if whatReady[0] == []: # Timeout
+            return False, delay
+        timeReceived = time.time()
+        
+        for sel in whatReady[0]:
+            recPacket = sel.recv(4096)
+            e = str(exp_pkt)
+            # exclude ethernet header
+            p = str(recPacket[14:])
+            if e == p:
+                if sel == exp_socket:
+                  delay = (timeReceived - time_sent) * 1000
+                  return True, delay
+        timeLeft = timeLeft - (timeReceived - startedSelect)
+        if timeLeft <= 0:
+            return False, delay
+        
+def create_decap_packet(interface, dst_out, dst_in, sockets, exp_socket, max_iter):
+    dscp = 16
+    tos = dscp << 2
+    tcp_hdr    = TCP(sport=1234, dport=80, flags="S", chksum=0)
+    for x in range(1, max_iter):
+        print "---------- Attempting to create decap packet that goes through %s, iteration: %d ---------" % (interface, x)
+        ip_src = socket.inet_ntoa(struct.pack('>I', random.randint(1, 0xffffffff)))
+        ip_src =ipaddress.IPv4Address(unicode(ip_src,'utf-8'))
+        while ip_src == ipaddress.IPv4Address(unicode(dst_in,'utf-8')) or \
+              ip_src.is_multicast or ip_src.is_private or ip_src.is_reserved:
+            ip_src = socket.inet_ntoa(struct.pack('>I', random.randint(1, 0xffffffff)))
+            ip_src =ipaddress.IPv4Address(unicode(ip_src,'utf-8'))
+        inner_pkt  = IP(src=ip_src, dst=dst_in, tos=tos, ttl=64, id=1, ihl=None,proto=4)/tcp_hdr
+        inner_pkt = inner_pkt/("".join([chr(x) for x in xrange(DEFAULT_PACKET_LEN - len(inner_pkt))]))
+        pkt = IP(src='4.4.4.4', dst=dst_out, tos=tos)/inner_pkt
+        exp_pkt = inner_pkt
+        exp_pkt['IP'].ttl = 63
+
+        time_sent = time.time()
+        res = send(pkt, iface=interface, verbose=False)
+        have_received, delay = receive(sockets, SELECT_TIMEOUT, exp_pkt, exp_socket, time_sent) 
+        if have_received:
+            return pkt, exp_pkt
+    return None, None
+
+def get_portchannel(interface):
+    configdb = swsssdk.ConfigDBConnector()
+    configdb.connect()
+    portchannels = configdb.get_table("PORTCHANNEL")
+    for key, value in portchannels.iteritems():
+        if interface in value['members']:
+            return key, value
+    print ("Interface %s is not a portchannel member. Please Check!" % interface)
+    sys.exit(1)
+
+def get_portchannel_ipv4(portchannel_name):
+    configdb = swsssdk.ConfigDBConnector()
+    configdb.connect()
+    config = configdb.get_config()
+    portchannel_interfaces = config["PORTCHANNEL_INTERFACE"]
+    for key in portchannel_interfaces.keys():
+        pc, ip = key
+        ip = ip.split("/")[0]
+        if pc == portchannel_name and ipaddress.IPAddress(ip).version == 4:
+            return ip
+    print ("Portchannel %s doesn't have IPV4 address. Please Check!" % portchannel)
+    sys.exit(1)
+   
+def create_socket(interface, portchannel):
+    # create sockets
+    try:
+        sockets = []
+        for iface in portchannel['members']:
+            s = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.htons(ETH_P_IP))
+            s.bind((iface, 0))
+            s.settimeout(RCV_TIMEOUT)
+            if iface == interface:
+                exp_socket = s
+            sockets.append(s)
+    except:
+        print "Unable to create socket. Check your permissions"
+        sys.exit(1)
+    return sockets, exp_socket
+
+def main():
+    parser  = argparse.ArgumentParser(description='Check portchannel member link state',
+                                      version='1.0.0',
+                                      formatter_class=argparse.RawTextHelpFormatter,
+                                      epilog=""" 
+    Example:
+    pcmping -p Ethernet8 -ip 10.10.10.10
+    pcmping -p Ethernet8 -ip 10.10.10.10 -c 5
+    pcmping -p Ethernet8 -ip 10.10.10.10 -c 5 -t 20
+"""
+    )
+
+    parser.add_argument('-p', '--port', type=str, required=True, help='Portchannel member interface')
+    parser.add_argument('-ip','--decapip', type=str, required=True, help='Neighbor decap ip (usually same as neighbor loopback ip)') 
+    parser.add_argument('-c', '--count', type=int, help='Number of decap packets to be sent.', default=0)
+    parser.add_argument('-t', '--trial', type=int, help='Maximum trial times to create decap packet.\nPlease increase the value as the number of portchannel members increases', default=20)
+    args = parser.parse_args()
+    
+    interface =  args.port
+    decap_ip = args.decapip
+    exp_count = args.count
+    max_trial =  args.trial
+
+    portchannel_name, portchannel = get_portchannel(interface)
+    portchannel_ip = get_portchannel_ipv4(portchannel_name)
+    sockets, exp_socket = create_socket(interface, portchannel)
+    pkt, exp_pkt = create_decap_packet(interface, decap_ip, portchannel_ip, sockets, exp_socket, max_trial)
+    if not pkt or not exp_pkt:
+        print ("Cannot create packet that goes through interface %s to %s, Please check!" % (interface, decap_ip))
+        sys.exit(1)
+    print "Preparation done! Start pcmping ............"
+    print "PORTCHANNEL Member PING %d btyes of data. PORTCHANNEL: %s, INTERFACE: %s" % (DEFAULT_PACKET_LEN, portchannel_name, interface)
+    recv_count = 0
+    total_count = 0
+    try:
+        while True:
+            time_sent = time.time()
+            res = send(pkt, iface=interface, verbose=False)
+            have_received, delay = receive(sockets, SELECT_TIMEOUT, exp_pkt, exp_socket, time_sent)
+            total_count = total_count + 1
+            if have_received:
+                print "%d bytes from %s: time=%0.4fms" % (DEFAULT_PACKET_LEN, interface, delay)
+                recv_count = recv_count + 1
+            else:
+                print "packet not received!"
+            if total_count == exp_count:
+                break;
+            time.sleep(1)
+    except KeyboardInterrupt:
+        print "\n--- %s ping statistics ---" % interface
+        print ("%d packets transmitted, %d received, %0.2f%% packet loss" % (total_count, recv_count, (total_count-recv_count)*1.0/total_count*100))
+        return 
+    print "\n--- %s ping statistics ---" % interface
+    print ("%d packets transmitted, %d received, %0.2f%% packet loss" % (total_count, recv_count, (total_count-recv_count)*1.0/total_count*100))
+
+if __name__ == '__main__':
+    main()

--- a/scripts/pcmping
+++ b/scripts/pcmping
@@ -2,7 +2,6 @@
 
 """
     Portchannel member ping: get portchannel member packet loss state.
-
 """
 
 from scapy.all import *
@@ -15,58 +14,66 @@ import ipaddr as ipaddress
 import sys
 import swsssdk
 
-RCV_SIZE_DEFAULT = 4096
+RCV_SIZE = 20480
 RCV_TIMEOUT = 10000
-DEFAULT_PACKET_LEN = 100
 SELECT_TIMEOUT = 2
+PROBE_PACKET_LEN = 9000
 
-def receive(my_socket, timeout, exp_pkt, exp_socket, time_sent):
+def receive(my_socket, timeout, exp_pkt, time_sent):
     timeLeft = timeout
     delay = 0
     while True:
         startedSelect = time.time()
         whatReady = select.select(my_socket, [], [], timeLeft)
         if whatReady[0] == []: # Timeout
-            return False, delay
+            return False, delay, None
         timeReceived = time.time()
         
         for sel in whatReady[0]:
-            recPacket = sel.recv(4096)
+            recPacket = sel.recv(RCV_SIZE)
             e = str(exp_pkt)
             # exclude ethernet header
             p = str(recPacket[14:])
             if e == p:
-                if sel == exp_socket:
-                  delay = (timeReceived - time_sent) * 1000
-                  return True, delay
+                delay = (timeReceived - time_sent) * 1000
+                return True, delay, sel
         timeLeft = timeLeft - (timeReceived - startedSelect)
         if timeLeft <= 0:
-            return False, delay
+            return False, delay, None
         
-def create_decap_packet(interface, dst_out, dst_in, sockets, exp_socket, max_iter):
-    dscp = 16
+def find_probe_packet(interface, dst_out, dst_in, sockets, exp_socket, max_iter):
+    dscp = random.randint(0, 32)
     tos = dscp << 2
-    tcp_hdr = TCP(sport=1234, dport=80, flags="S", chksum=0)
-    for x in range(1, max_iter):
-        print "---------- Attempting to create decap packet that goes through %s, iteration: %d ---------" % (interface, x)
+    src_out = dst_in
+    decap_valid = False
+    for x in range(0, max_iter):
+        print "---------- Attempting to create probe packet that goes through %s, iteration: %d ---------" % (interface, x)
         ip_src = socket.inet_ntoa(struct.pack('>I', random.randint(1, 0xffffffff)))
         ip_src =ipaddress.IPv4Address(unicode(ip_src,'utf-8'))
         while ip_src == ipaddress.IPv4Address(unicode(dst_in,'utf-8')) or \
               ip_src.is_multicast or ip_src.is_private or ip_src.is_reserved:
             ip_src = socket.inet_ntoa(struct.pack('>I', random.randint(1, 0xffffffff)))
-            ip_src =ipaddress.IPv4Address(unicode(ip_src,'utf-8'))
-        inner_pkt  = IP(src=ip_src, dst=dst_in, tos=tos, ttl=64, id=1, ihl=None,proto=4)/tcp_hdr
-        inner_pkt = inner_pkt/("".join([chr(x) for x in xrange(DEFAULT_PACKET_LEN - len(inner_pkt))]))
-        pkt = IP(src='4.4.4.4', dst=dst_out, tos=tos)/inner_pkt
+            ip_src = ipaddress.IPv4Address(unicode(ip_src,'utf-8'))
+        inner_pkt = IP(src=ip_src, dst=dst_in, tos=tos, ttl=64, id=1, ihl=None,proto=4)/ICMP()
+        inner_pkt = inner_pkt/("".join([chr(x%256) for x in xrange(PROBE_PACKET_LEN - len(inner_pkt))]))
+        pkt = IP(src=src_out, dst=dst_out, tos=tos)/inner_pkt
         exp_pkt = inner_pkt
         exp_pkt['IP'].ttl = 63
 
         time_sent = time.time()
         res = send(pkt, iface=interface, verbose=False)
-        have_received, delay = receive(sockets, SELECT_TIMEOUT, exp_pkt, exp_socket, time_sent) 
-        if have_received:
+        have_received, delay, recv_socket = receive(sockets, SELECT_TIMEOUT, exp_pkt, time_sent)
+        if have_received and recv_socket == exp_socket:
             return pkt, exp_pkt
-    return None, None
+        elif have_received:
+            decap_valid = True
+
+    if decap_valid:
+       print ("Decap works properly. link %s is unreachable, Please check!\n" % interface)
+       sys.exit(0)
+    else:
+       print ("Decap using %s doesn't work properly, Please Check!\n" % (dst_out))
+       sys.exit(0)
 
 def get_portchannel(interface):
     configdb = swsssdk.ConfigDBConnector()
@@ -75,7 +82,7 @@ def get_portchannel(interface):
     for key, value in portchannels.iteritems():
         if interface in value['members']:
             return key, value
-    print ("Interface %s is not a portchannel member. Please Check!" % interface)
+    sys.stderr.write("Interface %s is not a portchannel member. Please Check!\n" % interface)
     sys.exit(1)
 
 def get_portchannel_ipv4(portchannel_name):
@@ -88,7 +95,7 @@ def get_portchannel_ipv4(portchannel_name):
         ip = ip.split("/")[0]
         if pc == portchannel_name and ipaddress.IPAddress(ip).version == 4:
             return ip
-    print ("Portchannel %s doesn't have IPV4 address. Please Check!" % portchannel)
+    sys.stderr.write("Portchannel %s doesn't have IPV4 address. Please Check!\n" % portchannel)
     sys.exit(1)
    
 def create_socket(interface, portchannel):
@@ -103,7 +110,7 @@ def create_socket(interface, portchannel):
                 exp_socket = s
             sockets.append(s)
     except:
-        print "Unable to create socket. Check your permissions"
+        sys.stderr.write("Unable to create socket. Check your permissions\n")
         sys.exit(1)
     return sockets, exp_socket
 
@@ -112,47 +119,44 @@ def print_statistics(interface, total_count, recv_count):
     print ("%d packets transmitted, %d received, %0.2f%% packet loss" % (total_count, recv_count, (total_count-recv_count)*1.0/total_count*100))
 
 def main():
-    parser  = argparse.ArgumentParser(description='Check portchannel member link state',
+    parser = argparse.ArgumentParser(description='Check portchannel member link state',
                                       version='1.0.0',
                                       formatter_class=argparse.RawTextHelpFormatter,
                                       epilog=""" 
     Example:
-    pcmping -p Ethernet8 -ip 10.10.10.10
-    pcmping -p Ethernet8 -ip 10.10.10.10 -c 5
-    pcmping -p Ethernet8 -ip 10.10.10.10 -c 5 -t 20
+    pcmping -i Ethernet8 -ip 10.10.10.10
+    pcmping -i Ethernet8 -ip 10.10.10.10 -c 5
+    pcmping -i Ethernet8 -ip 10.10.10.10 -c 5 -t 20
 """
     )
 
-    parser.add_argument('-p', '--port', type=str, required=True, help='Portchannel member interface')
+    parser.add_argument('-i', '--interface', type=str, required=True, help='Portchannel member interface')
     parser.add_argument('-ip','--decapip', type=str, required=True, help='Neighbor decap ip (usually same as neighbor loopback ip)') 
     parser.add_argument('-c', '--count', type=int, help='Number of decap packets to be sent.', default=0)
-    parser.add_argument('-t', '--trial', type=int, help='Maximum trial times to create decap packet.\nPlease increase the value as the number of portchannel members increases', default=20)
+    parser.add_argument('-t', '--trial', type=int, help='Maximum attempt times to create probe packet.\nPlease increase the value as the number of portchannel members increases', default=20)
     args = parser.parse_args()
     
-    interface =  args.port
+    interface = args.interface
     decap_ip = args.decapip
     exp_count = args.count
-    max_trial =  args.trial
+    max_trial = args.trial
 
     portchannel_name, portchannel = get_portchannel(interface)
     portchannel_ip = get_portchannel_ipv4(portchannel_name)
     sockets, exp_socket = create_socket(interface, portchannel)
-    pkt, exp_pkt = create_decap_packet(interface, decap_ip, portchannel_ip, sockets, exp_socket, max_trial)
-    if not pkt or not exp_pkt:
-        print ("Cannot create packet that goes through interface %s to %s, Please check!" % (interface, decap_ip))
-        sys.exit(1)
-    print "Preparation done! Start pcmping ............"
-    print "PORTCHANNEL Member PING %d btyes of data. PORTCHANNEL: %s, INTERFACE: %s" % (DEFAULT_PACKET_LEN, portchannel_name, interface)
+    pkt, exp_pkt = find_probe_packet(interface, decap_ip, portchannel_ip, sockets, exp_socket, max_trial)
+    print "Preparation done! Start probing ............"
+    print "PORTCHANNEL Member PING %d btyes of data. PORTCHANNEL: %s, INTERFACE: %s" % (PROBE_PACKET_LEN, portchannel_name, interface)
     recv_count = 0
     total_count = 0
     try:
         while True:
             time_sent = time.time()
             res = send(pkt, iface=interface, verbose=False)
-            have_received, delay = receive(sockets, SELECT_TIMEOUT, exp_pkt, exp_socket, time_sent)
+            have_received, delay, recv_socket = receive(sockets, SELECT_TIMEOUT, exp_pkt, time_sent)
             total_count = total_count + 1
             if have_received:
-                print "%d bytes from %s: time=%0.4fms" % (DEFAULT_PACKET_LEN, interface, delay)
+                print "%d bytes from %s: time=%0.4fms" % (PROBE_PACKET_LEN, interface, delay)
                 recv_count = recv_count + 1
             else:
                 print "packet not received!"
@@ -163,5 +167,6 @@ def main():
         print_statistics(interface, total_count, recv_count)
         return
     print_statistics(interface, total_count, recv_count)
+
 if __name__ == '__main__':
     main()

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         'scripts/generate_dump',
         'scripts/intfutil',
         'scripts/lldpshow',
+        'scripts/pcmping',
         'scripts/port2alias',
         'scripts/portconfig',
         'scripts/portstat',


### PR DESCRIPTION
Signed-off-by: Sihui Han <sihan@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Add pcmping tool to get portchannel member packet loss state
**- How I did it**
1. Vary decap packet src ip to make the packet traverse target link within portchannel
2. Send the packet to see packet loss

**- How to verify it**
Tested on the DUT
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**
```
root@sonic:/home/admin# pcmping -h                                                 
usage: pcmping [-h] [-v] -i INTERFACE -ip DECAPIP [-c COUNT] [-t TRIAL]                         
                                                                                                
Check portchannel member link state                                                             
                                                                                                
optional arguments:                                                                             
  -h, --help            show this help message and exit                                         
  -v, --version         show program's version number and exit                                  
  -i INTERFACE, --interface INTERFACE                                                           
                        Portchannel member interface                                            
  -ip DECAPIP, --decapip DECAPIP                                                                
                        Neighbor decap ip (usually same as neighbor loopback ip)                
  -c COUNT, --count COUNT                                                                       
                        Number of decap packets to be sent.                                     
  -t TRIAL, --trial TRIAL                                                                       
                        Maximum attempt times to create probe packet.                           
                        Please increase the value as the number of portchannel members increases
                                                                                                
                                                                                                
    Example:                                                                                    
    pcmping -i Ethernet8 -ip 10.10.10.10                                                        
    pcmping -i Ethernet8 -ip 10.10.10.10 -c 5                                                   
    pcmping -i Ethernet8 -ip 10.10.10.10 -c 5 -t 20                                             
```                                                                   

```
root@sonic:/home/admin# pcmping -i Ethernet0 -ip 25.156.196.0 -c 5                     
---------- Attempting to create probe packet that goes through Ethernet0, iteration: 0 ---------    
Preparation done! Start probing ............                                                        
PORTCHANNEL Member PING 9000 btyes of data. PORTCHANNEL: PortChannel57, INTERFACE: Ethernet0        
9000 bytes from Ethernet0: time=87.7759ms                                                           
9000 bytes from Ethernet0: time=188.6780ms                                                          
9000 bytes from Ethernet0: time=68.7380ms                                                           
9000 bytes from Ethernet0: time=60.3421ms                                                           
9000 bytes from Ethernet0: time=103.9369ms                                                          
                                                                                                    
--- Ethernet0 ping statistics ---                                                                   
5 packets transmitted, 5 received, 0.00% packet loss                                                
root@sonic:/home/admin#                                                                                                                  
```
                               
```
root@sonic:/home/admin# pcmping -i Ethernet0 -ip 25.156.196.0                         
---------- Attempting to create probe packet that goes through Ethernet0, iteration: 0 ---------   
---------- Attempting to create probe packet that goes through Ethernet0, iteration: 1 ---------   
Preparation done! Start probing ............                                                       
PORTCHANNEL Member PING 9000 btyes of data. PORTCHANNEL: PortChannel57, INTERFACE: Ethernet0       
9000 bytes from Ethernet0: time=69.6931ms                                                          
9000 bytes from Ethernet0: time=80.5981ms                                                          
9000 bytes from Ethernet0: time=64.6479ms                                                          
9000 bytes from Ethernet0: time=76.1161ms                                                          
^C                                                                                                 
--- Ethernet0 ping statistics ---                                                                  
4 packets transmitted, 4 received, 0.00% packet loss                                               
root@sonic:/home/admin#                                                                    
```


-->

