### PR TITLE
[show] show interface status added vlan and portchannels to command

### DIFF
--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -265,11 +265,6 @@ def appl_db_portchannel_status_get(appl_db, config_db, po_name, status_type, por
         return "N/A"
     return status 
 
-
-
-
-
-
 # ========================== interface-status logic ==========================
 
 header_stat = ['Interface', 'Lanes', 'Speed', 'MTU', 'Alias', 'Vlan', 'Oper', 'Admin', 'Type', 'Asym PFC']

--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -358,7 +358,7 @@ header_desc = ['Interface', 'Oper', 'Admin', 'Alias', 'Description']
 
 class IntfDescription(object):
 
-    def display_intf_description(self, appl_db_keys):
+    def display_intf_description(self, appl_db_keys, front_panel_ports_list):
         """
             Generate interface-description output
         """
@@ -386,15 +386,18 @@ class IntfDescription(object):
 
     def __init__(self, intf_name):
 
+        self.config_db = db_connect_configdb()
         self.appl_db = db_connect_appl()
         if self.appl_db is None:
             return
-
+        if self.config_db is None:
+            return
+        self.front_panel_ports_list = get_frontpanel_port_list(self.config_db)
         appl_db_keys = appl_db_keys_get(self.appl_db, self.front_panel_ports_list, intf_name)
         if appl_db_keys is None:
             return
 
-        self.display_intf_description(appl_db_keys)
+        self.display_intf_description(appl_db_keys, self.front_panel_ports_list)
 
 
 

--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -66,7 +66,9 @@ def config_db_vlan_port_keys_get(int_to_vlan_dict, front_panel_ports_list, intf_
     vlan = "routed"
     if intf_name in front_panel_ports_list:
         if intf_name in int_to_vlan_dict.keys():
-            vlan = int_to_vlan_dict[intf_name] 
+            vlan = int_to_vlan_dict[intf_name]
+            if "Vlan" in vlan:
+                vlan = "trunk" 
     return vlan
 
 

--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -1,11 +1,13 @@
-#! /usr/bin/python
+#! /usr/bin/python 
 
 import swsssdk
 import sys
 import re
+import types
 from tabulate import tabulate
 from natsort import natsorted
-
+from swsssdk import ConfigDBConnector
+from pprint import pprint
 
 
 # ========================== Common interface-utils logic ==========================
@@ -23,26 +25,62 @@ PORT_DESCRIPTION = "description"
 PORT_OPTICS_TYPE = "type"
 PORT_PFC_ASYM_STATUS = "pfc_asym"
 
+def db_connect_configdb():
+    """
+    Connect to configdb
+    """
+    config_db = ConfigDBConnector()
+    if config_db is None: 
+        return None 
+    config_db.connect()
+    return config_db 
+
+
+def get_interface_vlan_dict(config_db):
+    """
+    Get info from REDIS ConfigDB and create interface to vlan mapping
+    """
+    get_int_vlan_configdb_info = config_db.get_table('VLAN_MEMBER')
+    int_list = []
+    vlan_list = []
+    for line in get_int_vlan_configdb_info:
+        vlan_number = line[0]
+        interface = line[1]
+        int_list.append(interface)
+        vlan_list.append(vlan_number)
+    int_to_vlan_dict = dict(zip(int_list, vlan_list))
+    return int_to_vlan_dict
+
+
+def config_db_vlan_port_keys_get(int_to_vlan_dict, intf_name):
+    """
+    Get interface vlan value and return it.
+    """
+    vlan = "routed"
+    if intf_name.startswith("Ethernet"):
+        if intf_name in int_to_vlan_dict.keys():
+            vlan = int_to_vlan_dict[intf_name] 
+    return vlan
+
 
 def db_connect_appl():
     appl_db = swsssdk.SonicV2Connector(host='127.0.0.1')
     if appl_db is None:
         return None
-
     appl_db.connect(appl_db.APPL_DB)
-
     return appl_db
 
 
 def appl_db_keys_get(appl_db, intf_name):
-
+    """
+    Get APPL_DB Keys
+    """
     if intf_name is None:
         appl_db_keys = appl_db.keys(appl_db.APPL_DB, "PORT_TABLE:*")
     elif intf_name.startswith('Ethernet'):
-        appl_db_keys = appl_db.keys(appl_db.APPL_DB, "PORT_TABLE:%s" % intf_name)
+        appl_db_keys = db.keys(appl_db.APPL_DB, "PORT_TABLE:%s" % intf_name)
     else:
         return None
-
     return appl_db_keys
 
 
@@ -50,15 +88,12 @@ def appl_db_port_status_get(appl_db, intf_name, status_type):
     """
     Get the port status
     """
-
     full_table_id = PORT_STATUS_TABLE_PREFIX + intf_name
     status = appl_db.get(appl_db.APPL_DB, full_table_id, status_type)
     if status is None:
         return "N/A"
-
     if status_type == PORT_SPEED and status != "N/A":
        status = '{}G'.format(status[:-3])
-
     return status
 
 
@@ -83,13 +118,136 @@ def state_db_port_optics_get(state_db, intf_name, type):
         return "N/A" 
     return optics_type 
 
+def merge(x,y):
+    # store a copy of x, but overwrite with y's values where applicable
+    merged = dict(x,**y)
+    xkeys = x.keys()
+    # if the value of merged[key] was overwritten with y[key]'s value
+    # then we need to put back any missing x[key] values
+    for key in xkeys:
+        # if this key is a dictionary, recurse
+        if type(x[key]) is types.DictType and y.has_key(key):
+            merged[key] = merge(x[key],y[key])
+    return merged
+
+def convert(tup, new_dict):
+    """
+    From a tuple create a dictionary that uses the first item in the tuple as a key
+    and the 2nd item in the tuple as a value. 
+    """
+    for a, b in tup:
+        new_dict.setdefault(a, []).append(b)
+    return new_dict
+
+
+def get_raw_portchannel_info(config_db):
+    """
+    This function uses the redis config_db as input and get getting the "PORTCHANNEL_MEMBER" tables
+    create
+    >>> get_po_int_configdb_info = get_portchannel_info(config_db)
+    >>> pprint(get_po_int_configdb_info)
+    {('PortChannel0001', 'Ethernet108'): {},
+     ('PortChannel0001', 'Ethernet112'): {},
+     ('PortChannel0002', 'Ethernet116'): {},
+     ('PortChannel0003', 'Ethernet120'): {},
+     ('PortChannel0004', 'Ethernet124'): {}}
+    This function returns a dictionary with the key being portchannels and interface tuple.
+    """
+    get_raw_po_int_configdb_info = config_db.get_table('PORTCHANNEL_MEMBER')
+    return get_raw_po_int_configdb_info     # Return a dictionary with the key being the portchannel and interface
+
+def get_portchannel_list(get_raw_po_int_configdb_info):
+    """
+    >>> portchannel_list = get_portchannel_list(get_raw_po_int_configdb_info)
+    >>> pprint(portchannel_list)
+    ['PortChannel0001', 'PortChannel0002', 'PortChannel0003', 'PortChannel0004']
+    >>> 
+    """
+    portchannel_list = []
+    for po in get_raw_po_int_configdb_info:
+        portchannel = po[0]
+        if portchannel not in portchannel_list:
+            portchannel_list.append(portchannel)
+    portchannel = portchannel_list.sort()
+    return portchannel_list
+
+def create_po_int_tuple_list(get_raw_po_int_configdb_info):
+    """
+    
+    >>> po_int_tuple = get_raw_po_int_configdb_info.keys()
+    >>> pprint(po_int_tuple_list)
+    [('PortChannel0001', 'Ethernet108'),
+     ('PortChannel0002', 'Ethernet116'),
+     ('PortChannel0004', 'Ethernet124'),
+     ('PortChannel0003', 'Ethernet120'),
+     ('PortChannel0001', 'Ethernet112')]
+    >>> 
+    """
+    po_int_tuple_list = get_raw_po_int_configdb_info.keys()
+    return po_int_tuple_list
+
+def create_po_int_dict(po_int_tuple_list):
+    temp_dict = {}
+    po_int_dict = convert(po_int_tuple_list, temp_dict)
+    return po_int_dict
+
+def create_int_to_portchannel_dict(po_int_tuple_list):
+    int_po_dict = {}
+    for po, intf in po_int_tuple_list:
+        int_po_dict.setdefault(intf, po)
+    return int_po_dict
+
+def po_speed_dict(po_int_dict, appl_db):
+    if po_int_dict: 
+        po_list = []
+        for key, value in po_int_dict.iteritems():
+            agg_speed_list =  []
+            po_list.append(key)
+            if len(value) == 1:
+                interface_speed = appl_db.get(appl_db.APPL_DB, "PORT_TABLE:" + value[0], "speed")
+                interface_speed = '{}G'.format(interface_speed[:-3])
+                po_list.append(interface_speed)
+            elif len(value) > 1:
+                for intf in value:
+                    temp_speed = appl_db.get(appl_db.APPL_DB, "PORT_TABLE:" + intf, "speed")
+                    temp_speed = int(temp_speed)
+                    agg_speed_list.append(temp_speed)
+                    interface_speed = sum(agg_speed_list)
+                    interface_speed = str(interface_speed)
+                    interface_speed = '{}G'.format(interface_speed[:-3])
+                po_list.append(interface_speed)
+            po_speed_dict = dict(po_list[i:i+2] for i in range(0, len(po_list), 2))
+        return po_speed_dict
+    else:
+        po_speed_dict = {}
+        return po_speed_dict
+
+def appl_db_portchannel_status_get(appl_db, po_name, status_type, portchannel_speed_dict):
+    """
+    Get the port status
+    """
+    full_table_id = "LAG_TABLE:" + po_name
+    #print(full_table_id)
+    if status_type == "speed":
+        status = portchannel_speed_dict[po_name]
+        return status
+    if status_type == "vlan":
+        status = "routed"
+        return status
+    status = appl_db.get(appl_db.APPL_DB, full_table_id, status_type)
+    #print(status)
+    if status is None: 
+        return "N/A"
+    return status 
+
+
 # ========================== interface-status logic ==========================
 
-header_stat = ['Interface', 'Lanes', 'Speed', 'MTU', 'Alias', 'Oper', 'Admin', 'Type', 'Asym PFC']
+header_stat = ['Interface', 'Lanes', 'Speed', 'MTU', 'Alias', 'Vlan', 'Oper', 'Admin', 'Type', 'Asym PFC']
 
 class IntfStatus(object):
 
-    def display_intf_status(self, appl_db_keys):
+    def display_intf_status(self, appl_db_keys, portchannel_speed_dict):
         """
             Generate interface-status output
         """
@@ -110,28 +268,58 @@ class IntfStatus(object):
                               appl_db_port_status_get(self.appl_db, key, PORT_SPEED),
                               appl_db_port_status_get(self.appl_db, key, PORT_MTU_STATUS),
                               appl_db_port_status_get(self.appl_db, key, PORT_ALIAS),
+                              config_db_vlan_port_keys_get(self.combined_int_to_vlan_po_dict, key),
                               appl_db_port_status_get(self.appl_db, key, PORT_OPER_STATUS),
                               appl_db_port_status_get(self.appl_db, key, PORT_ADMIN_STATUS),
                               state_db_port_optics_get(self.state_db, key, PORT_OPTICS_TYPE),
                               appl_db_port_status_get(self.appl_db, key, PORT_PFC_ASYM_STATUS)))
