### PR TITLE
Add 'alias mode' support for show commands

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -43,15 +43,15 @@ class InterfaceAliasConverter(object):
     """Class which handles conversion between interface name and alias"""
 
     def __init__(self):
-        self.vendor_name_max_length = 0
+        self.alias_max_length = 0
         cmd = 'sonic-cfggen -d --var-json "PORT"'
         p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
         self.port_dict = json.loads(p.stdout.read())
 
         for port_name in self.port_dict.keys():
-            if self.vendor_name_max_length < len(
+            if self.alias_max_length < len(
                     self.port_dict[port_name]['alias']):
-               self.vendor_name_max_length = len(
+               self.alias_max_length = len(
                     self.port_dict[port_name]['alias'])
 
     def name_to_alias(self, interface_name):
@@ -199,7 +199,7 @@ def print_output_in_alias_mode(output, index):
     if output.startswith("---"):
         word = output.split()
         dword = word[index]
-        underline = dword.rjust(iface_alias_converter.vendor_name_max_length,
+        underline = dword.rjust(iface_alias_converter.alias_max_length,
                                 '-')
         word[index] = underline
         output = '  ' .join(word)
@@ -212,9 +212,9 @@ def print_output_in_alias_mode(output, index):
             if interface_name == port_name:
                 alias_name = iface_alias_converter.port_dict[port_name]['alias']
     if alias_name:
-        if len(alias_name) < iface_alias_converter.vendor_name_max_length:
+        if len(alias_name) < iface_alias_converter.alias_max_length:
             alias_name = alias_name.rjust(
-                                iface_alias_converter.vendor_name_max_length)
+                                iface_alias_converter.alias_max_length)
         output = output.replace(interface_name, alias_name, 1)
 
     click.echo(output.rstrip('\n'))
@@ -242,7 +242,7 @@ def run_command_in_alias_mode(command):
                 index = 0
                 if output.startswith("IFACE"):
                     output = output.replace("IFACE", "IFACE".rjust(
-                               iface_alias_converter.vendor_name_max_length))
+                               iface_alias_converter.alias_max_length))
                 print_output_in_alias_mode(output, index)
 
             elif command == "pfcstat":
@@ -250,11 +250,11 @@ def run_command_in_alias_mode(command):
                 index = 0
                 if output.startswith("Port Tx"):
                     output = output.replace("Port Tx", "Port Tx".rjust(
-                                iface_alias_converter.vendor_name_max_length))
+                                iface_alias_converter.alias_max_length))
 
                 elif output.startswith("Port Rx"):
                     output = output.replace("Port Rx", "Port Rx".rjust(
-                                iface_alias_converter.vendor_name_max_length))
+                                iface_alias_converter.alias_max_length))
                 print_output_in_alias_mode(output, index)
 
             elif (command.startswith("sudo sfputil show")):
@@ -264,7 +264,7 @@ def run_command_in_alias_mode(command):
                 index = 0
                 if output.startswith("Port"):
                     output = output.replace("Port", "Port".rjust(
-                               iface_alias_converter.vendor_name_max_length))
+                               iface_alias_converter.alias_max_length))
                 print_output_in_alias_mode(output, index)
 
             elif command == "sudo lldpshow":
@@ -272,7 +272,7 @@ def run_command_in_alias_mode(command):
                 index = 0
                 if output.startswith("LocalPort"):
                     output = output.replace("LocalPort", "LocalPort".rjust(
-                               iface_alias_converter.vendor_name_max_length))
+                               iface_alias_converter.alias_max_length))
                 print_output_in_alias_mode(output, index)
 
             elif command.startswith("queuestat"):
@@ -280,7 +280,7 @@ def run_command_in_alias_mode(command):
                 index = 0
                 if output.startswith("Port"):
                     output = output.replace("Port", "Port".rjust(
-                               iface_alias_converter.vendor_name_max_length))
+                               iface_alias_converter.alias_max_length))
                 print_output_in_alias_mode(output, index)
 
             elif command == "fdbshow":

--- a/show/main.py
+++ b/show/main.py
@@ -1156,7 +1156,7 @@ def config(redis_unix_socket_path):
                 r.append(k)
                 r.append(data[k]['vlanid'])
                 if get_interface_mode() == "alias":
-                    alias = interface_name_to_alias(m)
+                    alias = _alias.interface_name_to_alias(m)
                     r.append(alias)
                 else:
                     r.append(m)

