### PR TITLE
Accommodate syntax change in ecn/wred profile apply

### DIFF
--- a/scripts/ecnconfig
+++ b/scripts/ecnconfig
@@ -134,7 +134,7 @@ class EcnQ(object):
     Process ecn on/off on queues
     """
     def __init__(self, queues, verbose):
-        self.ports_key = ''
+        self.ports_key = []
         self.queues = queues.split(',')
         self.validate_queues()
         self.verbose = verbose
@@ -156,35 +156,32 @@ class EcnQ(object):
     # TODO: Change to use active ports only
     def gen_ports_key(self):
         if self.ports_key is not None:
-            ports = []
-
             port_table = self.config_db.get_table(PORT_TABLE_NAME)
-            for port in port_table:
-                ports.append(port)
+            self.ports_key = port_table.keys()
 
-            self.ports_key = ','.join(sorted(ports, key = lambda k: int(k[8:])))
+            self.ports_key.sort(key = lambda k: int(k[8:]))
 
     def set(self, enable):
         if os.geteuid() != 0:
             sys.exit("Root privileges required for this operation")
         for queue in self.queues:
             if self.verbose:
-                print("%s ECN on %s queue %s" % ("Enable" if enable else "Disable", self.ports_key, queue))
-            key = '|'.join([self.ports_key, queue])
-            self.config_db.mod_entry(QUEUE_TABLE_NAME, key, {FIELD: ON if enable else OFF})
+                print("%s ECN on %s queue %s" % ("Enable" if enable else "Disable", ','.join(self.ports_key), queue))
+            for port_key in self.ports_key:
+                key = '|'.join([port_key, queue])
+                self.config_db.mod_entry(QUEUE_TABLE_NAME, key, {FIELD: ON if enable else OFF})
 
     def get(self):
         print("ECN status:")
         for queue in self.queues:
             out = ' '.join(['queue', queue])
             if self.verbose:
-                out = ' '.join([self.ports_key, out])
+                out = ' '.join([','.join(self.ports_key), out])
 
-            key = '|'.join([QUEUE_TABLE_NAME, self.ports_key, queue])
+            # ecn on/off status on a queue index is homogeneous among all ports
+            # checking one port is sufficient
+            key = '|'.join([QUEUE_TABLE_NAME, self.ports_key[0], queue])
             val = self.db.get(self.db.CONFIG_DB, key, FIELD)
-            if not val:
-                key = '|'.join([QUEUE_TABLE_NAME, self.ports_key, '3-4'])
-                val = self.db.get(self.db.CONFIG_DB, key, FIELD)
 
             if val == ON:
                 print("%s: on" % (out))


### PR DESCRIPTION
New syntax:

"Ethernet0|4": {
    "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]",
    "scheduler": "[SCHEDULER|scheduler.0]"
},

Signed-off-by: Wenda <wenni@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
On dut:

$ sudo ecnconfig -q 3 on -vv
Enable ECN on Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124 queue 3

$ sudo ecnconfig -q 4 off -vv 
Disable ECN on Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124 queue 4

$ sudo ecnconfig -q 3,4 -vv  
ECN status:
Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124 queue 3: on
Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124 queue 4: off

sudo config save -y

        },
        "Ethernet0|3": {
            "wred_profile": "[]",
            "scheduler": "[SCHEDULER|scheduler.0]"
        },
        "Ethernet0|4": {
            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]",
            "scheduler": "[SCHEDULER|scheduler.0]"
        },

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

