### PR TITLE
[clear/main.py]: clear ndp command.

### DIFF
--- a/clear/main.py
+++ b/clear/main.py
@@ -105,7 +105,12 @@ def get_routing_stack():
 routing_stack = get_routing_stack()
 
 
-def run_command(command, pager=False):
+def run_command(command, pager=False, return_output=False):
+    # Provide option for caller function to Process the output.
+    if return_output == True:
+        proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
+        return proc.communicate()
+
     if pager is True:
         #click.echo(click.style("Command: ", fg='cyan') + click.style(command, fg='green'))
         p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
@@ -290,14 +295,48 @@ def clear_pwm_q_multi():
 def arp(ipaddress):
     """Clear IP ARP table"""
     if ipaddress is not None:
-        command = 'sudo /usr/sbin/arp -d {}'.format(ipaddress)
-        run_command(command)
+        command = 'sudo ip -4 neigh show {}'.format(ipaddress)
+        (out, err) = run_command(command, return_output=True)
+        if not err and 'dev' in out:
+            outputList = out.split()
+            dev = outputList[outputList.index('dev') + 1]
+            command = 'sudo ip -4 neigh del {} dev {}'.format(ipaddress, dev)
+        else:
+            click.echo("Neighbor {} not found".format(ipaddress))
+            return
     else:
-        run_command("sudo ip -s -s neigh flush all")
+        command = "sudo ip -4 -s -s neigh flush all"
+
+    run_command(command)
+
+#
+# 'ndp' command ####
+#
+
+@click.command()
+@click.argument('ipaddress', required=False)
+def ndp(ipaddress):
+    """Clear IPv6 NDP table"""
+    if ipaddress is not None:
+        command = 'sudo ip -6 neigh show {}'.format(ipaddress)
+        (out, err) = run_command(command, return_output=True)
+        if not err and 'dev' in out:
+            outputList = out.split()
+            dev = outputList[outputList.index('dev') + 1]
+            command = 'sudo ip -6 neigh del {} dev {}'.format(ipaddress, dev)
+        else:
+            click.echo("Neighbor {} not found".format(ipaddress))
+            return
+    else:
+        command = 'sudo ip -6 -s -s neigh flush all'
+
+    run_command(command)
 
 # Add 'arp' command to both the root 'cli' group and the 'ip' subgroup
 cli.add_command(arp)
+cli.add_command(ndp)
 ip.add_command(arp)
+ip.add_command(ndp)
 
 #
 # 'fdb' command ####


### PR DESCRIPTION
Changes done:
---------------------------------------------------------------------------------------
1.) Clear ARP command clears NDP entries too today, With this fix, it will not clear NDP entries.
2.) Clear ndp <ip>(optional parameter) command has been added to clear one or all ndp neighbors.
3.) run_command function in clear/main.py file provides option for caller to process output.
4.) use ip neigh for clear arp\ndp instead of /usr/sbin/arp.

Reason for Point 4 
As per arp (8) - Linux Man Pages:
/usr/sbin/arp program is obsolete. For replacement check ip neigh. 

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
---------------------------------------------------------------------------------------
Added clear ndp <ip> command with below changes:
---------------------------------------------------------------------------------------

**- How I did it**
---------------------------------------------------------------------------------------
1.) Clear ARP used to clear both arp/ndp entries. I changed clear arp to not clear NDP entries.
2.) Clear ndp <ip>(optional parameter) command has been added to clear one or all ndp neighbors.
3.) run_command function provides option for caller to process output. This is needed in some cases, as in this case we need to find device info to clear one arp/ndp neighbor.
4.) use ip neigh for clear arp\ndp instead of /usr/sbin/arp because of arp (8) - Linux Man Pages.



**- How to verify it**
---------------------------------------------------------------------------------------
Testing