--- a/show/main.py
+++ b/show/main.py
@@ -259,7 +259,7 @@ def run_command_in_alias_mode(command):
                                 iface_alias_converter.alias_max_length))
                 print_output_in_alias_mode(output, index)
 
-            elif command == "sudo sfputil show eeprom":
+            elif (command.startswith("sudo sfputil show eeprom")):
                 """show interface transceiver eeprom"""
                 index = 0
                 print_output_in_alias_mode(raw_output, index)
@@ -516,6 +516,9 @@ def eeprom(interfacename, dump_dom, verbose):
         cmd += " --dom"
 
     if interfacename is not None:
+        if get_interface_mode() == "alias":
+            interfacename = iface_alias_converter.alias_to_name(interfacename)
+
         cmd += " -p {}".format(interfacename)
 
     run_command(cmd, display_cmd=verbose)
@@ -530,6 +533,9 @@ def lpmode(interfacename, verbose):
     cmd = "sudo sfputil show lpmode"
 
     if interfacename is not None:
+        if get_interface_mode() == "alias":
+            interfacename = iface_alias_converter.alias_to_name(interfacename)
+
         cmd += " -p {}".format(interfacename)
 
     run_command(cmd, display_cmd=verbose)
@@ -543,6 +549,9 @@ def presence(interfacename, verbose):
     cmd = "sudo sfputil show presence"
 
     if interfacename is not None:
+        if get_interface_mode() == "alias":
+            interfacename = iface_alias_converter.alias_to_name(interfacename)
+
         cmd += " -p {}".format(interfacename)
 
     run_command(cmd, display_cmd=verbose)

--- a/show/main.py
+++ b/show/main.py
@@ -184,7 +184,7 @@ def get_interface_mode():
 
 
 # Global class instance for SONiC interface name to alias conversion
-convert_interface = InterfaceAliasConverter()
+iface_alias_converter = InterfaceAliasConverter()
 
 
 def print_output_in_alias_mode(output, index):
@@ -199,7 +199,8 @@ def print_output_in_alias_mode(output, index):
     if output.startswith("---"):
         word = output.split()
         dword = word[index]
-        underline = dword.rjust(convert_interface.vendor_name_max_length, '-')
+        underline = dword.rjust(iface_alias_converter.vendor_name_max_length,
+                                '-')
         word[index] = underline
         output = '  ' .join(word)
 
@@ -207,13 +208,13 @@ def print_output_in_alias_mode(output, index):
     word = output.split()
     if word:
         interface_name = word[index]
-    for port_name in natsorted(convert_interface.port_dict.keys()):
+    for port_name in natsorted(iface_alias_converter.port_dict.keys()):
             if interface_name == port_name:
-                alias_name = convert_interface.port_dict[port_name]['alias']
+                alias_name = iface_alias_converter.port_dict[port_name]['alias']
     if alias_name:
-        if len(alias_name) < convert_interface.vendor_name_max_length:
+        if len(alias_name) < iface_alias_converter.vendor_name_max_length:
             alias_name = alias_name.rjust(
-                                convert_interface.vendor_name_max_length)
+                                iface_alias_converter.vendor_name_max_length)
         output = output.replace(interface_name, alias_name, 1)
 
     click.echo(output.rstrip('\n'))
@@ -241,7 +242,7 @@ def run_command_in_alias_mode(command):
                 index = 0
                 if output.startswith("IFACE"):
                     output = output.replace("IFACE", "IFACE".rjust(
-                                   convert_interface.vendor_name_max_length))
+                               iface_alias_converter.vendor_name_max_length))
                 print_output_in_alias_mode(output, index)
 
             elif command == "pfcstat":
@@ -249,11 +250,11 @@ def run_command_in_alias_mode(command):
                 index = 0
                 if output.startswith("Port Tx"):
                     output = output.replace("Port Tx", "Port Tx".rjust(
-                                    convert_interface.vendor_name_max_length))
+                                iface_alias_converter.vendor_name_max_length))
 
                 elif output.startswith("Port Rx"):
                     output = output.replace("Port Rx", "Port Rx".rjust(
-                                    convert_interface.vendor_name_max_length))
+                                iface_alias_converter.vendor_name_max_length))
                 print_output_in_alias_mode(output, index)
 
             elif (command.startswith("sudo sfputil show")):
