### PR TITLE
aclshow unittest

### DIFF
--- a/sonic-utilities-tests/aclshow_test.py
+++ b/sonic-utilities-tests/aclshow_test.py
@@ -1,0 +1,214 @@
+import sys
+import os
+from StringIO import StringIO
+import mock
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(test_path)
+scripts_path = os.path.join(modules_path, "scripts")
+sys.path.insert(0, modules_path)
+
+from imp import load_source
+load_source('aclshow', scripts_path+'/aclshow')
+from aclshow import *
+
+import mock_tables.dbconnector
+
+# Expected output for aclshow
+default_output = ''+ \
+"""RULE NAME     TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
+------------  ------------  ------  ---------------  -------------
+RULE_1        DATAACL         9999              101            100
+RULE_2        DATAACL         9998              201            200
+RULE_3        DATAACL         9997              301            300
+RULE_4        DATAACL         9996              401            400
+RULE_7        DATAACL         9993              701            700
+RULE_9        DATAACL         9991              901            900
+DEFAULT_RULE  DATAACL            1                2              1
+RULE_6        EVERFLOW        9994              601            600
+"""
+
+# Expected output for aclshow -a
+all_output = '' + \
+"""RULE NAME     TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
+------------  ------------  ------  ---------------  -------------
+RULE_1        DATAACL         9999              101            100
+RULE_2        DATAACL         9998              201            200
+RULE_3        DATAACL         9997              301            300
+RULE_4        DATAACL         9996              401            400
+RULE_05       DATAACL         9995                0              0
+RULE_7        DATAACL         9993              701            700
+RULE_9        DATAACL         9991              901            900
+DEFAULT_RULE  DATAACL            1                2              1
+RULE_6        EVERFLOW        9994              601            600
+RULE_08       EVERFLOW        9992                0              0
+"""
+
+# Expected output for aclshow -r RULE_1 -t DATAACL
+rule1_dataacl_output = '' + \
+"""RULE NAME    TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
+-----------  ------------  ------  ---------------  -------------
+RULE_1       DATAACL         9999              101            100
+"""
+
+# Expected output for aclshow -a -r RULE_05
+rule05_all_output = ''+ \
+"""RULE NAME    TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
+-----------  ------------  ------  ---------------  -------------
+RULE_05      DATAACL         9995                0              0
+"""
+
+# Expected output for aclshow -r RULE_0
+rule0_output = '' + \
+"""RULE NAME    TABLE NAME    PRIO    PACKETS COUNT    BYTES COUNT
+-----------  ------------  ------  ---------------  -------------
+"""
+
+# Expected output for aclshow -r RULE_4,RULE_6 -vv
+rule4_rule6_verbose_output = '' + \
+"""Reading ACL info...
+Total number of ACL Tables: 4
+Total number of ACL Rules: 10
+
+RULE NAME    TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
+-----------  ------------  ------  ---------------  -------------
+RULE_4       DATAACL         9996              401            400
+RULE_6       EVERFLOW        9994              601            600
+"""
+
+# Expected output for aclshow -t EVERFLOW
+everflow_output = '' + \
+"""RULE NAME    TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
+-----------  ------------  ------  ---------------  -------------
+RULE_6       EVERFLOW        9994              601            600
+"""
+
+# Expected output for aclshow -t DATAACL
+dataacl_output = '' + \
+"""RULE NAME     TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
+------------  ------------  ------  ---------------  -------------
+RULE_1        DATAACL         9999              101            100
+RULE_2        DATAACL         9998              201            200
+RULE_3        DATAACL         9997              301            300
+RULE_4        DATAACL         9996              401            400
+RULE_7        DATAACL         9993              701            700
+RULE_9        DATAACL         9991              901            900
+DEFAULT_RULE  DATAACL            1                2              1
+"""
+
+# Expected output for aclshow -c
+clear_output = ''
+
+# Expected output for
+# aclshow -a -c ; aclshow -a
+all_after_clear_output = '' + \
+"""RULE NAME     TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
+------------  ------------  ------  ---------------  -------------
+RULE_1        DATAACL         9999                0              0
+RULE_2        DATAACL         9998                0              0
+RULE_3        DATAACL         9997                0              0
+RULE_4        DATAACL         9996                0              0
+RULE_05       DATAACL         9995                0              0
+RULE_7        DATAACL         9993                0              0
+RULE_9        DATAACL         9991                0              0
+DEFAULT_RULE  DATAACL            1                0              0
+RULE_6        EVERFLOW        9994                0              0
+RULE_08       EVERFLOW        9992                0              0
+"""
+
+class Aclshow():
+    def __init__(self, *args, **kwargs):
+        """
+        nullify_on_start, nullify_on_exit will call nullify_counters()
+        before and/or after the test. By default - clear on start and exit.
+        """
+        self.nullify_on_start, self.nullify_on_exit = args if args else (True, True)
+        self.kwargs = kwargs
+        self.setUp()
+        self.runTest()
+        self.tearDown()
+
+    def nullify_counters(self):
+        """
+        This method is used to empty dumped counters
+        if exist in /tmp/.counters_acl.p (by default).
+        """
+        if os.path.isfile(COUNTER_POSITION):
+            with open(COUNTER_POSITION, 'wb') as fp:
+                json.dump([], fp)
+
+    def runTest(self):
+        """
+        This method invokes main() from aclshow utility (parametrized by argparse)
+        parametrized by mock argparse.
+        """
+        @mock.patch('argparse.ArgumentParser.parse_args', return_value = argparse.Namespace(**self.kwargs))
+        def run(mock_args):
+            main()
+        run()
+
+    def setUp(self):
+        if self.nullify_on_start:
+            self.nullify_counters()
+        self.old_stdout = sys.stdout
+        self.result = StringIO()
+        sys.stdout = self.result
+
+    def tearDown(self):
+        if self.nullify_on_exit:
+            self.nullify_counters()
+        sys.stdout = self.old_stdout
+
+# aclshow
+def test_default():
+    test = Aclshow(all = None, clear = None, rules = None, tables = None, verbose = None)
+    assert test.result.getvalue() == default_output
+
+# aclshow -a
+def test_all():
+    test = Aclshow(all = True, clear = None, rules = None, tables = None, verbose = None)
+    assert test.result.getvalue() == all_output
+
+# aclshow -r RULE_1 -t DATAACL
+def test_rule1_dataacl():
+    test = Aclshow(all = None, clear = None, rules = 'RULE_1', tables = 'DATAACL', verbose = None)
+    assert test.result.getvalue() == rule1_dataacl_output
+
+# aclshow -a -r RULE_05
+def test_rule05_all():
+    test = Aclshow(all = True, clear = None, rules = 'RULE_05', tables = None, verbose = None)
+    assert test.result.getvalue() == rule05_all_output
+
+# aclshow -r RULE_0
+def test_rule0():
+    test = Aclshow(all = None, clear = None, rules = 'RULE_0', tables = None, verbose = None)
+    assert test.result.getvalue() == rule0_output
+
+# aclshow -r RULE_4,RULE_6 -vv
+def test_rule4_rule6_verbose():
+    test = Aclshow(all = None, clear = None, rules = 'RULE_4,RULE_6', tables = None, verbose = True)
+    assert test.result.getvalue() == rule4_rule6_verbose_output
+
+# aclshow -t EVERFLOW
+def test_everflow():
+    test = Aclshow(all=None, clear=None, rules=None, tables='EVERFLOW', verbose=None)
+    assert test.result.getvalue() == everflow_output
+
+# aclshow -t DATAACL
+def test_dataacl():
+    test = Aclshow(all=None, clear=None, rules=None, tables='DATAACL', verbose=None)
+    assert test.result.getvalue() == dataacl_output
+
+# aclshow -c
+def test_clear():
+    test = Aclshow(all=None, clear=True, rules=None, tables=None, verbose=None)
+    assert test.result.getvalue() == clear_output
+
+# aclshow -a -c ; aclshow -a
+def test_all_after_clear():
+    nullify_on_start, nullify_on_exit = True, False
+    test = Aclshow(nullify_on_start, nullify_on_exit, all=True, clear=True, rules=None, tables=None, verbose=None)
+    assert test.result.getvalue() == clear_output
+    nullify_on_start, nullify_on_exit = False, True
+    test = Aclshow(nullify_on_start, nullify_on_exit, all=True, clear=False, rules=None, tables=None, verbose=None)
+    assert test.result.getvalue() == all_after_clear_output

