### PR TITLE
[pfc_asym]: Fix config CLI command according to latest changes

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -902,7 +902,8 @@ def ecn(profile, rmax, rmin, ymax, ymin, gmax, gmin, verbose):
 #
 
 @interface.group()
-def pfc():
+@click.pass_context
+def pfc(ctx):
     """Set PFC configuration."""
     pass
 
@@ -913,9 +914,12 @@ def pfc():
 
 @pfc.command()
 @click.argument('status', type=click.Choice(['on', 'off']))
-@click.argument('interface', type=click.STRING)
-def asymmetric(status, interface):
+@click.pass_context
+def asymmetric(ctx, status):
     """Set asymmetric PFC configuration."""
+    config_db = ctx.obj["config_db"]
+    interface = ctx.obj["interface_name"]
+
     run_command("pfc config asymmetric {0} {1}".format(status, interface))
 
 #


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Fix config CLI command according to latest changes
**- How I did it**
There was recent changes which changed syntax for ```interface`` config command (PR https://github.com/Azure/sonic-utilities/pull/308).
Asymmetric PFC config command wasn't aligned to the new syntax.
In order to fix the issue just changed the command in order to use new syntax.
**- How to verify it**
Verify that below commands are working without any errors
```
config interface Ethernet0 pfc asymmetric on
config interface Ethernet0 pfc asymmetric off
```
**- Previous command output (if the output of a command-line utility has changed)**
N/A
**- New command output (if the output of a command-line utility has changed)**
N/A