-
         # Sorting and tabulating the result table.
+        for po, value in portchannel_speed_dict.iteritems():
+            if po:
+                table.append((po,
+                            appl_db_portchannel_status_get(self.appl_db, po, PORT_LANES_STATUS, self.portchannel_speed_dict),
+                            appl_db_portchannel_status_get(self.appl_db, po, PORT_SPEED, self.portchannel_speed_dict),
+                            appl_db_portchannel_status_get(self.appl_db, po, PORT_MTU_STATUS, self.portchannel_speed_dict),
+                            appl_db_portchannel_status_get(self.appl_db, po, PORT_ALIAS, self.portchannel_speed_dict),
+                            appl_db_portchannel_status_get(self.appl_db, po, "vlan", self.portchannel_speed_dict),
+                            appl_db_portchannel_status_get(self.appl_db, po, PORT_OPER_STATUS, self.portchannel_speed_dict),
+                            appl_db_portchannel_status_get(self.appl_db, po, PORT_ADMIN_STATUS, self.portchannel_speed_dict),
+                            appl_db_portchannel_status_get(self.appl_db, po, PORT_OPTICS_TYPE, self.portchannel_speed_dict),
+                            appl_db_portchannel_status_get(self.appl_db, po, PORT_PFC_ASYM_STATUS, self.portchannel_speed_dict)))
+
         sorted_table = natsorted(table)
         print tabulate(sorted_table, header_stat, tablefmt="simple", stralign='right')
 
 
     def __init__(self, intf_name):
