### PR TITLE
[clock] sync os time to CMOS before rebooting

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -360,6 +360,11 @@ sync
 sleep 1
 sync
 
+# sync the current system time to CMOS
+if [ -x /sbin/hwclock ]; then
+    /sbin/hwclock -w || /bin/true
+fi
+
 # Reboot: explicity call Linux native reboot under sbin
 debug "Rebooting with ${REBOOT_METHOD} to ${NEXT_SONIC_IMAGE} ..."
 exec ${REBOOT_METHOD}

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -48,6 +48,11 @@ echo "User issued 'reboot' command [User: ${REBOOT_USER}, Time: ${REBOOT_TIME}]"
 sync
 sleep 3
 
+# sync the current system time to CMOS
+if [ -x /sbin/hwclock ]; then
+    /sbin/hwclock -w || /bin/true
+fi
+
 if [ -x ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT} ]; then
     echo "Rebooting with platform ${PLATFORM} specific tool ..."
     exec ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT} $@


### PR DESCRIPTION
**- What I did**
Sync o.s. time to CMOS before rebooting, so if CMOS clock has drifted, we fix it at reboot time after syncing with NTP.

What we found is that every time the o.s. boots up, the Linux kernel will take CMOS time and then sync with NTP. NTP fixes the time difference overtime. The o.s. syncs the o.s. time to CMOS at certain frequency that is not very often.

In a test setup when I continuously run warm-reboot, the small sync with the correct time got lost after every reboot.

**- How to verify it**
With this change, the small sync will be persisted to CMOS. With the change, over 24 hours period, I saw clock got fixed towards the right NTP time by 35-ish seconds. This is slow but better than no sync at all.