### PR TITLE
[sonic-utilities/config]: Fix Config Command for Change Port Speed

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -825,7 +825,7 @@ def shutdown(ctx):
 @click.pass_context
 @click.argument('interface_speed', metavar='<interface_speed>', required=True)
 @click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
-def speed(ctx, verbose):
+def speed(ctx, interface_speed, verbose):
     """Set interface speed"""
     interface_name = ctx.obj['interface_name']
 


### PR DESCRIPTION
* Fix Unexpected keyword argument when changing port speed using config
command

Signed-off-by: gene_kuo@edge-core.com

Fixes #397 

**- What I did**

Fix Unexpected keyword argument when changing port speed using config
command

**- How I did it**

Add argument "interface_speed" to function "speed" in config/main.py

**- How to verify it**

Run ```config interface Ethernet0 speed 100```

**- Previous command output (if the output of a command-line utility has changed)**

```
admin@sonic:~$ sudo config interface Ethernet0 speed 100
Traceback (most recent call last):
  File "/usr/bin/config", line 9, in <module>
    load_entry_point('sonic-utilities==1.2', 'console_scripts', 'config')()
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
TypeError: speed() got an unexpected keyword argument 'interface_speed'
```

**- New command output (if the output of a command-line utility has changed)**

No output expected
