### PR TITLE
Some improvement for Mellanox sniffer CLI

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -7,6 +7,8 @@ import json
 import subprocess
 import netaddr
 import re
+
+import sonic_platform
 from swsssdk import ConfigDBConnector
 from natsort import natsorted
 from minigraph import parse_device_desc_xml
@@ -926,7 +928,9 @@ def asymmetric(status, interface):
 @cli.group()
 def platform():
     """Platform-related configuration tasks"""
-platform.add_command(mlnx.mlnx)
+
+if (sonic_platform.get_sonic_version_info()['asic_type'] == 'mellanox'):
+    platform.add_command(mlnx.mlnx)
 
 
 #

--- a/show/main.py
+++ b/show/main.py
@@ -874,7 +874,8 @@ def platform():
     """Show platform-specific hardware info"""
     pass
 
-platform.add_command(mlnx.mlnx)
+if (sonic_platform.get_sonic_version_info()['asic_type'] == 'mellanox'):
+    platform.add_command(mlnx.mlnx)
 
 # 'summary' subcommand ("show platform summary")
 @platform.command()

--- a/show/mlnx.py
+++ b/show/mlnx.py
@@ -20,38 +20,35 @@ TMP_SNIFFER_CONF_FILE = '/tmp/tmp.conf'
 
 
 # run command
-def run_command(command, display_cmd=False):
-    if display_cmd:
-        click.echo(click.style("Command: ", fg='cyan') + click.style(command, fg='green'))
+def run_command(command, display_cmd=False, ignore_error=False):
+    """Run bash command and print output to stdout
+    """
+    if display_cmd == True:
+        click.echo(click.style("Running command: ", fg='cyan') + click.style(command, fg='green'))
 
     proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
+    (out, err) = proc.communicate()
 
-    while True:
-        output = proc.stdout.readline()
-        if output == "" and proc.poll() is not None:
-            break
-        if output:
-            click.echo(output.rstrip('\n'))
+    if len(out) > 0:
+        click.echo(out)
 
-    rc = proc.poll()
-    if rc != 0:
-        sys.exit(rc)
+    if proc.returncode != 0 and not ignore_error:
+        sys.exit(proc.returncode)
 
 
 # 'mlnx' group
 @click.group()
 def mlnx():
-    """Mellanox platform specific configuration tasks"""
+    """ Show Mellanox platform information """
     pass
 
 
 # get current status of sniffer from conf file
 def sniffer_status_get(env_variable_name):
     enabled = False
-
-    command = 'docker exec -ti ' + CONTAINER_NAME + ' bash -c "touch ' + SNIFFER_CONF_FILE + '"'
+    command = "docker exec {} bash -c 'touch {}'".format(CONTAINER_NAME, SNIFFER_CONF_FILE)
     run_command(command)
-    command = 'docker cp ' + SNIFFER_CONF_FILE_IN_CONTAINER + ' ' + TMP_SNIFFER_CONF_FILE
+    command = 'docker cp {} {}'.format(SNIFFER_CONF_FILE_IN_CONTAINER, TMP_SNIFFER_CONF_FILE)
     run_command(command)
     conf_file = open(TMP_SNIFFER_CONF_FILE, 'r')
     for env_variable_string in conf_file:
@@ -59,20 +56,19 @@ def sniffer_status_get(env_variable_name):
             enabled = True
             break
     conf_file.close()
-    command = 'rm -rf ' + TMP_SNIFFER_CONF_FILE
+    command = 'rm -rf {}'.format(TMP_SNIFFER_CONF_FILE)
     run_command(command)
-
     return enabled
 
 
-@mlnx.command('sniffer')
-def sniffer_status():
-    """ Sniffer running status """
+@mlnx.command()
+def sniffer():
+    """ Show sniffer status """
     components = ['sdk']
     env_variable_strings = [ENV_VARIABLE_SX_SNIFFER]
     for index in range(len(components)):
         enabled = sniffer_status_get(env_variable_strings[index])
         if enabled is True:
-            print components[index] + " sniffer is RUNNING"
+            print components[index] + " sniffer is enabled"
         else:
-            print components[index] + " sniffer is OFF"
+            print components[index] + " sniffer is disabled"


### PR DESCRIPTION
* Hide Mellanox sniffer CLI on other platforms
* Set enable/disable to be the argument of sniffer command rather
than the sub-command

Signed-off-by: Kevin Wang <kevinw@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Make the CLI "config/show platform mlnx" just appear on Mellanox platform. 
**- How I did it**
Use sonic_platform.get_sonic_version_info()['asic_type'] to identify the running platform.
**- How to verify it**
Should not see "config/show platform mlnx" CLI on the other platforms.
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

