### PR TITLE
Add warm/fast-boot feature processing for wedge100bf_32x/65x platforms

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -185,6 +185,9 @@ case "$REBOOT_TYPE" in
             # source mlnx-ffb.sh file with
             # functions to check ISSU upgrade possibility
             source mlnx-ffb.sh
+        elif [[ "$sonic_asic_type" == "barefoot" ]]; then
+            REBOOT_TYPE="fastfast-reboot"
+            BOOT_TYPE_ARG="fastfast"
         else
             BOOT_TYPE_ARG="warm"
         fi


### PR DESCRIPTION
**- What I did**
treat `warm-reboot` as a  `fastfast-reboot` for Barefoot based platforms

**- How to verify it**
run `sudo warm-reboot` on the hardware box

**- Description for the changelog**
Add warm/fast-boot feature processing for wedge100bf_32x/65x platforms

**- Should be merged together with**
https://github.com/Azure/sonic-sairedis/pull/434
https://github.com/Azure/sonic-buildimage/pull/2687

@akokhan, @mkbalani FYI