### PR TITLE
Fix to get all port related attributes from config_db

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -12,19 +12,16 @@ import sonic_platform
 from swsssdk import ConfigDBConnector
 from natsort import natsorted
 from minigraph import parse_device_desc_xml
-from portconfig import get_port_config
 
 import aaa
 import mlnx
 
-PLATFORM_ROOT_PATH = '/usr/share/sonic/device'
 SONIC_CFGGEN_PATH = '/usr/local/bin/sonic-cfggen'
-HWSKU_KEY = 'DEVICE_METADATA.localhost.hwsku'
-PLATFORM_KEY = 'DEVICE_METADATA.localhost.platform'
 
 #
 # Helper functions
 #
+
 
 def run_command(command, display_cmd=False, ignore_error=False):
     """Run bash command and print output to stdout

--- a/config/main.py
+++ b/config/main.py
@@ -52,6 +52,7 @@ def interface_alias_to_name(interface_alias):
     if interface_alias is not None:
         if not port_dict:
             click.echo("port_dict is None!")
+            raise click.Abort()
         for port_name in natsorted(port_dict.keys()):
             if interface_alias == port_dict[port_name]['alias']:
                 return port_name
@@ -70,6 +71,7 @@ def interface_name_to_alias(interface_name):
     if interface_name is not None:
         if not port_dict:
             click.echo("port_dict is None!")
+            raise click.Abort()
         for port_name in natsorted(port_dict.keys()):
             if interface_name == port_name:
                 return port_dict[port_name]['alias']

--- a/show/main.py
+++ b/show/main.py
@@ -19,10 +19,7 @@ from portconfig import get_port_config
 
 import mlnx
 
-PLATFORM_ROOT_PATH = '/usr/share/sonic/device'
 SONIC_CFGGEN_PATH = '/usr/local/bin/sonic-cfggen'
-HWSKU_KEY = 'DEVICE_METADATA.localhost.hwsku'
-PLATFORM_KEY = 'DEVICE_METADATA.localhost.platform'
 
 try:
     # noinspection PyPep8Naming

--- a/show/main.py
+++ b/show/main.py
@@ -61,6 +61,7 @@ class InterfaceAliasConverter(object):
 
         if not self.port_dict:
             click.echo("port_dict is None!")
+            raise click.Abort()
 
         for port_name in self.port_dict.keys():
             if self.alias_max_length < len(

--- a/show/main.py
+++ b/show/main.py
@@ -15,7 +15,6 @@ from tabulate import tabulate
 import sonic_platform
 from swsssdk import ConfigDBConnector
 from swsssdk import SonicV2Connector
-from portconfig import get_port_config
 
 import mlnx
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
- interface_naming_mode functions fetch the alias_interface_name via sonic-cfggen. But, with the recent change in config_db removes all port related entries when a sepecific interface is down. This affects the existing implementation of fetching port details to following fucntions [ interface_alias_to_name(), interface_name_to_allias(), InterfaceAliasConverter() ] and throws key error.

**- How I did it**

- To fix this, harnessed the existing port_config.ini file to fetch the interface details and populated a port_dict and this fetch the alias interface names quickly.

NOTE: config commands are entirely modified from linux commands to db format. This fix does not cover interface validation for those commands.


