### PR TITLE
Management vrf snmp cli support

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -6,6 +6,8 @@ import click
 import json
 import subprocess
 import netaddr
+import logging
+import logging.handlers
 import re
 import syslog
 
@@ -789,6 +791,174 @@ def del_vlan_member(ctx, vid, interface_name):
     db.set_entry('VLAN_MEMBER', (vlan_name, interface_name), None)
 
 
+
+def vrf_add_management_vrf():
+	"""Enable management vrf"""
+
+	config_db = ConfigDBConnector()
+	config_db.connect()
+        entry = config_db.get_entry('MGMT_VRF_CONFIG', "vrf_global")
+        if entry and entry['mgmtVrfEnabled'] == 'true' :
+	    click.echo("ManagementVRF is already Enabled.")
+	    return None
+	config_db.mod_entry('MGMT_VRF_CONFIG',"vrf_global",{"mgmtVrfEnabled": "true"})
+        cmd="service ntp stop"
+        os.system (cmd)
+        cmd="systemctl restart interfaces-config"
+        os.system (cmd)
+        cmd="service ntp start"
+        os.system (cmd)
+
+
+def vrf_delete_management_vrf():
+	"""Disable management vrf"""
+
+	config_db = ConfigDBConnector()
+	config_db.connect()
+        entry = config_db.get_entry('MGMT_VRF_CONFIG', "vrf_global")
+        if not entry or entry['mgmtVrfEnabled'] == 'false' :
+	    click.echo("ManagementVRF is already Disabled.")
+	    return None
+	config_db.mod_entry('MGMT_VRF_CONFIG',"vrf_global",{"mgmtVrfEnabled": "false"})
+        cmd="service ntp stop"
+        os.system (cmd)
+        cmd="systemctl restart interfaces-config"
+        os.system (cmd)
+        cmd="service ntp start"
+        os.system (cmd)
+
+
+#
+# 'vrf' group ('config vrf ...')
+#
+
+@config.group('vrf')
+def vrf():
+    """VRF-related configuration tasks"""
+    pass
+
+
+@vrf.command('add')
+@click.argument('vrfname', metavar='<vrfname>. Type mgmt for management VRF', required=True)
+@click.pass_context
+def vrf_add (ctx, vrfname):
+    """VRF ADD"""
+    if vrfname == 'mgmt' or vrfname == 'management':
+        vrf_add_management_vrf()
+    else:
+        click.echo("Creation of data vrf={} is not yet supported".format(vrfname))
+
+
+@vrf.command('del')
+@click.argument('vrfname', metavar='<vrfname>. Type mgmt for management VRF', required=False)
+@click.pass_context
+def vrf_del (ctx, vrfname):
+    """VRF Delete"""
+    if vrfname == 'mgmt' or vrfname == 'management':
+        vrf_delete_management_vrf()
+    else:
+        click.echo("Deletion of data vrf={} is not yet supported".format(vrfname))
+
+
+@config.command('clear_mgmt')
+@click.pass_context
+def clear_mgmt(ctx):
+    MGMT_TABLE_NAMES = [
+            'MGMT_INTERFACE',
+            'MGMT_VRF_CONFIG']
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    for mgmt_table in MGMT_TABLE_NAMES:
+        config_db.delete_table(mgmt_table)
+
+@config.group()
+def snmpagentaddress():
+    """SNMP agentaddress Related Task"""
+    pass
+
+@snmpagentaddress.command('add')
+@click.argument('agentip', metavar='<SNMP AGENT IP Address>', required=True)
+@click.argument('vrf', metavar='<VRF name mgmt/default/data>', required=False)
+@click.pass_context
+
+def add_snmp_agent_address(ctx, agentip, vrf):
+    """Add the SNMP agent IP and VRF configuration"""
+
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    if vrf:
+        entry = config_db.get_entry('MGMT_VRF_CONFIG', "vrf_global")
+        if entry == {}:
+            click.echo('Cannot set SNMP Agent ip address using when management VRF is not yet configured.')
+            return
+        if entry['mgmtVrfEnabled'] == "false" :
+            click.echo('Cannot set SNMP Agent ip address using when management VRF is not yet enabled.')
+            return
+
+    config_db.set_entry('SNMP_AGENT_ADDRESS_CONFIG', (agentip, vrf), {})
+    cmd="systemctl restart snmp"
+    os.system (cmd)
+
+@snmpagentaddress.command('del')
+@click.argument('agentip', metavar='<SNMP AGENT IP Address>', required=True)
+@click.argument('vrf', metavar='<VRF name mgmt/default/data>', required=False)
+@click.pass_context
+
+def del_snmp_agent_address(ctx, agentip, vrf):
+    """Del the SNMP agent IP and VRF configuration"""
+
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    if vrf:
+        entry = config_db.get_entry('MGMT_VRF_CONFIG', "vrf_global")
+        if entry == {}:
+            click.echo('Cannot set SNMP Agent ip address using when management VRF is not yet configured.')
+            return
+        if entry['mgmtVrfEnabled'] == "false" :
+            click.echo('Cannot set SNMP Agent ip address using when management VRF is not yet enabled.')
+            return
+
+    config_db.get_entry('SNMP_AGENT_ADDRESS_CONFIG', (agentip, vrf))
+    config_db.set_entry('SNMP_AGENT_ADDRESS_CONFIG', (agentip, vrf), None)
+    cmd="systemctl restart snmp"
+    os.system (cmd)
+
+@config.group()
+def snmptrap():
+    """SNMP Traps Related Task"""
+    pass
+
+@snmptrap.command('modify')
+@click.argument('ver', metavar='<SNMP Version>', type=click.Choice(['1', '2', '3']), required=True)
+@click.argument('serverip', metavar='<SNMP TRAP SERVER IP Address>', required=True)
+@click.argument('vrf', metavar='<VRF name mgmt/default/data>', required=False)
+@click.argument('trapport', metavar='<SNMP Trap Server port, default 162>', required=False)
+@click.pass_context
+def modify_snmptrap_server(ctx, ver, serverip, vrf, trapport):
+    """Add the SNMP Trap server configuration"""
+    if not trapport:
+        trapport = 162
+
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    if vrf and vrf == "mgmt":
+        entry = config_db.get_entry('MGMT_VRF_CONFIG', "vrf_global")
+        if entry == {}:
+            click.echo('Cannot set SNMPTrap server using --use-mgmt-vrf when management VRF is not yet configured.')
+            return
+        if entry['mgmtVrfEnabled'] == "false" :
+            click.echo('Cannot set SNMPTrap server using --use-mgmt-vrf when management VRF is not yet enabled.')
+            return
+
+    if ver == "1":
+        config_db.mod_entry('SNMP_TRAP_CONFIG',"v1TrapDest",{"DestIp": serverip, "DestPort": trapport, "vrf": vrf})
+    elif ver == "2":
+        config_db.mod_entry('SNMP_TRAP_CONFIG',"v2TrapDest",{"DestIp": serverip, "DestPort": trapport, "vrf": vrf})
+    else:
+        config_db.mod_entry('SNMP_TRAP_CONFIG',"v3TrapDest",{"DestIp": serverip, "DestPort": trapport, "vrf": vrf})
+    cmd="systemctl restart snmp"
+    os.system (cmd)
+
 #
 # 'bgp' group ('config bgp ...')
 #
