### PR TITLE
enable/disable warm_restart for teamd docker

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -564,14 +564,14 @@ def warm_restart(ctx, redis_unix_socket_path):
     pass
 
 @warm_restart.command('enable')
-@click.argument('module', metavar='<module>', default='system', required=False, type=click.Choice(["system", "swss", "bgp"]))
+@click.argument('module', metavar='<module>', default='system', required=False, type=click.Choice(["system", "swss", "bgp", "teamd"]))
 @click.pass_context
 def warm_restart_enable(ctx, module):
     db = ctx.obj['db']
     db.mod_entry('WARM_RESTART', module, {'enable': 'true'})
 
 @warm_restart.command('disable')
-@click.argument('module', metavar='<module>', default='system', required=False, type=click.Choice(["system", "swss", "bgp"]))
+@click.argument('module', metavar='<module>', default='system', required=False, type=click.Choice(["system", "swss", "bgp", "teamd"]))
 @click.pass_context
 def warm_restart_enable(ctx, module):
     db = ctx.obj['db']


### PR DESCRIPTION
Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
enable warm_restart for teamd and verify restarting teamd will have warm restart option.

```
admin@vlab-01:/usr/share$ sudo config warm_restart enable teamd
admin@vlab-01:/usr/share$ redis-cli -n 4
127.0.0.1:6379[4]> keys *WARM*
1) "WARM_RESTART|teamd"
127.0.0.1:6379[4]> hgetall "WARM_RESTART|teamd"
1) "enable"
2) "true"
127.0.0.1:6379[4]> exit
admin@vlab-01:/usr/share$ sudo systemctl restart teamd
admin@vlab-01:/usr/share$ ps aux | grep team
admin    29542  0.0  0.1  11820  2988 ?        Ss   09:36   0:00 /bin/bash /usr/bin/teamd.sh attach
admin    29546  0.6  1.2 162648 25668 ?        Sl   09:36   0:00 docker attach --no-stdin teamd
root     29622  7.0  0.7  49128 15272 pts/3    S    09:36   0:00 /usr/bin/python /usr/bin/supervisorctl start teammgrd
root     29623  0.0  0.2  99900  4036 pts/3    Sl   09:36   0:00 /usr/bin/teammgrd
root     29628  0.0  0.1  31356  2560 ?        S    09:36   0:00 /usr/bin/teamd -w -o -t PortChannel0001 -c {"device":"PortChannel0001","hwaddr":"52:54:00:6b:9c:76","runner":{"active":"true","name":"lacp","min_ports":1}} -L /var/warmboot/teamd/ -d
root     29636  0.0  0.1  31356  2504 ?        S    09:36   0:00 /usr/bin/teamd -w -o -t PortChannel0002 -c {"device":"PortChannel0002","hwaddr":"52:54:00:6b:9c:76","runner":{"active":"true","name":"lacp","min_ports":1}} -L /var/warmboot/teamd/ -d
root     29644  1.0  0.1  31356  2508 ?        S    09:36   0:00 /usr/bin/teamd -w -o -t PortChannel0003 -c {"device":"PortChannel0003","hwaddr":"52:54:00:6b:9c:76","runner":{"active":"true","name":"lacp","min_ports":1}} -L /var/warmboot/teamd/ -d
root     29652  0.0  0.1  31356  2496 ?        S    09:36   0:00 /usr/bin/teamd -w -o -t PortChannel0004 -c {"device":"PortChannel0004","hwaddr":"52:54:00:6b:9c:76","runner":{"active":"true","name":"lacp","min_ports":1}} -L /var/warmboot/teamd/ -d
admin    29658  0.0  0.0  13380   956 ttyS0    R+   09:36   0:00 grep team
```
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