--- a/sonic-utilities-tests/mock_tables/config_db.json
+++ b/sonic-utilities-tests/mock_tables/config_db.json
@@ -41,5 +41,74 @@
         "lanes": "116,117,118,119",
         "mtu": "9100",
         "speed": "40000"
+    },
+    "ACL_RULE|DATAACL|DEFAULT_RULE": {
+            "PACKET_ACTION": "DROP",
+            "PRIORITY": "1"
+    },
+    "ACL_RULE|DATAACL|RULE_1": {
+            "PACKET_ACTION": "FORWARD",
+            "PRIORITY": "9999",
+            "SRC_IP": "10.0.0.2/32"
+    },
+    "ACL_RULE|DATAACL|RULE_2": {
+            "DST_IP": "192.168.0.16/32",
+            "PACKET_ACTION": "FORWARD",
+            "PRIORITY": "9998"
+    },
+    "ACL_RULE|DATAACL|RULE_3": {
+            "DST_IP": "172.16.2.0/32",
+            "PACKET_ACTION": "FORWARD",
+            "PRIORITY": "9997"
+    },
+    "ACL_RULE|DATAACL|RULE_4": {
+            "L4_SRC_PORT": "4661",
+            "PACKET_ACTION": "FORWARD",
+            "PRIORITY": "9996"
+    },
+    "ACL_RULE|DATAACL|RULE_05": {
+            "IP_PROTOCOL": "126",
+            "PACKET_ACTION": "FORWARD",
+            "PRIORITY": "9995"
+    },
+    "ACL_RULE|EVERFLOW|RULE_6": {
+            "PACKET_ACTION": "FORWARD",
+            "PRIORITY": "9994",
+            "TCP_FLAGS": "0x12/0x12"
+    },
+    "ACL_RULE|DATAACL|RULE_7": {
+            "PACKET_ACTION": "DROP",
+            "PRIORITY": "9993",
+            "SRC_IP": "10.0.0.3/32"
+    },
+    "ACL_RULE|EVERFLOW|RULE_08": {
+            "PACKET_ACTION": "FORWARD",
+            "PRIORITY": "9992",
+            "SRC_IP": "10.0.0.3/32"
+    },
+    "ACL_RULE|DATAACL|RULE_9": {
+            "L4_DST_PORT": "4661",
+            "PACKET_ACTION": "FORWARD",
+            "PRIORITY": "9991"
+    },
+     "ACL_TABLE|DATAACL": {
+            "policy_desc": "DATAACL",
+            "ports@": "PortChannel0002,PortChannel0005,PortChannel0008,PortChannel0011,PortChannel0014,PortChannel0017,PortChannel0020,PortChannel0023,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124",
+            "type": "L3"
+    },
+    "ACL_TABLE|EVERFLOW": {
+            "policy_desc": "EVERFLOW",
+            "ports@": "PortChannel0002,PortChannel0005,PortChannel0008,PortChannel0011,PortChannel0014,PortChannel0017,PortChannel0020,PortChannel0023,Ethernet100,Ethernet104,Ethernet92,Ethernet96,Ethernet84,Ethernet88,Ethernet76,Ethernet80,Ethernet108,Ethernet112,Ethernet64,Ethernet120,Ethernet116,Ethernet124,Ethernet72,Ethernet68",
+            "type": "MIRROR"
+    },
+    "ACL_TABLE|SNMP_ACL": {
+            "policy_desc": "SNMP_ACL",
+            "services@": "SNMP",
+            "type": "CTRLPLANE"
+    },
+    "ACL_TABLE|SSH_ONLY": {
+            "policy_desc": "SSH_ONLY",
+            "services@": "SSH",
+            "type": "CTRLPLANE"
     }
 }

