### PR TITLE
[config]: Fix bug of losing data when setting admin status

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -749,9 +749,9 @@ def startup(ctx):
     interface_name = ctx.obj['interface_name']
 
     if interface_name.startswith("Ethernet"):
-        config_db.set_entry("PORT", interface_name, {"admin_status": "up"})
+        config_db.mod_entry("PORT", interface_name, {"admin_status": "up"})
     elif interface_name.startswith("PortChannel"):
-        config_db.set_entry("PORTCHANNEL", interface_name, {"admin_status": "up"})
+        config_db.mod_entry("PORTCHANNEL", interface_name, {"admin_status": "up"})
 #
 # 'shutdown' subcommand
 #
@@ -764,9 +764,9 @@ def shutdown(ctx):
     interface_name = ctx.obj['interface_name']
 
     if interface_name.startswith("Ethernet"):
-        config_db.set_entry("PORT", interface_name, {"admin_status": "down"})
+        config_db.mod_entry("PORT", interface_name, {"admin_status": "down"})
     elif interface_name.startswith("PortChannel"):
-        config_db.set_entry("PORTCHANNEL", interface_name, {"admin_status": "down"})
+        config_db.mod_entry("PORTCHANNEL", interface_name, {"admin_status": "down"})
 
 #
 # 'speed' subcommand


### PR DESCRIPTION
Shall use mod_entry instead of set_entry when updating partial
information in the configuration database. set_entry will delete
the rest of the data associated with this entry.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>

Test result:

```
admin@str-s6100-acs-2:~$ redis-dump -d 4 | python -mjson.tool | grep -A10 PORT\|Ethernet18
    "PORT|Ethernet18": {
        "type": "hash",
        "value": {
            "admin_status": "up",
            "alias": "fortyGigE1/2/3",
            "index": "18",
            "lanes": "29,30",
            "mtu": "9100",
            "speed": "40000"
        }
    },
admin@str-s6100-acs-2:~$ sudo config interface Ethernet18 shutdown
admin@str-s6100-acs-2:~$ redis-dump -d 4 | python -mjson.tool | grep -A10 PORT\|Ethernet18
    "PORT|Ethernet18": {
        "type": "hash",
        "value": {
            "admin_status": "down",
            "alias": "fortyGigE1/2/3",
            "index": "18",
            "lanes": "29,30",
            "mtu": "9100",
            "speed": "40000"
        }
    },
```