### PR TITLE
Stop teamd gracefully in both modes

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -101,10 +101,20 @@ docker exec -i bgp pkill -9 bgpd
 # Kill lldp, otherwise it sends informotion about reboot
 docker kill lldp > /dev/null
 
-# Kill teamd, otherwise it gets down all LAGs
-# Note: teamd must be killed before syncd, because it will send the last packet through CPU port
-# TODO: stop teamd gracefully to allow teamd to send last valid update to be sure we'll have 90 seconds reboot time
-docker kill teamd > /dev/null
+# Stop teamd gracefully
+if [[ "$REBOOT_TYPE" = "warm-reboot" ]]; then
+    # Send USR1 signal to all teamd instances to stop them
+    # It will prepare teamd for warm-reboot
+    # Note: We must send USR1 signal before syncd, because it will send the last packet through CPU port
+    docker exec -ti teamd pkill -USR1 teamd > /dev/null
+fi
+
+if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
+    # Kill teamd, otherwise it gets down all LAGs
+    # Note: teamd must be killed before syncd, because it will send the last packet through CPU port
+    # TODO: stop teamd gracefully to allow teamd to send last valid update to be sure we'll have 90 seconds reboot time
+    docker kill teamd > /dev/null
+fi
 
 # Kill swss dockers
 docker kill swss

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -106,7 +106,7 @@ if [[ "$REBOOT_TYPE" = "warm-reboot" ]]; then
     # Send USR1 signal to all teamd instances to stop them
     # It will prepare teamd for warm-reboot
     # Note: We must send USR1 signal before syncd, because it will send the last packet through CPU port
-    docker exec -ti teamd pkill -USR1 teamd > /dev/null
+    docker exec -i teamd pkill -USR1 teamd > /dev/null
 fi
 
 if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Change how we stop teamd.

**- How I did it**
In fast-reboot mode the teamd stopping method are the same.
In warm-reboot mode the teamd stopping method uses USR1 signal.

**- How to verify it**
1. Build an image with the changes and issue `sudo warm-reboot` command.
2. teamd must send lacp updates on all lagg member interfaces
3. After restart you should see lacp dump files in /host/warmboot/teamd/

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