--- a/sonic-utilities-tests/mock_tables/counters_db.json
+++ b/sonic-utilities-tests/mock_tables/counters_db.json
@@ -74,5 +74,45 @@
             "oid:0x600000000063c": "SAI_ROUTER_INTERFACE_TYPE_PORT",
             "oid:0x600000000063d": "SAI_ROUTER_INTERFACE_TYPE_PORT",
             "oid:0x600000000065f": "SAI_ROUTER_INTERFACE_TYPE_PORT"
+    },
+    "COUNTERS:DATAACL:DEFAULT_RULE": {
+            "Bytes": "1",
+            "Packets": "2"
+    },
+    "COUNTERS:DATAACL:RULE_1": {
+            "Bytes": "100",
+            "Packets": "101"
+    },
+    "COUNTERS:DATAACL:RULE_2": {
+            "Bytes": "200",
+            "Packets": "201"
+    },
+    "COUNTERS:DATAACL:RULE_3": {
+            "Bytes": "300",
+            "Packets": "301"
+    },
+    "COUNTERS:DATAACL:RULE_4": {
+            "Bytes": "400",
+            "Packets": "401"
+    },
+    "COUNTERS:DATAACL:RULE_05": {
+            "Bytes": "0",
+            "Packets": "0"
+    },
+    "COUNTERS:EVERFLOW:RULE_6": {
+            "Bytes": "600",
+            "Packets": "601"
+    },
+    "COUNTERS:DATAACL:RULE_7":{
+            "Bytes": "700",
+            "Packets": "701"
+    },
+    "COUNTERS:EVERFLOW:RULE_08": {
+            "Bytes": "0",
+            "Packets": "0"
+    },
+    "COUNTERS:DATAACL:RULE_9": {
+            "Bytes": "900",
+            "Packets": "901"
     }
 }


