### PR TITLE
[acl_loader]: Prevent crash in the event ac ACL entry has no 'MATCH' fields

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -580,7 +580,7 @@ class AclLoader(object):
             matches.sort()
 
             if len(matches) == 0:
-                matches.append("")
+                matches.append("N/A")
 
             rule_data = [[tname, rid, priority, action, matches[0]]]
             if len(matches) > 1:

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -579,6 +579,9 @@ class AclLoader(object):
 
             matches.sort()
 
+            if len(matches) == 0:
+                matches.append("")
+
             rule_data = [[tname, rid, priority, action, matches[0]]]
             if len(matches) > 1:
                 for m in matches[1:]:


### PR DESCRIPTION
Fix for crash while executing 'show acl rule' in case ACL entry doesn't
  have 'MATCH' fields (e.g. default action).

How to reproduce:
* apply config having ACL rule like

        "TESTACL|DEFAULT_RULE": {
            "PRIORITY": "1",
            "PACKET_ACTION": "DROP"
        }
* execute in console
        show acl rule

Fix details:
in case ACL entry doesn't have any MATCH field just emulate one by pushing
empty string into the array.

@lguohan @jipanyang @stcheng  Please review it

