### PR TITLE
Skip INTERFACE entries w/o prefix

### DIFF
--- a/scripts/pcmping
+++ b/scripts/pcmping
@@ -92,6 +92,8 @@ def get_portchannel_ipv4(portchannel_name):
     config = configdb.get_config()
     portchannel_interfaces = config["PORTCHANNEL_INTERFACE"]
     for key in portchannel_interfaces.keys():
+        if len(key) == 1:
+            continue
         pc, ip = key
         ip = ip.split("/")[0]
         if pc == portchannel_name and ipaddress.IPAddress(ip).version == 4:

--- a/show/main.py
+++ b/show/main.py
@@ -1390,6 +1390,8 @@ def brief(verbose):
 
     # Parsing VLAN Gateway info
     for key in natsorted(vlan_ip_data.keys()):
+        if len(key) == 1:
+            continue
         interface_key = str(key[0].strip("Vlan"))
         interface_value = str(key[1])
         if interface_key in vlan_ip_dict:


### PR DESCRIPTION
The two possible key formats of INTERFACE table are:
INTERFACE|<NAME>|<PREFIX>
INTERFACE|<NAME>

The last one carries RIF information without the prefix so it has to be
omitted

Signed-off-by: Marian Pritsak <marianp@mellanox.com>

