### PR TITLE
Root priviliege for ecn configuration set commands

### DIFF
--- a/scripts/ecnconfig
+++ b/scripts/ecnconfig
@@ -104,12 +104,16 @@ class EcnConfig(object):
             print("Total profiles: %d" % len(wred_profiles))
 
     def set_wred_threshold(self, profile, threshold, value):
+        if os.geteuid() != 0:
+            sys.exit("Root privileges required for this operation")
         field = WRED_CONFIG_FIELDS[threshold]
         if self.verbose:
             print("Setting %s value to %s" % (field, value))
         self.db.mod_entry(WRED_PROFILE_TABLE_NAME, profile, {field: value})
 
     def set_wred_prob(self, profile, drop_color, value):
+        if os.geteuid() != 0:
+            sys.exit("Root privileges required for this operation")
         field = WRED_CONFIG_FIELDS[drop_color]
         if self.verbose:
             print("Setting %s value to %s%%" % (field, value))
@@ -151,6 +155,8 @@ class EcnQ(object):
             self.ports_key = ','.join(sorted(ports, key = lambda k: int(k[8:])))
 
     def set(self, enable):
+        if os.geteuid() != 0:
+            sys.exit("Root privileges required for this operation")
         for queue in self.queues:
             if self.verbose:
                 print("%s ECN on %s queue %s" % ("Enable" if enable else "Disable", self.ports_key, queue))


### PR DESCRIPTION
Signed-off-by: Wenda <wenni@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
On dut:

$ ecnconfig -p AZURE_LOSSLESS -rmin 10000    
Root privileges required for this operation
$ sudo ecnconfig -p AZURE_LOSSLESS -rmin 10000

$ ecnconfig -p AZURE_LOSSLESS -rdrop 30     
Root privileges required for this operation
$ sudo ecnconfig -p AZURE_LOSSLESS -rdrop 30

$ ecnconfig -q 3 on 
Root privileges required for this operation
$ sudo ecnconfig -q 3 on

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

