### PR TITLE
[sonic_installer] preserve the backup file/directories structure, attributes etc

### DIFF
--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -229,7 +229,8 @@ def install(url):
         run_command(image_path)
         run_command('grub-set-default --boot-directory=' + HOST_PATH + ' 0')
     run_command("rm -rf /host/old_config")
-    run_command("cp -r /etc/sonic /host/old_config")
+    # copy directories and preserve original file structure, attributes and associated metadata
+    run_command("cp -ar /etc/sonic /host/old_config")
 
     # sync filesystem, keep at last step.
     run_command("sync")


### PR DESCRIPTION

Signed-off-by: Zhenggen Xu <zxu@linkedin.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
preserve the file/directories structure, attributes etc during backup.

This is needed for example FRR configuration under /etc/sonic/frr might not be under root ownership. with the old backup method, the ownership etc will be lost.

**- How I did it**
use "cp -ar" instead of "cp -r"

**- How to verify it**
/etc/sonic/frr is under admin:admin,  when it backed up, the structure and attributes were preserved.

-->

