### PR TITLE
[fast-reboot]: Use pkill instead of killall

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -95,8 +95,8 @@ if [[ "$REBOOT_TYPE" = "warm-reboot" ]]; then
 fi
 
 # Kill bgpd to start the bgp graceful restart procedure
-docker exec -i bgp killall -9 zebra
-docker exec -i bgp killall -9 bgpd
+docker exec -i bgp pkill -9 zebra
+docker exec -i bgp pkill -9 bgpd
 
 # Kill lldp, otherwise it sends informotion about reboot
 docker kill lldp > /dev/null


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Fix https://github.com/Azure/sonic-utilities/issues/364 Use pkill instead of killall as suggested.

**- How I did it**
sed s/killall/pkill/

**- How to verify it**
When sonic is running, issue sudo fast-reboot command and check you don't see any error messages on the screen.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

