### PR TITLE
Validate acl.json after parsed

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -201,6 +201,8 @@ class AclLoader(object):
         :return:
         """
         self.yang_acl = pybindJSON.load(filename, openconfig_acl, "openconfig_acl")
+        if pybindJSON.dumps(self.yang_acl) == '{}':
+            raise AclLoaderException("Invalid input file %s" % filename)
         self.convert_rules()
 
     def convert_action(self, table_name, rule_idx, rule):


### PR DESCRIPTION
pybindJSON.load() silently ignore invalid acl.json according to YANG model, and return an emtpy object. Detect this situation and report an error.