### PR TITLE
[show] adding optics info to show int status command 

### DIFF
--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -6,12 +6,10 @@ import re
 from tabulate import tabulate
 from natsort import natsorted
 
-
-
 # ========================== Common interface-utils logic ==========================
 
-
 PORT_STATUS_TABLE_PREFIX = "PORT_TABLE:"
+PORT_TRANSCEIVER_TABLE_PREFIX = "TRANSCEIVER_INFO|"
 PORT_LANES_STATUS = "lanes"
 PORT_ALIAS = "alias"
 PORT_OPER_STATUS = "oper_status"
@@ -19,27 +17,23 @@ PORT_ADMIN_STATUS = "admin_status"
 PORT_SPEED = "speed"
 PORT_MTU_STATUS = "mtu"
 PORT_DESCRIPTION = "description"
-
+PORT_OPTICS_TYPE = "type"
 
 def db_connect():
     db = swsssdk.SonicV2Connector(host='127.0.0.1')
     if db == None:
         return None
-
     db.connect(db.APPL_DB)
-
     return db
 
 
 def db_keys_get(db, intf_name):
-
     if intf_name == None:
         db_keys = db.keys(db.APPL_DB, "PORT_TABLE:*")
     elif intf_name.startswith('Ethernet'):
         db_keys = db.keys(db.APPL_DB, "PORT_TABLE:%s" % intf_name)
     else:
         return None
-
     return db_keys
 
 
@@ -47,33 +41,49 @@ def db_port_status_get(db, intf_name, status_type):
     """
     Get the port status
     """
-
     full_table_id = PORT_STATUS_TABLE_PREFIX + intf_name
     status = db.get(db.APPL_DB, full_table_id, status_type)
     if status is None:
         return "N/A"
-
     if status_type == PORT_SPEED and status != "N/A":
        status = '{}G'.format(status[:-3])
-
     return status
+
+def db_connect_optics():
+    """
+    Connect to REDIS STATE DB and get optics info
+    """
+    optics_db = swsssdk.SonicV2Connector(host='127.0.0.1')
+    if optics_db == None:
+        return None
+    optics_db.connect(optics_db.STATE_DB, False)   # Make one attempt only
+    return optics_db
+
+def db_port_optics_get(optics_db, intf_name, type):
+    """
+    Get optic type info for port
+    """
+    full_table_id = PORT_TRANSCEIVER_TABLE_PREFIX + intf_name
+    optics_type = optics_db.get(optics_db.STATE_DB,full_table_id, type)
+    if optics_type is None: 
+        return "N/A" 
+    return optics_type 
+
+
 
 
 # ========================== interface-status logic ==========================
 
-header_stat = ['Interface', 'Lanes', 'Speed', 'MTU', 'Alias', 'Oper', 'Admin']
+header_stat = ['Interface', 'Lanes', 'Speed', 'MTU', 'Alias', 'Oper', 'Admin', 'OpticsType']
 
 class IntfStatus(object):
-
     def display_intf_status(self, db_keys):
         """
             Generate interface-status output
         """
-
         i = {}
         table = []
         key = []
-
         #
         # Iterate through all the keys and append port's associated state to
         # the result table.
@@ -87,23 +97,22 @@ class IntfStatus(object):
                               db_port_status_get(self.db, key, PORT_MTU_STATUS),
                               db_port_status_get(self.db, key, PORT_ALIAS),
                               db_port_status_get(self.db, key, PORT_OPER_STATUS),
-                              db_port_status_get(self.db, key, PORT_ADMIN_STATUS)))
-
+                              db_port_status_get(self.db, key, PORT_ADMIN_STATUS),
+                              db_port_optics_get(self.optics_db, key, PORT_OPTICS_TYPE)))
         # Sorting and tabulating the result table.
+        #print(table)
         sorted_table = natsorted(table)
         print tabulate(sorted_table, header_stat, tablefmt="simple", stralign='right')
-
-
     def __init__(self, intf_name):
-
         self.db = db_connect()
+        self.optics_db = db_connect_optics()
         if self.db == None:
             return
