### PR TITLE
[acl_loader]: Add support for parsing input interface

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -305,7 +305,7 @@ class AclLoader(object):
         else:
             return port, False
 
-    def convert_transport(self,  table_name, rule_idx, rule):
+    def convert_transport(self, table_name, rule_idx, rule):
         rule_props = {}
 
         if rule.transport.config.source_port:
@@ -340,6 +340,14 @@ class AclLoader(object):
 
         return rule_props
 
+    def convert_input_interface(self, table_name, rule_idx, rule):
+        rule_props = {}
+
+        if rule.input_interface.interface_ref.config.interface:
+            rule_props["IN_PORTS"] = rule.input_interface.interface_ref.config.interface
+
+        return rule_props
+
     def convert_rule_to_db_schema(self, table_name, rule):
         """
         Convert rules format from openconfig ACL to Config DB schema
@@ -357,6 +365,7 @@ class AclLoader(object):
         deep_update(rule_props, self.convert_l2(table_name, rule_idx, rule))
         deep_update(rule_props, self.convert_ip(table_name, rule_idx, rule))
         deep_update(rule_props, self.convert_transport(table_name, rule_idx, rule))
+        deep_update(rule_props, self.convert_input_interface(table_name, rule_idx, rule))
 
         return rule_data
 


### PR DESCRIPTION
If input_interface is set, it will be converted to IN_PORTS.
```
format:
"input-interface": {
  "interface-ref": {
    "config": {
      "interface": <interface_list>
    }
  }
}
```
It will be parsed and converted to:
"IN_PORTS": <interface_list>
as an attribute to the current ACL rule.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>