### PR TITLE
Fix to make alias 'key' as optional atrribute in config/show commands

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -110,7 +110,7 @@ def set_interface_naming_mode(mode):
     user = os.getenv('SUDO_USER')
     bashrc_ifacemode_line = "export SONIC_CLI_IFACE_MODE={}".format(mode)
 
-    # Check alias 'key' presence in PORT dict
+    # Ensure all interfaces have an 'alias' key in PORT dict
     config_db = ConfigDBConnector()
     config_db.connect()
     port_dict = config_db.get_table('PORT')

--- a/config/main.py
+++ b/config/main.py
@@ -124,7 +124,7 @@ def set_interface_naming_mode(mode):
             if port_dict[port_name]['alias']:
                 pass
         except KeyError:
-            click.echo("Cannot set alias mode!")
+            click.echo("Platform does not support alias mapping")
             raise click.Abort()
 
     if not user:

--- a/config/main.py
+++ b/config/main.py
@@ -110,6 +110,23 @@ def set_interface_naming_mode(mode):
     user = os.getenv('SUDO_USER')
     bashrc_ifacemode_line = "export SONIC_CLI_IFACE_MODE={}".format(mode)
 
+    # Check alias 'key' presence in PORT dict
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    port_dict = config_db.get_table('PORT')
+
+    if not port_dict:
+        click.echo("port_dict is None!")
+        raise click.Abort()
+
+    for port_name in port_dict.keys():
+        try:
+            if port_dict[port_name]['alias']:
+                pass
+        except KeyError:
+            click.echo("Cannot set alias mode!")
+            raise click.Abort()
+
     if not user:
         user = os.getenv('USER')
 

--- a/show/main.py
+++ b/show/main.py
@@ -60,10 +60,13 @@ class InterfaceAliasConverter(object):
             raise click.Abort()
 
         for port_name in self.port_dict.keys():
-            if self.alias_max_length < len(
-                    self.port_dict[port_name]['alias']):
-               self.alias_max_length = len(
-                    self.port_dict[port_name]['alias'])
+            try:
+                if self.alias_max_length < len(
+                        self.port_dict[port_name]['alias']):
+                   self.alias_max_length = len(
+                        self.port_dict[port_name]['alias'])
+            except KeyError:
+                break
 
     def name_to_alias(self, interface_name):
         """Return vendor interface alias if SONiC


### PR DESCRIPTION
**- What I did**

- Relaxed the validation of alias 'key' attribute as optional one. Script won't crash in the absence of alias-names in config/show commands.

**- How I did it**
- In show/main.py we fetch the alias-interface-names at startup to calculate the maximum length. Fixed by raising exception for invalid KeyError and break the operation. So, other part of script-execution won't be affected by the absence.
- In config/main.py we need to force the user to avoid configuring the CLI ["sudo config interface_naming_mode alias" ] to alias_mode. Without any alias entries in config it is useless to proceed further. So, allow alias mode configuration only when all ports are configured with suitable alias entries.

- This fix address #403 

 **- How to verify it**
show interface status
show interface counters

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**
```
root@sonic:/home/admin# show interface status
  Interface            Lanes    Speed    MTU            Alias    Oper    Admin
-----------  ---------------  -------  -----  ---------------  ------  -------
  Ethernet0      49,50,51,52      N/A   9100   hundredGigE1/1    down       up
  Ethernet4      53,54,55,56      N/A   9100   hundredGigE1/2    down       up
  Ethernet8      57,58,59,60      N/A   9100   hundredGigE1/3    down       up
 Ethernet12      61,62,63,64      N/A   9100   hundredGigE1/4    down       up
 Ethernet16      65,66,67,68      N/A   9100   hundredGigE1/5    down       up
 Ethernet20      69,70,71,72      N/A   9100   hundredGigE1/6    down       up
 Ethernet24      73,74,75,76      N/A   9100   hundredGigE1/7    down       up
...
..
```

