### PR TITLE
[warm boot] save log level DB contents

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -130,6 +130,8 @@ if [[ "$REBOOT_TYPE" = "warm-reboot" ]]; then
     $DUMP_CMD -d 6 -k "[FW][DA][BR][_M][T_][AR][BE][LS][ET][|A]*" -o $WARM_DIR/state_db.json
     # Save asicDB in /host/warm-reboot/asic_db.json
     $DUMP_CMD -d 1 -o $WARM_DIR/asic_db.json
+    # Save loglevelDB in /host/warm-reboot/loglevel_db.json
+    $DUMP_CMD -d 3 -o $WARM_DIR/loglevel_db.json
 fi
 
 if [[ "$REBOOT_TYPE" = "warm-reboot" ]]; then


### PR DESCRIPTION
Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- What I did**
Back up log level db contents during warm shutdown. And restore in warm boot up sequence. 

So that after warm reboot, the log level will remain the same as before
warm boot.

**- How to verify it**
Use swssloglevel to set syncd log level to INFO, execute full system warm reboot, verify that after boot up, syncd log level is still at INFO level.
(Require build image PR 2233)