1.) Show Initial ARP and NDP Table: (Note: arp_ndp.sh does "show arp" and "show ndp")
---------------------------------------------
```admin@lnos-x1-a-csw03:~$ ./arp_ndp.sh
Command: /usr/sbin/arp -n
Address                  HWtype  HWaddress           Flags Mask            Iface
172.25.11.20             ether   00:06:f6:2b:67:6c   C                     eth0
172.25.11.1              ether   28:6f:7f:ba:1c:ff   C                     eth0
172.25.11.11             ether   bc:16:65:b3:ce:8e   C                     eth0
172.25.11.15             ether   6c:41:6a:1e:cd:8e   C                     eth0

Command: /bin/ip -6 neigh show
fe80::be16:65ff:feb3:ce8e dev eth0 lladdr bc:16:65:b3:ce:8e REACHABLE
fe80::6e41:6aff:fe1e:cd8e dev eth0 lladdr 6c:41:6a:1e:cd:8e STALE
fe80::2a6f:7fff:feba:1cff dev eth0 lladdr 28:6f:7f:ba:1c:ff router STALE


 2.) Test: Try to clear Non existing NDP neighbor:
---------------------------------------------
    admin@lnos-x1-a-csw03:~$ clear ndp fe80::6e41:6aff:fe1e:cd9e
    Neighbor fe80::6e41:6aff:fe1e:cd9e not found
    admin@lnos-x1-a-csw03:~$


3.) Try to clear ndp entry but give Wrong Address format to command:
---------------------------------------------
admin@lnos-x1-a-csw03:~$ clear ndp werq:rq
Error: an inet prefix is expected rather than "werq:rq".
Neighbor werq:rq not found
admin@lnos-x1-a-csw03:~$


4.) Clear Existing ndp neighbor and make sure neighbor is deleted:
---------------------------------------------
admin@lnos-x1-a-csw03:~$ clear ndp fe80::6e41:6aff:fe1e:cd8e

admin@lnos-x1-a-csw03:~$ ./arp_ndp.sh
Command: /usr/sbin/arp -n
Address                  HWtype  HWaddress           Flags Mask            Iface
172.25.11.20             ether   00:06:f6:2b:67:6c   C                     eth0
172.25.11.1              ether   28:6f:7f:ba:1c:ff   C                     eth0
172.25.11.11             ether   bc:16:65:b3:ce:8e   C                     eth0
172.25.11.15             ether   6c:41:6a:1e:cd:8e   C                     eth0

Command: /bin/ip -6 neigh show
fe80::be16:65ff:feb3:ce8e dev eth0 lladdr bc:16:65:b3:ce:8e STALE
fe80::6e41:6aff:fe1e:cd8e dev eth0  FAILED <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< [Cleaned]
fe80::2a6f:7fff:feba:1cff dev eth0 lladdr 28:6f:7f:ba:1c:ff router STALE

admin@lnos-x1-a-csw03:~$



5.) Clear All NDP neighbors and check that all entries are cleaned:
---------------------------------------------
admin@lnos-x1-a-csw03:~$ clear ndp 
fe80::be16:65ff:feb3:ce8e dev eth0 lladdr bc:16:65:b3:ce:8e used 238/238/215 probes 4 STALE
fe80::2a6f:7fff:feba:1cff dev eth0 lladdr 28:6f:7f:ba:1c:ff router used 60267/50132/4 probes 0 STALE

Round 1, deleting 2 entries
Flush is complete after 1 round

admin@lnos-x1-a-csw03:~$

admin@lnos-x1-a-csw03:~$ ./arp_ndp.sh
Command: /usr/sbin/arp -n
Address                  HWtype  HWaddress           Flags Mask            Iface
172.25.11.20             ether   00:06:f6:2b:67:6c   C                     eth0
172.25.11.1              ether   28:6f:7f:ba:1c:ff   C                     eth0
172.25.11.11             ether   bc:16:65:b3:ce:8e   C                     eth0
172.25.11.15             ether   6c:41:6a:1e:cd:8e   C                     eth0

Command: /bin/ip -6 neigh show
fe80::be16:65ff:feb3:ce8e dev eth0  FAILED
fe80::6e41:6aff:fe1e:cd8e dev eth0  FAILED
fe80::2a6f:7fff:feba:1cff dev eth0  router FAILED


6.) Learn IPV6 neighbors again:
---------------------------------------------
admin@lnos-x1-a-csw03:~$  sudo ping6  fe80::6e41:6aff:fe1e:cd8e%eth0 -c 1
PING fe80::6e41:6aff:fe1e:cd8e%eth0(fe80::6e41:6aff:fe1e:cd8e) 56 data bytes
64 bytes from fe80::6e41:6aff:fe1e:cd8e: icmp_seq=1 ttl=64 time=0.375 ms

--- fe80::6e41:6aff:fe1e:cd8e%eth0 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 0.375/0.375/0.375/0.000 ms

admin@lnos-x1-a-csw03:~$ sudo ping6  fe80::2a6f:7fff:feba:1cff%eth0 -c 1
PING fe80::2a6f:7fff:feba:1cff%eth0(fe80::2a6f:7fff:feba:1cff) 56 data bytes
64 bytes from fe80::2a6f:7fff:feba:1cff: icmp_seq=1 ttl=64 time=4.63 ms

--- fe80::2a6f:7fff:feba:1cff%eth0 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 4.633/4.633/4.633/0.000 ms




7.) Clear one ARP and check arp entry is cleared:
---------------------------------------------
admin@lnos-x1-a-csw03:~$ clear arp 172.25.11.11

admin@lnos-x1-a-csw03:~$ ./arp_ndp.sh
Command: /usr/sbin/arp -n
Address                  HWtype  HWaddress           Flags Mask            Iface
172.25.11.20             ether   00:06:f6:2b:67:6c   C                     eth0
172.25.11.1              ether   28:6f:7f:ba:1c:ff   C                     eth0
172.25.11.11                     (incomplete)                              eth0<<<<<<<<<<< cleaned
172.25.11.15             ether   6c:41:6a:1e:cd:8e   C                     eth0

Command: /bin/ip -6 neigh show
fe80::6e41:6aff:fe1e:cd8e dev eth0 lladdr 6c:41:6a:1e:cd:8e STALE
fe80::2a6f:7fff:feba:1cff dev eth0 lladdr 28:6f:7f:ba:1c:ff router STALE
fe80::be16:65ff:feb3:ce8e dev eth0 lladdr bc:16:65:b3:ce:8e STALE

admin@lnos-x1-a-csw03:~$ 



8.) Clear all ARP:
---------------------------------------------
admin@lnos-x1-a-csw03:~$ clear arp
172.25.11.20 dev eth0 lladdr 00:06:f6:2b:67:6c ref 1 used 632/632/627 probes 4 REACHABLE
172.25.11.1 dev eth0 lladdr 28:6f:7f:ba:1c:ff ref 1 used 2865/0/2860 probes 1 REACHABLE
172.25.11.15 dev eth0 lladdr 6c:41:6a:1e:cd:8e ref 1 used 868/670/868 probes 4 REACHABLE

Round 1, deleting 3 entries
Flush is complete after 1 round

admin@lnos-x1-a-csw03:~$ ./arp_ndp.sh
Command: /usr/sbin/arp -n
Address                  HWtype  HWaddress           Flags Mask            Iface
172.25.11.20                     (incomplete)                              eth0
172.25.11.1              ether   28:6f:7f:ba:1c:ff   C                     eth0
172.25.11.11                     (incomplete)                              eth0
172.25.11.15                     (incomplete)                              eth0

Command: /bin/ip -6 neigh show
fe80::6e41:6aff:fe1e:cd8e dev eth0 lladdr 6c:41:6a:1e:cd:8e STALE
fe80::2a6f:7fff:feba:1cff dev eth0 lladdr 28:6f:7f:ba:1c:ff router STALE
fe80::be16:65ff:feb3:ce8e dev eth0 lladdr bc:16:65:b3:ce:8e STALE```
——————————————
Note: We learn 172.25.11.1 quickly.



