### PR TITLE
[warm reboot] don't remove opennsl module during warm reboot

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -160,11 +160,13 @@ docker ps -q | xargs docker kill > /dev/null
 # Stop the docker container engine. Otherwise we will have a broken docker storage
 systemctl stop docker.service
 
-# Stop opennsl modules for Broadcom platform
-if [[ "$sonic_asic_type" = 'broadcom' ]];
-then
-  service_name=$(systemctl list-units --plain --no-pager --no-legend --type=service | grep opennsl | cut -f 1 -d' ')
-  systemctl stop "$service_name"
+if [[ "$REBOOT_TYPE" != "warm-reboot" ]]; then
+    # Stop opennsl modules for Broadcom platform
+    if [[ "$sonic_asic_type" = 'broadcom' ]];
+    then
+      service_name=$(systemctl list-units --plain --no-pager --no-legend --type=service | grep opennsl | cut -f 1 -d' ')
+      systemctl stop "$service_name"
+    fi
 fi
 
 # Stop kernel modules for Nephos platform


### PR DESCRIPTION
Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- What I did**
Do not explicitly remove opennsl module during warm reboot. Removing the module introduces a 30+ seconds delay when kernel removes the netdevs.
