### PR TITLE
Log message during config load_minigraph/reload

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -258,6 +258,7 @@ def _stop_services():
             run_command("systemctl stop %s" % service, display_cmd=True)
         except SystemExit as e:
             log_error("Stopping {} failed with error {}".format(service, e))
+            raise
 
 def _restart_services():
     services = [
@@ -278,6 +279,7 @@ def _restart_services():
             run_command("systemctl restart %s" % service, display_cmd=True)
         except SystemExit as e:
             log_error("Restart {} failed with error {}".format(service, e))
+            raise
 
 # This is our main entrypoint - the main 'config' command
 @click.group()


### PR DESCRIPTION
**- What I did**
Log message during `config load_minigraph`, `config reload `

**- How I did it**
Catch exception during `stop/restart` service and log the error. Reference [PR](https://github.com/Azure/sonic-utilities/pull/259) for this changes. 

**- How to verify it**
Verify the syslog

**- Previous command output (if the output of a command-line utility has changed)**
None

**- New command output (if the output of a command-line utility has changed)**
```
Nov  9 21:48:03.211117 sonic INFO config: 'load_minigraph' executing...
Nov  9 21:48:03.235307 sonic ERR config: Stopping swss failed with error 1
```

```
Nov  9 21:48:29.134913 sonic INFO config: 'reload' executing...
Nov  9 21:48:29.167651 sonic ERR config: Stopping swss failed with error 1
```

-->