-
+        """
+        Class constructor method
+        :param self: 
+        :param intf_name: string of interface
+        :return: 
+        """
         self.appl_db = db_connect_appl()
         self.state_db = db_connect_state()
+        self.config_db = db_connect_configdb()
         if self.appl_db is None:
             return
         if self.state_db is None: 
             return
+        if self.config_db is None:
+            return
         appl_db_keys = appl_db_keys_get(self.appl_db, intf_name)
+        self.int_to_vlan_dict = get_interface_vlan_dict(self.config_db)
+        self.get_raw_po_int_configdb_info = get_raw_portchannel_info(self.config_db)
+        self.portchannel_list = get_portchannel_list(self.get_raw_po_int_configdb_info)
+        self.po_int_tuple_list = create_po_int_tuple_list(self.get_raw_po_int_configdb_info)
+        self.po_int_dict = create_po_int_dict(self.po_int_tuple_list)
+        self.int_po_dict = create_int_to_portchannel_dict(self.po_int_tuple_list)
+        self.combined_int_to_vlan_po_dict = merge(self.int_to_vlan_dict, self.int_po_dict)
+        self.portchannel_speed_dict = po_speed_dict(self.po_int_dict, self.appl_db)
+        self.portchannel_keys = self.portchannel_speed_dict.keys()
         if appl_db_keys is None:
             return