@@ -925,6 +1095,14 @@ def speed(ctx, interface_name, interface_speed, verbose):
         command += " -vv"
     run_command(command, display_cmd=verbose)
 
+def _get_all_mgmtinterface_keys():
+    """Returns list of strings containing mgmt interface keys 
+    """
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    return config_db.get_table('MGMT_INTERFACE').keys()
+
+
 #
 # 'ip' subgroup ('config interface ip ...')
 #
@@ -942,8 +1120,9 @@ def ip(ctx):
 @ip.command()
 @click.argument('interface_name', metavar='<interface_name>', required=True)
 @click.argument("ip_addr", metavar="<ip_addr>", required=True)
+@click.argument('gw', metavar='<default gateway IP address>', required=False)
 @click.pass_context
-def add(ctx, interface_name, ip_addr):
+def add(ctx, interface_name, ip_addr, gw):
     """Add an IP address towards the interface"""
     config_db = ctx.obj["config_db"]
     if get_interface_naming_mode() == "alias":
@@ -956,6 +1135,32 @@ def add(ctx, interface_name, ip_addr):
         if interface_name.startswith("Ethernet"):
             config_db.set_entry("INTERFACE", (interface_name, ip_addr), {"NULL": "NULL"})
             config_db.set_entry("INTERFACE", interface_name, {"NULL": "NULL"})
+        elif interface_name == 'eth0':
+
+            # Configuring more than 1 IPv4 or more than 1 IPv6 address fails.
+            # Allow only one IPv4 and only one IPv6 address to be configured for IPv6.
+            # If a row already exist, overwrite it (by doing delete and add).
+            mgmtintf_key_list = _get_all_mgmtinterface_keys()
+
+            for key in mgmtintf_key_list:
+                # For loop runs for max 2 rows, once for IPv4 and once for IPv6.
+                if ':' in ip_addr and ':' in key[1]:
+                    # If user has configured IPv6 address and the already available row is also IPv6, delete it here.
+                    config_db.set_entry("MGMT_INTERFACE", ("eth0", key[1]), None)
+                elif ':' not in ip_addr and ':' not in key[1]:
+                    # If user has configured IPv4 address and the already available row is also IPv6, delete it here.
+                    config_db.set_entry("MGMT_INTERFACE", ("eth0", key[1]), None)
+
+            # Set the new row with new value
+            if not gw:
+                config_db.set_entry("MGMT_INTERFACE", (interface_name, ip_addr), {"NULL": "NULL"})
+            else:
+                config_db.set_entry("MGMT_INTERFACE", (interface_name, ip_addr), {"gwaddr": gw})
+            cmd="systemctl restart interfaces-config"
+            os.system (cmd)
+            cmd="systemctl restart ntp-config"
+            os.system (cmd)
+
         elif interface_name.startswith("PortChannel"):
             config_db.set_entry("PORTCHANNEL_INTERFACE", (interface_name, ip_addr), {"NULL": "NULL"})
             config_db.set_entry("PORTCHANNEL_INTERFACE", interface_name, {"NULL": "NULL"})
@@ -991,6 +1196,12 @@ def remove(ctx, interface_name, ip_addr):
         if interface_name.startswith("Ethernet"):
             config_db.set_entry("INTERFACE", (interface_name, ip_addr), None)
             if_table = "INTERFACE"
+        elif interface_name == 'eth0':
+            config_db.set_entry("MGMT_INTERFACE", (interface_name, ip_addr), None)
+            cmd="systemctl restart interfaces-config"
+            os.system (cmd)
+            cmd="systemctl restart ntp-config"
+            os.system (cmd)
         elif interface_name.startswith("PortChannel"):
             config_db.set_entry("PORTCHANNEL_INTERFACE", (interface_name, ip_addr), None)
             if_table = "PORTCHANNEL_INTERFACE"
@@ -1003,7 +1214,7 @@ def remove(ctx, interface_name, ip_addr):
             ctx.fail("'interface_name' is not valid. Valid names [Ethernet/PortChannel/Vlan/Loopback]")
     except ValueError:
         ctx.fail("'ip_addr' is not valid.")
-    
+
     exists = False
     if if_table:
         interfaces = config_db.get_table(if_table)

--- a/config/main.py
+++ b/config/main.py
@@ -6,8 +6,6 @@ import click
 import json
 import subprocess
 import netaddr
-import logging
-import logging.handlers
 import re
 import syslog
 
@@ -20,8 +18,11 @@ from minigraph import parse_device_desc_xml
 import aaa
 import mlnx
 
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help', '-?'])
+
 SONIC_CFGGEN_PATH = '/usr/local/bin/sonic-cfggen'
 SYSLOG_IDENTIFIER = "config"
+VLAN_SUB_INTERFACE_SEPARATOR = '.'
 
 # ========================== Syslog wrappers ==========================
 
@@ -47,6 +48,16 @@ def log_error(msg):
     syslog.openlog(SYSLOG_IDENTIFIER)
     syslog.syslog(syslog.LOG_ERR, msg)
     syslog.closelog()
+
+#
+# Load asic_type for further use
+#
+
+try:
+    version_info = sonic_device_util.get_sonic_version_info()
+    asic_type = version_info['asic_type']
+except KeyError, TypeError:
+    raise click.Abort()
 
 #
 # Helper functions
@@ -76,16 +87,26 @@ def interface_alias_to_name(interface_alias):
     config_db.connect()
     port_dict = config_db.get_table('PORT')
 
+    vlan_id = ""
+    sub_intf_sep_idx = -1
+    if interface_alias is not None:
+        sub_intf_sep_idx = interface_alias.find(VLAN_SUB_INTERFACE_SEPARATOR)
+        if sub_intf_sep_idx != -1:
+            vlan_id = interface_alias[sub_intf_sep_idx + 1:]
+            # interface_alias holds the parent port name so the subsequent logic still applies
+            interface_alias = interface_alias[:sub_intf_sep_idx]
+
     if interface_alias is not None:
         if not port_dict:
             click.echo("port_dict is None!")
             raise click.Abort()
         for port_name in port_dict.keys():
             if interface_alias == port_dict[port_name]['alias']:
-                return port_name
+                return port_name if sub_intf_sep_idx == -1 else port_name + VLAN_SUB_INTERFACE_SEPARATOR + vlan_id
 
-    # Interface alias not in port_dict, just return interface_alias
-    return interface_alias
+    # Interface alias not in port_dict, just return interface_alias, e.g.,
+    # portchannel is passed in as argument, which does not have an alias
+    return interface_alias if sub_intf_sep_idx == -1 else interface_alias + VLAN_SUB_INTERFACE_SEPARATOR + vlan_id
 
 
 def interface_name_is_valid(interface_name):
@@ -95,6 +116,7 @@ def interface_name_is_valid(interface_name):
     config_db.connect()
     port_dict = config_db.get_table('PORT')
     port_channel_dict = config_db.get_table('PORTCHANNEL')
+    sub_port_intf_dict = config_db.get_table('VLAN_SUB_INTERFACE')
 
     if get_interface_naming_mode() == "alias":
         interface_name = interface_alias_to_name(interface_name)
@@ -109,6 +131,10 @@ def interface_name_is_valid(interface_name):
         if port_channel_dict:
             for port_channel_name in port_channel_dict.keys():
                 if interface_name == port_channel_name:
