### PR TITLE
 SONIC_CLI_IFACE_MODE variable in bashrc for portalias feature

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -77,7 +77,7 @@ def set_interface_mode(mode):
     """Modify SONIC_CLI_IFACE_MODE env variable in user .bashrc
     """
     user = os.getenv('SUDO_USER')
-    bashrc_ifacemode_line = "SONIC_CLI_IFACE_MODE={}".format(mode)
+    bashrc_ifacemode_line = "export SONIC_CLI_IFACE_MODE={}".format(mode)
 
     if not user:
         user = os.getenv('USER')
@@ -95,7 +95,7 @@ def set_interface_mode(mode):
         newdata = filedata + bashrc_ifacemode_line
         newdata += "\n"
     else:
-        newdata = re.sub(r"SONIC_CLI_IFACE_MODE=\w+",
+        newdata = re.sub(r"export SONIC_CLI_IFACE_MODE=\w+",
                          bashrc_ifacemode_line, filedata)
     f = open(bashrc, 'w')
     f.write(newdata)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Export environment variable "SONIC_CLI_IFACE_MODE" in user bashrc to store the interface mode. 

**- How I did it**
Introduced variable in config/main.py script. set_interface_mode() function will set the interface mode preferred by user.

**- How to verify it**
Execute "config interface_naming_mode alias/default" and check the changes in ~/.bashrc. 
Logout and log back in the shell to see changes are taken into effect.

**- New command output (if the output of a command-line utility has changed)**
~~~
admin@sonic:~$ sudo config interface_naming_mode alias
Please logout and log back in for changes take effect.
~~~





-->

