### PR TITLE
Update restart_count to restore_count for warm restart

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1210,7 +1210,7 @@ def state(redis_unix_socket_path):
         entry = db.get_all(db.STATE_DB, tk)
         r = []
         r.append(remove_prefix(tk, prefix))
-        r.append(entry['restart_count'])
+        r.append(entry['restore_count'])
 
         if 'state' not in  entry:
             r.append("")
@@ -1219,7 +1219,7 @@ def state(redis_unix_socket_path):
 
         table.append(r)
 
-    header = ['name', 'restart_count', 'state']
+    header = ['name', 'restore_count', 'state']
     click.echo(tabulate(table, header))
 
 @warm_restart.command()


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>


**- What I did**
With changes introduced in https://github.com/Azure/sonic-swss/pull/600
WARM_RESTART_TABLE:restart_count got changed to WARM_RESTART_TABLE:restore_count

"show warm_restart state" needs to change accordingly.
 


**- How I did it**

**- How to verify it**

root@sonic:/home/admin# show warm_restart state
name          restore_count  state
----------  ---------------  -------
portsyncd                 0
neighsyncd                0
orchagent                 0
vlanmgrd                  0
root@sonic:/home/admin# show warm_restart state
name          restore_count  state
----------  ---------------  ----------
portsyncd                 1
neighsyncd                1  reconciled
orchagent                 1  reconciled
vlanmgrd                  1

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

