### PR TITLE
[warm reboot] unload kexec before rebooting and when error exiting from warm boot

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -9,6 +9,7 @@ WARM_DIR=/host/warmboot
 function clear_warm_boot()
 {
     config warm_restart disable || /bin/true
+    /sbin/kexec -u || /bin/true
 
     TIMESTAMP=`date +%Y%m%d-%H%M%S`
     if [[ -f ${WARM_DIR}/config_db.json ]]; then

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -23,6 +23,7 @@ function clear_warm_boot()
     if [[ -f ${WARM_DIR}/config_db.json ]]; then
         mv -f ${WARM_DIR}/config_db.json ${WARM_DIR}/config_db-${TIMESTAMP}.json
     fi
+    /sbin/kexec -u || /bin/true
 }
 
 # Exit if not superuser


### PR DESCRIPTION
Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- What I did**
unload kexec config before rebooting and/or during warm reboot failure clean up.