### PR TITLE
Move warm_restart enable/disable config to stateDB WARM_RESTART_ENABL…

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -159,7 +159,8 @@ function backup_database()
     # Delete keys in stateDB except FDB_TABLE|* and WARM_RESTA*
     redis-cli -n 6 eval "
         for _, k in ipairs(redis.call('keys', '*')) do
-            if not string.match(k, 'FDB_TABLE|') and not string.match(k, 'WARM_RESTART_TABLE|') then
+            if not string.match(k, 'FDB_TABLE|') and not string.match(k, 'WARM_RESTART_TABLE|') \
+                                          and not string.match(k, 'WARM_RESTART_ENABLE_TABLE|') then
                 redis.call('del', k)
             end
         end

--- a/show/main.py
+++ b/show/main.py
@@ -1731,10 +1731,11 @@ def config(redis_unix_socket_path):
     def tablelize(keys, data, enable_table_keys, prefix):
         table = []
 
-        for k in enable_table_keys:
-            k = k.replace(prefix, "")
-            if k not in keys:
-                keys.append(k)
+        if enable_table_keys is not None:
+            for k in enable_table_keys:
+                k = k.replace(prefix, "")
+                if k not in keys:
+                    keys.append(k)
 
         for k in keys:
             r = []

--- a/show/main.py
+++ b/show/main.py
@@ -782,7 +782,7 @@ def route_map(route_map_name, verbose):
         cmd += ' {}'.format(route_map_name)
     cmd += '"'
     run_command(cmd, display_cmd=verbose)
-	
+
 #
 # 'ip' group ("show ip ...")
 #
@@ -1717,21 +1717,39 @@ def config(redis_unix_socket_path):
     config_db = ConfigDBConnector(**kwargs)
     config_db.connect(wait_for_init=False)
     data = config_db.get_table('WARM_RESTART')
+    # Python dictionary keys() Method
     keys = data.keys()
 
-    def tablelize(keys, data):
+    state_db = SonicV2Connector(host='127.0.0.1')
+    state_db.connect(state_db.STATE_DB, False)   # Make one attempt only
+    TABLE_NAME_SEPARATOR = '|'
+    prefix = 'WARM_RESTART_ENABLE_TABLE' + TABLE_NAME_SEPARATOR
+    _hash = '{}{}'.format(prefix, '*')
+    # DBInterface keys() method
+    enable_table_keys = state_db.keys(state_db.STATE_DB, _hash)
+
+    def tablelize(keys, data, enable_table_keys, prefix):
         table = []
+
+        for k in enable_table_keys:
+            k = k.replace(prefix, "")
+            if k not in keys:
+                keys.append(k)
 
         for k in keys:
             r = []
             r.append(k)
 
-            if 'enable' not in  data[k]:
+            enable_k = prefix + k
+            if enable_table_keys is None or enable_k not in enable_table_keys:
                 r.append("false")
             else:
-                r.append(data[k]['enable'])
+                r.append(state_db.get(state_db.STATE_DB, enable_k, "enable"))
 
-            if 'neighsyncd_timer' in  data[k]:
+            if k not in data:
+                r.append("NULL")
+                r.append("NULL")
+            elif 'neighsyncd_timer' in  data[k]:
                 r.append("neighsyncd_timer")
                 r.append(data[k]['neighsyncd_timer'])
             elif 'bgp_timer' in data[k]:
@@ -1749,8 +1767,8 @@ def config(redis_unix_socket_path):
         return table
 
     header = ['name', 'enable', 'timer_name', 'timer_duration']
-    click.echo(tabulate(tablelize(keys, data), header))
-
+    click.echo(tabulate(tablelize(keys, data, enable_table_keys, prefix), header))
+    state_db.close(state_db.STATE_DB)
 
 if __name__ == '__main__':
     cli()


### PR DESCRIPTION
…E_TABLE

Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>