@@ -263,7 +264,7 @@ def run_command_in_alias_mode(command):
                 index = 0
                 if output.startswith("Port"):
                     output = output.replace("Port", "Port".rjust(
-                                   convert_interface.vendor_name_max_length))
+                               iface_alias_converter.vendor_name_max_length))
                 print_output_in_alias_mode(output, index)
 
             elif command == "sudo lldpshow":
@@ -271,7 +272,7 @@ def run_command_in_alias_mode(command):
                 index = 0
                 if output.startswith("LocalPort"):
                     output = output.replace("LocalPort", "LocalPort".rjust(
-                                   convert_interface.vendor_name_max_length))
+                               iface_alias_converter.vendor_name_max_length))
                 print_output_in_alias_mode(output, index)
 
             elif command.startswith("queuestat"):
@@ -279,7 +280,7 @@ def run_command_in_alias_mode(command):
                 index = 0
                 if output.startswith("Port"):
                     output = output.replace("Port", "Port".rjust(
-                                   convert_interface.vendor_name_max_length))
+                               iface_alias_converter.vendor_name_max_length))
                 print_output_in_alias_mode(output, index)
 
             elif command == "fdbshow":
@@ -301,7 +302,7 @@ def run_command_in_alias_mode(command):
 
             else:
                 if index:
-                    for port_name in convert_interface.port_dict.keys():
+                    for port_name in iface_alias_converter.port_dict.keys():
                         regex = re.compile(r"\b{}\b".format(port_name))
                         result = re.findall(regex, raw_output)
                         if result:
@@ -309,7 +310,7 @@ def run_command_in_alias_mode(command):
                             if not raw_output.startswith("    PortID:"):
                                 raw_output = raw_output.replace(
                                     interface_name,
-                                    convert_interface.name_to_alias(
+                                    iface_alias_converter.name_to_alias(
                                             interface_name))
                     click.echo(raw_output.rstrip('\n'))
 
@@ -351,7 +352,7 @@ def arp(ipaddress, iface, verbose):
         if get_interface_mode() == "alias":
             if not ((iface.startswith("PortChannel")) or
                     (iface.startswith("eth"))):
-                iface = convert_interface.alias_to_name(iface)
+                iface = iface_alias_converter.alias_to_name(iface)
 
         cmd += " -if {}".format(iface)
 
@@ -403,7 +404,7 @@ def alias(interfacename):
     if interfacename is not None:
 
         if get_interface_mode() == "alias":
-            interfacename = convert_interface.alias_to_name(interfacename)
+            interfacename = iface_alias_converter.alias_to_name(interfacename)
 
         # If we're given an interface name, output name and alias for that interface only
         if interfacename in port_dict:
@@ -483,7 +484,7 @@ def summary(interfacename, verbose):
 
     if interfacename is not None:
         if get_interface_mode() == "alias":
-            interfacename = convert_interface.alias_to_name(interfacename)
+            interfacename = iface_alias_converter.alias_to_name(interfacename)
 
         cmd += " {}".format(interfacename)
 
@@ -551,7 +552,7 @@ def description(interfacename, verbose):
 
     if interfacename is not None:
         if get_interface_mode() == "alias":
-            interfacename = convert_interface.alias_to_name(interfacename)
+            interfacename = iface_alias_converter.alias_to_name(interfacename)
 
         cmd += " {}".format(interfacename)
 
@@ -568,7 +569,7 @@ def status(interfacename, verbose):
 
     if interfacename is not None:
         if get_interface_mode() == "alias":
-            interfacename = convert_interface.alias_to_name(interfacename)
+            interfacename = iface_alias_converter.alias_to_name(interfacename)
 
         cmd += " {}".format(interfacename)
 
@@ -648,7 +649,7 @@ def counters(interfacename, clear, verbose):
 
     if interfacename is not None:
         if get_interface_mode() == "alias":
-            interfacename = convert_interface.alias_to_name(interfacename)
+            interfacename = iface_alias_converter.alias_to_name(interfacename)
 
     if clear:
         cmd += " -c"
@@ -797,7 +798,7 @@ def neighbors(interfacename, verbose):
 
     if interfacename is not None:
         if get_interface_mode() == "alias":
-            interfacename = convert_interface.alias_to_name(interfacename)
+            interfacename = iface_alias_converter.alias_to_name(interfacename)
 
         cmd += " {}".format(interfacename)
 
@@ -1171,7 +1172,7 @@ def config(redis_unix_socket_path):
                 r.append(k)
                 r.append(data[k]['vlanid'])
                 if get_interface_mode() == "alias":
-                    alias = convert_interface.name_to_alias(m)
+                    alias = iface_alias_converter.name_to_alias(m)
                     r.append(alias)
                 else:
                     r.append(m)

--- a/show/main.py
+++ b/show/main.py
@@ -55,8 +55,8 @@ class InterfaceAliasConverter(object):
                     self.port_dict[port_name]['alias'])
 
     def name_to_alias(self, interface_name):
