### PR TITLE
[warm boot] move warm reboot/fast reboot knowledge to syncd service script

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -147,22 +147,8 @@ if [[ "$REBOOT_TYPE" = "warm-reboot" ]]; then
     $DUMP_CMD -d 3 -o $WARM_DIR/loglevel_db.json
 fi
 
-if [[ "$REBOOT_TYPE" = "warm-reboot" ]]; then
-    # Gracefully stop syncd for warm-reboot
-    systemctl stop syncd
-elif [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
-    # syncd graceful stop for fast-reboot is supported only for Broadcom platforms only for now
-    if [[ "$sonic_asic_type" = 'broadcom' ]]; then
-        # Gracefully stop syncd
-        docker exec -i syncd /usr/bin/syncd_request_shutdown --cold > /dev/null
-
-        # Check that syncd was stopped
-        while docker top syncd | grep -q /usr/bin/syncd
-        do
-            sleep 0.1
-        done
-    fi
-fi
+# syncd service stop is capable of handling both warm/fast/cold shutdown
+systemctl stop syncd
 
 # Kill other containers to make the reboot faster
 docker ps -q | xargs docker kill > /dev/null

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -132,6 +132,9 @@ fi
 # Kill swss dockers
 docker kill swss
 
+# syncd service stop is capable of handling both warm/fast/cold shutdown
+systemctl stop syncd
+
 # Warm reboot: dump state to host disk
 # Note: even if syncd changed ASIC_DB before killed, we don't care
 if [[ "$REBOOT_TYPE" = "warm-reboot" ]]; then
@@ -153,9 +156,6 @@ if [[ "$REBOOT_TYPE" = "warm-reboot" ]]; then
     # Save loglevelDB in /host/warm-reboot/loglevel_db.json
     $DUMP_CMD -d 3 -o $WARM_DIR/loglevel_db.json
 fi
-
-# syncd service stop is capable of handling both warm/fast/cold shutdown
-systemctl stop syncd
 
 # Kill other containers to make the reboot faster
 docker ps -q | xargs docker kill > /dev/null

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -4,6 +4,17 @@ REBOOT_USER=$(logname)
 REBOOT_TIME=$(date)
 REBOOT_CAUSE_FILE="/var/cache/sonic/reboot-cause.txt"
 REBOOT_TYPE=$(basename $0)
+WARM_DIR=/host/warmboot
+
+function clear_warm_boot()
+{
+    config warm_restart disable || /bin/true
+
+    TIMESTAMP=`date +%Y%m%d-%H%M%S`
+    if [[ -f ${WARM_DIR}/config_db.json ]]; then
+        mv -f ${WARM_DIR}/config_db.json ${WARM_DIR}/config_db-${TIMESTAMP}.json || /bin/true
+    fi
+}
 
 # Check reboot type supported
 BOOT_TYPE_ARG="cold"
@@ -13,6 +24,8 @@ case "$REBOOT_TYPE" in
         ;;
     "warm-reboot")
         BOOT_TYPE_ARG="warm"
+        trap clear_warm_boot EXIT HUP INT QUIT TERM KILL ABRT ALRM
+        config warm_restart enable system
         ;;
     *)
         echo "Not supported reboot type: $REBOOT_TYPE" >&2
@@ -116,11 +129,6 @@ if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
     docker kill teamd > /dev/null
 fi
 
-if [[ "$REBOOT_TYPE" = "warm-reboot" ]]; then
-    # Set whole system warm reboot flag
-    config warm_restart enable system
-fi
-
 # Kill swss dockers
 docker kill swss
 
@@ -130,7 +138,6 @@ if [[ "$REBOOT_TYPE" = "warm-reboot" ]]; then
     # Dump redis content to directory
     # Note: don't use pretty mode redis-dump (1.1) since there is a known bug with key pattern
     DUMP_CMD="redis-dump -s /var/run/redis/redis.sock"
-    WARM_DIR=/host/warmboot
     mkdir -p $WARM_DIR
     # Note: requiring redis-dump-load
     # Save applDB in /host/warm-reboot/appl_db.json

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 REBOOT_USER=$(logname)
 REBOOT_TIME=$(date)

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -116,14 +116,17 @@ if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
     docker kill teamd > /dev/null
 fi
 
+if [[ "$REBOOT_TYPE" = "warm-reboot" ]]; then
+    # Set whole system warm reboot flag
+    config warm_restart enable system
+fi
+
 # Kill swss dockers
 docker kill swss
 
 # Warm reboot: dump state to host disk
 # Note: even if syncd changed ASIC_DB before killed, we don't care
 if [[ "$REBOOT_TYPE" = "warm-reboot" ]]; then
-    # Set whole system warm reboot flag
-    config warm_restart enable system
     # Dump redis content to directory
     # Note: don't use pretty mode redis-dump (1.1) since there is a known bug with key pattern
     DUMP_CMD="redis-dump -s /var/run/redis/redis.sock"


### PR DESCRIPTION
**- What I did**
This PR is enabled by sonic-buildimage PR 2238

In test, we found that when issue-ing "docker kill swss", it causes swss service to become FAILED. As result, systemctrl will execute swss stop script. Which will also stop syncd service if the warmboot flag is not set in warm boot case. Before sonic-buildimage PR 2238, this will cause syncd process being killed instead of shutting down properly in both warm/fast reboot cases. Most importantly switch_remove() is not called. For both warm boot and fast reboot, properly shutting down syncd process is very crucial to the operations.

- Setting warm boot flag before kill swss docker, so that it won't stop syncd at the same time. (syncd will be stopped explicitly later)
- In fast reboot case, syncd script has knowledge to stop syncd process before killing the docker, which satisfies the fast reboot requirement.

**- How to verify it**
Please see verification steps in sonic-buildimage PR 2238