Prerequisite PR: [Azure/sonic-swss-common#260](https://github.com/Azure/sonic-swss-common/pull/260)

**What I did**

For warm_restart enable/disable configuration, putting them into configDB caused confusion in configuration save and restore. They are not supposed to be persistent across cold boot. Moving them to stateDB which will be saved and restored during warm reboot.

https://github.com/Azure/sonic-swss-common/pull/260

https://github.com/Azure/sonic-swss/pull/786

https://github.com/Azure/sonic-sairedis/pull/418

https://github.com/Azure/sonic-utilities/pull/458

https://github.com/Azure/sonic-buildimage/pull/2538

**- How I did it**

**- How to verify it**

config and show

```
admin@sonic:~$ show warm_restart config
name    enable    timer_name    timer_duration
------  --------  ------------  ----------------
system  true      NULL          NULL
swss    true      NULL          NULL
admin@sonic:~$ config warm_restart enable bgp
Root privileges are required for this operation
admin@sonic:~$ sudo su
root@sonic:/home/admin# config warm_restart enable bgp
root@sonic:/home/admin#  show warm_restart config
name    enable    timer_name    timer_duration
------  --------  ------------  ----------------
system  true      NULL          NULL
swss    true      NULL          NULL
bgp     true      NULL          NULL
root@sonic:/home/admin# config warm_restart disable  bgp
root@sonic:/home/admin# 
root@sonic:/home/admin# 
root@sonic:/home/admin#  show warm_restart config
name    enable    timer_name    timer_duration
------  --------  ------------  ----------------
system  true      NULL          NULL
swss    true      NULL          NULL
bgp     false     NULL          NULL
root@sonic:/home/admin# 
root@sonic:/home/admin# 
root@sonic:/home/admin# config warm_restart 
bgp_timer         disable           enable            neighsyncd_timer  teamsyncd_timer   
root@sonic:/home/admin# config warm_restart 
bgp_timer         disable           enable            neighsyncd_timer  teamsyncd_timer   
root@sonic:/home/admin# config warm_restart --help
Usage: config warm_restart [OPTIONS] COMMAND [ARGS]...

  warm_restart-related configuration tasks

Options:
  -s, --redis-unix-socket-path TEXT
                                  unix socket path for redis connection
  --help                          Show this message and exit.

Commands:
  bgp_timer
  disable
  enable
  neighsyncd_timer
  teamsyncd_timer
root@sonic:/home/admin# config warm_restart bgp_timer  180
root@sonic:/home/admin# 
root@sonic:/home/admin# show warm_restart config
name    enable    timer_name    timer_duration
------  --------  ------------  ----------------
bgp     false     bgp_timer     180
system  true      NULL          NULL
swss    true      NULL          NULL
root@sonic:/home/admin# 
root@sonic:/home/admin# redis-cli -n 6
127.0.0.1:6379[6]> keys WARM*
 1) "WARM_RESTART_TABLE|vlanmgrd"
 2) "WARM_RESTART_TABLE|neighsyncd"
 3) "WARM_RESTART_TABLE|portsyncd"
 4) "WARM_RESTART_TABLE|teammgrd"
 5) "WARM_RESTART_TABLE|syncd"
 6) "WARM_RESTART_ENABLE_TABLE|system"
 7) "WARM_RESTART_TABLE|teamsyncd"
 8) "WARM_RESTART_ENABLE_TABLE|swss"
 9) "WARM_RESTART_TABLE|bgp"
10) "WARM_RESTART_ENABLE_TABLE|bgp"
11) "WARM_RESTART_TABLE|orchagent"
127.0.0.1:6379[6]> hgetall   "WARM_RESTART_ENABLE_TABLE|bgp"
1) "enable"
2) "false"
127.0.0.1:6379[6]> select 4
OK
127.0.0.1:6379[4]> keys WAR*
1) "WARM_RESTART|bgp"
127.0.0.1:6379[4]> hgetall  "WARM_RESTART|bgp"
1) "bgp_timer"
2) "180"
127.0.0.1:6379[4]> 
```


Warm upgrade docker check:
```
root@sonic:/home/admin# sonic_installer upgrade_docker swss  --enforce_check --cleanup_image /tmp/docker-orchagent-brcm.gz 
New docker image will be installed, continue? [y/N]: y
Orchagent is not in clean state, RESTARTCHECK failed 1
Command: sleep 1

Orchagent is not in clean state, RESTARTCHECK failed 2
Command: sleep 1

Orchagent is not in clean state, RESTARTCHECK failed 3
Command: sleep 1

Orchagent is not in clean state, RESTARTCHECK failed 4
Command: sleep 1

Orchagent is not in clean state, RESTARTCHECK failed 5
```

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

