### PR TITLE
[sonic_installer] Improve error handling

### DIFF
--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -188,6 +188,27 @@ def get_docker_tag_name(image):
         return "unknown"
     return tag
 
+# Function which validates whether a given URL specifies an existent file
+# on a reachable remote machine. Will abort the current operation if not
+def validate_url_or_abort(url):
+    # Attempt to retrieve HTTP response code
+    try:
+        urlfile = urllib.urlopen(url)
+        response_code = urlfile.getcode()
+        urlfile.close()
+    except IOError, err:
+        response_code = None
+
+    if not response_code:
+        click.echo("Did not receive a response from remote machine. Aborting...")
+        raise click.Abort()
+    else:
+        # Check for a 4xx response code which indicates a nonexistent URL
+        if response_code / 100 == 4:
+            click.echo("Image file not found on remote machine. Aborting...")
+            raise click.Abort()
+
+
 # Callback for confirmation prompt. Aborts if user enters "n"
 def abort_if_false(ctx, param, value):
     if not value:
@@ -217,25 +238,12 @@ def install(url):
 
     if url.startswith('http://') or url.startswith('https://'):
         click.echo('Downloading image...')
-
-        # Get HTTP response code first before downloading file
+        validate_url_or_abort(url)
         try:
-            urlfile = urllib.urlopen(url)
-            response_code = urlfile.getcode()
-            urlfile.close()
-        except IOError, err:
-            response_code = None
-
-        if not response_code:
-            click.echo("Did not receive a response from remote machine. Aborting...")
+            urllib.urlretrieve(url, DEFAULT_IMAGE_PATH, reporthook)
+        except Exception, e:
+            click.echo("Download error", e)
             raise click.Abort()
-        else:
-            # Check for a 4xx response code which indicates a nonexistent URL
-            if response_code / 100 == 4:
-                click.echo("Image file not found on remote machine. Aborting...")
-                raise click.Abort()
-
-        urllib.urlretrieve(url, DEFAULT_IMAGE_PATH, reporthook)
         image_path = DEFAULT_IMAGE_PATH
     else:
         image_path = os.path.join("./", url)
@@ -248,6 +256,7 @@ def install(url):
             click.echo("Image file does not exist or is not a regular file. Aborting...")
             raise click.Abort()
 
+        # TODO: Validate file is a proper SONiC image file
         os.chmod(image_path, stat.S_IXUSR)
         run_command(image_path)
         run_command('grub-set-default --boot-directory=' + HOST_PATH + ' 0')
@@ -410,11 +419,12 @@ def upgrade_docker(container_name, url, cleanup_image, enforce_check, tag):
     DEFAULT_IMAGE_PATH = os.path.join("/tmp/", image_name)
     if url.startswith('http://') or url.startswith('https://'):
         click.echo('Downloading image...')
+        validate_url_or_abort(url)
         try:
             urllib.urlretrieve(url, DEFAULT_IMAGE_PATH, reporthook)
         except Exception, e:
             click.echo("Download error", e)
-            return
+            raise click.Abort()
         image_path = DEFAULT_IMAGE_PATH
     else:
         image_path = os.path.join("./", url)

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -208,7 +208,6 @@ def validate_url_or_abort(url):
             click.echo("Image file not found on remote machine. Aborting...")
             raise click.Abort()
 
-
 # Callback for confirmation prompt. Aborts if user enters "n"
 def abort_if_false(ctx, param, value):
     if not value:

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -248,15 +248,16 @@ def install(url):
     else:
         image_path = os.path.join("./", url)
 
+    # Verify that the local file exists and is a regular file
+    # TODO: Verify the file is a *proper SONiC image file*
+    if not os.path.isfile(image_path):
+        click.echo("Image file '{}' does not exist or is not a regular file. Aborting...".format(image_path))
+        raise click.Abort()
+
     if get_image_type() == IMAGE_TYPE_ABOOT:
         run_command("/usr/bin/unzip -od /tmp %s boot0" % image_path)
         run_command("swipath=%s target_path=/host sonic_upgrade=1 . /tmp/boot0" % image_path)
     else:
-        if not os.path.isfile(image_path):
-            click.echo("Image file does not exist or is not a regular file. Aborting...")
-            raise click.Abort()
-
-        # TODO: Validate file is a proper SONiC image file
         os.chmod(image_path, stat.S_IXUSR)
         run_command(image_path)
         run_command('grub-set-default --boot-directory=' + HOST_PATH + ' 0')
@@ -429,7 +430,11 @@ def upgrade_docker(container_name, url, cleanup_image, enforce_check, tag):
     else:
         image_path = os.path.join("./", url)
 
-    # TODO: Validate the new docker image before disrupting existsing images.
+    # Verify that the local file exists and is a regular file
+    # TODO: Verify the file is a *proper Docker image file*
+    if not os.path.isfile(image_path):
+        click.echo("Image file '{}' does not exist or is not a regular file. Aborting...".format(image_path))
+        raise click.Abort()
 
     warm = False
     config_db = ConfigDBConnector()


### PR DESCRIPTION
**- What I did**
Improve error handling in sonic_installer. Output messages to console rather than crashing and displaying backtrace.

**- How I did it**
1. If attempting to install a local image, first check whether the specified image file exists and is a regular file. If not, output an error message to the console and abort the operation.
2. If provided a URL as an image location, check for an HTTP response from the remote machine, and verify that the response is not 4xx. If either of these conditions exist, output a message to the console  and abort the operation.

**- How to verify it**

1. Pass sonic-installer the name of an image file which doesn't exist on the local machine. Instead of a backtrace, you should see the following message:
```
Image file does not exist or is not a regular file. Aborting...
Aborted!
```

2. Pass sonic-installer a URL containing an unreachable remote machine. Instead of a backtrace, you should see the following message:
```
Did not receive a response from remote machine. Aborting...
Aborted!
```

3. Pass sonic-installer a URL containing a path to a nonexistent file on a reachable remote machine. Instead of a backtrace, you should see the following message:
```
Image file not found on remote machine. Aborting...
Aborted!
```