-        self.display_intf_status(appl_db_keys)
+        self.display_intf_status(appl_db_keys, self.portchannel_speed_dict)
 
 
 
@@ -204,3 +392,5 @@ def main(args):
 
 if __name__ == "__main__":
     main(sys.argv[1:])
+
+

--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -1,4 +1,4 @@
-#! /usr/bin/python 
+#! /usr/bin/python
 
 import swsssdk
 import sys
@@ -35,6 +35,13 @@ def db_connect_configdb():
     config_db.connect()
     return config_db 
 
+def get_frontpanel_port_list(config_db):
+    ports_dict = config_db.get_table('PORT')
+    front_panel_ports_list = []
+    for port in ports_dict.iterkeys():
+        front_panel_ports_list.append(port)
+    return front_panel_ports_list
+
 
 def get_interface_vlan_dict(config_db):
     """
@@ -52,12 +59,12 @@ def get_interface_vlan_dict(config_db):
     return int_to_vlan_dict
 
 
-def config_db_vlan_port_keys_get(int_to_vlan_dict, intf_name):
+def config_db_vlan_port_keys_get(int_to_vlan_dict, front_panel_ports_list, intf_name):
     """
     Get interface vlan value and return it.
     """
     vlan = "routed"
-    if intf_name.startswith("Ethernet"):
+    if intf_name in front_panel_ports_list:
         if intf_name in int_to_vlan_dict.keys():
             vlan = int_to_vlan_dict[intf_name] 
     return vlan
@@ -71,13 +78,13 @@ def db_connect_appl():
     return appl_db
 
 
-def appl_db_keys_get(appl_db, intf_name):
+def appl_db_keys_get(appl_db, front_panel_ports_list, intf_name):
     """
     Get APPL_DB Keys
     """
     if intf_name is None:
         appl_db_keys = appl_db.keys(appl_db.APPL_DB, "PORT_TABLE:*")
-    elif intf_name.startswith('Ethernet'):
+    elif intf_name in front_panel_ports_list:
         appl_db_keys = db.keys(appl_db.APPL_DB, "PORT_TABLE:%s" % intf_name)
     else:
         return None
@@ -118,7 +125,7 @@ def state_db_port_optics_get(state_db, intf_name, type):
         return "N/A" 
     return optics_type 
 
-def merge(x,y):
+def merge_dicts(x,y):
     # store a copy of x, but overwrite with y's values where applicable
     merged = dict(x,**y)
     xkeys = x.keys()
@@ -130,7 +137,7 @@ def merge(x,y):
             merged[key] = merge(x[key],y[key])
     return merged
 
-def convert(tup, new_dict):
+def tuple_to_dict(tup, new_dict):
     """
     From a tuple create a dictionary that uses the first item in the tuple as a key
     and the 2nd item in the tuple as a value. 
@@ -142,7 +149,7 @@ def convert(tup, new_dict):
 
 def get_raw_portchannel_info(config_db):
     """
-    This function uses the redis config_db as input and get getting the "PORTCHANNEL_MEMBER" tables
+    This function uses the redis config_db as input and gets the "PORTCHANNEL_MEMBER" table
     create
     >>> get_po_int_configdb_info = get_portchannel_info(config_db)
     >>> pprint(get_po_int_configdb_info)
@@ -173,7 +180,6 @@ def get_portchannel_list(get_raw_po_int_configdb_info):
 
 def create_po_int_tuple_list(get_raw_po_int_configdb_info):
     """
