### PR TITLE
Enhanced "show arp/ndp" output

### DIFF
--- a/scripts/nbrshow
+++ b/scripts/nbrshow
@@ -1,0 +1,238 @@
+#!/usr/bin/python
+"""
+    Script to show Ipv4/Ipv6 neighbor entries
+
+    usage: nbrshow [-h] [-ip IPADDR] [-if IFACE] v
+    optional arguments:
+        -ip IPADDR, --ipaddr IPADDR
+                        Neigbhor for a specific address
+        -if IFACE, --iface IFACE
+                        Neigbhors learned on specific L3 interface
+
+    Example of the output:
+    admin@str~$nbrshow -4
+    Address       MacAddress         Iface            Vlan
+    ------------  -----------------  ---------------  ------
+    10.0.0.57     52:54:00:87:8f:2c  PortChannel0001  -
+    10.64.246.1   00:00:5e:00:01:f6  eth0             -
+    192.168.0.2   24:8a:07:4c:f5:0a  Ethernet20       1000
+    ..
+    Total number of entries 10 
+    admin@str:~$ nbrshow -6 -ip fc00::72
+    Address    MacAddress         Iface            Vlan    Status
+    ---------  -----------------  ---------------  ------  ---------
+    fc00::72   52:54:00:87:8f:2c  PortChannel0001  -       REACHABLE
+    Total number of entries 1 
+
+"""
+import argparse
+import json
+import sys
+import subprocess
+import re
+
+from natsort import natsorted
+from swsssdk import SonicV2Connector, port_util
+from tabulate import tabulate
+
+"""
+   Base class for v4 and v6 neighbor. 
+"""
+class NbrBase(object):
+
+    HEADER = []
+    NBR_COUNT = 0
+
+    def __init__(self, cmd):
+        super(NbrBase,self).__init__()
+        self.db = SonicV2Connector(host="127.0.0.1")
+        self.if_name_map, \
+        self.if_oid_map = port_util.get_interface_oid_map(self.db)
+        self.if_br_oid_map = port_util.get_bridge_port_map(self.db)
+        self.fetch_fdb_data()
+        self.cmd = cmd
+        self.err = None
+        self.nbrdata = []
+        return
+
+
+    def fetch_fdb_data(self):
+        """
+            Fetch FDB entries from ASIC DB. 
+            @Todo, this code can be reused
+        """
+        self.db.connect(self.db.ASIC_DB)
+        self.bridge_mac_list = []
+
+        fdb_str = self.db.keys('ASIC_DB', "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY:*")
+        if not fdb_str:
+            return
+
+        if self.if_br_oid_map is None:
+            return
+
+        oid_pfx = len("oid:0x")
+        for s in fdb_str:
+            fdb_entry = s.decode()
+            fdb = json.loads(fdb_entry .split(":", 2)[-1])
+            if not fdb:
+                continue
+
+            ent = self.db.get_all('ASIC_DB', s, blocking=True)
+            br_port_id = ent[b"SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID"][oid_pfx:]
+            ent_type = ent[b"SAI_FDB_ENTRY_ATTR_TYPE"]
+            if br_port_id not in self.if_br_oid_map:
+                continue
+            port_id = self.if_br_oid_map[br_port_id]
+            if_name = self.if_oid_map[port_id]
+            if 'vlan' in fdb:
+                vlan_id = fdb["vlan"]
+            elif 'bvid' in fdb:
+                vlan_id = port_util.get_vlan_id_from_bvid(self.db, fdb["bvid"])
+            self.bridge_mac_list.append((int(vlan_id),) + (fdb["mac"],) + (if_name,))
+
+        return
+
+
+    def fetch_nbr_data(self):
+        """
+            Fetch Neighbor data (ARP/IPv6 Neigh) from kernel. 
+        """
+        p = subprocess.Popen(self.cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        (output, err) = p.communicate() 
+        rc = p.wait()
+
+        if rc == 0:
+            rawdata = output
+        else:
+            self.err = err
+            rawdata = None
+
+        return rawdata
+
+
+    def display(self, ipaddr, iface, vpos=3):
+        """
+            Display formatted Neighbor entries (ARP/IPv6 Neigh). 
+        """
+
+        output = []
+
+        for ent in self.nbrdata:
+
+            if iface is not None and iface != ent[2]:
+                continue                
+
+            if ipaddr is not None and ipaddr != ent[0]:
+                continue
+
+            self.NBR_COUNT += 1
+            vlan = '-'
+            if 'Vlan' in ent[2]:
+                vlanid = int(re.search(r'\d+', ent[2]).group())
+                mac = unicode(ent[1].upper())
+                fdb_ent = next((fdb for fdb in self.bridge_mac_list[:]
+                               if fdb[0] == vlanid and fdb[1] == mac), None)
+                if fdb_ent is not None:
+                    vlan = vlanid
+                    ent[2] = fdb_ent[2]
+
+            ent.insert(vpos, vlan)
+            output.append(ent)
+
+        self.nbrdata = natsorted(output, key = lambda x: x[0])
+
+        print tabulate(self.nbrdata, self.HEADER)
+        print "Total number of entries {0} ".format(self.NBR_COUNT)
+
+
+    def display_err(self):
+        print "Error fetching Neighbors: {} ".format(self.err)
+
+
+class ArpShow(NbrBase):
+
+    HEADER = ['Address', 'MacAddress', 'Iface', 'Vlan']
+    CMD = "/usr/sbin/arp -n"
+
+    def __init__(self):
+        NbrBase.__init__(self, self.CMD)
+        return
+
+
+    def display(self, ipaddr, iface):
+        """
+            Format "arp -n" output from kernel 
+            Address        HWtype  HWaddress           Flags Mask    Iface
+            10.64.246.2    ether   f4:b5:2f:79:b3:f0   C             eth0
+            10.0.0.63      ether   52:54:00:ae:11:49   C             PortChannel0004
+        """
+        self.arpraw = self.fetch_nbr_data()
+
+        if self.arpraw == None:
+            self.display_err()
+            return
+
+        for line in self.arpraw.splitlines()[1:]:
+            ent = line.split()[::2]
+            self.nbrdata.append(ent)
+
+        super(ArpShow, self).display(ipaddr, iface)
+
+
+class NeighShow(NbrBase):
+
+    HEADER = ['Address', 'MacAddress', 'Iface', 'Vlan', 'Status']
+    CMD = "/bin/ip -6 neigh show"
+
+    def __init__(self):
+        NbrBase.__init__(self, self.CMD)
+        return
+
+
+    def display(self, ipaddr, iface):
+        """
+            Format "ip -6 neigh" output from kernel 
+            "fc00::76 dev PortChannel0002 lladdr 52:54:00:33:90:d0 router REACHABLE"
+        """
+        self.arpraw = self.fetch_nbr_data()
+
+        if self.arpraw == None:
+            self.display_err()
+            return
+
+        for line in self.arpraw.splitlines()[:]:
+            ent = line.split()[::2]
+            ent[1], ent[2] = ent[2], ent[1]
+            self.nbrdata.append(ent)
+
+        super(NeighShow, self).display(ipaddr, iface)
+
+
+def main():
+
+    parser = argparse.ArgumentParser(description='Show Neigbhor entries',
+                                     formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument('-ip', '--ipaddr', type=str, 
+                        help='Neigbhor for a specific address', default=None)
+    parser.add_argument('-if', '--iface', type=str, 
+                        help='Neigbhors learned on specific L3 interface', default=None)
+    parser.add_argument('v', help='IP Version -4 or -6')
+
+    args = parser.parse_args()
+
+    try:
+        if (args.v == '-6'):
+            neigh = NeighShow()
+            neigh.display(args.ipaddr, args.iface)
+        else:
+            arp = ArpShow()
+            arp.display(args.ipaddr, args.iface)
+
+    except Exception as e:
+        print e.message
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/nbrshow
+++ b/scripts/nbrshow
@@ -17,12 +17,12 @@
     10.64.246.1   00:00:5e:00:01:f6  eth0             -
     192.168.0.2   24:8a:07:4c:f5:0a  Ethernet20       1000
     ..
-    Total number of entries 10 
+    Total number of entries 10
     admin@str:~$ nbrshow -6 -ip fc00::72
     Address    MacAddress         Iface            Vlan    Status
     ---------  -----------------  ---------------  ------  ---------
     fc00::72   52:54:00:87:8f:2c  PortChannel0001  -       REACHABLE
-    Total number of entries 1 
+    Total number of entries 1
 
 """
 import argparse
@@ -36,18 +36,19 @@ from swsssdk import SonicV2Connector, port_util
 from tabulate import tabulate
 
 """
-   Base class for v4 and v6 neighbor. 
+   Base class for v4 and v6 neighbor.
 """
+
+
 class NbrBase(object):
 
     HEADER = []
     NBR_COUNT = 0
 
     def __init__(self, cmd):
-        super(NbrBase,self).__init__()
+        super(NbrBase, self).__init__()
         self.db = SonicV2Connector(host="127.0.0.1")
-        self.if_name_map, \
-        self.if_oid_map = port_util.get_interface_oid_map(self.db)
+        self.if_name_map, self.if_oid_map = port_util.get_interface_oid_map(self.db)
         self.if_br_oid_map = port_util.get_bridge_port_map(self.db)
         self.fetch_fdb_data()
         self.cmd = cmd
@@ -55,10 +56,9 @@ class NbrBase(object):
         self.nbrdata = []
         return
 
-
     def fetch_fdb_data(self):
         """
-            Fetch FDB entries from ASIC DB. 
+            Fetch FDB entries from ASIC DB.
             @Todo, this code can be reused
         """
         self.db.connect(self.db.ASIC_DB)
@@ -93,13 +93,12 @@ class NbrBase(object):
 
         return
 
-
     def fetch_nbr_data(self):
         """
-            Fetch Neighbor data (ARP/IPv6 Neigh) from kernel. 
+            Fetch Neighbor data (ARP/IPv6 Neigh) from kernel.
         """
         p = subprocess.Popen(self.cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        (output, err) = p.communicate() 
+        (output, err) = p.communicate()
         rc = p.wait()
 
         if rc == 0:
@@ -110,10 +109,9 @@ class NbrBase(object):
 
         return rawdata
 
-
     def display(self, vpos=3):
         """
-            Display formatted Neighbor entries (ARP/IPv6 Neigh). 
+            Display formatted Neighbor entries (ARP/IPv6 Neigh).
         """
 
         output = []
@@ -134,11 +132,10 @@ class NbrBase(object):
             ent.insert(vpos, vlan)
             output.append(ent)
 
-        self.nbrdata = natsorted(output, key = lambda x: x[0])
+        self.nbrdata = natsorted(output, key=lambda x: x[0])
 
         print tabulate(self.nbrdata, self.HEADER)
         print "Total number of entries {0} ".format(self.NBR_COUNT)
-
 
     def display_err(self):
         print "Error fetching Neighbors: {} ".format(self.err)
@@ -160,17 +157,16 @@ class ArpShow(NbrBase):
         NbrBase.__init__(self, self.CMD)
         return
 
-
     def display(self):
         """
-            Format "arp -n" output from kernel 
+            Format "arp -n" output from kernel
             Address        HWtype  HWaddress           Flags Mask    Iface
             10.64.246.2    ether   f4:b5:2f:79:b3:f0   C             eth0
             10.0.0.63      ether   52:54:00:ae:11:49   C             PortChannel0004
         """
         self.arpraw = self.fetch_nbr_data()
 
-        if self.arpraw == None:
+        if self.arpraw is None:
             self.display_err()
             return
 
@@ -198,7 +194,6 @@ class NeighShow(NbrBase):
         NbrBase.__init__(self, self.CMD)
         return
 
-
     def display(self):
         """
             Format "ip -6 neigh show " output from kernel
@@ -208,7 +203,7 @@ class NeighShow(NbrBase):
         """
         self.arpraw = self.fetch_nbr_data()
 
-        if self.arpraw == None:
+        if self.arpraw is None:
             self.display_err()
             return
 
@@ -229,9 +224,9 @@ def main():
 
     parser = argparse.ArgumentParser(description='Show Neigbhor entries',
                                      formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument('-ip', '--ipaddr', type=str, 
+    parser.add_argument('-ip', '--ipaddr', type=str,
                         help='Neigbhor for a specific address', default=None)
-    parser.add_argument('-if', '--iface', type=str, 
+    parser.add_argument('-if', '--iface', type=str,
                         help='Neigbhors learned on specific L3 interface', default=None)
     parser.add_argument('v', help='IP Version -4 or -6')
 

--- a/scripts/nbrshow
+++ b/scripts/nbrshow
@@ -111,7 +111,7 @@ class NbrBase(object):
         return rawdata
 
 
-    def display(self, ipaddr, iface, vpos=3):
+    def display(self, vpos=3):
         """
             Display formatted Neighbor entries (ARP/IPv6 Neigh). 
         """
@@ -119,12 +119,6 @@ class NbrBase(object):
         output = []
 
         for ent in self.nbrdata:
-
-            if iface is not None and iface != ent[2]:
-                continue                
-
-            if ipaddr is not None and ipaddr != ent[0]:
-                continue
 
             self.NBR_COUNT += 1
             vlan = '-'
@@ -153,14 +147,21 @@ class NbrBase(object):
 class ArpShow(NbrBase):
 
     HEADER = ['Address', 'MacAddress', 'Iface', 'Vlan']
-    CMD = "/usr/sbin/arp -n"
+    CMD = "/usr/sbin/arp -n "
 
-    def __init__(self):
+    def __init__(self, ipaddr, iface):
+
+        if ipaddr is not None:
+            self.CMD += ipaddr
+
+        if iface is not None:
+            self.CMD += ' -i ' + iface
+
         NbrBase.__init__(self, self.CMD)
         return
 
 
-    def display(self, ipaddr, iface):
+    def display(self):
         """
             Format "arp -n" output from kernel 
             Address        HWtype  HWaddress           Flags Mask    Iface
@@ -177,23 +178,33 @@ class ArpShow(NbrBase):
             ent = line.split()[::2]
             self.nbrdata.append(ent)
 
-        super(ArpShow, self).display(ipaddr, iface)
+        super(ArpShow, self).display()
 
 
 class NeighShow(NbrBase):
 
     HEADER = ['Address', 'MacAddress', 'Iface', 'Vlan', 'Status']
-    CMD = "/bin/ip -6 neigh show"
+    CMD = "/bin/ip -6 neigh show "
 
-    def __init__(self):
+    def __init__(self, ipaddr, iface):
+
+        if ipaddr is not None:
+            self.CMD += ipaddr
+
+        if iface is not None:
+            self.CMD += ' dev ' + iface
+
+        self.iface = iface
         NbrBase.__init__(self, self.CMD)
         return
 
 
-    def display(self, ipaddr, iface):
+    def display(self):
         """
-            Format "ip -6 neigh" output from kernel 
+            Format "ip -6 neigh show " output from kernel
             "fc00::76 dev PortChannel0002 lladdr 52:54:00:33:90:d0 router REACHABLE"
+            Format "ip -6 neigh show dev PortChannel0003"
+            "fc00::7a lladdr 52:54:00:6b:1d:0a router STALE"
         """
         self.arpraw = self.fetch_nbr_data()
 
@@ -203,10 +214,15 @@ class NeighShow(NbrBase):
 
         for line in self.arpraw.splitlines()[:]:
             ent = line.split()[::2]
-            ent[1], ent[2] = ent[2], ent[1]
+
+            if self.iface is not None:
+                ent.insert(2, self.iface)
+            else:
+                ent[1], ent[2] = ent[2], ent[1]
+
             self.nbrdata.append(ent)
 
-        super(NeighShow, self).display(ipaddr, iface)
+        super(NeighShow, self).display()
 
 
 def main():
@@ -223,11 +239,11 @@ def main():
 
     try:
         if (args.v == '-6'):
-            neigh = NeighShow()
-            neigh.display(args.ipaddr, args.iface)
+            neigh = NeighShow(args.ipaddr, args.iface)
+            neigh.display()
         else:
-            arp = ArpShow()
-            arp.display(args.ipaddr, args.iface)
+            arp = ArpShow(args.ipaddr, args.iface)
+            arp.display()
 
     except Exception as e:
         print e.message

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,8 @@ setup(
         'scripts/pfcstat',
         'scripts/queuestat',
         'scripts/reboot',
-        'scripts/teamshow'
+        'scripts/teamshow',
+        'scripts/nbrshow'
     ],
     data_files=[
         ('/etc/bash_completion.d', glob.glob('data/etc/bash_completion.d/*')),

--- a/show/main.py
+++ b/show/main.py
@@ -149,13 +149,17 @@ def cli():
 
 @cli.command()
 @click.argument('ipaddress', required=False)
+@click.option('-if', '--iface')
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
-def arp(ipaddress, verbose):
+def arp(ipaddress, iface, verbose):
     """Show IP ARP table"""
-    cmd = "/usr/sbin/arp -n"
+    cmd = "nbrshow -4"
 
     if ipaddress is not None:
-        cmd += " {}".format(ipaddress)
+        cmd += " -ip {}".format(ipaddress)
+
+    if iface is not None:
+        cmd += " -if {}".format(iface)
 
     run_command(cmd, display_cmd=verbose)
 
@@ -165,13 +169,17 @@ def arp(ipaddress, verbose):
 
 @cli.command()
 @click.argument('ip6address', required=False)
+@click.option('-if', '--iface')
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
-def ndp(ip6address):
+def ndp(ip6address, iface, verbose):
     """Show IPv6 Neighbour table"""
-    cmd = "/bin/ip -6 neigh show"
+    cmd = "nbrshow -6"
 
     if ip6address is not None:
-        cmd += ' {}'.format(ip6address)
+        cmd += " -ip {}".format(ip6address)
+
+    if iface is not None:
+        cmd += " -if {}".format(iface)
 
     run_command(cmd, display_cmd=verbose)
 


### PR DESCRIPTION
**- What I did**

1. Enhanced the output of  `show arp/ndp` to have Vlan member info.
2. Added the option to fetch neighbor entries for a specified interface. 

**- How I did it**
Fetch `arp/ipv6` neigh info from kernel and `fdb` info from ASIC db. Compare the `Interface `and `Mac address` from the neighbor info and get the matching entry from FDB table to append the physical interface. 

**- How to verify it**
Execute `show arp` and `show ndp` commands

**- Previous command output (if the output of a command-line utility has changed)**
```
show arp
Address                  HWtype  HWaddress           Flags Mask            Iface
192.168.0.2              ether   24:8a:07:4c:f5:0a   CM                    Vlan1000
10.64.247.30             ether   00:50:b6:20:e2:41   C                     eth0
10.64.246.1              ether   00:00:5e:00:01:f6   C                     eth0
10.0.0.59                ether   52:54:00:33:90:d0   C                     PortChannel0002
10.0.0.57                ether   52:54:00:87:8f:2c   C                     PortChannel0001
```

```
show ndp
fc00::76 dev PortChannel0002 lladdr 52:54:00:33:90:d0 router REACHABLE
fe80::5054:ff:fe33:90d0 dev PortChannel0002 lladdr 52:54:00:33:90:d0 router STALE
fc00::7a dev PortChannel0003 lladdr 52:54:00:6b:1d:0a router REACHABLE
fe80::2a01:111:e210:b000:1 dev eth0 lladdr 00:00:5e:00:02:10 router STALE
fc00::72 dev PortChannel0001 lladdr 52:54:00:87:8f:2c router REACHABLE
fc00::7e dev PortChannel0004 lladdr 52:54:00:ae:11:49 router STALE
fe80::5054:ff:fe87:8f2c dev PortChannel0001 lladdr 52:54:00:87:8f:2c router STALE
```

**- New command output (if the output of a command-line utility has changed)**

```
admin@str-a7060cx-acs-1:~$ show arp
Address       MacAddress         Iface            Vlan
------------  -----------------  ---------------  ------
10.0.0.57     52:54:00:87:8f:2c  PortChannel0001  -
10.0.0.59     52:54:00:33:90:d0  PortChannel0002  -
10.64.246.1   00:00:5e:00:01:f6  eth0             -
10.64.247.30  00:50:b6:20:e2:41  eth0             -
192.168.0.2   24:8a:07:4c:f5:0a  Ethernet20       1000
192.168.0.3   24:8a:07:4c:f5:01  Ethernet2        1000
192.168.0.4   24:8a:07:4c:f5:0d  Ethernet28       1000

..
Total number of entries 12
```

```
admin@str-a7060cx-acs-1:~$ show ndp
Address                     MacAddress         Iface            Vlan    Status
--------------------------  -----------------  ---------------  ------  ---------
fc00::7a                    52:54:00:6b:1d:0a  PortChannel0003  -       DELAY
fc00::72                    52:54:00:87:8f:2c  PortChannel0001  -       REACHABLE
fc00::76                    52:54:00:33:90:d0  PortChannel0002  -       STALE
fe80::2a01:111:e210:b000:1  00:00:5e:00:02:10  eth0             -       STALE
fe80::2a01:111:e210:b000:2  f4:b5:2f:79:b3:f0  eth0             -       STALE
fe80::5054:ff:fe33:90d0     52:54:00:33:90:d0  PortChannel0002  -       STALE
fe80::5054:ff:fe87:8f2c     52:54:00:87:8f:2c  PortChannel0001  -       STALE
..
Total number of entries 10 
```
