### PR TITLE
[warm reboot] wait 1 second before retrying pausing orchagent

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -105,6 +105,7 @@ if [[ "$REBOOT_TYPE" = "warm-reboot" ]]; then
             echo "RESTARTCHECK failed finally" >&2
             exit 10
         fi
+        sleep 1
     done
 fi
 


### PR DESCRIPTION
Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- What I did**
When pausing orchagent fails, it could fail quickly in succession. That defeats the purpose of retrying 5 times. Add a sleep in between retries.
