### PR TITLE
[reboot] clear warm boot files when reboot is requested

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -14,6 +14,16 @@ function stop_sonic_services()
     sleep 3
 }
 
+function clear_warm_boot()
+{
+    # If reboot is requested, make sure the outstanding warm-boot is cleared
+    # So the system will come up from a cold boot.
+    WB_DIR="/host/warmboot"
+    if [[ -d ${WB_DIR} ]]; then
+        rm -f ${WB_DIR}/*.json
+    fi
+}
+
 # Exit if not superuser
 if [[ "$EUID" -ne 0 ]]; then
     echo "This command must be run as root" >&2
@@ -22,6 +32,8 @@ fi
 
 # Stop SONiC services gracefully.
 stop_sonic_services
+
+clear_warm_boot
 
 # Update the reboot cause file to reflect that user issued 'reboot' command
 # Upon next boot, the contents of this file will be used to determine the

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -18,9 +18,10 @@ function clear_warm_boot()
 {
     # If reboot is requested, make sure the outstanding warm-boot is cleared
     # So the system will come up from a cold boot.
-    WB_DIR="/host/warmboot"
-    if [[ -d ${WB_DIR} ]]; then
-        rm -f ${WB_DIR}/*.json
+    WARM_DIR="/host/warmboot"
+    TIMESTAMP=`date +%Y%m%d-%H%M%S`
+    if [[ -f ${WARM_DIR}/config_db.json ]]; then
+        mv -f ${WARM_DIR}/config_db.json ${WARM_DIR}/config_db-${TIMESTAMP}.json
     fi
 }
 


### PR DESCRIPTION
Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- What I did**
Both warm/fast reboot are invoking /sbin/reboot directly.

If user invoked 'reboot', one scenario could be that user tried to issue
either fast or warm reboot and failed to complete. User then tries to
recover the system with a cold reboot.

In this scenario, particularly after warm-reboot request failed, we should
remove db backup files, so that the system will come up and perform a cold
recovery.

**- How to verify it**
created a few .json files under /host/warmboot. issue reboot, and after device rebooted, these .json files are gone.

touch /host/warmboot/config_db.json
reboot
After device boot up, check /host/warmboot, config_db.json has been renamed to config_db-\<timestamp\>.json