### PR TITLE
[mellanox] Upgrade FW if neccesary before fast reboot

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -36,6 +36,22 @@ INITRD=$(echo $KERNEL_IMAGE | sed 's/vmlinuz/initrd.img/g')
 
 sonic_asic_type=$(sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)
 
+# Install new FW for mellanox platforms before control plane goes down
+# So on boot switch will not spend time to upgrade FW increasing the CP downtime
+if [[ "$sonic_asic_type" == "mellanox" ]];
+then
+    CURRENT_SONIC_IMAGE=$(sonic_installer list | grep "Current: " | cut -d ' ' -f 2)
+    if [[ "${CURRENT_SONIC_IMAGE}" != "${NEXT_SONIC_IMAGE}" ]]; then
+        echo "Prepare ASIC to fast reboot: install new FW if requiered"
+        NEXT_IMAGE_FS_PATH="/host/image-${NEXT_SONIC_IMAGE#SONiC-OS-}/fs.squashfs"
+        FS_MOUNTPOINT="/tmp/image-${NEXT_SONIC_IMAGE#SONiC-OS-}-fs"
+        mkdir -p "$FS_MOUNTPOINT"
+        mount -t squashfs "$NEXT_IMAGE_FS_PATH" "$FS_MOUNTPOINT"
+        /usr/bin/mlnx-fw-upgrade.sh "$FS_MOUNTPOINT/etc/mlnx/fw-SPC.mfa"
+        umount "$FS_MOUNTPOINT"
+    fi
+fi
+
 # Load kernel into the memory
 /sbin/kexec -l "$KERNEL_IMAGE" --initrd="$INITRD" --append="$BOOT_OPTIONS"
 


### PR DESCRIPTION
Fast-booting to a new image with new SDK/FW may increase
control plane downtime by 1.5 min, because of new FW installation.
Upgrading FW before fast reboot does not increase downtime of
control/data plane traffic

NOTE: This PR depends on https://github.com/Azure/sonic-buildimage/pull/1994, please merge only after that PR is merged

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

