### PR TITLE
[ntp] show ntp may take 20 seconds due to DNS issue.

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1145,7 +1145,7 @@ def bgp(verbose):
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def ntp(verbose):
     """Show NTP information"""
-    cmd = "ntpq -p"
+    cmd = "ntpq -p -n"
     run_command(cmd, display_cmd=verbose)
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Fix `show ntp` takes about 20 seconds.

**- How I did it**
add `-n` option to `ntpq`

**- How to verify it**
```
axxx@xxx-yyy:~$ date; show ntp; date
Wed Oct 24 08:44:28 CST 2018
Command: ntpq -p
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
 11.1.1.99       .INIT.          16 u    -   64    0    0.000    0.000   0.000

Wed Oct 24 08:44:48 CST 2018

axxx@xxx-yyy:~$ date; show ntp; date
Wed Oct 24 09:00:07 CST 2018
Command: ntpq -p -n
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
 11.1.1.99       .XFAC.          16 u    -   64    0    0.000    0.000   0.000

Wed Oct 24 09:00:07 CST 2018
axxx@xxx-yyy:~$ 
```

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

