### PR TITLE
Removed 'show interfaces alias / summary'.

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -405,43 +405,6 @@ def interfaces():
     """Show details of the network interfaces"""
     pass
 
-# 'alias' subcommand ("show interfaces alias")
-@interfaces.command()
-@click.argument('interfacename', required=False)
-def alias(interfacename):
-    """Show Interface Name/Alias Mapping"""
-
-    cmd = 'sonic-cfggen -d --var-json "PORT"'
-    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
-
-    port_dict = json.loads(p.stdout.read())
-
-    header = ['Name', 'Alias']
-    body = []
-
-    if interfacename is not None:
-        if get_interface_mode() == "alias":
-            interfacename = iface_alias_converter.alias_to_name(interfacename)
-
-        # If we're given an interface name, output name and alias for that interface only
-        if interfacename in port_dict:
-            if 'alias' in port_dict[interfacename]:
-                body.append([interfacename, port_dict[interfacename]['alias']])
-            else:
-                body.append([interfacename, interfacename])
-        else:
-            click.echo("Invalid interface name, '{0}'".format(interfacename))
-            return
-    else:
-        # Output name and alias for all interfaces
-        for port_name in natsorted(port_dict.keys()):
-            if 'alias' in port_dict[port_name]:
-                body.append([port_name, port_dict[port_name]['alias']])
-            else:
-                body.append([port_name, port_name])
-
-    click.echo(tabulate(body, header))
-
 #
 # 'neighbor' group ###
 #
@@ -489,23 +452,6 @@ def expected(interfacename):
                          neighbor_metadata_dict[device]['type']])
 
     click.echo(tabulate(body, header))
-
-# 'summary' subcommand ("show interfaces summary")
-@interfaces.command()
-@click.argument('interfacename', required=False)
-@click.option('--verbose', is_flag=True, help="Enable verbose output")
-def summary(interfacename, verbose):
-    """Show interface status and information"""
-
-    cmd = "/sbin/ifconfig"
-
-    if interfacename is not None:
-        if get_interface_mode() == "alias":
-            interfacename = iface_alias_converter.alias_to_name(interfacename)
-
-        cmd += " {}".format(interfacename)
-
-    run_command(cmd, display_cmd=verbose)
 
 
 @interfaces.group(cls=AliasedGroup, default_if_no_args=False)


### PR DESCRIPTION
1. Removed 'show interfaces alias' command, based on https://github.com/Azure/SONiC/issues/290
2. Removed 'show interfaces summary' command, based on https://github.com/Azure/SONiC/issues/293

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Removed definition of 'show interfaces summary' and 'show interfaces alias' from ./show/main.py

**- How I did it**

**- How to verify it**
1. Check if 'show interfaces summary' and 'show interfaces alias' are invalid commands in Sonic shell, and do not provide any output.
2. Check if 'alias' and 'summary' are not available from 'show interfaces --help'.
3. Check if other 8 interfaces subcommands are not affected.

**- Previous command output (if the output of a command-line utility has changed)**
```
show interfaces summary
Bridge: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet6 fe80::581a:58ff:fedd:996  prefixlen 64  scopeid 0x20<link>
        ether 5a:1a:58:dd:09:96  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 5  bytes 650 (650.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

```
```
show interfaces alias
Name         Alias
-----------  -----------
Ethernet0    Ethernet0

```
**- New command output (if the output of a command-line utility has changed)**
```
show interfaces alias
Usage: show interfaces [OPTIONS] COMMAND [ARGS]...

Error: No such command "alias".
```
```
show interfaces summary
Usage: show interfaces [OPTIONS] COMMAND [ARGS]...

Error: No such command "summary".
```
-->