-
+        if self.optics_db == None: 
+            return 
         db_keys = db_keys_get(self.db, intf_name)
         if db_keys == None:
             return
-
         self.display_intf_status(db_keys)
 
 
@@ -114,16 +123,13 @@ header_desc = ['Interface', 'Oper', 'Admin', 'Alias', 'Description']
 
 
 class IntfDescription(object):
-
     def display_intf_description(self, db_keys):
         """
             Generate interface-description output
         """
-
         i = {}
         table = []
         key = []
-
         #
         # Iterate through all the keys and append port's associated state to
         # the result table.
@@ -136,42 +142,32 @@ class IntfDescription(object):
                               db_port_status_get(self.db, key, PORT_ADMIN_STATUS),
                               db_port_status_get(self.db, key, PORT_ALIAS),
                               db_port_status_get(self.db, key, PORT_DESCRIPTION)))
-
         # Sorting and tabulating the result table.
         sorted_table = natsorted(table)
         print tabulate(sorted_table, header_desc, tablefmt="simple", stralign='right')
-
     def __init__(self, intf_name):
-
         self.db = db_connect()
         if self.db == None:
             return
-
         db_keys = db_keys_get(self.db, intf_name)
         if db_keys == None:
             return
-
         self.display_intf_description(db_keys)
-
 
 
 def main(args):
     if len(args) == 0:
         print "No valid arguments provided"
         return
-
     command = args[0]
     if command != "status" and command != "description":
         print "No valid command provided"
         return
-
     intf_name = args[1] if len(args) == 2 else None
-
     if command == "status":
         interface_stat = IntfStatus(intf_name)
     elif command == "description":
         interface_desc = IntfDescription(intf_name)
-
     sys.exit(0)
 
 if __name__ == "__main__":

--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -33,19 +33,19 @@ def db_connect_appl():
     return appl_db
 
 
-def db_keys_get(appl_db, intf_name):
+def appl_db_keys_get(appl_db, intf_name):
 
     if intf_name is None:
-        db_keys = appl_db.keys(appl_db.APPL_DB, "PORT_TABLE:*")
+        appl_db_keys = appl_db.keys(appl_db.APPL_DB, "PORT_TABLE:*")
     elif intf_name.startswith('Ethernet'):
-        db_keys = db.keys(appl_db.APPL_DB, "PORT_TABLE:%s" % intf_name)
+        appl_db_keys = db.keys(appl_db.APPL_DB, "PORT_TABLE:%s" % intf_name)
     else:
         return None
 
-    return db_keys
+    return appl_db_keys
 
 
-def db_port_status_get(appl_db, intf_name, status_type):
+def appl_db_port_status_get(appl_db, intf_name, status_type):
     """
     Get the port status
     """
@@ -72,7 +72,7 @@ def db_connect_state():
     return state_db
 
 
-def db_port_optics_get(state_db, intf_name, type):
+def state_db_port_optics_get(state_db, intf_name, type):
     """
     Get optic type info for port
     """
@@ -88,7 +88,7 @@ header_stat = ['Interface', 'Lanes', 'Speed', 'MTU', 'Alias', 'Oper', 'Admin', '
 
 class IntfStatus(object):
 
-    def display_intf_status(self, db_keys):
+    def display_intf_status(self, appl_db_keys):
         """
             Generate interface-status output
         """
@@ -101,17 +101,17 @@ class IntfStatus(object):
         # Iterate through all the keys and append port's associated state to
         # the result table.
         #
-        for i in db_keys:
+        for i in appl_db_keys:
             key = re.split(':', i, maxsplit=1)[-1].strip()
             if key and key.startswith('Ethernet'):
                 table.append((key,
-                              db_port_status_get(self.appl_db, key, PORT_LANES_STATUS),
-                              db_port_status_get(self.appl_db, key, PORT_SPEED),
-                              db_port_status_get(self.appl_db, key, PORT_MTU_STATUS),
-                              db_port_status_get(self.appl_db, key, PORT_ALIAS),
-                              db_port_status_get(self.appl_db, key, PORT_OPER_STATUS),
-                              db_port_status_get(self.appl_db, key, PORT_ADMIN_STATUS),
-                              db_port_optics_get(self.state_db, key, PORT_OPTICS_TYPE)))
+                              appl_db_port_status_get(self.appl_db, key, PORT_LANES_STATUS),
+                              appl_db_port_status_get(self.appl_db, key, PORT_SPEED),
+                              appl_db_port_status_get(self.appl_db, key, PORT_MTU_STATUS),
+                              appl_db_port_status_get(self.appl_db, key, PORT_ALIAS),
+                              appl_db_port_status_get(self.appl_db, key, PORT_OPER_STATUS),
+                              appl_db_port_status_get(self.appl_db, key, PORT_ADMIN_STATUS),
+                              state_db_port_optics_get(self.state_db, key, PORT_OPTICS_TYPE)))
 
         # Sorting and tabulating the result table.
         sorted_table = natsorted(table)
