### PR TITLE
[show]: Fixing traceback for show vlan brief

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1232,8 +1232,14 @@ def brief(verbose):
     # vlan_dhcp_helper_dict={}, vlan_ip_dict = {}, vlan_ports_dict = {}
     for key in natsorted(vlan_dhcp_helper_dict.keys()):
         dhcp_helpers = ','.replace(',', '\n').join(vlan_dhcp_helper_dict[key])
-        ip_address = ','.replace(',', '\n').join(vlan_ip_dict[key])
-        vlan_ports = ','.replace(',', '\n').join((vlan_ports_dict[key]))
+        if key not in vlan_ip_dict:
+            ip_address = ""
+        else:
+            ip_address = ','.replace(',', '\n').join(vlan_ip_dict[key])
+        if key not in vlan_ports_dict:
+            vlan_ports = ""
+        else:
+            vlan_ports = ','.replace(',', '\n').join((vlan_ports_dict[key]))
         body.append([key, ip_address, vlan_ports, dhcp_helpers])
     click.echo(tabulate(body, header, tablefmt="grid"))
 


### PR DESCRIPTION
     * Fixing `show vlan brief` traceback

       Signed-off-by: Stegen Smith <stegen@owns.com>

This resolves #357 

**- What I did**
Did some key checking to ensure the key exists in the dict, instead of assuming it does.

**- How I did it**

**- How to verify it**
Run `show vlan brief` with the fix.
**- Previous command output (if the output of a command-line utility has changed)**
```
root@sonic:/home/user# show vlan brief
Traceback (most recent call last):
  File "/usr/bin/show", line 9, in <module>
    load_entry_point('sonic-utilities==1.2', 'console_scripts', 'show')()
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/show/main.py", line 1233, in brief
    ip_address = ','.replace(',', '\n').join(vlan_ip_dict[key])
KeyError: '1000'
root@sonic:/home/user#
```
**- New command output (if the output of a command-line utility has changed)**

```
root@sonic:/home/user# show vlan brief
+-----------+--------------+------------+-----------------------+
|   VLAN ID | IP Address   | Ports      | DHCP Helper Address   |
+===========+==============+============+=======================+
|      1000 |              | Ethernet0  |                       |
+-----------+--------------+------------+-----------------------+
|      1001 |              | Ethernet4  |                       |
+-----------+--------------+------------+-----------------------+
|      1002 |              | Ethernet8  |                       |
+-----------+--------------+------------+-----------------------+
|      1003 |              | Ethernet12 |                       |
+-----------+--------------+------------+-----------------------+
|      2000 |              | Ethernet0  |                       |
+-----------+--------------+------------+-----------------------+
|      2001 |              | Ethernet4  |                       |
+-----------+--------------+------------+-----------------------+
|      2002 |              | Ethernet8  |                       |
+-----------+--------------+------------+-----------------------+
|      2003 |              | Ethernet12 |                       |
+-----------+--------------+------------+-----------------------+
root@sonic:/home/user# 
```

This is pretty similar to the work being done in #355, but my changes aren't captured there.

