### PR TITLE
Remove explicit dependency on tabulate; Add comments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,11 +85,19 @@ setup(
             'undebug = undebug.main:cli',
         ]
     },
+    # NOTE: sonic-utilities also depends on other packages that are either only
+    # available as .whl files or the latest available Debian packages are
+    # out-of-date and we must install newer versions via pip. These
+    # dependencies cannot be listed here, as this package is built as a .deb,
+    # therefore all dependencies will be assumed to also be available as .debs.
+    # These unlistable dependencies are as follows:
+    # - sonic-config-engine
+    # - swsssdk
+    # - tabulate
     install_requires=[
         'click-default-group',
         'click',
-        'natsort',
-        'tabulate'
+        'natsort'
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
The latest version of Python tabulate library available as a Debian package for Stretch is 0.7.7. However, the new "show vlan" command requires support for multi-line output in a cell, a feature that was added in tabulate v0.8.1.

Tabulate v0.8.2 is the latest version available via pip, so I am now installing this package in the base image here: https://github.com/Azure/sonic-buildimage/pull/2130

I have also added comments describing the change and listing the packages that we cannot currently specify as explicit dependencies because they cannot be installed as .deb packages.