@@ -125,12 +125,12 @@ class IntfStatus(object):
         if self.appl_db is None:
             return
         if self.state_db is None: 
-            return 
-        db_keys = db_keys_get(self.appl_db, intf_name)
-        if db_keys is None:
             return
+        appl_db_keys = appl_db_keys_get(self.appl_db, intf_name)
+        if appl_db_keys is None:
+            return
+        self.display_intf_status(appl_db_keys)
 
-        self.display_intf_status(db_keys)
 
 
 # ========================== interface-description logic ==========================
@@ -141,7 +141,7 @@ header_desc = ['Interface', 'Oper', 'Admin', 'Alias', 'Description']
 
 class IntfDescription(object):
 
-    def display_intf_description(self, db_keys):
+    def display_intf_description(self, appl_db_keys):
         """
             Generate interface-description output
         """
@@ -154,14 +154,14 @@ class IntfDescription(object):
         # Iterate through all the keys and append port's associated state to
         # the result table.
         #
-        for i in db_keys:
+        for i in appl_db_keys:
             key = re.split(':', i, maxsplit=1)[-1].strip()
             if key and key.startswith('Ethernet'):
                 table.append((key,
-                              db_port_status_get(self.db, key, PORT_OPER_STATUS),
-                              db_port_status_get(self.db, key, PORT_ADMIN_STATUS),
-                              db_port_status_get(self.db, key, PORT_ALIAS),
-                              db_port_status_get(self.db, key, PORT_DESCRIPTION)))
+                              appl_db_port_status_get(self.appl_db, key, PORT_OPER_STATUS),
+                              appl_db_port_status_get(self.appl_db, key, PORT_ADMIN_STATUS),
+                              appl_db_port_status_get(self.appl_db, key, PORT_ALIAS),
+                              appl_db_port_status_get(self.appl_db, key, PORT_DESCRIPTION)))
 
         # Sorting and tabulating the result table.
         sorted_table = natsorted(table)
@@ -169,15 +169,15 @@ class IntfDescription(object):
 
     def __init__(self, intf_name):
 
-        self.db = db_connect_appl()
-        if self.db is None:
+        self.appl_db = db_connect_appl()
+        if self.appl_db is None:
             return
 
-        db_keys = db_keys_get(self.db, intf_name)
-        if db_keys is None:
+        appl_db_keys = appl_db_keys_get(self.appl_db, intf_name)
+        if appl_db_keys is None:
             return
 
-        self.display_intf_description(db_keys)
+        self.display_intf_description(appl_db_keys)
 
 
 

--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -25,7 +25,7 @@ PORT_OPTICS_TYPE = "type"
 
 def db_connect_appl():
     appl_db = swsssdk.SonicV2Connector(host='127.0.0.1')
-    if appl_db == None:
+    if appl_db is None:
         return None
 
     appl_db.connect(appl_db.APPL_DB)
@@ -35,7 +35,7 @@ def db_connect_appl():
 
 def db_keys_get(appl_db, intf_name):
 
