### PR TITLE
[fast/warm reboot] set default reboot method to "kexec -e"

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -9,7 +9,7 @@ REBOOT_SCRIPT_NAME=$(basename $0)
 REBOOT_TYPE="${REBOOT_SCRIPT_NAME}"
 VERBOSE=no
 FORCE=no
-REBOOT_METHOD="/sbin/reboot"
+REBOOT_METHOD="/sbin/kexec -e"
 
 EXIT_SUCCESS=0
 EXIT_FAILURE=1
@@ -43,8 +43,8 @@ function showHelpAndExit()
     echo "    -h -? : get this help"
     echo "    -v    : turn on verbose"
     echo "    -f    : force execution"
-    echo "    -r    : reboot with /sbin/reboot [default]"
-    echo "    -k    : reboot with /sbin/kexec -e"
+    echo "    -r    : reboot with /sbin/reboot"
+    echo "    -k    : reboot with /sbin/kexec -e [default]"
     echo "    -x    : execute script with -x flag"
 
     exit "${EXIT_SUCCESS}"


### PR DESCRIPTION
**- What I did**

'/sbin/reboot' randomly trigger a delay in shutdown path on some
platforms, this delay caused the lags to timeout.

Tested 'kexec -e' 1500+ times and never triggered the shutdown delay.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
