### PR TITLE
Added argument forwarder for platform reboot.

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -38,22 +38,19 @@ sonic_asic_type=$(sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)
 
 # Install new FW for mellanox platforms before control plane goes down
 # So on boot switch will not spend time to upgrade FW increasing the CP downtime
-if [[ "$sonic_asic_type" == "mellanox" ]];
-then
-    CURRENT_SONIC_IMAGE=$(sonic_installer list | grep "Current: " | cut -d ' ' -f 2)
-    if [[ "${CURRENT_SONIC_IMAGE}" != "${NEXT_SONIC_IMAGE}" ]]; then
-        echo "Prepare ASIC to fast reboot: install new FW if requiered"
-        NEXT_IMAGE_FS_PATH="/host/image-${NEXT_SONIC_IMAGE#SONiC-OS-}/fs.squashfs"
-        FS_MOUNTPOINT="/tmp/image-${NEXT_SONIC_IMAGE#SONiC-OS-}-fs"
-        mkdir -p "$FS_MOUNTPOINT"
-        mount -t squashfs "$NEXT_IMAGE_FS_PATH" "$FS_MOUNTPOINT"
-        /usr/bin/mlnx-fw-upgrade.sh "$FS_MOUNTPOINT/etc/mlnx/fw-SPC.mfa"
-        EXIT_CODE=$?
-        umount "$FS_MOUNTPOINT"
-        if [[ $EXIT_CODE != 0 ]]; then
-            echo "Failed to burn FW"
-            exit 1
-        fi
+if [[ "$sonic_asic_type" == "mellanox" ]]; then
+    echo "Prepare MLNX ASIC to fast reboot: install new FW if required"
+
+    MLNX_EXIT_SUCCESS="0"
+    MLNX_EXIT_ERROR="1"
+
+    MLNX_FW_UPGRADE_SCRIPT="/usr/bin/mlnx-fw-upgrade.sh"
+
+    ${MLNX_FW_UPGRADE_SCRIPT} --upgrade
+    MLNX_EXIT_CODE="$?"
+    if [[ "${MLNX_EXIT_CODE}" != "${MLNX_EXIT_SUCCESS}" ]]; then
+        echo "Failed to burn MLNX FW: errno=${MLNX_EXIT_CODE}"
+        exit "${MLNX_EXIT_ERROR}"
     fi
 fi
 

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 
 REBOOT_USER=$(logname)
 REBOOT_TIME=$(date)
@@ -13,7 +13,6 @@ function stop_sonic_services()
     docker exec -i syncd /usr/bin/syncd_request_shutdown --cold > /dev/null
     sleep 3
 }
-
 
 # Exit if not superuser
 if [[ "$EUID" -ne 0 ]]; then
@@ -33,7 +32,7 @@ sleep 3
 
 if [ -x ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT} ]; then
     echo "Rebooting with platform ${PLATFORM} specific tool ..."
-    exec ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT}
+    exec ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT} $@
 else
     # If no platform-specific reboot tool, just run /sbin/reboot
     exec /sbin/reboot $@


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

**- What I did**
1. Fixed Mellanox fast reboot script
2. Added argument forwarder for platform reboot

**- How I did it**
* N/A

**- How to verify it**
To verify fast reboot:
1. Run fast reboot

To verify argument forwarding:
1. Pass custom arguments to platform reboot script

**- Previous command output (if the output of a command-line utility has changed)**
* N/A

**- New command output (if the output of a command-line utility has changed)**
* N/A

**- External dependencies**
1. https://github.com/Azure/sonic-buildimage/pull/2111