### PR TITLE
Adding bgp's warmrestart timer and on-off knob

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -524,14 +524,14 @@ def warm_restart(ctx, redis_unix_socket_path):
     pass
 
 @warm_restart.command('enable')
-@click.argument('module', metavar='<module>', default='system', required=False, type=click.Choice(["system", "swss"]))
+@click.argument('module', metavar='<module>', default='system', required=False, type=click.Choice(["system", "swss", "bgp"]))
 @click.pass_context
 def warm_restart_enable(ctx, module):
     db = ctx.obj['db']
     db.mod_entry('WARM_RESTART', module, {'enable': 'true'})
 
 @warm_restart.command('disable')
-@click.argument('module', metavar='<module>', default='system', required=False, type=click.Choice(["system", "swss"]))
+@click.argument('module', metavar='<module>', default='system', required=False, type=click.Choice(["system", "swss", "bgp"]))
 @click.pass_context
 def warm_restart_enable(ctx, module):
     db = ctx.obj['db']
@@ -545,6 +545,15 @@ def warm_restart_neighsyncd_timer(ctx, seconds):
     if seconds not in range(1,9999):
         ctx.fail("neighsyncd warm restart timer must be in range 1-9999")
     db.mod_entry('WARM_RESTART', 'swss', {'neighsyncd_timer': seconds})
+
+@warm_restart.command('bgp_timer')
+@click.argument('seconds', metavar='<seconds>', required=True, type=int)
+@click.pass_context
+def warm_restart_bgp_timer(ctx, seconds):
+    db = ctx.obj['db']
+    if seconds not in range(1,3600):
+        ctx.fail("bgp warm restart timer must be in range 1-3600")
+    db.mod_entry('WARM_RESTART', 'bgp', {'bgp_timer': seconds})
 
 #
 # 'vlan' group ('config vlan ...')

--- a/show/main.py
+++ b/show/main.py
@@ -1657,6 +1657,9 @@ def config(redis_unix_socket_path):
             if 'neighsyncd_timer' in  data[k]:
                 r.append("neighsyncd_timer")
                 r.append(data[k]['neighsyncd_timer'])
+            elif 'bgp_timer' in data[k]:
+                r.append("bgp_timer")
+                r.append(data[k]['bgp_timer'])
             else:
                 r.append("NULL")
                 r.append("NULL")


### PR DESCRIPTION
```
root@node1# config warm_restart bgp_timer 14

root@node1# show warm_restart config
name    enable    timer_name    timer_duration
------  --------  ------------  ----------------
bgp     false     bgp_timer     14
system  true      NULL          NULL


root@node1:/# config warm_restart enable bgp

root@node1:/# show warm_restart config
name    enable    timer_name    timer_duration
------  --------  ------------  ----------------
bgp     true      bgp_timer     14
system  false     NULL          NULL
```

Signed-off-by: Rodny Molina <rmolina@linkedin.com>