-    
     >>> po_int_tuple = get_raw_po_int_configdb_info.keys()
     >>> pprint(po_int_tuple_list)
     [('PortChannel0001', 'Ethernet108'),
@@ -187,17 +193,32 @@ def create_po_int_tuple_list(get_raw_po_int_configdb_info):
     return po_int_tuple_list
 
 def create_po_int_dict(po_int_tuple_list):
+    """
+    This function takes the portchannel to interface tuple
+    and converts that into a portchannel to interface dictionary
+    with the portchannels as the key and the interfaces as the values.
+    """
     temp_dict = {}
-    po_int_dict = convert(po_int_tuple_list, temp_dict)
+    po_int_dict = tuple_to_dict(po_int_tuple_list, temp_dict)
     return po_int_dict
 
 def create_int_to_portchannel_dict(po_int_tuple_list):
+    """
+    This function takes the portchannel to interface tuple
+    and converts that into an interface to portchannel dictionary
+    with the interfaces as the key and the portchannels as the values.
+    """
     int_po_dict = {}
     for po, intf in po_int_tuple_list:
         int_po_dict.setdefault(intf, po)
     return int_po_dict
 
 def po_speed_dict(po_int_dict, appl_db):
+    """
+    This function takes the portchannel to interface dictionary 
+    and the appl_db and then creates a portchannel to speed
+    dictionary. 
+    """
     if po_int_dict: 
         po_list = []
         for key, value in po_int_dict.iteritems():
@@ -222,17 +243,21 @@ def po_speed_dict(po_int_dict, appl_db):
         po_speed_dict = {}
         return po_speed_dict
 
-def appl_db_portchannel_status_get(appl_db, po_name, status_type, portchannel_speed_dict):
+def appl_db_portchannel_status_get(appl_db, config_db, po_name, status_type, portchannel_speed_dict):
     """
     Get the port status
     """
     full_table_id = "LAG_TABLE:" + po_name
+    po_table_id = "PORTCHANNEL|" + po_name
     #print(full_table_id)
     if status_type == "speed":
         status = portchannel_speed_dict[po_name]
         return status
     if status_type == "vlan":
         status = "routed"
+        return status
+    if status_type == "mtu":
+        status = config_db.get(config_db.CONFIG_DB, po_table_id, status_type)
         return status
     status = appl_db.get(appl_db.APPL_DB, full_table_id, status_type)
     #print(status)
@@ -241,13 +266,17 @@ def appl_db_portchannel_status_get(appl_db, po_name, status_type, portchannel_sp
     return status 
 
 
+
+
+
+
 # ========================== interface-status logic ==========================
 
 header_stat = ['Interface', 'Lanes', 'Speed', 'MTU', 'Alias', 'Vlan', 'Oper', 'Admin', 'Type', 'Asym PFC']
 
 class IntfStatus(object):
 
-    def display_intf_status(self, appl_db_keys, portchannel_speed_dict):
+    def display_intf_status(self, appl_db_keys, front_panel_ports_list, portchannel_speed_dict):
         """
             Generate interface-status output
         """
@@ -262,13 +291,13 @@ class IntfStatus(object):
         #
         for i in appl_db_keys:
             key = re.split(':', i, maxsplit=1)[-1].strip()
-            if key and key.startswith('Ethernet'):
+            if key in front_panel_ports_list:
                 table.append((key,
                               appl_db_port_status_get(self.appl_db, key, PORT_LANES_STATUS),
                               appl_db_port_status_get(self.appl_db, key, PORT_SPEED),
                               appl_db_port_status_get(self.appl_db, key, PORT_MTU_STATUS),
                               appl_db_port_status_get(self.appl_db, key, PORT_ALIAS),
-                              config_db_vlan_port_keys_get(self.combined_int_to_vlan_po_dict, key),
+                              config_db_vlan_port_keys_get(self.combined_int_to_vlan_po_dict, self.front_panel_ports_list, key),
                               appl_db_port_status_get(self.appl_db, key, PORT_OPER_STATUS),
                               appl_db_port_status_get(self.appl_db, key, PORT_ADMIN_STATUS),
                               state_db_port_optics_get(self.state_db, key, PORT_OPTICS_TYPE),
@@ -277,15 +306,15 @@ class IntfStatus(object):
         for po, value in portchannel_speed_dict.iteritems():
             if po:
                 table.append((po,
-                            appl_db_portchannel_status_get(self.appl_db, po, PORT_LANES_STATUS, self.portchannel_speed_dict),
-                            appl_db_portchannel_status_get(self.appl_db, po, PORT_SPEED, self.portchannel_speed_dict),
-                            appl_db_portchannel_status_get(self.appl_db, po, PORT_MTU_STATUS, self.portchannel_speed_dict),
-                            appl_db_portchannel_status_get(self.appl_db, po, PORT_ALIAS, self.portchannel_speed_dict),
-                            appl_db_portchannel_status_get(self.appl_db, po, "vlan", self.portchannel_speed_dict),
-                            appl_db_portchannel_status_get(self.appl_db, po, PORT_OPER_STATUS, self.portchannel_speed_dict),
-                            appl_db_portchannel_status_get(self.appl_db, po, PORT_ADMIN_STATUS, self.portchannel_speed_dict),
-                            appl_db_portchannel_status_get(self.appl_db, po, PORT_OPTICS_TYPE, self.portchannel_speed_dict),
-                            appl_db_portchannel_status_get(self.appl_db, po, PORT_PFC_ASYM_STATUS, self.portchannel_speed_dict)))
+                            appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_LANES_STATUS, self.portchannel_speed_dict),
+                            appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_SPEED, self.portchannel_speed_dict),
+                            appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_MTU_STATUS, self.portchannel_speed_dict),
+                            appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_ALIAS, self.portchannel_speed_dict),
+                            appl_db_portchannel_status_get(self.appl_db, self.config_db, po, "vlan", self.portchannel_speed_dict),
+                            appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_OPER_STATUS, self.portchannel_speed_dict),
+                            appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_ADMIN_STATUS, self.portchannel_speed_dict),
+                            appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_OPTICS_TYPE, self.portchannel_speed_dict),
+                            appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_PFC_ASYM_STATUS, self.portchannel_speed_dict)))
 
         sorted_table = natsorted(table)
         print tabulate(sorted_table, header_stat, tablefmt="simple", stralign='right')
