### PR TITLE
add show route-map and show ip prefix-list commands

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -2,6 +2,8 @@
 
 import errno
 import json
+import netaddr
+import netifaces
 import os
 import re
 import subprocess
@@ -60,10 +62,13 @@ class InterfaceAliasConverter(object):
             raise click.Abort()
 
         for port_name in self.port_dict.keys():
-            if self.alias_max_length < len(
-                    self.port_dict[port_name]['alias']):
-               self.alias_max_length = len(
-                    self.port_dict[port_name]['alias'])
+            try:
+                if self.alias_max_length < len(
+                        self.port_dict[port_name]['alias']):
+                   self.alias_max_length = len(
+                        self.port_dict[port_name]['alias'])
+            except KeyError:
+                break
 
     def name_to_alias(self, interface_name):
         """Return vendor interface alias if SONiC
@@ -405,43 +410,6 @@ def interfaces():
     """Show details of the network interfaces"""
     pass
 
-# 'alias' subcommand ("show interfaces alias")
-@interfaces.command()
-@click.argument('interfacename', required=False)
-def alias(interfacename):
-    """Show Interface Name/Alias Mapping"""
-
-    cmd = 'sonic-cfggen -d --var-json "PORT"'
-    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
-
-    port_dict = json.loads(p.stdout.read())
-
-    header = ['Name', 'Alias']
-    body = []
-
-    if interfacename is not None:
-        if get_interface_mode() == "alias":
-            interfacename = iface_alias_converter.alias_to_name(interfacename)
-
-        # If we're given an interface name, output name and alias for that interface only
-        if interfacename in port_dict:
-            if 'alias' in port_dict[interfacename]:
-                body.append([interfacename, port_dict[interfacename]['alias']])
-            else:
-                body.append([interfacename, interfacename])
-        else:
-            click.echo("Invalid interface name, '{0}'".format(interfacename))
-            return
-    else:
-        # Output name and alias for all interfaces
-        for port_name in natsorted(port_dict.keys()):
-            if 'alias' in port_dict[port_name]:
-                body.append([port_name, port_dict[port_name]['alias']])
-            else:
-                body.append([port_name, port_name])
-
-    click.echo(tabulate(body, header))
-
 #
 # 'neighbor' group ###
 #
@@ -489,23 +457,6 @@ def expected(interfacename):
                          neighbor_metadata_dict[device]['type']])
 
     click.echo(tabulate(body, header))
-
-# 'summary' subcommand ("show interfaces summary")
-@interfaces.command()
-@click.argument('interfacename', required=False)
-@click.option('--verbose', is_flag=True, help="Enable verbose output")
-def summary(interfacename, verbose):
-    """Show interface status and information"""
-
-    cmd = "/sbin/ifconfig"
-
-    if interfacename is not None:
-        if get_interface_mode() == "alias":
-            interfacename = iface_alias_converter.alias_to_name(interfacename)
-
-        cmd += " {}".format(interfacename)
-
-    run_command(cmd, display_cmd=verbose)
 
 
 @interfaces.group(cls=AliasedGroup, default_if_no_args=False)
@@ -841,7 +792,7 @@ def mac(vlan, port, verbose):
     run_command(cmd, display_cmd=verbose)
 
 #
-# 'show route-map' command ("show route-map") 
+# 'show route-map' command ("show route-map")
 #
 
 @cli.command('route-map')
@@ -854,15 +805,97 @@ def route_map(route_map_name, verbose):
         cmd += ' {}'.format(route_map_name)
     cmd += '"'
     run_command(cmd, display_cmd=verbose)
+	
 #
 # 'ip' group ("show ip ...")
 #
 
 # This group houses IP (i.e., IPv4) commands and subgroups
-@cli.group()
+@cli.group(cls=AliasedGroup, default_if_no_args=False)
 def ip():
     """Show IP (IPv4) commands"""
     pass
+
+
+#
+# get_if_admin_state
+#
+# Given an interface name, return its admin state reported by the kernel.
+#
+def get_if_admin_state(iface):
+    admin_file = "/sys/class/net/{0}/flags"
+
+    try:
+        state_file = open(admin_file.format(iface), "r")
+    except IOError as e:
+        print "Error: unable to open file: %s" % str(e)
+        return "error"
+
+    content = state_file.readline().rstrip()
+    flags = int(content, 16)
+
+    if flags & 0x1:
+        return "up"
+    else:
+        return "down"
+
+
+#
+# get_if_oper_state
+#
+# Given an interface name, return its oper state reported by the kernel.
+#
+def get_if_oper_state(iface):
+    oper_file = "/sys/class/net/{0}/carrier"
+
+    try:
+        state_file = open(oper_file.format(iface), "r")
+    except IOError as e:
+        print "Error: unable to open file: %s" % str(e)
+        return "error"
+
+    oper_state = state_file.readline().rstrip()
+    if oper_state == "1":
+        return "up"
+    else:
+        return "down"
+
+
+#
+# 'show ip interfaces' command
+#
+# Display all interfaces with an IPv4 address and their admin/oper states.
+# Addresses from all scopes are included. Interfaces with no addresses are
+# excluded.
+#
+@ip.command()
+def interfaces():
+    """Show interfaces IPv4 address"""
+    header = ['Interface', 'IPv4 address/mask', 'Admin/Oper']
+    data = []
+
+    interfaces = natsorted(netifaces.interfaces())
+
+    for iface in interfaces:
+        ipaddresses = netifaces.ifaddresses(iface)
+
+        if netifaces.AF_INET in ipaddresses:
+            ifaddresses = []
+            for ipaddr in ipaddresses[netifaces.AF_INET]:
+                netmask = netaddr.IPAddress(ipaddr['netmask']).netmask_bits()
+                ifaddresses.append(["", str(ipaddr['addr']) + "/" + str(netmask)])
+
+            if len(ifaddresses) > 0:
+                admin = get_if_admin_state(iface)
+                if admin == "up":
+                    oper = get_if_oper_state(iface)
+                else:
+                    oper = "down"
+                data.append([iface, ifaddresses[0][1], admin + "/" + oper])
+            for ifaddr in ifaddresses[1:]:
+                data.append(["", ifaddr[1], ""])
+
+    print tabulate(data, header, tablefmt="simple", stralign='left', missingval="")
 
 
 #
@@ -884,7 +917,7 @@ def route(ipaddress, verbose):
     run_command(cmd, display_cmd=verbose)
 
 #
-# 'prefix-list' subcommand ("show ip prefix-list") 
+# 'prefix-list' subcommand ("show ip prefix-list")
 #
 
 @ip.command('prefix-list')
@@ -913,10 +946,47 @@ def protocol(verbose):
 #
 
 # This group houses IPv6-related commands and subgroups
-@cli.group()
+@cli.group(cls=AliasedGroup, default_if_no_args=False)
 def ipv6():
     """Show IPv6 commands"""
     pass
+
+
+#
+# 'show ipv6 interfaces' command
+#
+# Display all interfaces with an IPv6 address and their admin/oper states.
+# Addresses from all scopes are included. Interfaces with no addresses are
+# excluded.
+#
+@ipv6.command()
+def interfaces():
+    """Show interfaces IPv6 address"""
+    header = ['Interface', 'IPv6 address/mask', 'Admin/Oper']
+    data = []
+
+    interfaces = natsorted(netifaces.interfaces())
+
+    for iface in interfaces:
+        ipaddresses = netifaces.ifaddresses(iface)
+
+        if netifaces.AF_INET6 in ipaddresses:
+            ifaddresses = []
+            for ipaddr in ipaddresses[netifaces.AF_INET6]:
+                netmask = ipaddr['netmask'].split('/', 1)[-1]
+                ifaddresses.append(["", str(ipaddr['addr']) + "/" + str(netmask)])
+
+            if len(ifaddresses) > 0:
+                admin = get_if_admin_state(iface)
+                if admin == "up":
+                    oper = get_if_oper_state(iface)
+                else:
+                    oper = "down"
+                data.append([iface, ifaddresses[0][1], admin + "/" + oper])
+            for ifaddr in ifaddresses[1:]:
+                data.append(["", ifaddr[1], ""])
+
+    print tabulate(data, header, tablefmt="simple", stralign='left', missingval="")
 
 
 #
@@ -1503,22 +1573,13 @@ def tacacs():
                 output += ('               %s %s\n' % (key, str(entry[key])))
     click.echo(output)
 
-
 #
-# 'mirror' group ###
+# 'mirror_session' command  ("show mirror_session ...")
 #
-
-@cli.group(cls=AliasedGroup, default_if_no_args=False)
-def mirror():
-    """Show mirroring (Everflow) information"""
-    pass
-
-
-# 'session' subcommand  ("show mirror session")
-@mirror.command()
+@cli.command()
 @click.argument('session_name', required=False)
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
-def session(session_name, verbose):
+def mirror_session(session_name, verbose):
     """Show existing everflow sessions"""
     cmd = "acl-loader show session"
 
@@ -1654,9 +1715,12 @@ def state(redis_unix_socket_path):
         entry = db.get_all(db.STATE_DB, tk)
         r = []
         r.append(remove_prefix(tk, prefix))
-        r.append(entry['restore_count'])
+        if 'restore_count' not in entry:
+            r.append("")
+        else:
+            r.append(entry['restore_count'])
 
-        if 'state' not in  entry:
+        if 'state' not in entry:
             r.append("")
         else:
             r.append(entry['state'])
@@ -1696,6 +1760,9 @@ def config(redis_unix_socket_path):
             elif 'bgp_timer' in data[k]:
                 r.append("bgp_timer")
                 r.append(data[k]['bgp_timer'])
+            elif 'teamsyncd_timer' in data[k]:
+                r.append("teamsyncd_timer")
+                r.append(data[k]['teamsyncd_timer'])
             else:
                 r.append("NULL")
                 r.append("NULL")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
I updated the /usr/lib/python2.7/dist-packages/show/main.py file to add new commands
show route-map 
show ip prefix-list 

**- How I did it**
I'm pulling the information from quagga (vtysh) into the main cli. 

**- How to verify it**
run commands
"show route-map"
and 
"show ip prefix-list" 

**- Previous command output (if the output of a command-line utility has changed)**
There was no previous command for this unless you went into vtysh 

**- New command output (if the output of a command-line utility has changed)**

admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/show$ show route-map
ZEBRA:
route-map RM_SET_SRC, permit, sequence 10
  Match clauses:
  Set clauses:
    src 10.1.0.32
  Call clause:
  Action:
    Exit routemap
ZEBRA:
route-map RM_SET_SRC6, permit, sequence 10
  Match clauses:
  Set clauses:
    src fc00:1::32
  Call clause:
  Action:
    Exit routemap
BGP:
route-map FROM_TIER0_V4, permit, sequence 10
  Match clauses:
    community UPSTREAM_PREFIX
    ip address prefix-list DEFAULT_IPV4
  Set clauses:
  Call clause:
  Action:
    Exit routemap
route-map FROM_TIER0_V4, permit, sequence 20
  Match clauses:
    community LEAK_COMMUNITY
    ip address prefix-list IPV4_18_OR_LONGER
  Set clauses:
    comm-list LEAK_COMMUNITY delete
  Call clause:
  Action:
    Exit routemap
route-map FROM_TIER0_V4, permit, sequence 30
  Match clauses:
    ip address prefix-list IPV4_18_OR_LONGER
  Set clauses:
  Call clause:
  Action:
    Exit routemap
route-map FROM_TIER0_V4, deny, sequence 1000
  Match clauses:
  Set clauses:
  Call clause:
  Action:
    Exit routemap
BGP:
route-map FROM_TIER0_V6, permit, sequence 10
  Match clauses:
    community UPSTREAM_PREFIX
    ipv6 address prefix-list DEFAULT_IPV6
  Set clauses:
  Call clause:
  Action:
    Exit routemap
route-map FROM_TIER0_V6, permit, sequence 20
  Match clauses:
    community LEAK_COMMUNITY
    ipv6 address prefix-list IPV6_64_ONLY
  Set clauses:
    comm-list LEAK_COMMUNITY delete
  Call clause:
  Action:
    Exit routemap
route-map FROM_TIER0_V6, permit, sequence 30
  Match clauses:
    ipv6 address prefix-list IPV6_64_ONLY
  Set clauses:
  Call clause:
  Action:
    Exit routemap
route-map FROM_TIER0_V6, deny, sequence 1000
  Match clauses:
  Set clauses:
  Call clause:
  Action:
    Exit routemap
BGP:
route-map FROM_TIER2_V4, permit, sequence 10
  Match clauses:
  Set clauses:
    community 8075:54000 additive
  Call clause:
  Action:
    Exit routemap
BGP:
route-map FROM_TIER2_V6, permit, sequence 10
  Match clauses:
  Set clauses:
    community 8075:54000 additive
  Call clause:
  Action:
    Exit routemap
BGP:
route-map TO_TIER0_V4, permit, sequence 10
  Match clauses:
    community UPSTREAM_PREFIX
    ip address prefix-list DEFAULT_IPV4
  Set clauses:
  Call clause:
  Action:
    Exit routemap
route-map TO_TIER0_V4, permit, sequence 20
  Match clauses:
    community LEAK_COMMUNITY
  Set clauses:
  Call clause:
  Action:
    Exit routemap
route-map TO_TIER0_V4, permit, sequence 30
  Match clauses:
    community UPSTREAM_PREFIX
  Set clauses:
    community no-export additive
  Call clause:
  Action:
    Exit routemap
route-map TO_TIER0_V4, permit, sequence 1000
  Match clauses:
  Set clauses:
  Call clause:
  Action:
    Exit routemap
BGP:
route-map TO_TIER0_V6, permit, sequence 10
  Match clauses:
    community UPSTREAM_PREFIX
    ipv6 address prefix-list DEFAULT_IPV6
  Set clauses:
  Call clause:
  Action:
    Exit routemap
route-map TO_TIER0_V6, permit, sequence 20
  Match clauses:
    community LEAK_COMMUNITY
  Set clauses:
  Call clause:
  Action:
    Exit routemap
route-map TO_TIER0_V6, permit, sequence 30
  Match clauses:
    community UPSTREAM_PREFIX
  Set clauses:
    community no-export additive
  Call clause:
  Action:
    Exit routemap
route-map TO_TIER0_V6, permit, sequence 1000
  Match clauses:
  Set clauses:
  Call clause:
  Action:
    Exit routemap
BGP:
route-map TO_TIER2_V4, deny, sequence 5
  Match clauses:
    community UPSTREAM_PREFIX
  Set clauses:
  Call clause:
  Action:
    Exit routemap
route-map TO_TIER2_V4, permit, sequence 10
  Match clauses:
  Set clauses:
  Call clause:
  Action:
    Exit routemap
BGP:
route-map TO_TIER2_V6, deny, sequence 5
  Match clauses:
    community UPSTREAM_PREFIX
  Set clauses:
  Call clause:
  Action:
    Exit routemap
route-map TO_TIER2_V6, permit, sequence 10
  Match clauses:
  Set clauses:
  Call clause:
  Action:
    Exit routemap
BGP:
route-map TO_TYCOON_ER_V4, permit, sequence 100
  Match clauses:
    ip address prefix-list DEFAULT_IPV4
  Set clauses:
  Call clause:
  Action:
    Exit routemap
route-map TO_TYCOON_ER_V4, deny, sequence 10000
  Match clauses:
  Set clauses:
  Call clause:
  Action:
    Exit routemap
BGP:
route-map FROM_TYCOON_ER_V4, deny, sequence 100
  Match clauses:
    ip address prefix-list DEFAULT_IPV4
  Set clauses:
  Call clause:
  Action:
    Exit routemap
route-map FROM_TYCOON_ER_V4, permit, sequence 200
  Match clauses:
    community TYCOON_ER_COMMUNITY
    ip address prefix-list IPV4_30_OR_LONGER
  Set clauses:
  Call clause:
  Action:
    Exit routemap
route-map FROM_TYCOON_ER_V4, deny, sequence 10000
  Match clauses:
  Set clauses:
  Call clause:
  Action:
    Exit routemap
BGP:
route-map TO_TYCOON_ER_V6, permit, sequence 100
  Match clauses:
    ipv6 address prefix-list DEFAULT_IPV6
  Set clauses:
  Call clause:
  Action:
    Exit routemap
route-map TO_TYCOON_ER_V6, deny, sequence 10000
  Match clauses:
  Set clauses:
  Call clause:
  Action:
    Exit routemap
BGP:
route-map FROM_TYCOON_ER_V6, deny, sequence 100
  Match clauses:
    ipv6 address prefix-list DEFAULT_IPV6
  Set clauses:
  Call clause:
  Action:
    Exit routemap
route-map FROM_TYCOON_ER_V6, permit, sequence 200
  Match clauses:
    community TYCOON_ER_COMMUNITY
    ipv6 address prefix-list IPV6_64_ONLY
  Set clauses:
  Call clause:
  Action:
    Exit routemap
route-map FROM_TYCOON_ER_V6, deny, sequence 10000
  Match clauses:
  Set clauses:
  Call clause:
  Action:
    Exit routemap
BGP:
route-map ISOLATE, permit, sequence 10
  Match clauses:
  Set clauses:
    as-path prepend 65100
  Call clause:
  Action:
    Exit routemap



admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/show$ show ip prefix-list 
BGP: ip prefix-list DEFAULT_IPV4: 1 entries
   seq 5 permit 0.0.0.0/0
BGP: ip prefix-list IPV4_18_OR_LONGER: 1 entries
   seq 5 permit 0.0.0.0/0 ge 18
BGP: ip prefix-list IPV4_30_OR_LONGER: 1 entries
   seq 5 permit 0.0.0.0/0 ge 30


-->

