### PR TITLE
Warm reboot: warm_restart config and show commands

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -444,14 +444,24 @@ def warm_restart(ctx, redis_unix_socket_path):
 @click.pass_context
 def warm_restart_enable(ctx, module):
     db = ctx.obj['db']
-    db.set_entry('WARM_RESTART', module, {'enable': 'true'})
+    db.mod_entry('WARM_RESTART', module, {'enable': 'true'})
 
 @warm_restart.command('disable')
 @click.argument('module', metavar='<module>', default='system', required=False, type=click.Choice(["system", "swss"]))
 @click.pass_context
 def warm_restart_enable(ctx, module):
     db = ctx.obj['db']
-    db.set_entry('WARM_RESTART', module, {'enable': 'false'})
+    db.mod_entry('WARM_RESTART', module, {'enable': 'false'})
+
+@warm_restart.command('neighsyncd_timer')
+@click.argument('seconds', metavar='<seconds>', required=True, type=int)
+@click.pass_context
+def warm_restart_neighsyncd_timer(ctx, seconds):
+    db = ctx.obj['db']
+    if seconds not in range(1,9999):
+        print "neighsyncd warm restart timer must be in range 1-9999"
+        raise click.Abort
+    db.mod_entry('WARM_RESTART', 'swss', {'neighsyncd_timer': seconds})
 
 #
 # 'vlan' group

