### PR TITLE
[reboot cause] Move reboot-cause files to /host directory so they persist across SONiC upgrades

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -2,7 +2,7 @@
 
 REBOOT_USER=$(logname)
 REBOOT_TIME=$(date)
-REBOOT_CAUSE_FILE="/var/cache/sonic/reboot-cause.txt"
+REBOOT_CAUSE_FILE="/host/reboot-cause/reboot-cause.txt"
 WARM_DIR=/host/warmboot
 REDIS_FILE=dump.rdb
 REBOOT_SCRIPT_NAME=$(basename $0)

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -6,7 +6,7 @@ PLATFORM=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
 ASIC_TYPE=$(sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)
 DEVPATH="/usr/share/sonic/device"
 PLAT_REBOOT="platform_reboot"
-REBOOT_CAUSE_FILE="/var/cache/sonic/reboot-cause.txt"
+REBOOT_CAUSE_FILE="/host/reboot-cause/reboot-cause.txt"
 
 function stop_sonic_services()
 {

--- a/show/main.py
+++ b/show/main.py
@@ -1658,7 +1658,7 @@ def mmu():
 @cli.command('reboot-cause')
 def reboot_cause():
     """Show cause of most recent reboot"""
-    PREVIOUS_REBOOT_CAUSE_FILE = "/var/cache/sonic/previous-reboot-cause.txt"
+    PREVIOUS_REBOOT_CAUSE_FILE = "/host/reboot-cause/previous-reboot-cause.txt"
 
     # At boot time, PREVIOUS_REBOOT_CAUSE_FILE is generated based on
     # the contents of the 'reboot cause' file as it was left when the device


### PR DESCRIPTION
Move reboot-cause files from /var/cache/ to /host in order for the files to persist across SONiC upgrades (i.e., so that upon upgrading SONiC, we can still access the previous reboot cause from within the old image.

Note that this also requires corresponding changes in sonic-buildimage repo. PR to be opened soon.