+                    return True
+        if sub_port_intf_dict:
+            for sub_port_intf_name in sub_port_intf_dict.keys():
+                if interface_name == sub_port_intf_name:
                     return True
     return False
 
@@ -240,6 +266,31 @@ def _change_bgp_session_status(ipaddr_or_hostname, status, verbose):
     for ip_addr in ip_addrs:
         _change_bgp_session_status_by_addr(ip_addr, status, verbose)
 
+def _validate_bgp_neighbor(neighbor_ip_or_hostname):
+    """validates whether the given ip or host name is a BGP neighbor
+    """
+    ip_addrs = []
+    if _is_neighbor_ipaddress(neighbor_ip_or_hostname.lower()):
+        ip_addrs.append(neighbor_ip_or_hostname.lower())
+    else:
+        ip_addrs = _get_neighbor_ipaddress_list_by_hostname(neighbor_ip_or_hostname.upper())
+
+    if not ip_addrs:
+        click.get_current_context().fail("Could not locate neighbor '{}'".format(neighbor_ip_or_hostname))
+
+    return ip_addrs
+
+def _remove_bgp_neighbor_config(neighbor_ip_or_hostname):
+    """Removes BGP configuration of the given neighbor
+    """
+    ip_addrs = _validate_bgp_neighbor(neighbor_ip_or_hostname)
+    config_db = ConfigDBConnector()
+    config_db.connect()
+
+    for ip_addr in ip_addrs:
+        config_db.mod_entry('bgp_neighbor', ip_addr, None)
+        click.echo("Removed configuration of BGP neighbor {}".format(ip_addr))
+
 def _change_hostname(hostname):
     current_hostname = os.uname()[1]
     if current_hostname != hostname:
@@ -289,47 +340,89 @@ def _abort_if_false(ctx, param, value):
         ctx.abort()
 
 def _stop_services():
