### PR TITLE
Revert "[acl_loader] fix show acl table  (#329)"

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -498,8 +498,7 @@ class AclLoader(object):
                 if not val["ports"]:
                     data.append([key, val["type"], "", val["policy_desc"]])
                 else:
-                    ports = val["ports"].split(",")
-                    ports.sort(key=lambda name:int(name.strip('Ethernet')))
+                    ports = natsorted(val["ports"])
                     data.append([key, val["type"], ports[0], val["policy_desc"]])
 
                     if len(ports) > 1:


### PR DESCRIPTION
This reverts commit 7a51a85615eccab3e4bed943e0e25deb39dec4c7.

@kevinwangsk reported regression:
> Recently we found CLI “acl-loader show table” crashed. The error is “ports = val["ports"].split(",")  AttributeError: 'list' object has no attribute 'split'”.