### PR TITLE
[Warm-reboot] Don't allow warm-reboot script to err exit when bgpd process doesn't exist(EXIT_CODE 1)

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -281,7 +281,7 @@ fi
 # Kill bgpd to start the bgp graceful restart procedure
 debug "Stopping bgp ..."
 docker exec -i bgp pkill -9 zebra
-docker exec -i bgp pkill -9 bgpd
+docker exec -i bgp pkill -9 bgpd || [ $? == 1 ]
 debug "Stopped  bgp ..."
 
 # Kill lldp, otherwise it sends informotion about reboot


### PR DESCRIPTION
* when bgp is not configured, there is no bgpd process, we should ignore the err check.
* when bgpd does not exist, EXIT_CODE is 1, we allow it along with EXIT_CODE SUCCESS 0, for both, we make it pass the errexit check
  

Signed-off-by: Dong Zhang d.zhang@alibaba-inc.com