### PR DESCRIPTION
Signed-off-by: Roman Kachur <romankac@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
I created a unittest for the aclshow utility
**- How I did it**
Exploiting mock_tables, I added mock Rules, Databases, and occasional Counters.
Unittest calls aclshow with different arguments, and compares its output with the predefined outputs.
In total 10 cases were covered:
- aclshow
- aclshow -a
- aclshow -r RULE_1 -t DATAACL
- aclshow -r RULE_0 -a
- aclshow -r RULE_0
- aclshow -r RULE_6,RULE_4 -vv
- aclshow -t EVERFLOW
- aclshow -t DATAACL
- aclshow -c
- aclshow -c ; aclshow -a

**- How to verify it**
python2 -m py.test  aclshow_test.py -v
**- Previous command output (if the output of a command-line utility has changed)**
N/A
**- New command output (if the output of a command-line utility has changed)**
```
collected 10 items

aclshow_test.py::test_default PASSED
aclshow_test.py::test_all PASSED
aclshow_test.py::test_rule1_dataacl PASSED
aclshow_test.py::test_rule05_all PASSED
aclshow_test.py::test_rule0 PASSED
aclshow_test.py::test_rule4_rule6_verbose PASSED
aclshow_test.py::test_everflow PASSED
aclshow_test.py::test_dataacl PASSED
aclshow_test.py::test_clear PASSED
aclshow_test.py::test_all_after_clear PASSED
```

-->

