### PR TITLE
Revert "[reboot] stop docker service before rebooting"

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -15,10 +15,6 @@ function stop_sonic_services()
         docker exec -i syncd /usr/bin/syncd_request_shutdown --cold > /dev/null
         sleep 3
     fi
-
-    # Stop docker service to avoid 5-10 minutes delay in shutdown
-    # while waiting for existing docker containers to quit.
-    timeout 30s systemctl stop docker
 }
 
 function clear_warm_boot()


### PR DESCRIPTION
Reverts Azure/sonic-utilities#423

The issue has been addressed properly by https://github.com/Azure/sonic-buildimage/pull/2451

Removing the workaround.