### PR TITLE
show acl table command output should show binding column correctly ev…

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -516,12 +516,15 @@ class AclLoader(object):
                 if not val["ports"]:
                     data.append([key, val["type"], "", val["policy_desc"]])
                 else:
-                    ports = natsorted(val["ports"])
-                    data.append([key, val["type"], ports[0], val["policy_desc"]])
+                    if isinstance(val["ports"], list):
+                        ports = natsorted(val["ports"])
+                        data.append([key, val["type"], ports[0], val["policy_desc"]])
 
-                    if len(ports) > 1:
-                        for port in ports[1:]:
-                            data.append(["", "", port, ""])
+                        if len(ports) > 1:
+                            for port in ports[1:]:
+                                data.append(["", "", port, ""])
+                    else:
+                      data.append([key, val["type"], val["ports"], val["policy_desc"]])
 
         print(tabulate.tabulate(data, headers=header, tablefmt="simple", missingval=""))
 


### PR DESCRIPTION
…en with single port

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Fixed show acl table command output to show "Binding" column correctly even with a single binding port.

**- How I did it**
The acl_loader script was always assuming a ports list on an ACL table. I have now added a case to handle display of ACL table with single port on it. 



**- How to verify it**
1. Add the below lines to a json file eg: `acl.json`
```
{ 
   "ACL_TABLE": { 
      "dataacl": { 
          "policy_desc": "Counter", 
          "stage": "INGRESS", 
           "type": "l3", 
           "ports": "Ethernet0" 
           }, 
       "10": { 
          "policy_desc": "Counter", 
          "stage": "INGRESS", 
          "type": "l3", 
          "ports": [ 
                        "Ethernet1", 
                        "Ethernet2", 
                        "Ethernet12" 
                ] 
             }, 
       "20": { 
          "policy_desc": "Counter", 
           "stage": "INGRESS", 
           "type": "l3v6", 
           "ports": "Ethernet2" 
             } 
       } 
}
```

2. `config load acl.json -y`
3. `show acl table`

**- Previous command output (if the output of a command-line utility has changed)**
```
root@sonic:/home/admin# show acl table                                
Name     Type    Binding     Description                              
-------  ------  ----------  -------------                            
10       l3      Ethernet1   Counter                                  
                 Ethernet2                                            
                 Ethernet12                                           
dataacl  l3      0           Counter                                  
                 E                                                    
                 e                                                    
                 e                                                    
                 h                                                    
                 n                                                    
                 r                                                    
                 t                                                    
                 t                                                    
20       l3v6    2           Counter                                  
                 E                                                    
                 e                                                    
                 e                                                    
                 h                                                    
                 n                                                    
                 r                                                    
                 t                                                    
                 t                                
```    
**- New command output (if the output of a command-line utility has changed)**
```
root@sonic:/home/admin# show acl table  
Name     Type    Binding     Description
-------  ------  ----------  -------------
10       l3      Ethernet1   Counter
                 Ethernet2
                 Ethernet12
dataacl  l3      Ethernet0   Counter
20       l3v6    Ethernet2   Counter

```
-->

