### PR TITLE
[sfputil] add logic to avoid access none present SFP eeprom

### DIFF
--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -185,7 +185,11 @@ def port_eeprom_data_string_pretty(logical_port_name, dump_dom):
 
     for physical_port in physical_port_list:
         port_name = get_physical_port_name(logical_port_name, i, ganged)
-        eeprom_dict = platform_sfputil.get_eeprom_dict(physical_port)
+        if not platform_sfputil.get_presence(physical_port):
+            eeprom_dict = None
+        else:
+            eeprom_dict = platform_sfputil.get_eeprom_dict(physical_port)
+
         if eeprom_dict is not None:
             eeprom_iface_dict = eeprom_dict.get('interface')
             iface_data_dict = eeprom_iface_dict.get('data')
@@ -228,7 +232,10 @@ def port_eeprom_data_string_pretty_oneline(logical_port_name,
         ganged = True
 
     for physical_port in physical_port_list:
-        eeprom_dict = platform_sfputil.get_eeprom_dict(physical_port)
+        if not platform_sfputil.get_presence(physical_port):
+            eeprom_dict = None
+        else:
+            eeprom_dict = platform_sfputil.get_eeprom_dict(physical_port)
 
         # Only print detected sfp ports for oneline
         if eeprom_dict is not None:
@@ -266,7 +273,11 @@ def port_eeprom_data_raw_string_pretty(logical_port_name):
 
     for physical_port in physical_port_list:
         port_name = get_physical_port_name(logical_port_name, i, ganged)
-        eeprom_raw = platform_sfputil.get_eeprom_raw(physical_port)
+        if not platform_sfputil.get_presence(physical_port):
+            eeprom_raw = None
+        else:
+            eeprom_raw = platform_sfputil.get_eeprom_raw(physical_port)
+
         if eeprom_raw is None:
             result += get_sfp_eeprom_status_string(port_name, False)
             result += "\n"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
When access an SFP eeprom which not presente will cause error print from the kernel modules:
    `ERR kernel: [41770.216758] mlxsw_minimal 2-0048: Eeprom query failed`
to avoid this need to prevent from accessing none presence SFP eeprom

**- How I did it**
before read the SFP eeprom, add logic to determine the presence of SFP with method get_presence() 

**- How to verify it**
run "show interface transceiver eeprom EthernetX" command to verify

**- Previous command output (if the output of a command-line utility has changed)**
no change for command output

**- New command output (if the output of a command-line utility has changed)**
no change for command output