**- Previous command output (if the output of a command-line utility has changed)**

Only the output of Clear Arp is changing.

---------------------------------------------
admin@falco-test-dut01:~$ clear arp
fe80::5054:ff:fe5e:ad59 dev PortChannel0003 lladdr 52:54:00:5e:ad:59 router used 77317/77317/75068 probes 1 STALE
fe80::2e0:ecff:fe3b:d9be dev eth0 lladdr 00:e0:ec:3b:d9:be used 61110/61110/58692 probes 1 STALE
fe80::5054:ff:fee4:3a41 dev PortChannel0001 lladdr 52:54:00:e4:3a:41 router used 77343/77343/74756 probes 1 STALE
fe80::5054:ff:feba:5a35 dev PortChannel0002 lladdr 52:54:00:ba:5a:35 router used 77314/77314/75475 probes 1 STALE
fe80::2a6f:7fff:feba:1cff dev eth0 lladdr 28:6f:7f:ba:1c:ff router used 149790/153390/156 probes 0 STALE
fe80::5054:ff:fedc:b1e5 dev PortChannel0004 lladdr 52:54:00:dc:b1:e5 router used 77341/77341/75633 probes 1 STALE
172.25.11.20 dev eth0 lladdr 00:06:f6:2b:67:6c used 65494/65494/64295 probes 4 STALE
172.25.11.1 dev eth0 lladdr 28:6f:7f:ba:1c:ff ref 1 used 55/0/50 probes 1 REACHABLE

Round 1, deleting 8 entries
Flush is complete after 1 round 




**- New command output (if the output of a command-line utility has changed)**
---------------------------------------------
admin@lnos-x1-a-csw03:~$ clear arp           
172.25.11.15 dev eth0 lladdr 6c:41:6a:1e:cd:8e ref 1 used 10/10/5 probes 4 REACHABLE
172.25.11.1 dev eth0 lladdr 28:6f:7f:ba:1c:ff ref 1 used 2414/0/2414 probes 4 REACHABLE
172.25.11.11 dev eth0 lladdr bc:16:65:b3:ce:8e ref 1 used 2219/2183/1887 probes 4 REACHABLE"""
-->

