### PR TITLE
[config/main.py]Fixed - added a validation such that delete portchann…

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -450,7 +450,11 @@ def add_portchannel(ctx, portchannel_name, min_links, fallback):
 def remove_portchannel(ctx, portchannel_name):
     """Remove port channel"""
     db = ctx.obj['db']
-    db.set_entry('PORTCHANNEL', portchannel_name, None)
+    if len(db.get_entry('PORTCHANNEL', portchannel_name)) != 0:
+        db.set_entry('PORTCHANNEL', portchannel_name, None)
+    else:
+        ctx.fail("{} is not configured".format(portchannel_name))
+
 
 @portchannel.group('member')
 @click.pass_context
@@ -474,9 +478,11 @@ def add_portchannel_member(ctx, portchannel_name, port_name):
 def del_portchannel_member(ctx, portchannel_name, port_name):
     """Remove member from portchannel"""
     db = ctx.obj['db']
-    db.set_entry('PORTCHANNEL_MEMBER', (portchannel_name, port_name), None)
-    db.set_entry('PORTCHANNEL_MEMBER', portchannel_name + '|' + port_name, None)
-
+    if len(db.get_entry('PORTCHANNEL_MEMBER', portchannel_name + '|' + port_namee)) != 0:
+        db.set_entry('PORTCHANNEL_MEMBER', (portchannel_name, port_name), None)
+        db.set_entry('PORTCHANNEL_MEMBER', portchannel_name + '|' + port_name, None)
+    else:
+        ctx.fail("{} is not part of {}".format(port_name, portchannel_name))
 
 #
 # 'mirror_session' group ('config mirror_session ...')


### PR DESCRIPTION
…el or portchannel members only when it is configured (#277)

commit d7f6154bba5ffd8ba2e1c550c27e60a213d06531 (HEAD -> azure-277, origin/azure-277)
Author: madhu Pal <madhupa@aviznetworks.com>
Date:   Fri Jan 25 16:58:10 2019 +0000

    [config/main.py]Fixed - added a validation such that delete portchannel or portchannel members only when it is configured (#277)

Signed-off by : madhupa@aviznetworks.com

**- What I did**
Added validation logic such that, delete port channel/port channel members only if the it is configured and exists in configDB.
**- How I did it**
Fixed config/main.py by checking whether the portchannel or portchannelmember exists in portchannel/portchannelmember table before delete it.
**- How to verify it**
**BEFORE FIX**
There is no Error message while delete non existing portchannel/portchannel member
ex1: config portchannel del PortChannel0019
ex2:config portchannel member del PortChannel0019 Ethernet40
Executed without any error message to the user that the portchannel/members are not configured etc.
**AFTER FIX**
**delete portchannel which is not configured** 
config portchannel del <PortChannelName>
Ex1:
root@sonic:/home/admin# config portchannel del PortChannel0019
Usage: config portchannel del [OPTIONS] <portchannel_name>
**Error: PortChannel0019 is not configured**

**delete portchannel member which doesn't configured**
root@sonic:/home/admin# config portchannel member del PortChannel009 Ethernet80
Usage: config portchannel member del [OPTIONS] <portchannel_name> <port_name>

**Error: Ethernet80 is not part of PortChannel009**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

