### PR TITLE
[aclshow] restore PRIO column and sort entries by priority

### DIFF
--- a/scripts/aclshow
+++ b/scripts/aclshow
@@ -35,7 +35,7 @@ from natsort import natsorted
 COUNTER_POSITION = '/tmp/.counters_acl.p'
 
 ### acl display header
-ACL_HEADER = ["RULE NAME", "TABLE NAME", "PACKETS COUNT", "BYTES COUNT"]
+ACL_HEADER = ["RULE NAME", "TABLE NAME", "PRIO", "PACKETS COUNT", "BYTES COUNT"]
 
 # some constants for rule properties
 PACKETS_COUNTER = "packets counter"
@@ -178,12 +178,13 @@ class AclStat(object):
                 continue
             rule = self.acl_rules[rule_key]
             line = [rule_key[1], rule_key[0],
+                    rule['PRIORITY'],
                     self.get_counter_value(rule_key, 'packets'),
                     self.get_counter_value(rule_key, 'bytes')]
             aclstat.append(line)
 
         # sort the list with table name first and then descending priority
-        aclstat.sort(key=lambda x: (x[1], -int(x[3])))
+        aclstat.sort(key=lambda x: (x[1], -int(x[2])))
         print(tabulate(aclstat, header))
 
     def clear_counters(self):


### PR DESCRIPTION
Signed-off-by: Roman Kachur <romankac@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
I reverted PRIO column to aclshow output.
Set sorting of rules to 'first by Table then by Priority',
before it was 'first by Table then by Counter'.
**- How I did it**
Added PRIO column to aclshow, changes sorting.
**- How to verify it**
Load acl rules and run _aclshow -a_
**- Previous command output (if the output of a command-line utility has changed)**
```
RULE NAME     TABLE NAME      PACKETS COUNT    BYTES COUNT
------------  ------------  ---------------  -------------
RULE_9        DATAACL                   901            900
RULE_7        DATAACL                   701            700
RULE_4        DATAACL                   401            400
RULE_3        DATAACL                   301            300
RULE_2        DATAACL                   201            200
RULE_1        DATAACL                   101            100
DEFAULT_RULE  DATAACL                     2              1
RULE_05       DATAACL                     0              0
RULE_6        EVERFLOW                  601            600
RULE_08       EVERFLOW                    0              0
```


**- New command output (if the output of a command-line utility has changed)**
```
RULE NAME     TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
------------  ------------  ------  ---------------  -------------
RULE_1        DATAACL         9999              101            100
RULE_2        DATAACL         9998              201            200
RULE_3        DATAACL         9997              301            300
RULE_4        DATAACL         9996              401            400
RULE_05       DATAACL         9995                0              0
RULE_7        DATAACL         9993              701            700
RULE_9        DATAACL         9991              901            900
DEFAULT_RULE  DATAACL            1                2              1
RULE_6        EVERFLOW        9994              601            600
RULE_08       EVERFLOW        9992                0              0
```

-->

