### PR TITLE
ecnconfig check against invalid argument value

### DIFF
--- a/scripts/ecnconfig
+++ b/scripts/ecnconfig
@@ -106,6 +106,11 @@ class EcnConfig(object):
     def set_wred_threshold(self, profile, threshold, value):
         if os.geteuid() != 0:
             sys.exit("Root privileges required for this operation")
+
+        v = int(value)
+        if v < 0 :
+            raise Exception("Invalid %s" % (threshold))
+
         field = WRED_CONFIG_FIELDS[threshold]
         if self.verbose:
             print("Setting %s value to %s" % (field, value))
@@ -114,6 +119,11 @@ class EcnConfig(object):
     def set_wred_prob(self, profile, drop_color, value):
         if os.geteuid() != 0:
             sys.exit("Root privileges required for this operation")
+
+        v = int(value)
+        if v < 0 or v > 100:
+            raise Exception("Invalid %s" % (drop_color))
+
         field = WRED_CONFIG_FIELDS[drop_color]
         if self.verbose:
             print("Setting %s value to %s%%" % (field, value))


### PR DESCRIPTION
Signed-off-by: Wenda <wenni@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
On dut:
$ sudo ecnconfig -p AZURE_LOSSLESS -ymin -1 
Exception caught:  Invalid ymin

$ sudo ecnconfig -p AZURE_LOSSLESS -gdrop 101    
Exception caught:  Invalid gdrop
$ sudo ecnconfig -p AZURE_LOSSLESS -gdrop -1 
Exception caught:  Invalid gdrop
$ sudo ecnconfig -p AZURE_LOSSLESS -gdrop o    
Exception caught:  invalid literal for int() with base 10: 'o'


**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

