### PR TITLE
[show ip interface] Add support for 'alias' interface naming mode

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -79,8 +79,8 @@ class InterfaceAliasConverter(object):
                 if interface_name == port_name:
                     return self.port_dict[port_name]['alias']
 
-        click.echo("Invalid interface {}".format(interface_name))
-        raise click.Abort()
+        # interface_name not in port_dict. Just return interface_name
+        return interface_name
 
     def alias_to_name(self, interface_alias):
         """Return SONiC interface name if vendor
@@ -91,8 +91,8 @@ class InterfaceAliasConverter(object):
                 if interface_alias == self.port_dict[port_name]['alias']:
                     return port_name
 
-        click.echo("Invalid interface {}".format(interface_alias))
-        raise click.Abort()
+        # interface_alias not in port_dict. Just return interface_alias
+        return interface_alias
 
 
 # Global Config object
@@ -902,7 +902,12 @@ def interfaces():
                     oper = get_if_oper_state(iface)
                 else:
                     oper = "down"
+
+                if get_interface_mode() == "alias":
+                    iface = iface_alias_converter.name_to_alias(iface)
+
                 data.append([iface, ifaddresses[0][1], admin + "/" + oper])
+
             for ifaddr in ifaddresses[1:]:
                 data.append(["", ifaddr[1], ""])
 


### PR DESCRIPTION
**- What I did**
- Add support for 'alias' interface naming mode to the `show ip interface` command.

- Also modify `InterfaceAliasConverter.name_to_alias()` and `InterfaceAliasConverteralias_to_name.()` so that they no longer raise click.Abort(). Instead, if the interface name or alias to translate is not found in the PORT table of ConfigDB, we simply and gracefully return the untranslated parameter that was passed. A command like `show ip interfaces` will present interfaces besides front-panel interfaces (eth0, docker0, lo, etc.), so this prevents the need to do yet another test of whether the port is a front-panel port or not.

**- How to verify it**
```
sudo config interface_naming_mode alias
logout
<log back in to device>
show ip interfaces
<confirm output now contains interface aliases>

sudo config interface_naming_mode default
logout
<log back in to device>
show ip interfaces
<confirm output now contains SONiC port names>
```

**- Previous command output (if the output of a command-line utility has changed)**
```
admin@sonic:~$ show interface naming_mode 
alias
admin@sonic:~$ show ip interfaces
Interface    IPv4 address/mask    Admin/Oper
-----------  -------------------  ------------
Ethernet0    10.0.0.0/31          up/up
Ethernet4    10.0.0.2/31          up/up
Ethernet8    10.0.0.4/31          up/up
Ethernet12   10.0.0.6/31          up/up
Ethernet16   10.0.0.8/31          up/up
Ethernet20   10.0.0.10/31         up/up
Ethernet24   10.0.0.12/31         up/up
Ethernet28   10.0.0.14/31         up/up
Ethernet32   10.0.0.16/31         up/up
Ethernet36   10.0.0.18/31         up/up
Ethernet40   10.0.0.20/31         up/up
Ethernet44   10.0.0.22/31         up/up
Ethernet48   10.0.0.24/31         up/up
Ethernet52   10.0.0.26/31         up/up
Ethernet56   10.0.0.28/31         up/down
Ethernet60   10.0.0.30/31         up/up
Ethernet64   10.0.0.32/31         up/up
Ethernet68   10.0.0.34/31         up/up
Ethernet72   10.0.0.36/31         up/up
Ethernet76   10.0.0.38/31         up/up
Ethernet80   10.0.0.40/31         up/up
Ethernet84   10.0.0.42/31         up/up
Ethernet88   10.0.0.44/31         up/up
Ethernet92   10.0.0.46/31         up/up
Ethernet96   10.0.0.48/31         up/up
Ethernet100  10.0.0.50/31         up/up
Ethernet104  10.0.0.52/31         up/up
Ethernet108  10.0.0.54/31         up/up
Ethernet112  10.0.0.56/31         up/up
Ethernet116  10.0.0.58/31         up/up
Ethernet120  10.0.0.60/31         up/up
Ethernet124  10.0.0.62/31         up/up
docker0      240.127.1.1/24       up/down
eth0         10.3.147.239/23      up/up
lo           127.0.0.1/8          up/up
             10.1.0.32/32
```

**- New command output (if the output of a command-line utility has changed)**

```
admin@sonic:~$ show interface naming_mode 
alias
admin@sonic:~$ show ip interfaces                  
Interface       IPv4 address/mask    Admin/Oper
--------------  -------------------  ------------
fortyGigE0/0    10.0.0.0/31          up/up
fortyGigE0/4    10.0.0.2/31          up/up
fortyGigE0/8    10.0.0.4/31          up/up
fortyGigE0/12   10.0.0.6/31          up/up
fortyGigE0/16   10.0.0.8/31          up/up
fortyGigE0/20   10.0.0.10/31         up/up
fortyGigE0/24   10.0.0.12/31         up/up
fortyGigE0/28   10.0.0.14/31         up/up
fortyGigE0/32   10.0.0.16/31         up/up
fortyGigE0/36   10.0.0.18/31         up/up
fortyGigE0/40   10.0.0.20/31         up/up
fortyGigE0/44   10.0.0.22/31         up/up
fortyGigE0/48   10.0.0.24/31         up/up
fortyGigE0/52   10.0.0.26/31         up/up
fortyGigE0/56   10.0.0.28/31         up/down
fortyGigE0/60   10.0.0.30/31         up/up
fortyGigE0/64   10.0.0.32/31         up/up
fortyGigE0/68   10.0.0.34/31         up/up
fortyGigE0/72   10.0.0.36/31         up/up
fortyGigE0/76   10.0.0.38/31         up/up
fortyGigE0/80   10.0.0.40/31         up/up
fortyGigE0/84   10.0.0.42/31         up/up
fortyGigE0/88   10.0.0.44/31         up/up
fortyGigE0/92   10.0.0.46/31         up/up
fortyGigE0/96   10.0.0.48/31         up/up
fortyGigE0/100  10.0.0.50/31         up/up
fortyGigE0/104  10.0.0.52/31         up/up
fortyGigE0/108  10.0.0.54/31         up/up
fortyGigE0/112  10.0.0.56/31         up/up
fortyGigE0/116  10.0.0.58/31         up/up
fortyGigE0/120  10.0.0.60/31         up/up
fortyGigE0/124  10.0.0.62/31         up/up
docker0         240.127.1.1/24       up/down
eth0            10.3.147.239/23      up/up
lo              127.0.0.1/8          up/up
                10.1.0.32/32
```
