### PR TITLE
Fix pfcwd start_default

### DIFF
--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -197,8 +197,10 @@ def start_default():
     configdb = swsssdk.ConfigDBConnector()
     configdb.connect()
     enable = configdb.get_entry('DEVICE_METADATA', 'localhost').get('default_pfcwd_status')
+    countersdb = swsssdk.SonicV2Connector(host='127.0.0.1')
+    countersdb.connect(countersdb.COUNTERS_DB)
 
-    all_ports = get_all_ports(configdb)
+    all_ports = get_all_ports(countersdb)
 
     if not enable or enable.lower() != "enable":
        return


### PR DESCRIPTION
Fix the following error when running 'pfcwd start_default'

Traceback (most recent call last):
  File "/usr/bin/pfcwd", line 9, in <module>
    load_entry_point('sonic-utilities==1.2', 'console_scripts', 'pfcwd')()
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/pfcwd/main.py", line 201, in start_default
    all_ports = get_all_ports(configdb)
  File "/usr/lib/python2.7/dist-packages/pfcwd/main.py", line 42, in get_all_ports
    port_names = db.get_all(db.COUNTERS_DB, 'COUNTERS_PORT_NAME_MAP')
  File "/usr/local/lib/python2.7/dist-packages/swsssdk/interface.py", line 38, in wrapped
    ret_data = f(inst, db_name, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/swsssdk/interface.py", line 305, in get_all
    client = self.redis_clients[db_name]
  File "/usr/local/lib/python2.7/dist-packages/swsssdk/interface.py", line 78, in __getitem__
    raise MissingClientError("No client connected for db_name '{}'".format(item))
swsssdk.exceptions.MissingClientError: No client connected for db_name 'COUNTERS_DB'

Signed-off-by: Wenda Ni <wenni@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
Verified on dut: pfcwd show config to be correct after config load_minigraph -y 

$ pfcwd show config 
Changed polling interval to 200ms
       PORT    ACTION    DETECTION TIME    RESTORATION TIME
-----------  --------  ----------------  ------------------
  Ethernet0      drop               200                 200
  Ethernet4      drop               200                 200
  Ethernet8      drop               200                 200
 Ethernet12      drop               200                 200
 Ethernet16      drop               200                 200
 Ethernet20      drop               200                 200
 Ethernet24      drop               200                 200
 Ethernet28      drop               200                 200
 Ethernet32      drop               200                 200
 Ethernet36      drop               200                 200
 Ethernet40      drop               200                 200
 Ethernet44      drop               200                 200
 Ethernet48      drop               200                 200
 Ethernet52      drop               200                 200
 Ethernet56      drop               200                 200

$ sudo config load_minigraph 
Reload config from minigraph? [y/N]: y
Running command: service dhcp_relay stop
Running command: service swss stop
Running command: service snmp stop
Warning: Stopping snmp.service, but it can still be activated by:
  snmp.timer
Running command: service lldp stop
Running command: service pmon stop
Running command: service bgp stop
Running command: service teamd stop
Running command: sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --write-to-db
Running command: pfcwd start_default
Running command: acl-loader update full /etc/sonic/acl.json
Running command: config qos reload
Running command: sonic-cfggen -m -t /usr/share/sonic/device/x86_64-arista_7050_qx32s/Arista-7050-QX-32S/buffers.json.j2 >/tmp/buffers.json
Running command: sonic-cfggen -j /tmp/buffers.json --write-to-db
Running command: sonic-cfggen -j /usr/share/sonic/device/x86_64-arista_7050_qx32s/Arista-7050-QX-32S/qos.json --write-to-db

Running command: service hostname-config restart
Running command: service interfaces-config restart
Running command: service ntp-config restart
Running command: service rsyslog-config restart
Running command: service swss restart
Running command: service bgp restart
Running command: service teamd restart
Running command: service pmon restart
Running command: service lldp restart
Running command: service snmp restart
Running command: service dhcp_relay restart
Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`.


**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