-    services = [
-        'dhcp_relay',
+    # on Mellanox platform pmon is stopped by syncd
+    services_to_stop = [
         'swss',
-        'snmp',
         'lldp',
         'pmon',
         'bgp',
-        'teamd',
         'hostcfgd',
     ]
-    for service in services:
+    if asic_type == 'mellanox' and 'pmon' in services_to_stop:
+        services_to_stop.remove('pmon')
+
+    for service in services_to_stop:
         try:
-            run_command("systemctl stop %s" % service, display_cmd=True)
+            click.echo("Stopping service {} ...".format(service))
+            run_command("systemctl stop {}".format(service))
+
         except SystemExit as e:
             log_error("Stopping {} failed with error {}".format(service, e))
             raise
 
+def _reset_failed_services():
+    services_to_reset = [
+        'bgp',
+        'dhcp_relay',
+        'hostcfgd',
+        'hostname-config',
+        'interfaces-config',
+        'lldp',
+        'ntp-config',
+        'pmon',
+        'radv',
+        'rsyslog-config',
+        'snmp',
+        'swss',
+        'syncd',
+        'teamd'
+    ]
+
+    for service in services_to_reset:
+        try:
+            click.echo("Resetting failed status for service {} ...".format(service))
+            run_command("systemctl reset-failed {}".format(service))
+        except SystemExit as e:
+            log_error("Failed to reset failed status for service {}".format(service))
+            raise
+
 def _restart_services():
-    services = [
+    # on Mellanox platform pmon is started by syncd
+    services_to_restart = [
         'hostname-config',
         'interfaces-config',
         'ntp-config',
         'rsyslog-config',
         'swss',
         'bgp',
-        'teamd',
         'pmon',
         'lldp',
-        'snmp',
-        'dhcp_relay',
         'hostcfgd',
     ]
-    for service in services:
+    if asic_type == 'mellanox' and 'pmon' in services_to_restart:
+        services_to_restart.remove('pmon')
+
+    for service in services_to_restart:
         try:
-            run_command("systemctl restart %s" % service, display_cmd=True)
+            click.echo("Restarting service {} ...".format(service))
+            run_command("systemctl restart {}".format(service))
         except SystemExit as e:
             log_error("Restart {} failed with error {}".format(service, e))
             raise
 
+def is_ipaddress(val):
+    """ Validate if an entry is a valid IP """
+    if not val:
+        return False
+    try:
+        netaddr.IPAddress(str(val))
+    except:
+        return False
+    return True
+
+
 # This is our main entrypoint - the main 'config' command
-@click.group()
+@click.group(context_settings=CONTEXT_SETTINGS)
 def config():
     """SONiC command line - 'config' command"""
     if os.geteuid() != 0:
@@ -396,6 +489,9 @@ def reload(filename, yes, load_sysinfo):
     if os.path.isfile(db_migrator) and os.access(db_migrator, os.X_OK):
         run_command(db_migrator + ' -o migrate')
 
+    # We first run "systemctl reset-failed" to remove the "failed"
+    # status from all services before we attempt to restart them
+    _reset_failed_services()
     _restart_services()
 
 @config.command()
@@ -452,10 +548,32 @@ def load_minigraph():
     if os.path.isfile(db_migrator) and os.access(db_migrator, os.X_OK):
         run_command(db_migrator + ' -o set_version')
 
+    # We first run "systemctl reset-failed" to remove the "failed"
+    # status from all services before we attempt to restart them
+    _reset_failed_services()
     #FIXME: After config DB daemon is implemented, we'll no longer need to restart every service.
     _restart_services()
     click.echo("Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`.")
 
+
+#
+# 'hostname' command
+#
+@config.command('hostname')
+@click.argument('new_hostname', metavar='<new_hostname>', required=True)
+def hostname(new_hostname):
+    """Change device hostname without impacting the traffic."""
+
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    config_db.mod_entry('DEVICE_METADATA' , 'localhost', {"hostname" : new_hostname})
+    try:
+        command = "service hostname-config restart"
+        run_command(command, display_cmd=True)
+    except SystemExit as e:
+        click.echo("Restarting hostname-config  service failed with error {}".format(e))
+        raise
+    click.echo("Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`.")
 
 #
 # 'portchannel' group ('config portchannel ...')
@@ -790,43 +908,46 @@ def del_vlan_member(ctx, vid, interface_name):
     db.set_entry('VLAN', vlan_name, vlan)
     db.set_entry('VLAN_MEMBER', (vlan_name, interface_name), None)
 
-
+def mvrf_restart_services():
+    """Restart interfaces-config service and NTP service when mvrf is changed"""
+    """
+    When mvrf is enabled, eth0 should be moved to mvrf; when it is disabled,
+    move it back to default vrf. Restarting the "interfaces-config" service
+    will recreate the /etc/network/interfaces file and restart the
+    "networking" service that takes care of the eth0 movement.
+    NTP service should also be restarted to rerun the NTP service with or
+    without "cgexec" accordingly.
+    """
+    cmd="service ntp stop"
+    os.system (cmd)
+    cmd="systemctl restart interfaces-config"
+    os.system (cmd)
+    cmd="service ntp start"
+    os.system (cmd)
 
 def vrf_add_management_vrf():
-	"""Enable management vrf"""
+    """Enable management vrf in config DB"""
 
-	config_db = ConfigDBConnector()
-	config_db.connect()
-        entry = config_db.get_entry('MGMT_VRF_CONFIG', "vrf_global")
-        if entry and entry['mgmtVrfEnabled'] == 'true' :
-	    click.echo("ManagementVRF is already Enabled.")
-	    return None
-	config_db.mod_entry('MGMT_VRF_CONFIG',"vrf_global",{"mgmtVrfEnabled": "true"})
-        cmd="service ntp stop"
-        os.system (cmd)
-        cmd="systemctl restart interfaces-config"
-        os.system (cmd)
-        cmd="service ntp start"
-        os.system (cmd)
-
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    entry = config_db.get_entry('MGMT_VRF_CONFIG', "vrf_global")
+    if entry and entry['mgmtVrfEnabled'] == 'true' :
+        click.echo("ManagementVRF is already Enabled.")
+        return None
+    config_db.mod_entry('MGMT_VRF_CONFIG',"vrf_global",{"mgmtVrfEnabled": "true"})
+    mvrf_restart_services()
 
 def vrf_delete_management_vrf():
-	"""Disable management vrf"""
+    """Disable management vrf in config DB"""
 
-	config_db = ConfigDBConnector()
-	config_db.connect()
-        entry = config_db.get_entry('MGMT_VRF_CONFIG', "vrf_global")
-        if not entry or entry['mgmtVrfEnabled'] == 'false' :
-	    click.echo("ManagementVRF is already Disabled.")
-	    return None
-	config_db.mod_entry('MGMT_VRF_CONFIG',"vrf_global",{"mgmtVrfEnabled": "false"})
-        cmd="service ntp stop"
-        os.system (cmd)
-        cmd="systemctl restart interfaces-config"
-        os.system (cmd)
-        cmd="service ntp start"
-        os.system (cmd)
-
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    entry = config_db.get_entry('MGMT_VRF_CONFIG', "vrf_global")
+    if not entry or entry['mgmtVrfEnabled'] == 'false' :
+        click.echo("ManagementVRF is already Disabled.")
+        return None
+    config_db.mod_entry('MGMT_VRF_CONFIG',"vrf_global",{"mgmtVrfEnabled": "false"})
+    mvrf_restart_services()
 
 #
 # 'vrf' group ('config vrf ...')
@@ -837,127 +958,183 @@ def vrf():
     """VRF-related configuration tasks"""
     pass
 
-
 @vrf.command('add')
 @click.argument('vrfname', metavar='<vrfname>. Type mgmt for management VRF', required=True)
 @click.pass_context
 def vrf_add (ctx, vrfname):
-    """VRF ADD"""
+    """Create management VRF and move eth0 into it"""
     if vrfname == 'mgmt' or vrfname == 'management':
         vrf_add_management_vrf()
     else:
         click.echo("Creation of data vrf={} is not yet supported".format(vrfname))
 
-
 @vrf.command('del')
 @click.argument('vrfname', metavar='<vrfname>. Type mgmt for management VRF', required=False)
 @click.pass_context
 def vrf_del (ctx, vrfname):
-    """VRF Delete"""
+    """Delete management VRF and move back eth0 to default VRF"""
     if vrfname == 'mgmt' or vrfname == 'management':
         vrf_delete_management_vrf()
     else:
         click.echo("Deletion of data vrf={} is not yet supported".format(vrfname))
 
-
-@config.command('clear_mgmt')
+@config.group()
 @click.pass_context
-def clear_mgmt(ctx):
-    MGMT_TABLE_NAMES = [
-            'MGMT_INTERFACE',
-            'MGMT_VRF_CONFIG']
+def snmpagentaddress(ctx):
+    """SNMP agent listening IP address, port, vrf configuration"""
     config_db = ConfigDBConnector()
     config_db.connect()
-    for mgmt_table in MGMT_TABLE_NAMES:
-        config_db.delete_table(mgmt_table)
-
-@config.group()
-def snmpagentaddress():
-    """SNMP agentaddress Related Task"""
+    ctx.obj = {'db': config_db}
     pass
 
 @snmpagentaddress.command('add')
-@click.argument('agentip', metavar='<SNMP AGENT IP Address>', required=True)
-@click.argument('vrf', metavar='<VRF name mgmt/default/data>', required=False)
+@click.argument('agentip', metavar='<SNMP AGENT LISTENING IP Address>', required=True)
+@click.option('-p', '--port', help="SNMP AGENT LISTENING PORT")
+@click.option('-v', '--vrf', help="VRF Name mgmt/DataVrfName/None")
 @click.pass_context
+def add_snmp_agent_address(ctx, agentip, port, vrf):
+    """Add the SNMP agent listening IP:Port%Vrf configuration"""
 
-def add_snmp_agent_address(ctx, agentip, vrf):
-    """Add the SNMP agent IP and VRF configuration"""
-
-    config_db = ConfigDBConnector()
-    config_db.connect()
+    #Construct SNMP_AGENT_ADDRESS_CONFIG table key in the format ip|<port>|<vrf>
+    key = agentip+'|'
+    if port:
+        key = key+port   
+    key = key+'|'
     if vrf:
-        entry = config_db.get_entry('MGMT_VRF_CONFIG', "vrf_global")
-        if entry == {}:
-            click.echo('Cannot set SNMP Agent ip address using when management VRF is not yet configured.')
-            return
-        if entry['mgmtVrfEnabled'] == "false" :
-            click.echo('Cannot set SNMP Agent ip address using when management VRF is not yet enabled.')
-            return
+        key = key+vrf
+    config_db = ctx.obj['db']
+    config_db.set_entry('SNMP_AGENT_ADDRESS_CONFIG', key, {})
 
-    config_db.set_entry('SNMP_AGENT_ADDRESS_CONFIG', (agentip, vrf), {})
+    #Restarting the SNMP service will regenerate snmpd.conf and rerun snmpd
     cmd="systemctl restart snmp"
     os.system (cmd)
 
 @snmpagentaddress.command('del')
-@click.argument('agentip', metavar='<SNMP AGENT IP Address>', required=True)
-@click.argument('vrf', metavar='<VRF name mgmt/default/data>', required=False)
+@click.argument('agentip', metavar='<SNMP AGENT LISTENING IP Address>', required=True)
+@click.option('-p', '--port', help="SNMP AGENT LISTENING PORT")
+@click.option('-v', '--vrf', help="VRF Name mgmt/DataVrfName/None")
 @click.pass_context
+def del_snmp_agent_address(ctx, agentip, port, vrf):
+    """Delete the SNMP agent listening IP:Port%Vrf configuration"""
 
-def del_snmp_agent_address(ctx, agentip, vrf):
-    """Del the SNMP agent IP and VRF configuration"""
-
-    config_db = ConfigDBConnector()
-    config_db.connect()
+    key = agentip+'|'
+    if port:
+        key = key+port   
+    key = key+'|'
     if vrf:
-        entry = config_db.get_entry('MGMT_VRF_CONFIG', "vrf_global")
-        if entry == {}:
-            click.echo('Cannot set SNMP Agent ip address using when management VRF is not yet configured.')
-            return
-        if entry['mgmtVrfEnabled'] == "false" :
-            click.echo('Cannot set SNMP Agent ip address using when management VRF is not yet enabled.')
-            return
-
-    config_db.get_entry('SNMP_AGENT_ADDRESS_CONFIG', (agentip, vrf))
-    config_db.set_entry('SNMP_AGENT_ADDRESS_CONFIG', (agentip, vrf), None)
+        key = key+vrf
+    config_db = ctx.obj['db']
+    config_db.set_entry('SNMP_AGENT_ADDRESS_CONFIG', key, None)
     cmd="systemctl restart snmp"
     os.system (cmd)
 
 @config.group()
-def snmptrap():
-    """SNMP Traps Related Task"""
+@click.pass_context
+def snmptrap(ctx):
+    """SNMP Trap server configuration to send traps"""
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    ctx.obj = {'db': config_db}
     pass
 
 @snmptrap.command('modify')
 @click.argument('ver', metavar='<SNMP Version>', type=click.Choice(['1', '2', '3']), required=True)
 @click.argument('serverip', metavar='<SNMP TRAP SERVER IP Address>', required=True)
-@click.argument('vrf', metavar='<VRF name mgmt/default/data>', required=False)
-@click.argument('trapport', metavar='<SNMP Trap Server port, default 162>', required=False)
+@click.option('-p', '--port', help="SNMP Trap Server port, default 162", default="162")
+@click.option('-v', '--vrf', help="VRF Name mgmt/DataVrfName/None", default="None")
+@click.option('-c', '--comm', help="Community", default="public")
 @click.pass_context
-def modify_snmptrap_server(ctx, ver, serverip, vrf, trapport):
-    """Add the SNMP Trap server configuration"""
-    if not trapport:
-        trapport = 162
+def modify_snmptrap_server(ctx, ver, serverip, port, vrf, comm):
+    """Modify the SNMP Trap server configuration"""
 
-    config_db = ConfigDBConnector()
-    config_db.connect()
-    if vrf and vrf == "mgmt":
-        entry = config_db.get_entry('MGMT_VRF_CONFIG', "vrf_global")
-        if entry == {}:
-            click.echo('Cannot set SNMPTrap server using --use-mgmt-vrf when management VRF is not yet configured.')
-            return
-        if entry['mgmtVrfEnabled'] == "false" :
-            click.echo('Cannot set SNMPTrap server using --use-mgmt-vrf when management VRF is not yet enabled.')
-            return
-
+    #SNMP_TRAP_CONFIG for each SNMP version
+    config_db = ctx.obj['db']
     if ver == "1":
-        config_db.mod_entry('SNMP_TRAP_CONFIG',"v1TrapDest",{"DestIp": serverip, "DestPort": trapport, "vrf": vrf})
+        #By default, v1TrapDest value in snmp.yml is "NotConfigured". Modify it.
+        config_db.mod_entry('SNMP_TRAP_CONFIG',"v1TrapDest",{"DestIp": serverip, "DestPort": port, "vrf": vrf, "Community": comm})
     elif ver == "2":
-        config_db.mod_entry('SNMP_TRAP_CONFIG',"v2TrapDest",{"DestIp": serverip, "DestPort": trapport, "vrf": vrf})
+        config_db.mod_entry('SNMP_TRAP_CONFIG',"v2TrapDest",{"DestIp": serverip, "DestPort": port, "vrf": vrf, "Community": comm})
     else:
-        config_db.mod_entry('SNMP_TRAP_CONFIG',"v3TrapDest",{"DestIp": serverip, "DestPort": trapport, "vrf": vrf})
+        config_db.mod_entry('SNMP_TRAP_CONFIG',"v3TrapDest",{"DestIp": serverip, "DestPort": port, "vrf": vrf, "Community": comm})
+
     cmd="systemctl restart snmp"
     os.system (cmd)
+
+@snmptrap.command('del')
+@click.argument('ver', metavar='<SNMP Version>', type=click.Choice(['1', '2', '3']), required=True)
+@click.pass_context
+def delete_snmptrap_server(ctx, ver):
+    """Delete the SNMP Trap server configuration"""
+
+    config_db = ctx.obj['db']
+    if ver == "1":
+        config_db.mod_entry('SNMP_TRAP_CONFIG',"v1TrapDest",None)
+    elif ver == "2":
+        config_db.mod_entry('SNMP_TRAP_CONFIG',"v2TrapDest",None)
+    else:
+        config_db.mod_entry('SNMP_TRAP_CONFIG',"v3TrapDest",None)
+    cmd="systemctl restart snmp"
+    os.system (cmd)
+
+@vlan.group('dhcp_relay')
+@click.pass_context
+def vlan_dhcp_relay(ctx):
+    pass
+
+@vlan_dhcp_relay.command('add')
+@click.argument('vid', metavar='<vid>', required=True, type=int)
+@click.argument('dhcp_relay_destination_ip', metavar='<dhcp_relay_destination_ip>', required=True)
+@click.pass_context
+def add_vlan_dhcp_relay_destination(ctx, vid, dhcp_relay_destination_ip):
+    """ Add a destination IP address to the VLAN's DHCP relay """
+    if not is_ipaddress(dhcp_relay_destination_ip):
+        ctx.fail('Invalid IP address')
+    db = ctx.obj['db']
+    vlan_name = 'Vlan{}'.format(vid)
+    vlan = db.get_entry('VLAN', vlan_name)
+
+    if len(vlan) == 0:
+        ctx.fail("{} doesn't exist".format(vlan_name))
+    dhcp_relay_dests = vlan.get('dhcp_servers', [])
+    if dhcp_relay_destination_ip in dhcp_relay_dests:
+        click.echo("{} is already a DHCP relay destination for {}".format(dhcp_relay_destination_ip, vlan_name))
+        return
+    else:
+        dhcp_relay_dests.append(dhcp_relay_destination_ip)
+        db.set_entry('VLAN', vlan_name, {"dhcp_servers":dhcp_relay_dests})
+        click.echo("Added DHCP relay destination address {} to {}".format(dhcp_relay_destination_ip, vlan_name))
+        try:
+            click.echo("Restarting DHCP relay service...")
+            run_command("systemctl restart dhcp_relay", display_cmd=False)
+        except SystemExit as e:
+            ctx.fail("Restart service dhcp_relay failed with error {}".format(e))
+
+@vlan_dhcp_relay.command('del')
+@click.argument('vid', metavar='<vid>', required=True, type=int)
+@click.argument('dhcp_relay_destination_ip', metavar='<dhcp_relay_destination_ip>', required=True)
+@click.pass_context
+def del_vlan_dhcp_relay_destination(ctx, vid, dhcp_relay_destination_ip):
+    """ Remove a destination IP address from the VLAN's DHCP relay """
+    if not is_ipaddress(dhcp_relay_destination_ip):
+        ctx.fail('Invalid IP address')
+    db = ctx.obj['db']
+    vlan_name = 'Vlan{}'.format(vid)
+    vlan = db.get_entry('VLAN', vlan_name)
+
+    if len(vlan) == 0:
+        ctx.fail("{} doesn't exist".format(vlan_name))
+    dhcp_relay_dests = vlan.get('dhcp_servers', [])
+    if dhcp_relay_destination_ip in dhcp_relay_dests:
+        dhcp_relay_dests.remove(dhcp_relay_destination_ip)
+        db.set_entry('VLAN', vlan_name, {"dhcp_servers":dhcp_relay_dests})
+        click.echo("Removed DHCP relay destination address {} from {}".format(dhcp_relay_destination_ip, vlan_name))
+        try:
+            click.echo("Restarting DHCP relay service...")
+            run_command("systemctl restart dhcp_relay", display_cmd=False)
+        except SystemExit as e:
+            ctx.fail("Restart service dhcp_relay failed with error {}".format(e))
+    else:
+        ctx.fail("{} is not a DHCP relay destination for {}".format(dhcp_relay_destination_ip, vlan_name))
 
 #
 # 'bgp' group ('config bgp ...')
@@ -1017,6 +1194,21 @@ def neighbor(ipaddr_or_hostname, verbose):
     _change_bgp_session_status(ipaddr_or_hostname, 'up', verbose)
 
 #
+# 'remove' subgroup ('config bgp remove ...')
+#
+
+@bgp.group()
+def remove():
+    "Remove BGP neighbor configuration from the device"
+    pass
+
+@remove.command('neighbor')
+@click.argument('neighbor_ip_or_hostname', metavar='<neighbor_ip_or_hostname>', required=True)
+def remove_neighbor(neighbor_ip_or_hostname):
+    """Deletes BGP neighbor configuration of given hostname or ip from devices"""
+    _remove_bgp_neighbor_config(neighbor_ip_or_hostname)
+
+#
 # 'interface' group ('config interface ...')
 #
 
@@ -1048,9 +1240,15 @@ def startup(ctx, interface_name):
         ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
 
     if interface_name.startswith("Ethernet"):
-        config_db.mod_entry("PORT", interface_name, {"admin_status": "up"})
+        if VLAN_SUB_INTERFACE_SEPARATOR in interface_name:
+            config_db.mod_entry("VLAN_SUB_INTERFACE", interface_name, {"admin_status": "up"})
+        else:
+            config_db.mod_entry("PORT", interface_name, {"admin_status": "up"})
     elif interface_name.startswith("PortChannel"):
-        config_db.mod_entry("PORTCHANNEL", interface_name, {"admin_status": "up"})
+        if VLAN_SUB_INTERFACE_SEPARATOR in interface_name:
+            config_db.mod_entry("VLAN_SUB_INTERFACE", interface_name, {"admin_status": "up"})
+        else:
+            config_db.mod_entry("PORTCHANNEL", interface_name, {"admin_status": "up"})
 #
 # 'shutdown' subcommand
 #
@@ -1070,9 +1268,15 @@ def shutdown(ctx, interface_name):
         ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
 
     if interface_name.startswith("Ethernet"):
-        config_db.mod_entry("PORT", interface_name, {"admin_status": "down"})
+        if VLAN_SUB_INTERFACE_SEPARATOR in interface_name:
+            config_db.mod_entry("VLAN_SUB_INTERFACE", interface_name, {"admin_status": "down"})
+        else:
+            config_db.mod_entry("PORT", interface_name, {"admin_status": "down"})
     elif interface_name.startswith("PortChannel"):
-        config_db.mod_entry("PORTCHANNEL", interface_name, {"admin_status": "down"})
+        if VLAN_SUB_INTERFACE_SEPARATOR in interface_name:
+            config_db.mod_entry("VLAN_SUB_INTERFACE", interface_name, {"admin_status": "down"})
+        else:
+            config_db.mod_entry("PORTCHANNEL", interface_name, {"admin_status": "down"})
 
 #
 # 'speed' subcommand
@@ -1102,6 +1306,20 @@ def _get_all_mgmtinterface_keys():
     config_db.connect()
     return config_db.get_table('MGMT_INTERFACE').keys()
 
+def mgmt_ip_restart_services():
+    """Restart the required services when mgmt inteface IP address is changed"""
+    """
+    Whenever the eth0 IP address is changed, restart the "interfaces-config"
+    service which regenerates the /etc/network/interfaces file and restarts
+    the networking service to make the new/null IP address effective for eth0.
+    "ntp-config" service should also be restarted based on the new
+    eth0 IP address since the ntp.conf (generated from ntp.conf.j2) is
+    made to listen on that particular eth0 IP address or reset it back.
+    """
+    cmd="systemctl restart interfaces-config"
+    os.system (cmd)
+    cmd="systemctl restart ntp-config"
+    os.system (cmd)
 
 #
 # 'ip' subgroup ('config interface ip ...')
@@ -1133,8 +1351,12 @@ def add(ctx, interface_name, ip_addr, gw):
     try:
         ipaddress.ip_network(unicode(ip_addr), strict=False)
         if interface_name.startswith("Ethernet"):
-            config_db.set_entry("INTERFACE", (interface_name, ip_addr), {"NULL": "NULL"})
-            config_db.set_entry("INTERFACE", interface_name, {"NULL": "NULL"})
+            if VLAN_SUB_INTERFACE_SEPARATOR in interface_name:
+                config_db.set_entry("VLAN_SUB_INTERFACE", interface_name, {"admin_status": "up"})
+                config_db.set_entry("VLAN_SUB_INTERFACE", (interface_name, ip_addr), {"NULL": "NULL"})
+            else:
+                config_db.set_entry("INTERFACE", (interface_name, ip_addr), {"NULL": "NULL"})
+                config_db.set_entry("INTERFACE", interface_name, {"NULL": "NULL"})
         elif interface_name == 'eth0':
 
             # Configuring more than 1 IPv4 or more than 1 IPv6 address fails.
@@ -1144,11 +1366,11 @@ def add(ctx, interface_name, ip_addr, gw):
 
             for key in mgmtintf_key_list:
                 # For loop runs for max 2 rows, once for IPv4 and once for IPv6.
-                if ':' in ip_addr and ':' in key[1]:
-                    # If user has configured IPv6 address and the already available row is also IPv6, delete it here.
-                    config_db.set_entry("MGMT_INTERFACE", ("eth0", key[1]), None)
-                elif ':' not in ip_addr and ':' not in key[1]:
-                    # If user has configured IPv4 address and the already available row is also IPv6, delete it here.
+                # No need to capture the exception since the ip_addr is already validated earlier
+                ip_input = ipaddress.ip_interface(ip_addr)
+                current_ip = ipaddress.ip_interface(key[1])
+                if (ip_input.version == current_ip.version):
+                    # If user has configured IPv4/v6 address and the already available row is also IPv4/v6, delete it here.
                     config_db.set_entry("MGMT_INTERFACE", ("eth0", key[1]), None)
 
             # Set the new row with new value
@@ -1156,14 +1378,15 @@ def add(ctx, interface_name, ip_addr, gw):
                 config_db.set_entry("MGMT_INTERFACE", (interface_name, ip_addr), {"NULL": "NULL"})
             else:
                 config_db.set_entry("MGMT_INTERFACE", (interface_name, ip_addr), {"gwaddr": gw})
-            cmd="systemctl restart interfaces-config"
-            os.system (cmd)
-            cmd="systemctl restart ntp-config"
-            os.system (cmd)
+            mgmt_ip_restart_services()
 
         elif interface_name.startswith("PortChannel"):
-            config_db.set_entry("PORTCHANNEL_INTERFACE", (interface_name, ip_addr), {"NULL": "NULL"})
-            config_db.set_entry("PORTCHANNEL_INTERFACE", interface_name, {"NULL": "NULL"})
+            if VLAN_SUB_INTERFACE_SEPARATOR in interface_name:
+                config_db.set_entry("VLAN_SUB_INTERFACE", interface_name, {"admin_status": "up"})
+                config_db.set_entry("VLAN_SUB_INTERFACE", (interface_name, ip_addr), {"NULL": "NULL"})
+            else:
+                config_db.set_entry("PORTCHANNEL_INTERFACE", (interface_name, ip_addr), {"NULL": "NULL"})
+                config_db.set_entry("PORTCHANNEL_INTERFACE", interface_name, {"NULL": "NULL"})
         elif interface_name.startswith("Vlan"):
             config_db.set_entry("VLAN_INTERFACE", (interface_name, ip_addr), {"NULL": "NULL"})
             config_db.set_entry("VLAN_INTERFACE", interface_name, {"NULL": "NULL"})
@@ -1194,17 +1417,22 @@ def remove(ctx, interface_name, ip_addr):
     try:
         ipaddress.ip_network(unicode(ip_addr), strict=False)
         if interface_name.startswith("Ethernet"):
-            config_db.set_entry("INTERFACE", (interface_name, ip_addr), None)
-            if_table = "INTERFACE"
+            if VLAN_SUB_INTERFACE_SEPARATOR in interface_name:
+                config_db.set_entry("VLAN_SUB_INTERFACE", (interface_name, ip_addr), None)
+                if_table = "VLAN_SUB_INTERFACE"
+            else:
+                config_db.set_entry("INTERFACE", (interface_name, ip_addr), None)
+                if_table = "INTERFACE"
         elif interface_name == 'eth0':
             config_db.set_entry("MGMT_INTERFACE", (interface_name, ip_addr), None)
-            cmd="systemctl restart interfaces-config"
-            os.system (cmd)
-            cmd="systemctl restart ntp-config"
-            os.system (cmd)
+            mgmt_ip_restart_services()
         elif interface_name.startswith("PortChannel"):
-            config_db.set_entry("PORTCHANNEL_INTERFACE", (interface_name, ip_addr), None)
-            if_table = "PORTCHANNEL_INTERFACE"
+            if VLAN_SUB_INTERFACE_SEPARATOR in interface_name:
+                config_db.set_entry("VLAN_SUB_INTERFACE", (interface_name, ip_addr), None)
+                if_table = "VLAN_SUB_INTERFACE"
+            else:
+                config_db.set_entry("PORTCHANNEL_INTERFACE", (interface_name, ip_addr), None)
+                if_table = "PORTCHANNEL_INTERFACE"
         elif interface_name.startswith("Vlan"):
             config_db.set_entry("VLAN_INTERFACE", (interface_name, ip_addr), None)
             if_table = "VLAN_INTERFACE"
@@ -1277,7 +1505,8 @@ def get_acl_bound_ports():
 @click.argument("table_type", metavar="<table_type>")
 @click.option("-d", "--description")
 @click.option("-p", "--ports")
-def table(table_name, table_type, description, ports):
+@click.option("-s", "--stage", type=click.Choice(["ingress", "egress"]), default="ingress")
+def table(table_name, table_type, description, ports, stage):
     """
     Add ACL table
     """
@@ -1295,6 +1524,8 @@ def table(table_name, table_type, description, ports):
         table_info["ports@"] = ports
     else:
         table_info["ports@"] = ",".join(get_acl_bound_ports())
+
+    table_info["stage"] = stage
 
     config_db.set_entry("ACL_TABLE", table_name, table_info)
 
@@ -1398,14 +1629,17 @@ def pfc(ctx):
 #
 
 @pfc.command()
+@click.argument('interface_name', metavar='<interface_name>', required=True)
 @click.argument('status', type=click.Choice(['on', 'off']))
 @click.pass_context
-def asymmetric(ctx, status):
+def asymmetric(ctx, interface_name, status):
     """Set asymmetric PFC configuration."""
-    config_db = ctx.obj["config_db"]
-    interface = ctx.obj["interface_name"]
+    if get_interface_naming_mode() == "alias":
+        interface_name = interface_alias_to_name(interface_name)
+        if interface_name is None:
+            ctx.fail("'interface_name' is None!")
 
-    run_command("pfc config asymmetric {0} {1}".format(status, interface))
+    run_command("pfc config asymmetric {0} {1}".format(status, interface_name))
 
 #
 # 'platform' group ('config platform ...')
@@ -1415,8 +1649,7 @@ def asymmetric(ctx, status):
 def platform():
     """Platform-related configuration tasks"""
 
-version_info = sonic_device_util.get_sonic_version_info()
-if (version_info and version_info.get('asic_type') == 'mellanox'):
+if asic_type == 'mellanox':
     platform.add_command(mlnx.mlnx)
 
 #
@@ -1460,6 +1693,111 @@ def naming_mode_alias():
     """Set CLI interface naming mode to ALIAS (Vendor port alias)"""
     set_interface_naming_mode('alias')
 
+#
+# 'syslog' group ('config syslog ...')
+#
+@config.group('syslog')
+@click.pass_context
+def syslog_group(ctx):
+    """Syslog server configuration tasks"""
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    ctx.obj = {'db': config_db}
+    pass
+
+@syslog_group.command('add')
+@click.argument('syslog_ip_address', metavar='<syslog_ip_address>', required=True)
+@click.pass_context
+def add_syslog_server(ctx, syslog_ip_address):
+    """ Add syslog server IP """
+    if not is_ipaddress(syslog_ip_address):
+        ctx.fail('Invalid ip address')
+    db = ctx.obj['db']
+    syslog_servers = db.get_table("SYSLOG_SERVER")
+    if syslog_ip_address in syslog_servers:
+        click.echo("Syslog server {} is already configured".format(syslog_ip_address))
+        return
+    else:
+        db.set_entry('SYSLOG_SERVER', syslog_ip_address, {'NULL': 'NULL'})
+        click.echo("Syslog server {} added to configuration".format(syslog_ip_address))
+        try:
+            click.echo("Restarting rsyslog-config service...")
+            run_command("systemctl restart rsyslog-config", display_cmd=False)
+        except SystemExit as e:
+            ctx.fail("Restart service rsyslog-config failed with error {}".format(e))
+
+@syslog_group.command('del')
+@click.argument('syslog_ip_address', metavar='<syslog_ip_address>', required=True)
+@click.pass_context
+def del_syslog_server(ctx, syslog_ip_address):
+    """ Delete syslog server IP """
+    if not is_ipaddress(syslog_ip_address):
+        ctx.fail('Invalid IP address')
+    db = ctx.obj['db']
+    syslog_servers = db.get_table("SYSLOG_SERVER")
+    if syslog_ip_address in syslog_servers:
+        db.set_entry('SYSLOG_SERVER', '{}'.format(syslog_ip_address), None)
+        click.echo("Syslog server {} removed from configuration".format(syslog_ip_address))
+    else:
+        ctx.fail("Syslog server {} is not configured.".format(syslog_ip_address))
+    try:
+        click.echo("Restarting rsyslog-config service...")
+        run_command("systemctl restart rsyslog-config", display_cmd=False)
+    except SystemExit as e:
+        ctx.fail("Restart service rsyslog-config failed with error {}".format(e))
+
+#
+# 'ntp' group ('config ntp ...')
+#
+@config.group()
+@click.pass_context
+def ntp(ctx):
+    """NTP server configuration tasks"""
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    ctx.obj = {'db': config_db}
+    pass
+
+@ntp.command('add')
+@click.argument('ntp_ip_address', metavar='<ntp_ip_address>', required=True)
+@click.pass_context
+def add_ntp_server(ctx, ntp_ip_address):
+    """ Add NTP server IP """
+    if not is_ipaddress(ntp_ip_address):
+        ctx.fail('Invalid ip address')
+    db = ctx.obj['db']
+    ntp_servers = db.get_table("NTP_SERVER")
+    if ntp_ip_address in ntp_servers:
+        click.echo("NTP server {} is already configured".format(ntp_ip_address))
+        return
+    else: 
+        db.set_entry('NTP_SERVER', ntp_ip_address, {'NULL': 'NULL'})
+        click.echo("NTP server {} added to configuration".format(ntp_ip_address))
+        try:
+            click.echo("Restarting ntp-config service...")
+            run_command("systemctl restart ntp-config", display_cmd=False)
+        except SystemExit as e:
+            ctx.fail("Restart service ntp-config failed with error {}".format(e))
+
+@ntp.command('del')
+@click.argument('ntp_ip_address', metavar='<ntp_ip_address>', required=True)
+@click.pass_context
+def del_ntp_server(ctx, ntp_ip_address):
+    """ Delete NTP server IP """
+    if not is_ipaddress(ntp_ip_address):
+        ctx.fail('Invalid IP address')
+    db = ctx.obj['db']
+    ntp_servers = db.get_table("NTP_SERVER")
+    if ntp_ip_address in ntp_servers:
+        db.set_entry('NTP_SERVER', '{}'.format(ntp_ip_address), None)
+        click.echo("NTP server {} removed from configuration".format(ntp_ip_address))
+    else: 
+        ctx.fail("NTP server {} is not configured.".format(ntp_ip_address))
+    try:
+        click.echo("Restarting ntp-config service...")
+        run_command("systemctl restart ntp-config", display_cmd=False)
+    except SystemExit as e:
+        ctx.fail("Restart service ntp-config failed with error {}".format(e))
 
 if __name__ == '__main__':
     config()

--- a/show/main.py
+++ b/show/main.py
@@ -419,6 +419,93 @@ def ndp(ip6address, iface, verbose):
     run_command(cmd, display_cmd=verbose)
 
 #
+# 'mgmt-vrf' group ("show mgmt-vrf ...")
+#
+
+@cli.group('mgmt-vrf', invoke_without_command=True)
+@click.pass_context
+def mgmt_vrf(ctx):
+
+	"""Show management VRF attributes"""
+
+	if ctx.invoked_subcommand is None:
+		cmd = 'sonic-cfggen -d --var-json "MGMT_VRF_CONFIG"'
+		
+		p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+		res = p.communicate()
+		if p.returncode == 0 :
+			p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+			mvrf_dict = json.loads(p.stdout.read())
+		
+			# if the mgmtVrfEnabled attribute is configured, check the value
+			# and print Enabled or Disabled accordingly.
+			if 'mgmtVrfEnabled' in mvrf_dict['vrf_global']:
+				if (mvrf_dict['vrf_global']['mgmtVrfEnabled'] == "true"):
+					click.echo("\nManagementVRF : Enabled")
+				else:
+					click.echo("\nManagementVRF : Disabled")
+	
+		click.echo("\nManagement VRF in Linux:")
+		cmd = "sudo ip link show type vrf"
+		run_command(cmd)
+
+@mgmt_vrf.command('interfaces')
+def mgmt_vrf_interfaces ():
+	"""Show management VRF attributes"""
+	
+	click.echo("\neth0 Interfaces in Management VRF:")
+	cmd = "sudo ifconfig eth0"
+	run_command(cmd)
+	return None
+
+@mgmt_vrf.command('route')
+def mgmt_vrf_route ():
+	"""Show management VRF routes"""
+	
+	click.echo("\nRoutes in Management VRF Routing Table:")
+	cmd = "sudo ip route show table 1001"
+	run_command(cmd)
+	return None
+
+
+@mgmt_vrf.command('addresses')
+def mgmt_vrf_addresses ():
+	"""Show management VRF addresses"""
+	
+	click.echo("\nIP Addresses for interfaces in Management VRF:")
+	cmd = "sudo ip address show mgmt"
+	run_command(cmd)
+	return None
+
+
+
+#
+# 'management_interface' group ("show management_interface ...")
+#
+
+@cli.group(cls=AliasedGroup, default_if_no_args=False)
+def management_interface():
+    """Show management interface parameters"""
+    pass
+
+# 'address' subcommand ("show management_interface address")
+@management_interface.command()
+def address ():
+    """Show IP address configured for management interface"""
+
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    header = ['IFNAME', 'IP Address', 'PrefixLen',]
+    body = []
+
+    # Fetching data from config_db for MGMT_INTERFACE
+    mgmt_ip_data = config_db.get_table('MGMT_INTERFACE')
+    for key in natsorted(mgmt_ip_data.keys()):
+        click.echo("Management IP address = {0}".format(key[1]))
+        click.echo("Management NetWork Default Gateway = {0}".format(mgmt_ip_data[key]['gwaddr']))
+
+
+#
 # 'interfaces' group ("show interfaces ...")
 #
 
@@ -1443,8 +1530,15 @@ def bgp(verbose):
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def ntp(verbose):
     """Show NTP information"""
-    cmd = "ntpq -p -n"
-    run_command(cmd, display_cmd=verbose)
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    entry = config_db.get_entry('MGMT_VRF_CONFIG', "vrf_global")
+    if entry and entry['mgmtVrfEnabled'] == 'true' :
+        cmd = "mgmtvrf_ntpq -p -n"
+        run_command(cmd, display_cmd=verbose)
+    else:
+        cmd = "ntpq -p -n"
+        run_command(cmd, display_cmd=verbose)
 
 
 #


### PR DESCRIPTION
CLI commands for configuring few parameters that are required in snmpd.conf.
1) "snmpd" daemon (snmp agent) shall use this configured IP address and VRF to listen on the particular IP address on that particular VRF.
2) "snmpd" daemon shall use the configured TRAP IP address and VRF to send the TRAPs to those servers connected in that particular VRF.
Requried back end snmpd patches are already applied in sonic-buildimage to handle this additional "VRF" configuration.

**Configuration**  
root@sonic:# config vrf add mgmt
root@sonic:# config snmpagentaddress add 100.104.45.9 -v mgmt
root@sonic:# config snmptrap modify 3 100.94.212.7 -v mgmt
root@sonic:# cat /etc/sonic/snmp.yml
snmp_rocommunity: public
snmp_location: public
v1_trap_dest: NotConfigured
v2_trap_dest: NotConfigured
v3_trap_dest: 100.94.212.7:162%mgmt public
snmp_agent_address_1: 100.104.45.9%mgmt

root@sonic:~# docker exec -it snmp bash
The file /etc/snmp/snmpd.conf inside snmp docker shows the following configuration which will be used by snmpd daemon.
Following  %mgmt will be used by snmpd to listen to the IP 100.104.45.9 in "mgmt" vrf.
agentAddress 100.104.45.9%mgmt  

Following %mgmt will be used by snmpd to send traps to the server 100.94.212.7 in "mgmt" vrf.
informsink 100.94.212.7:162%mgmt public
