### PR TITLE
[show command] allow warm restart table contains empty restore_count

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1624,12 +1624,12 @@ def state(redis_unix_socket_path):
         entry = db.get_all(db.STATE_DB, tk)
         r = []
         r.append(remove_prefix(tk, prefix))
-        if 'restore_count' not in  entry:
+        if 'restore_count' not in entry:
             r.append("")
         else:
             r.append(entry['restore_count'])
 
-        if 'state' not in  entry:
+        if 'state' not in entry:
             r.append("")
         else:
             r.append(entry['state'])

--- a/show/main.py
+++ b/show/main.py
@@ -1624,7 +1624,10 @@ def state(redis_unix_socket_path):
         entry = db.get_all(db.STATE_DB, tk)
         r = []
         r.append(remove_prefix(tk, prefix))
-        r.append(entry['restore_count'])
+        if 'restore_count' not in  entry:
+            r.append("")
+        else:
+            r.append(entry['restore_count'])
 
         if 'state' not in  entry:
             r.append("")


### PR DESCRIPTION
Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- What I did**
In practice, a software bug could cause not having restore_count, and
we could have use case (e.g. warm-shutdown) has state without
restore_count.

It would be nice that the command show all these rows without exception.
