### PR TITLE
[teamshow]: Fixed teamshow output not displaying the custom portchann…

### DIFF
--- a/scripts/teamshow
+++ b/scripts/teamshow
@@ -63,7 +63,7 @@ class Teamshow(object):
         """
             Skip the 'PortChannel' prefix and extract the team id.
         """
-        return team[11:]
+        return team[:]
 
     def get_teamdctl(self):
         """
@@ -123,7 +123,7 @@ class Teamshow(object):
         header = ['No.', 'Team Dev', 'Protocol', 'Ports']
         output = []
         for team_id in natsorted(self.summary):
-            output.append([team_id, 'PortChannel'+team_id, self.summary[team_id]['protocol'], self.summary[team_id]['ports']])
+            output.append([team_id[11:], team_id, self.summary[team_id]['protocol'], self.summary[team_id]['ports']])
         print tabulate(output, header)
 
 def main():


### PR DESCRIPTION
…els #276

commit 4e80674b95b436a155bc4f0de3e158d757ec4fd2 (HEAD -> teamshow, origin/teamshow)
Author: madhu Pal <madhupa@aviznetworks.com>
Date:   Fri Jan 18 04:45:06 2019 +0000

    [teamshow]: Fixed teamshow output not displaying the custom portchannels #276

**- What I did**
Custom port channels created by user are displayed incorrectly in teamshow output. 
The root cause is - teamshow is expecting a "Portchannel" prefix in configured port channels. Hence it is incorrectly displays the port channels when the there is no prefix. Ex:  1) TestingChannel 2) Interface. 

**- How I did it**
Fixed code in teamshow to display the port channels currently irrespective of "Portchannel" Prefix.

**- How to verify it**
root@sonic-testing:/home/admin# config portchannel add TestingChannel
root@sonic-testing:/home/admin# teamshow
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available, S - selected, D - deselected
No.    Team Dev         Protocol     Ports
-----  ---------------  -----------  -------------------------
001    PortChannel001   LACP(A)(Dw)  Ethernet8(D) Ethernet4(D)
**nel    PortChannelnel**   LACP(A)(Dw)  N/A

**AFTER FIX**
root@sonic-testing:/home/admin# config portchannel add TestingChannel
root@sonic-testing:/home/admin# teamshow
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available, S - selected, D - deselected
No.    Team Dev         Protocol     Ports
________________________________________________________________________
001    PortChannel001   LACP(A)(Dw)  Ethernet8(D) Ethernet4(D)
**nel TestingChannel** LACP(A)(Dw) N/A

root@sonic:/home/admin# ifconfig TestingChannel
**TestingChannel:** flags=4099<UP,BROADCAST,MULTICAST>  mtu 9100
        ether 52:54:00:12:34:56  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
