### PR TITLE
tacacs management vrf changes

### DIFF
--- a/config/aaa.py
+++ b/config/aaa.py
@@ -161,8 +161,8 @@ default.add_command(passkey)
 @click.option('-a', '--auth_type', help='Authentication type, default pap', type=click.Choice(["chap", "pap", "mschap", "login"]))
 @click.option('-o', '--port', help='TCP port range is 1 to 65535, default 49', type=click.IntRange(1, 65535), default=49)
 @click.option('-p', '--pri', help="Priority, default 1", type=click.IntRange(1, 64), default=1)
-@click.option('-v', '--vrf', help="Management vrf, default is no vrf")
-def add(address, timeout, key, auth_type, port, pri, vrf):
+@click.option('-m', '--use-mgmt-vrf', help="Management vrf, default is no vrf", is_flag=True)
+def add(address, timeout, key, auth_type, port, pri, use_mgmt_vrf):
     """Specify a TACACS+ server"""
     if not is_ipaddress(address):
         click.echo('Invalid ip address')
@@ -184,8 +184,8 @@ def add(address, timeout, key, auth_type, port, pri, vrf):
             data['timeout'] = str(timeout)
         if key is not None:
             data['passkey'] = key
-        if vrf is not None:
-            data['vrf'] = vrf
+        if use_mgmt_vrf :
+            data['vrf'] = "mgmt"
         config_db.set_entry('TACPLUS_SERVER', address, data)
 tacacs.add_command(add)
 

--- a/config/aaa.py
+++ b/config/aaa.py
@@ -161,7 +161,8 @@ default.add_command(passkey)
 @click.option('-a', '--auth_type', help='Authentication type, default pap', type=click.Choice(["chap", "pap", "mschap", "login"]))
 @click.option('-o', '--port', help='TCP port range is 1 to 65535, default 49', type=click.IntRange(1, 65535), default=49)
 @click.option('-p', '--pri', help="Priority, default 1", type=click.IntRange(1, 64), default=1)
-def add(address, timeout, key, auth_type, port, pri):
+@click.option('-v', '--vrf', help="Management vrf, default is no vrf")
+def add(address, timeout, key, auth_type, port, pri, vrf):
     """Specify a TACACS+ server"""
     if not is_ipaddress(address):
         click.echo('Invalid ip address')
@@ -183,6 +184,8 @@ def add(address, timeout, key, auth_type, port, pri):
             data['timeout'] = str(timeout)
         if key is not None:
             data['passkey'] = key
+        if vrf is not None:
+            data['vrf'] = vrf
         config_db.set_entry('TACPLUS_SERVER', address, data)
 tacacs.add_command(add)
 


### PR DESCRIPTION
**- What I did**
Changes for accepting "vrfname" as an optional parameter for the command "config tacacs -v [vrfname] server_ip" and pass it to TACPLUS_SERVER in the config DB.

**- How I did it**
Added checks for argument "vrf" and passed it to config DB. Diff is at https://github.com/kannankvs/sonic-utilities/commit/bf51bb12b5c820fc40eff7d9b6d02405af2e68be  

**- How to verify it**
Tested it along with the command "config tacacs -v mgmt 10.11.55.40" and verified that the passed parameter "vrfname" is there in /etc/sonic/config_db.json file under TACPLUS_SERVER. Verified that "show tacacs" displays the newly configured vrfname for the server IP.

**- Previous command output (if the output of a command-line utility has changed)**
```
root@sonic:/etc/sonic# show tacacs
TACPLUS global auth_type login
TACPLUS global timeout 5 (default)
TACPLUS global passkey testing123

TACPLUS_SERVER address 10.11.55.40
               priority 1
               tcp_port 49
```

**- New command output (if the output of a command-line utility has changed)**
```
root@sonic:/etc/sonic# config tacacs add -v mgmt 10.11.55.40
root@sonic:/etc/sonic# show tacacs
TACPLUS global auth_type login
TACPLUS global timeout 5 (default)
TACPLUS global passkey testing123

TACPLUS_SERVER address 10.11.55.40
               priority 1
               tcp_port 49
               vrf mgmt

-->
```