### PR TITLE
Obfuscate TACACS key in `show run all` and `show tacacs`

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1166,7 +1166,7 @@ def runningconfiguration():
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def all(verbose):
     """Show full running configuration"""
-    cmd = "sonic-cfggen -d --print-data"
+    cmd = "sonic-cfggen -d --print-data | sed 's/\\\"passkey\\\": \\\".*\\\"/\\\"passkey\\\": \\\"********\\\"/g'"
     run_command(cmd, display_cmd=verbose)
 
 
@@ -1455,12 +1455,16 @@ def tacacs():
     tacplus = {
         'global': {
             'auth_type': 'pap (default)',
-            'timeout': '5 (default)',
-            'passkey': '<EMPTY_STRING> (default)'
+            'timeout': '5 (default)'
         }
     }
     if 'global' in data:
         tacplus['global'].update(data['global'])
+        if 'passkey' in data['global']:
+            tacplus['global']['passkey'] = data['global']['passkey'][0:2] + '******'
+    if not 'passkey' in tacplus['global']:
+        tacplus['global']['passkey'] = '<EMPTY_STRING> (default)'
+
     for key in tacplus['global']:
         output += ('TACPLUS global %s %s\n' % (str(key), str(tacplus['global'][key])))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Obfuscate TACACS passkey in `show run all` and `show tacacs` output.
Please note that in DB the passkey is still in clear text.

**- Previous command output (if the output of a command-line utility has changed)**
```
admin@sonic:~$ show tacacs
TACPLUS global auth_type login
TACPLUS global timeout 5 (default)
TACPLUS global passkey mypasskey

TACPLUS_SERVER address 10.0.0.1
               priority 1
               tcp_port 49

TACPLUS_SERVER address 10.0.0.2
               priority 1
               tcp_port 49
```

**- New command output (if the output of a command-line utility has changed)**
```
admin@sonic:~$ show tacacs
TACPLUS global auth_type login
TACPLUS global timeout 5 (default)
TACPLUS global passkey my******

TACPLUS_SERVER address 10.0.0.1
               priority 1
               tcp_port 49

TACPLUS_SERVER address 10.0.0.2
               priority 1
               tcp_port 49
```
-->

