### PR TITLE
[reboot] stop docker service before rebooting

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -14,11 +14,11 @@ function stop_sonic_services()
         echo "Stopping syncd process..."
         docker exec -i syncd /usr/bin/syncd_request_shutdown --cold > /dev/null
         sleep 3
-
-        # Stop docker service to avoid 5-10 minutes delay in shutdown
-        # while waiting for existing docker containers to quit.
-        systemctl stop docker
     fi
+
+    # Stop docker service to avoid 5-10 minutes delay in shutdown
+    # while waiting for existing docker containers to quit.
+    timeout 30s systemctl stop docker
 }
 
 function clear_warm_boot()

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -14,6 +14,10 @@ function stop_sonic_services()
         echo "Stopping syncd process..."
         docker exec -i syncd /usr/bin/syncd_request_shutdown --cold > /dev/null
         sleep 3
+
+        # Stop docker service to avoid 5-10 minutes delay in shutdown
+        # while waiting for existing docker containers to quit.
+        systemctl stop docker
     fi
 }
 


### PR DESCRIPTION
**- What I did**
After upgrading to docker-ce 18.09.0. Shutdown SONiC takes 5-10 minutes
waiting for all the running docker containers to quit. They all enventually
hit the timeout and caused the huge delay.

This is a work-around until proper solution is found.

**- How to verify it**
with the change, reboot takes little time after upgrading to docker-ce 18.09.0. Otherwise the reboot takes about 5-10 minutes on shutdown path.