-    if intf_name == None:
+    if intf_name is None:
         db_keys = appl_db.keys(appl_db.APPL_DB, "PORT_TABLE:*")
     elif intf_name.startswith('Ethernet'):
         db_keys = db.keys(appl_db.APPL_DB, "PORT_TABLE:%s" % intf_name)
@@ -66,7 +66,7 @@ def db_connect_state():
     Connect to REDIS STATE DB and get optics info
     """
     state_db = swsssdk.SonicV2Connector(host='127.0.0.1')
-    if state_db == None:
+    if state_db is None:
         return None
     state_db.connect(state_db.STATE_DB, False)   # Make one attempt only
     return state_db
@@ -81,9 +81,6 @@ def db_port_optics_get(state_db, intf_name, type):
     if optics_type is None: 
         return "N/A" 
     return optics_type 
-
-
-
 
 # ========================== interface-status logic ==========================
 
@@ -125,12 +122,12 @@ class IntfStatus(object):
 
         self.appl_db = db_connect_appl()
         self.state_db = db_connect_state()
-        if self.appl_db == None:
+        if self.appl_db is None:
             return
-        if self.state_db == None: 
+        if self.state_db is None: 
             return 
         db_keys = db_keys_get(self.appl_db, intf_name)
-        if db_keys == None:
+        if db_keys is None:
             return
 
         self.display_intf_status(db_keys)
@@ -173,11 +170,11 @@ class IntfDescription(object):
     def __init__(self, intf_name):
 
         self.db = db_connect_appl()
-        if self.db == None:
+        if self.db is None:
             return
 
         db_keys = db_keys_get(self.db, intf_name)
-        if db_keys == None:
+        if db_keys is None:
             return
 
         self.display_intf_description(db_keys)

--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -6,7 +6,10 @@ import re
 from tabulate import tabulate
 from natsort import natsorted
 
+
+
 # ========================== Common interface-utils logic ==========================
+
 
 PORT_STATUS_TABLE_PREFIX = "PORT_TABLE:"
 PORT_TRANSCEIVER_TABLE_PREFIX = "TRANSCEIVER_INFO|"
@@ -19,52 +22,62 @@ PORT_MTU_STATUS = "mtu"
 PORT_DESCRIPTION = "description"
 PORT_OPTICS_TYPE = "type"
 
-def db_connect():
-    db = swsssdk.SonicV2Connector(host='127.0.0.1')
-    if db == None:
+
+def db_connect_appl():
+    appl_db = swsssdk.SonicV2Connector(host='127.0.0.1')
+    if appl_db == None:
         return None
-    db.connect(db.APPL_DB)
-    return db
+
+    appl_db.connect(appl_db.APPL_DB)
+
+    return appl_db
 
 
-def db_keys_get(db, intf_name):
+def db_keys_get(appl_db, intf_name):
+
     if intf_name == None:
-        db_keys = db.keys(db.APPL_DB, "PORT_TABLE:*")
+        db_keys = appl_db.keys(appl_db.APPL_DB, "PORT_TABLE:*")
     elif intf_name.startswith('Ethernet'):
-        db_keys = db.keys(db.APPL_DB, "PORT_TABLE:%s" % intf_name)
+        db_keys = db.keys(appl_db.APPL_DB, "PORT_TABLE:%s" % intf_name)
     else:
         return None
+
     return db_keys
 
 
-def db_port_status_get(db, intf_name, status_type):
+def db_port_status_get(appl_db, intf_name, status_type):
     """
     Get the port status
     """
+
     full_table_id = PORT_STATUS_TABLE_PREFIX + intf_name
-    status = db.get(db.APPL_DB, full_table_id, status_type)
+    status = appl_db.get(appl_db.APPL_DB, full_table_id, status_type)
     if status is None:
         return "N/A"
+
     if status_type == PORT_SPEED and status != "N/A":
        status = '{}G'.format(status[:-3])
+
     return status
 
-def db_connect_optics():
+
+def db_connect_state():
     """
     Connect to REDIS STATE DB and get optics info
     """
-    optics_db = swsssdk.SonicV2Connector(host='127.0.0.1')
-    if optics_db == None:
+    state_db = swsssdk.SonicV2Connector(host='127.0.0.1')
+    if state_db == None:
         return None
-    optics_db.connect(optics_db.STATE_DB, False)   # Make one attempt only
-    return optics_db
+    state_db.connect(state_db.STATE_DB, False)   # Make one attempt only
+    return state_db
 
-def db_port_optics_get(optics_db, intf_name, type):
+
+def db_port_optics_get(state_db, intf_name, type):
     """
     Get optic type info for port
     """
     full_table_id = PORT_TRANSCEIVER_TABLE_PREFIX + intf_name
-    optics_type = optics_db.get(optics_db.STATE_DB,full_table_id, type)
+    optics_type = state_db.get(state_db.STATE_DB, full_table_id, type)
     if optics_type is None: 
         return "N/A" 
     return optics_type 
@@ -74,16 +87,19 @@ def db_port_optics_get(optics_db, intf_name, type):
 
 # ========================== interface-status logic ==========================
 
-header_stat = ['Interface', 'Lanes', 'Speed', 'MTU', 'Alias', 'Oper', 'Admin', 'OpticsType']
+header_stat = ['Interface', 'Lanes', 'Speed', 'MTU', 'Alias', 'Oper', 'Admin', 'Type']
 
 class IntfStatus(object):
+
     def display_intf_status(self, db_keys):
         """
             Generate interface-status output
         """
+
         i = {}
         table = []
         key = []
+
         #
         # Iterate through all the keys and append port's associated state to
         # the result table.
@@ -92,27 +108,31 @@ class IntfStatus(object):
             key = re.split(':', i, maxsplit=1)[-1].strip()
             if key and key.startswith('Ethernet'):
                 table.append((key,
-                              db_port_status_get(self.db, key, PORT_LANES_STATUS),
-                              db_port_status_get(self.db, key, PORT_SPEED),
-                              db_port_status_get(self.db, key, PORT_MTU_STATUS),
-                              db_port_status_get(self.db, key, PORT_ALIAS),
-                              db_port_status_get(self.db, key, PORT_OPER_STATUS),
-                              db_port_status_get(self.db, key, PORT_ADMIN_STATUS),
-                              db_port_optics_get(self.optics_db, key, PORT_OPTICS_TYPE)))
+                              db_port_status_get(self.appl_db, key, PORT_LANES_STATUS),
+                              db_port_status_get(self.appl_db, key, PORT_SPEED),
+                              db_port_status_get(self.appl_db, key, PORT_MTU_STATUS),
+                              db_port_status_get(self.appl_db, key, PORT_ALIAS),
+                              db_port_status_get(self.appl_db, key, PORT_OPER_STATUS),
+                              db_port_status_get(self.appl_db, key, PORT_ADMIN_STATUS),
+                              db_port_optics_get(self.state_db, key, PORT_OPTICS_TYPE)))
+
         # Sorting and tabulating the result table.
-        #print(table)
         sorted_table = natsorted(table)
         print tabulate(sorted_table, header_stat, tablefmt="simple", stralign='right')
+
+
     def __init__(self, intf_name):
-        self.db = db_connect()
-        self.optics_db = db_connect_optics()
-        if self.db == None:
+
+        self.appl_db = db_connect_appl()
+        self.state_db = db_connect_state()
+        if self.appl_db == None:
             return
-        if self.optics_db == None: 
+        if self.state_db == None: 
             return 
-        db_keys = db_keys_get(self.db, intf_name)
+        db_keys = db_keys_get(self.appl_db, intf_name)
         if db_keys == None:
             return
+
         self.display_intf_status(db_keys)
 
 
@@ -123,13 +143,16 @@ header_desc = ['Interface', 'Oper', 'Admin', 'Alias', 'Description']
 
 
 class IntfDescription(object):
+
     def display_intf_description(self, db_keys):
         """
             Generate interface-description output
         """
+
         i = {}
         table = []
         key = []
+
         #
         # Iterate through all the keys and append port's associated state to
         # the result table.
@@ -142,32 +165,42 @@ class IntfDescription(object):
                               db_port_status_get(self.db, key, PORT_ADMIN_STATUS),
                               db_port_status_get(self.db, key, PORT_ALIAS),
                               db_port_status_get(self.db, key, PORT_DESCRIPTION)))
+
         # Sorting and tabulating the result table.
         sorted_table = natsorted(table)
         print tabulate(sorted_table, header_desc, tablefmt="simple", stralign='right')
+
     def __init__(self, intf_name):
-        self.db = db_connect()
+
+        self.db = db_connect_appl()
         if self.db == None:
             return
+
         db_keys = db_keys_get(self.db, intf_name)
         if db_keys == None:
             return
+
         self.display_intf_description(db_keys)
+
 
 
 def main(args):
     if len(args) == 0:
         print "No valid arguments provided"
         return
+
     command = args[0]
     if command != "status" and command != "description":
         print "No valid command provided"
         return
+
     intf_name = args[1] if len(args) == 2 else None
+
     if command == "status":
         interface_stat = IntfStatus(intf_name)
     elif command == "description":
         interface_desc = IntfDescription(intf_name)
+
     sys.exit(0)
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
I've added the OpticsType onto the output at the end of the "show interface status" command

**- How I did it**
I did this by getting the optics info from the REDIS STATE DB

**- How to verify it**
You will be able to verify it if the optics are removed or changed on an interface. 

**- Previous command output (if the output of a command-line utility has changed)**
```
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/show$ show int status
  Interface            Lanes    Speed    MTU           Alias    Oper    Admin
-----------  ---------------  -------  -----  --------------  ------  -------
  Ethernet0      29,30,31,32      40G   9100    fortyGigE0/0    down       up
  Ethernet4      25,26,27,28      40G   9100    fortyGigE0/4    down       up
  Ethernet8      37,38,39,40      40G   9100    fortyGigE0/8    down       up
 Ethernet12      33,34,35,36      40G   9100   fortyGigE0/12    down       up
 Ethernet16      41,42,43,44      40G   9100   fortyGigE0/16    down       up
 Ethernet20      45,46,47,48      40G   9100   fortyGigE0/20    down       up
 Ethernet24          5,6,7,8      40G   9100   fortyGigE0/24    down       up
 Ethernet28          1,2,3,4      40G   9100   fortyGigE0/28    down       up
 Ethernet32       9,10,11,12      40G   9100   fortyGigE0/32    down       up
 Ethernet36      13,14,15,16      40G   9100   fortyGigE0/36    down       up
 Ethernet40      21,22,23,24      40G   9100   fortyGigE0/40    down       up
 Ethernet44      17,18,19,20      40G   9100   fortyGigE0/44    down       up
 Ethernet48      49,50,51,52      40G   9100   fortyGigE0/48    down       up
 Ethernet52      53,54,55,56      40G   9100   fortyGigE0/52    down       up
 Ethernet56      61,62,63,64      40G   9100   fortyGigE0/56    down       up
 Ethernet60      57,58,59,60      40G   9100   fortyGigE0/60    down       up
 Ethernet64      65,66,67,68      40G   9100   fortyGigE0/64    down       up
 Ethernet68      69,70,71,72      40G   9100   fortyGigE0/68    down       up
 Ethernet72      77,78,79,80      40G   9100   fortyGigE0/72    down       up
 Ethernet76      73,74,75,76      40G   9100   fortyGigE0/76    down       up
 Ethernet80  105,106,107,108      40G   9100   fortyGigE0/80    down       up
 Ethernet84  109,110,111,112      40G   9100   fortyGigE0/84    down       up
 Ethernet88  117,118,119,120      40G   9100   fortyGigE0/88    down       up
 Ethernet92  113,114,115,116      40G   9100   fortyGigE0/92    down       up
 Ethernet96  121,122,123,124      40G   9100   fortyGigE0/96    down       up
Ethernet100  125,126,127,128      40G   9100  fortyGigE0/100    down       up
Ethernet104      85,86,87,88      40G   9100  fortyGigE0/104    down       up
Ethernet108      81,82,83,84      40G   9100  fortyGigE0/108    down       up
Ethernet112      89,90,91,92      40G   9100  fortyGigE0/112    down       up
Ethernet116      93,94,95,96      40G   9100  fortyGigE0/116    down       up
Ethernet120     97,98,99,100      40G   9100  fortyGigE0/120    down       up
Ethernet124  101,102,103,104      40G   9100  fortyGigE0/124    down       up
```

**- New command output (if the output of a command-line utility has changed)**
```
admin@str-s6000-acs-11:/usr/bin$ show int status
  Interface            Lanes    Speed    MTU           Alias    Oper    Admin    OpticsType
-----------  ---------------  -------  -----  --------------  ------  -------  ------------
  Ethernet0      29,30,31,32      40G   9100    fortyGigE0/0    down       up         QSFP+
  Ethernet4      25,26,27,28      40G   9100    fortyGigE0/4    down       up         QSFP+
  Ethernet8      37,38,39,40      40G   9100    fortyGigE0/8    down       up         QSFP+
 Ethernet12      33,34,35,36      40G   9100   fortyGigE0/12    down       up         QSFP+
 Ethernet16      41,42,43,44      40G   9100   fortyGigE0/16    down       up         QSFP+
 Ethernet20      45,46,47,48      40G   9100   fortyGigE0/20    down       up         QSFP+
 Ethernet24          5,6,7,8      40G   9100   fortyGigE0/24    down       up         QSFP+
 Ethernet28          1,2,3,4      40G   9100   fortyGigE0/28    down       up         QSFP+
 Ethernet32       9,10,11,12      40G   9100   fortyGigE0/32    down       up         QSFP+
 Ethernet36      13,14,15,16      40G   9100   fortyGigE0/36    down       up         QSFP+
 Ethernet40      21,22,23,24      40G   9100   fortyGigE0/40    down       up         QSFP+
 Ethernet44      17,18,19,20      40G   9100   fortyGigE0/44    down       up         QSFP+
 Ethernet48      49,50,51,52      40G   9100   fortyGigE0/48    down       up         QSFP+
 Ethernet52      53,54,55,56      40G   9100   fortyGigE0/52    down       up         QSFP+
 Ethernet56      61,62,63,64      40G   9100   fortyGigE0/56    down       up         QSFP+
 Ethernet60      57,58,59,60      40G   9100   fortyGigE0/60    down       up           N/A
 Ethernet64      65,66,67,68      40G   9100   fortyGigE0/64    down       up         QSFP+
 Ethernet68      69,70,71,72      40G   9100   fortyGigE0/68    down       up         QSFP+
 Ethernet72      77,78,79,80      40G   9100   fortyGigE0/72    down       up         QSFP+
 Ethernet76      73,74,75,76      40G   9100   fortyGigE0/76    down       up         QSFP+
 Ethernet80  105,106,107,108      40G   9100   fortyGigE0/80    down       up         QSFP+
 Ethernet84  109,110,111,112      40G   9100   fortyGigE0/84    down       up         QSFP+
 Ethernet88  117,118,119,120      40G   9100   fortyGigE0/88    down       up         QSFP+
 Ethernet92  113,114,115,116      40G   9100   fortyGigE0/92    down       up         QSFP+
 Ethernet96  121,122,123,124      40G   9100   fortyGigE0/96    down       up         QSFP+
Ethernet100  125,126,127,128      40G   9100  fortyGigE0/100    down       up         QSFP+
Ethernet104      85,86,87,88      40G   9100  fortyGigE0/104    down       up         QSFP+
Ethernet108      81,82,83,84      40G   9100  fortyGigE0/108    down       up         QSFP+
Ethernet112      89,90,91,92      40G   9100  fortyGigE0/112    down       up         QSFP+
Ethernet116      93,94,95,96      40G   9100  fortyGigE0/116    down       up         QSFP+
Ethernet120     97,98,99,100      40G   9100  fortyGigE0/120    down       up         QSFP+
Ethernet124  101,102,103,104      40G   9100  fortyGigE0/124    down       up         QSFP+
```