@@ -307,19 +336,20 @@ class IntfStatus(object):
             return
         if self.config_db is None:
             return
-        appl_db_keys = appl_db_keys_get(self.appl_db, intf_name)
+        self.front_panel_ports_list = get_frontpanel_port_list(self.config_db)
+        appl_db_keys = appl_db_keys_get(self.appl_db, self.front_panel_ports_list, intf_name)
         self.int_to_vlan_dict = get_interface_vlan_dict(self.config_db)
         self.get_raw_po_int_configdb_info = get_raw_portchannel_info(self.config_db)
         self.portchannel_list = get_portchannel_list(self.get_raw_po_int_configdb_info)
         self.po_int_tuple_list = create_po_int_tuple_list(self.get_raw_po_int_configdb_info)
         self.po_int_dict = create_po_int_dict(self.po_int_tuple_list)
         self.int_po_dict = create_int_to_portchannel_dict(self.po_int_tuple_list)
-        self.combined_int_to_vlan_po_dict = merge(self.int_to_vlan_dict, self.int_po_dict)
+        self.combined_int_to_vlan_po_dict = merge_dicts(self.int_to_vlan_dict, self.int_po_dict)
         self.portchannel_speed_dict = po_speed_dict(self.po_int_dict, self.appl_db)
         self.portchannel_keys = self.portchannel_speed_dict.keys()
         if appl_db_keys is None:
             return
-        self.display_intf_status(appl_db_keys, self.portchannel_speed_dict)
+        self.display_intf_status(appl_db_keys, self.front_panel_ports_list, self.portchannel_speed_dict)
 
 
 
@@ -346,7 +376,7 @@ class IntfDescription(object):
         #
         for i in appl_db_keys:
             key = re.split(':', i, maxsplit=1)[-1].strip()
