### PR TITLE
[aclshow]: Fix the KeyError issue in aclshow

### DIFF
--- a/scripts/aclshow
+++ b/scripts/aclshow
@@ -201,7 +201,6 @@ class AclStat(object):
                     self.get_counter_value(rule_key, 'packets') == 'N/A'):
                 continue
             rule = self.acl_rules[rule_key]
-            ports = self.acl_tables[rule_key[0]]['ports']
             line = [rule_key[1], rule_key[0],
                     self.acl_tables[rule_key[0]]['type'],
                     rule['PRIORITY'],


### PR DESCRIPTION
The variable ports is not used and it causes issue while the
control plane ACLs doesn't have this key in the dictionary.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>