--- a/config/main.py
+++ b/config/main.py
@@ -219,7 +219,6 @@ def _stop_services():
     services = [
         'dhcp_relay',
         'swss',
-        'syncd',
         'snmp',
         'lldp',
         'pmon',
@@ -236,7 +235,6 @@ def _restart_services():
         'ntp-config',
         'rsyslog-config',
         'swss',
-        'syncd',
         'bgp',
         'teamd',
         'pmon',

--- a/config/main.py
+++ b/config/main.py
@@ -143,6 +143,7 @@ def _stop_services():
     services = [
         'dhcp_relay',
         'swss',
+        'syncd',
         'snmp',
         'lldp',
         'pmon',
@@ -159,6 +160,7 @@ def _restart_services():
         'ntp-config',
         'rsyslog-config',
         'swss',
+        'syncd',
         'bgp',
         'teamd',
         'pmon',

--- a/show/main.py
+++ b/show/main.py
@@ -1175,7 +1175,6 @@ def line():
     """Show all /dev/ttyUSB lines and their info"""
     cmd = "consutil show"
     run_command(cmd, display_cmd=verbose)
-    # TODO: Stub
     return
 
 
@@ -1247,9 +1246,9 @@ def config(redis_unix_socket_path):
             else:
                 r.append(data[k]['enable'])
 
-            if 'timer_name' in  data[k]:
-                r.append(data[k]['timer_name'])
-                r.append(data[k]['timer_duration'])
+            if 'neighsyncd_timer' in  data[k]:
+                r.append("neighsyncd_timer")
+                r.append(data[k]['neighsyncd_timer'])
             else:
                 r.append("NULL")
                 r.append("NULL")

--- a/show/main.py
+++ b/show/main.py
@@ -11,6 +11,7 @@ from click_default_group import DefaultGroup
 from natsort import natsorted
 from tabulate import tabulate
 from swsssdk import ConfigDBConnector
+from swsssdk import SonicV2Connector
 
 try:
     # noinspection PyPep8Naming
@@ -744,7 +745,7 @@ def cpu(verbose):
     # Run top in batch mode to prevent unexpected newline after each newline
     cmd = "top -bn 1 -o %CPU"
     run_command(cmd, display_cmd=verbose)
- 
+
 # 'memory' subcommand
 @processes.command()
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
@@ -1137,6 +1138,89 @@ def line():
     """Show all /dev/ttyUSB lines and their info"""
     cmd = "consutil show"
     run_command(cmd, display_cmd=verbose)
+
+
+@cli.group(cls=AliasedGroup, default_if_no_args=False)
+def warm_restart():
+    """Show warm restart configuration and state"""
+    pass
+
+@warm_restart.command()
+@click.option('-s', '--redis-unix-socket-path', help='unix socket path for redis connection')
+def state(redis_unix_socket_path):
+    """Show warm restart state"""
+    kwargs = {}
+    if redis_unix_socket_path:
+        kwargs['unix_socket_path'] = redis_unix_socket_path
+
+    data = {}
+    db = SonicV2Connector(host='127.0.0.1')
+    db.connect(db.STATE_DB, False)   # Make one attempt only
+
+    TABLE_NAME_SEPARATOR = '|'
+    prefix = 'WARM_RESTART_TABLE' + TABLE_NAME_SEPARATOR
+    _hash = '{}{}'.format(prefix, '*')
+    table_keys = db.keys(db.STATE_DB, _hash)
+
+    def remove_prefix(text, prefix):
+        if text.startswith(prefix):
+            return text[len(prefix):]
+        return text
+
+    table = []
+    for tk in table_keys:
+        entry = db.get_all(db.STATE_DB, tk)
+        r = []
+        r.append(remove_prefix(tk, prefix))
+        r.append(entry['restart_count'])
+
+        if 'state' not in  entry:
+            r.append("")
+        else:
+            r.append(entry['state'])
+
+        table.append(r)
+
+    header = ['name', 'restart_count', 'state']
+    click.echo(tabulate(table, header))
+
+@warm_restart.command()
+@click.option('-s', '--redis-unix-socket-path', help='unix socket path for redis connection')
+def config(redis_unix_socket_path):
+    """Show warm restart config"""
+    kwargs = {}
+    if redis_unix_socket_path:
+        kwargs['unix_socket_path'] = redis_unix_socket_path
+    config_db = ConfigDBConnector(**kwargs)
+    config_db.connect(wait_for_init=False)
+    data = config_db.get_table('WARM_RESTART')
+    keys = data.keys()
+
+    def tablelize(keys, data):
+        table = []
+
+        for k in keys:
+            r = []
+            r.append(k)
+
+            if 'enable' not in  data[k]:
+                r.append("false")
+            else:
+                r.append(data[k]['enable'])
+
+            if 'timer_name' in  data[k]:
+                r.append(data[k]['timer_name'])
+                r.append(data[k]['timer_duration'])
+            else:
+                r.append("NULL")
+                r.append("NULL")
+
+            table.append(r)
+
+        return table
+
+    header = ['name', 'enable', 'timer_name', 'timer_duration']
+    click.echo(tabulate(tablelize(keys, data), header))
 
 if __name__ == '__main__':
     cli()


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>


**- What I did**
warm_restart config and show commands

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

```

root@sonic:/# config warm_restart enable
root@sonic:/# config warm_restart disable swss
root@sonic:/# 


root@sonic:/# show warm_restart 
Usage: show warm_restart [OPTIONS] COMMAND [ARGS]...

  Show warm restart configuration and state

Options:
  -?, -h, --help  Show this message and exit.

Commands:
  config  Show warm restart config
  state   Show warm restart state


root@sonic:/# show warm_restart  config
name    enable    timer_name    timer_duration
------  --------  ------------  ----------------
swss    false     NULL          NULL
system  true      NULL          NULL
root@sonic:/# 
root@sonic:/# config warm_restart enable swss
root@sonic:/# 


root@sonic:/# show warm_restart config
name    enable    timer_name    timer_duration
------  --------  ------------  ----------------
swss    true      NULL          NULL
system  true      NULL          NULL
root@sonic:/# 


root@sonic:/# show warm_restart  state
name          restart_count  state
----------  ---------------  -------
orchagent                 2  init
neighsyncd                1
portsyncd                 2
vlanmgrd                  1

root@sonic:/# show warm_restart state 
name          restart_count  state
----------  ---------------  ----------
orchagent                 2  reconciled
neighsyncd                2
portsyncd                 2
vlanmgrd                  2


```


-->