-            if key and key.startswith('Ethernet'):
+            if key in front_panel_ports_list:
                 table.append((key,
                               appl_db_port_status_get(self.appl_db, key, PORT_OPER_STATUS),
                               appl_db_port_status_get(self.appl_db, key, PORT_ADMIN_STATUS),
@@ -363,7 +393,7 @@ class IntfDescription(object):
         if self.appl_db is None:
             return
 
-        appl_db_keys = appl_db_keys_get(self.appl_db, intf_name)
+        appl_db_keys = appl_db_keys_get(self.appl_db, self.front_panel_ports_list, intf_name)
         if appl_db_keys is None:
             return
 
@@ -392,5 +422,3 @@ def main(args):
 
 if __name__ == "__main__":
     main(sys.argv[1:])
-
-


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Updated the file to add a "VLAN" column that reports "routed", ~~"VlanXXXX"~~ "trunk", or "PortChannelXXXX" depending on how that interface is configured.  This is how Arista/Cisco report on this command. 

Also added PortChannels to the bottom on the command like Cisco/Arista.

**- How I did it**
Updated the intfutil file to add additonal methods to support this.

**- How to verify it**
run the "show int status" command on the sonic systems.

**- Previous command output (if the output of a command-line utility has changed)**
```
admin@str-s6000-acs-11:/usr/bin$ show int status
  Interface            Lanes    Speed    MTU           Alias    Oper    Admin    Type    Asym PFC
-----------  ---------------  -------  -----  --------------  ------  -------  ------  ----------
  Ethernet0      25,26,27,28      40G   9100    fortyGigE0/0      up       up   QSFP+         off
  Ethernet4      29,30,31,32      40G   9100    fortyGigE0/4      up       up   QSFP+         off
  Ethernet8      33,34,35,36      40G   9100    fortyGigE0/8      up       up   QSFP+         off
 Ethernet12      37,38,39,40      40G   9100   fortyGigE0/12      up       up   QSFP+         off
 Ethernet16      45,46,47,48      40G   9100   fortyGigE0/16      up       up   QSFP+         off
 Ethernet20      41,42,43,44      40G   9100   fortyGigE0/20      up       up   QSFP+         off
 Ethernet24          1,2,3,4      40G   9100   fortyGigE0/24      up       up   QSFP+         off
 Ethernet28          5,6,7,8      40G   9100   fortyGigE0/28      up       up   QSFP+         off
 Ethernet32      13,14,15,16      40G   9100   fortyGigE0/32      up       up   QSFP+         off
 Ethernet36       9,10,11,12      40G   9100   fortyGigE0/36      up       up   QSFP+         off
 Ethernet40      17,18,19,20      40G   9100   fortyGigE0/40      up       up   QSFP+         off
 Ethernet44      21,22,23,24      40G   9100   fortyGigE0/44      up       up   QSFP+         off
 Ethernet48      53,54,55,56      40G   9100   fortyGigE0/48      up       up   QSFP+         off
 Ethernet52      49,50,51,52      40G   9100   fortyGigE0/52      up       up   QSFP+         off
 Ethernet56      57,58,59,60      40G   9100   fortyGigE0/56    down       up   QSFP+         off
 Ethernet60      61,62,63,64      40G   9100   fortyGigE0/60      up       up     N/A         off
 Ethernet64      69,70,71,72      40G   9100   fortyGigE0/64      up       up   QSFP+         off
 Ethernet68      65,66,67,68      40G   9100   fortyGigE0/68      up       up   QSFP+         off
 Ethernet72      73,74,75,76      40G   9100   fortyGigE0/72      up       up   QSFP+         off
 Ethernet76      77,78,79,80      40G   9100   fortyGigE0/76      up       up   QSFP+         off
 Ethernet80  109,110,111,112      40G   9100   fortyGigE0/80      up       up   QSFP+         off
 Ethernet84  105,106,107,108      40G   9100   fortyGigE0/84      up       up   QSFP+         off
 Ethernet88  113,114,115,116      40G   9100   fortyGigE0/88      up       up   QSFP+         off
 Ethernet92  117,118,119,120      40G   9100   fortyGigE0/92      up       up   QSFP+         off
 Ethernet96  125,126,127,128      40G   9100   fortyGigE0/96      up       up   QSFP+         off
Ethernet100  121,122,123,124      40G   9100  fortyGigE0/100      up       up   QSFP+         off
Ethernet104      81,82,83,84      40G   9100  fortyGigE0/104      up       up   QSFP+         off
Ethernet108      85,86,87,88      40G   9100  fortyGigE0/108      up       up   QSFP+         off
Ethernet112      93,94,95,96      40G   9100  fortyGigE0/112      up       up   QSFP+         off
Ethernet116      89,90,91,92      40G   9100  fortyGigE0/116      up       up   QSFP+         off
Ethernet120  101,102,103,104      40G   9100  fortyGigE0/120      up       up   QSFP+         off
Ethernet124     97,98,99,100      40G   9100  fortyGigE0/124      up       up   QSFP+         off
```

**- New command output (if the output of a command-line utility has changed)**
```
admin@str-s6000-acs-11:/usr/bin$ show int status
      Interface            Lanes    Speed    MTU           Alias             Vlan    Oper    Admin    Type    Asym PFC
---------------  ---------------  -------  -----  --------------  ---------------  ------  -------  ------  ----------
      Ethernet0      25,26,27,28      40G   9100    fortyGigE0/0           routed      up       up   QSFP+         off
      Ethernet4      29,30,31,32      40G   9100    fortyGigE0/4           routed      up       up   QSFP+         off
      Ethernet8      33,34,35,36      40G   9100    fortyGigE0/8           routed      up       up   QSFP+         off
     Ethernet12      37,38,39,40      40G   9100   fortyGigE0/12           routed      up       up   QSFP+         off
     Ethernet16      45,46,47,48      40G   9100   fortyGigE0/16           routed      up       up   QSFP+         off
     Ethernet20      41,42,43,44      40G   9100   fortyGigE0/20           routed      up       up   QSFP+         off
     Ethernet24          1,2,3,4      40G   9100   fortyGigE0/24           routed      up       up   QSFP+         off
     Ethernet28          5,6,7,8      40G   9100   fortyGigE0/28           routed      up       up   QSFP+         off
     Ethernet32      13,14,15,16      40G   9100   fortyGigE0/32           routed      up       up   QSFP+         off
     Ethernet36       9,10,11,12      40G   9100   fortyGigE0/36           routed      up       up   QSFP+         off
     Ethernet40      17,18,19,20      40G   9100   fortyGigE0/40           routed      up       up   QSFP+         off
     Ethernet44      21,22,23,24      40G   9100   fortyGigE0/44            trunk      up       up   QSFP+         off
     Ethernet48      53,54,55,56      40G   9100   fortyGigE0/48           routed      up       up   QSFP+         off
     Ethernet52      49,50,51,52      40G   9100   fortyGigE0/52           routed      up       up   QSFP+         off
     Ethernet56      57,58,59,60      40G   9100   fortyGigE0/56           routed    down       up   QSFP+         off
     Ethernet60      61,62,63,64      40G   9100   fortyGigE0/60           routed      up       up     N/A         off
     Ethernet64      69,70,71,72      40G   9100   fortyGigE0/64           routed      up       up   QSFP+         off
     Ethernet68      65,66,67,68      40G   9100   fortyGigE0/68           routed      up       up   QSFP+         off
     Ethernet72      73,74,75,76      40G   9100   fortyGigE0/72           routed      up       up   QSFP+         off
     Ethernet76      77,78,79,80      40G   9100   fortyGigE0/76           routed      up       up   QSFP+         off
     Ethernet80  109,110,111,112      40G   9100   fortyGigE0/80           routed      up       up   QSFP+         off
     Ethernet84  105,106,107,108      40G   9100   fortyGigE0/84           routed      up       up   QSFP+         off
     Ethernet88  113,114,115,116      40G   9100   fortyGigE0/88           routed      up       up   QSFP+         off
     Ethernet92  117,118,119,120      40G   9100   fortyGigE0/92           routed      up       up   QSFP+         off
     Ethernet96  125,126,127,128      40G   9100   fortyGigE0/96           routed      up       up   QSFP+         off
    Ethernet100  121,122,123,124      40G   9100  fortyGigE0/100           routed      up       up   QSFP+         off
    Ethernet104      81,82,83,84      40G   9100  fortyGigE0/104           routed      up       up   QSFP+         off
    Ethernet108      85,86,87,88      40G   9100  fortyGigE0/108  PortChannel0001      up       up   QSFP+         off
    Ethernet112      93,94,95,96      40G   9100  fortyGigE0/112           routed      up       up   QSFP+         off
    Ethernet116      89,90,91,92      40G   9100  fortyGigE0/116           routed      up       up   QSFP+         off
    Ethernet120  101,102,103,104      40G   9100  fortyGigE0/120           routed      up       up   QSFP+         off
    Ethernet124     97,98,99,100      40G   9100  fortyGigE0/124           routed      up       up   QSFP+         off
    PortChannel0001          N/A      40G   9100             N/A           routed    down       up     N/A         N/A
```
