### PR TITLE
Fix pfcwd start_default: Use config_db to get the active port list. 

### DIFF
--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -42,6 +42,9 @@ def get_all_ports(db):
     port_names = db.get_all(db.COUNTERS_DB, 'COUNTERS_PORT_NAME_MAP')
     return natsorted(port_names.keys())
 
+def get_active_ports_from_configdb(cfgdb):
+    return natsorted(cfgdb.get_table('DEVICE_NEIGHBOR').keys())
+
 def get_server_facing_ports(db):
     candidates = db.get_table('DEVICE_NEIGHBOR')
     server_facing_ports = []
@@ -197,10 +200,8 @@ def start_default():
     configdb = swsssdk.ConfigDBConnector()
     configdb.connect()
     enable = configdb.get_entry('DEVICE_METADATA', 'localhost').get('default_pfcwd_status')
-    countersdb = swsssdk.SonicV2Connector(host='127.0.0.1')
-    countersdb.connect(countersdb.COUNTERS_DB)
 
-    all_ports = get_all_ports(countersdb)
+    active_ports = get_active_ports_from_configdb(configdb)
 
     if not enable or enable.lower() != "enable":
        return
@@ -215,7 +216,7 @@ def start_default():
         'action': DEFAULT_ACTION
     }
 
-    for port in all_ports:
+    for port in active_ports:
         configdb.set_entry("PFC_WD_TABLE", port, pfcwd_info)
 
     pfcwd_info = {}


### PR DESCRIPTION
Remove the use of counters_db because start_default can be called on a device where no
pfcwd is enabled, so the only source we can reply on to get the port info is the config_db not counters_db.

Signed-off-by: Wenda Ni <wenni@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
Verified on dut the call to pfcwd start_default:
1) reboot, with no pfcwd enabled by default saved before reboot
2) at runtime
 
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

