### PR TITLE
Fix for failed arp entries, minor display modification

### DIFF
--- a/scripts/nbrshow
+++ b/scripts/nbrshow
@@ -125,10 +125,11 @@ class NbrBase(object):
                 mac = unicode(ent[1].upper())
                 fdb_ent = next((fdb for fdb in self.bridge_mac_list[:]
                                if fdb[0] == vlanid and fdb[1] == mac), None)
+                vlan = vlanid
                 if fdb_ent is not None:
-                    vlan = vlanid
                     ent[2] = fdb_ent[2]
-
+                else:
+                    ent[2] = '-'
             ent.insert(vpos, vlan)
             output.append(ent)
 
@@ -171,6 +172,9 @@ class ArpShow(NbrBase):
             return
 
         for line in self.arpraw.splitlines()[1:]:
+            if 'ether' not in line.split():
+                continue
+
             ent = line.split()[::2]
             self.nbrdata.append(ent)
 
@@ -208,7 +212,14 @@ class NeighShow(NbrBase):
             return
 
         for line in self.arpraw.splitlines()[:]:
-            ent = line.split()[::2]
+            split = line.split()
+            if 'lladdr' not in split:
+                continue
+
+            ent = split[::2]
+
+            if 'router' not in split:
+                ent.append(split[-1])
 
             if self.iface is not None:
                 ent.insert(2, self.iface)


### PR DESCRIPTION
**- What I did**
Fix case when neighbor entry is in failed nud state. Modify display if fdb entry is not present/age-out
fixes #402 , fixes https://github.com/Azure/sonic-buildimage/issues/2258, 

**- How I did it**
-

**- How to verify it**
Run the command `show arp` and `show ndp` in DUT

**- Previous command output (if the output of a command-line utility has changed)**

```
show arp
Address       MacAddress         Iface            Vlan
------------  -----------------  ---------------  ------
192.168.0.77  00:00:11:22:33:4d  Vlan1000         -
```


**- New command output (if the output of a command-line utility has changed)**
```
show arp
Address       MacAddress         Iface            Vlan
------------  -----------------  ---------------  ------
192.168.0.77  00:00:11:22:33:4d  -                1000
```

-->