-        """Return alias interface name if default
-           name is given as argument
+        """Return vendor interface alias if SONiC
+           interface name is given as argument
         """
         if interface_name is not None:
             for port_name in self.port_dict.keys():
@@ -67,7 +67,8 @@ class InterfaceAliasConverter(object):
         raise click.Abort()
 
     def alias_to_name(self, interface_alias):
-        """Return default interface name if alias name is given as argument
+        """Return SONiC interface name if vendor
+           port alias is given as argument
         """
         if interface_alias is not None:
             for port_name in self.port_dict.keys():
@@ -402,7 +403,6 @@ def alias(interfacename):
     body = []
 
     if interfacename is not None:
-
         if get_interface_mode() == "alias":
             interfacename = iface_alias_converter.alias_to_name(interfacename)
 

--- a/show/main.py
+++ b/show/main.py
@@ -238,9 +238,6 @@ def run_command_in_alias_mode(command, linux_command=False):
                                                 _interface.vendor_name_max_length))
                 elif command == "queuestat":
                     """show queue counters"""
-                    if output.startswith("LocalPort"):
-                        output = output.replace("LocalPort", "LocalPort".rjust(
-                                                _interface.vendor_name_max_length))
                     if output.startswith("Port"):
                         output = output.replace("Port", "Port".rjust(
                                                 _interface.vendor_name_max_length))

--- a/show/main.py
+++ b/show/main.py
@@ -209,6 +209,7 @@ def print_output_in_alias_mode(output, index):
     word = output.split()
     if word:
         interface_name = word[index]
+        interface_name = interface_name.replace(':', '')
     for port_name in natsorted(iface_alias_converter.port_dict.keys()):
             if interface_name == port_name:
                 alias_name = iface_alias_converter.port_dict[port_name]['alias']
@@ -258,9 +259,14 @@ def run_command_in_alias_mode(command):
                                 iface_alias_converter.alias_max_length))
                 print_output_in_alias_mode(output, index)
 
+            elif command == "sudo sfputil show eeprom":
+                """show interface transceiver eeprom"""
+                index = 0
+                print_output_in_alias_mode(raw_output, index)
+
             elif (command.startswith("sudo sfputil show")):
                 """show interface transceiver lpmode,
-                  presence, eeprom
+                   presence
                 """
                 index = 0
                 if output.startswith("Port"):
@@ -628,6 +634,15 @@ def counters(clear, verbose):
 
     run_command(cmd, display_cmd=verbose)
 
+# 'naming_mode' subcommand ("show interfaces naming_mode")
+@interfaces.command()
+@click.option('--verbose', is_flag=True, help="Enable verbose output")
+def naming_mode(verbose):
+    """Show interface naming_mode status"""
+
+    click.echo(get_interface_mode())
+
+
 #
 # 'queue' group ("show queue ...")
 #
@@ -967,7 +982,6 @@ def cpu(verbose):
     # Run top in batch mode to prevent unexpected newline after each newline
     cmd = "top -bn 1 -o %CPU"
     run_command(cmd, display_cmd=verbose)
-
 
 # 'memory' subcommand
 @processes.command()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**

Added portalias support for following commands.  To enable alias output in CLI execute "sudo config interface_naming_mode alias" command and use the below commands.

- show ip route
- show ipv6 route
- show interface transceiver eeprom
- show arp 
- show lldp neighbors
- show vlan brief
- show vlan config

**- How I did it**

Implemented a seperate run_command_in_alias_mode function  to change the results of linux commands from default interface name to vendor specific name. This function read each line of the output and replace the equivalent vendor names. To speed up the result for mutli-line output ( show ip route/ipv6 route/arp)  we cache the alias_names from port_config.ini at init. This results in quick substitution.

**- How to verify it**
Execute the commands as described above

