### PR TITLE
[decode-syseeprom] Add option '-d' for decode-syseeprom

### DIFF
--- a/scripts/decode-syseeprom
+++ b/scripts/decode-syseeprom
@@ -27,7 +27,7 @@ CACHE_ROOT = '/var/cache/sonic/decode-syseeprom'
 CACHE_FILE = 'syseeprom_cache'
 
 def main():
-
+    support_eeprom_db = True
     if not os.geteuid() == 0:
         raise RuntimeError("must be root to run")
 
@@ -36,6 +36,9 @@ def main():
 
     platform_path = '/'.join([PLATFORM_ROOT, platform])
 
+    # Currently, don't support eeprom db on Arista platform
+    if 'arista' in platform_path:
+        support_eeprom_db = False
     #
     # Currently we only support board eeprom decode.
     #
@@ -55,7 +58,7 @@ def main():
     #
     # execute the command
     #
-    run(t, opts, args)
+    run(t, opts, args, support_eeprom_db)
 
 #-------------------------------------------------------------------------------
 #
@@ -63,6 +66,8 @@ def main():
 #
 def get_cmdline_opts():
     optcfg = optparse.OptionParser(usage="usage: %s [-s][-m]" % sys.argv[0])
+    optcfg.add_option("-d", dest="db", action="store_true",
+                      default=False, help="print eeprom from database")
     optcfg.add_option("-s", dest="serial", action="store_true",
                       default=False, help="print device serial number/service tag")
     optcfg.add_option("-m", dest="mgmtmac", action="store_true", default=False,
@@ -75,7 +80,16 @@ def get_cmdline_opts():
 #
 # Run
 #
-def run(target, opts, args):
+def run(target, opts, args, support_eeprom_db):
+
+    if support_eeprom_db and opts.db:
+        err = target.read_eeprom_db()
+        if err:
+            # Failed to read EEPROM information from database. Read from cache file
+            pass
+        else:
+            return 0
+
     status = target.check_status()
     if status <> 'ok':
         sys.stderr.write("Device is not ready: " + status + "\n")
@@ -109,8 +123,10 @@ def run(target, opts, args):
         pass
 
     if opts.init:
-        return 0
-
+        err = target.update_eeprom_db(e)
+        if err:
+            print "Failed to update eeprom database"
+            return -1
     elif opts.mgmtmac:
         mm = target.mgmtaddrstr(e)
         if mm != None:

--- a/show/main.py
+++ b/show/main.py
@@ -1116,7 +1116,7 @@ def summary():
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def syseeprom(verbose):
     """Show system EEPROM information"""
-    cmd = "sudo decode-syseeprom"
+    cmd = "sudo decode-syseeprom -d"
     run_command(cmd, display_cmd=verbose)
 
 # 'psustatus' subcommand ("show platform psustatus")


### PR DESCRIPTION
* Option '-d' means read the EEPROM information from DB directly
* CLI "show platform syseeprom" will invoke decode-syseeprom with
  '-d' option

Signed-off-by: Kevin Wang <kevinw@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Add a new option '-d' for decode-syseeprom to read EEPROM data from DB directly rather than from cache file.
It will support on the platforms which are using the TLV format in EEPROM file. As Arista uses a different format, so doesn't support this function on Arista platform until the update_eeprom_db() and read_eeprom_db() are overridden on Arista platform.
This change depends on the parent PR https://github.com/Azure/sonic-platform-common/pull/21.
Should not be merged before the parent PR is merged.
At the init stage, need to invoke command"decode-syseeprom --init" to update the EEPROM information from cache file to the database. This command needs to be added in rc.local of sonic-buildimage repo after this PR is merged.
**- How I did it**
Change the CLI 'show platform syseeprom' to invoke decode-syseeprom with the new option '-d'
**- How to verify it**
show platform syseeprom
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

