### PR TITLE
Add ip config support for Vlan

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -813,6 +813,8 @@ def add(ctx, ip_addr):
         config_db.set_entry("INTERFACE", (interface_name, ip_addr), {"NULL": "NULL"})
     elif interface_name.startswith("PortChannel"):
         config_db.set_entry("PORTCHANNEL_INTERFACE", (interface_name, ip_addr), {"NULL": "NULL"})
+    elif interface_name.startswith("Vlan"):
+        config_db.set_entry("VLAN_INTERFACE", (interface_name, ip_addr), {"NULL": "NULL"})
 
 #
 # 'del' subcommand
@@ -830,6 +832,9 @@ def remove(ctx, ip_addr):
         config_db.set_entry("INTERFACE", (interface_name, ip_addr), None)
     elif interface_name.startswith("PortChannel"):
         config_db.set_entry("PORTCHANNEL_INTERFACE", (interface_name, ip_addr), None)
+    elif interface_name.startswith("Vlan"):
+        config_db.set_entry("VLAN_INTERFACE", (interface_name, ip_addr), None)
+
 #
 # 'acl' group
 #


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>


**- What I did**
IP config on Vlan interface.

**- How I did it**

**- How to verify it**

```
root@sonic:/home/admin# config  interface Vlan10  ip add 20.20.20.20/24 
root@sonic:/home/admin# 
root@sonic:/home/admin# 
root@sonic:/home/admin# ip add show Vlan10
6: Vlan10@Bridge: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether 00:05:64:30:73:c0 brd ff:ff:ff:ff:ff:ff
    inet 11.163.117.119/26 scope global Vlan10
       valid_lft forever preferred_lft forever
    inet 11.213.14.247/26 scope global Vlan10
       valid_lft forever preferred_lft forever
    inet 20.20.20.20/24 scope global Vlan10
       valid_lft forever preferred_lft forever
    inet6 fe80::205:64ff:fe30:73c0/64 scope link 
       valid_lft forever preferred_lft forever
```

```
root@sonic:/home/admin# config  interface Vlan10  ip remove 20.20.20.20/24 
root@sonic:/home/admin# 
root@sonic:/home/admin# 
root@sonic:/home/admin# ip add show Vlan10
6: Vlan10@Bridge: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether 00:05:64:30:73:c0 brd ff:ff:ff:ff:ff:ff
    inet 11.163.117.119/26 scope global Vlan10
       valid_lft forever preferred_lft forever
    inet 11.213.14.247/26 scope global Vlan10
       valid_lft forever preferred_lft forever
    inet6 fe80::205:64ff:fe30:73c0/64 scope link 
       valid_lft forever preferred_lft forever
root@sonic:/home/admin# 
```
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

