### PR TITLE
[show] Add serial numbers/uptime/hwinfo to 'show version' output

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -192,6 +192,7 @@ def run_command(command, display_cmd=False):
     if rc != 0:
         sys.exit(rc)
 
+
 def get_interface_mode():
     mode = os.getenv('SONIC_CLI_IFACE_MODE')
     if mode is None:
@@ -1107,10 +1108,6 @@ def get_hw_info_dict():
     hw_info_dict['asic_type'] = asic_type
     return hw_info_dict
 
-# This calls teh get_hw_info_dict function and creates a dictionary
-hw_info_dict = get_hw_info_dict()
-
-
 @cli.group(cls=AliasedGroup, default_if_no_args=False)
 def platform():
     """Show platform-specific hardware info"""
@@ -1124,6 +1121,7 @@ if (version_info and version_info.get('asic_type') == 'mellanox'):
 @platform.command()
 def summary():
     """Show hardware platform information"""
+    hw_info_dict = get_hw_info_dict()
     click.echo("Platform: {}".format(hw_info_dict['platform']))
     click.echo("HwSKU: {}".format(hw_info_dict['hwsku']))
     click.echo("ASIC: {}".format(hw_info_dict['asic_type']))
@@ -1187,6 +1185,7 @@ def logging(process, lines, follow, verbose):
 def version(verbose):
     """Show version information"""
     version_info = sonic_platform.get_sonic_version_info()
+    hw_info_dict = get_hw_info_dict()
     serial_number_cmd = "sudo decode-syseeprom -s"
     serial_number = subprocess.Popen(serial_number_cmd, shell=True, stdout=subprocess.PIPE)    
     sys_uptime_cmd = "uptime"

--- a/show/main.py
+++ b/show/main.py
@@ -192,22 +192,6 @@ def run_command(command, display_cmd=False):
     if rc != 0:
         sys.exit(rc)
 
-def run_command_save(command, display_cmd=False):
-    """run a command and save the output"""
-    if display_cmd:
-        click.echo(click.style("Command: ", fg='cyan') + click.style(command, fg='green'))
-    try: 
-        proc = subprocess.Popen(command,
-                                stdout=subprocess.PIPE,
-                                shell=True,
-                                stderr=subprocess.STDOUT)
-        stdout = proc.communicate()[0]
-        proc.wait()
-        result = stdout.rstrip('\n')
-    except OSError, e:
-        raise OSError("Error running command")
-    return (result)
-
 def get_interface_mode():
     mode = os.getenv('SONIC_CLI_IFACE_MODE')
     if mode is None:

--- a/show/main.py
+++ b/show/main.py
@@ -1102,6 +1102,31 @@ def table(verbose):
 # 'platform' group ("show platform ...")
 #
 
+def get_hw_info_dict():
+    """
+    This function is used to get the HW info helper function  
+    """
+    hw_info_dict = {}
+    machine_info = sonic_platform.get_machine_info()
+    platform = sonic_platform.get_platform_info(machine_info)
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    data = config_db.get_table('DEVICE_METADATA')
+    try: 
+        hwsku = data['localhost']['hwsku']
+    except KeyError:
+        hwsku = "Unknown"
+    version_info = sonic_platform.get_sonic_version_info()
+    asic_type = version_info['asic_type']
+    hw_info_dict['platform'] = platform
+    hw_info_dict['hwsku'] = hwsku
+    hw_info_dict['asic_type'] = asic_type
+    return hw_info_dict
+
+# This calls teh get_hw_info_dict function and creates a dictionary
+hw_info_dict = get_hw_info_dict()
+
+
 @cli.group(cls=AliasedGroup, default_if_no_args=False)
 def platform():
     """Show platform-specific hardware info"""
@@ -1115,24 +1140,9 @@ if (version_info and version_info.get('asic_type') == 'mellanox'):
 @platform.command()
 def summary():
     """Show hardware platform information"""
-    machine_info = sonic_platform.get_machine_info()
-    platform = sonic_platform.get_platform_info(machine_info)
-
-    config_db = ConfigDBConnector()
-    config_db.connect()
-    data = config_db.get_table('DEVICE_METADATA')
-
-    try:
-        hwsku = data['localhost']['hwsku']
-    except KeyError:
-        hwsku = "Unknown"
-
-    version_info = sonic_platform.get_sonic_version_info()
-    asic_type = version_info['asic_type']
-
-    click.echo("Platform: {}".format(platform))
-    click.echo("HwSKU: {}".format(hwsku))
-    click.echo("ASIC: {}".format(asic_type))
+    click.echo("Platform: {}".format(hw_info_dict['platform']))
+    click.echo("HwSKU: {}".format(hw_info_dict['hwsku']))
+    click.echo("ASIC: {}".format(hw_info_dict['asic_type']))
 
 # 'syseeprom' subcommand ("show platform syseeprom")
 @platform.command()
@@ -1189,22 +1199,25 @@ def logging(process, lines, follow, verbose):
 #
 
 @cli.command()
-def version():
+@click.option("--verbose", is_flag=True, help="Enable verbose output")
+def version(verbose):
     """Show version information"""
     version_info = sonic_platform.get_sonic_version_info()
-    serial_number = run_command_save("sudo decode-syseeprom -s")
-    hw_info = run_command_save("show platform summary")
-    sys_uptime = run_command_save("uptime")
+    serial_number_cmd = "sudo decode-syseeprom -s"
+    serial_number = subprocess.Popen(serial_number_cmd, shell=True, stdout=subprocess.PIPE)    
+    sys_uptime_cmd = "uptime"
+    sys_uptime = subprocess.Popen(sys_uptime_cmd, shell=True, stdout=subprocess.PIPE)
     click.echo("\nSONiC Software Version: SONiC.{}".format(version_info['build_version']))
     click.echo("Distribution: Debian {}".format(version_info['debian_version']))
     click.echo("Kernel: {}".format(version_info['kernel_version']))
     click.echo("Build commit: {}".format(version_info['commit_id']))
     click.echo("Build date: {}".format(version_info['build_date']))
     click.echo("Built by: {}".format(version_info['built_by']))
-    click.echo("\n{}".format(hw_info))
-    click.echo("Serial Number: {}".format(serial_number))
-    click.echo("Uptime: {}".format(sys_uptime))
-
+    click.echo("\nPlatform: {}".format(hw_info_dict['platform']))
+    click.echo("HwSKU: {}".format(hw_info_dict['hwsku']))
+    click.echo("ASIC: {}".format(hw_info_dict['asic_type']))
+    click.echo("Serial Number: {}".format(serial_number.stdout.read().strip()))
+    click.echo("Uptime: {}".format(sys_uptime.stdout.read().strip()))
     click.echo("\nDocker images:")
     cmd = 'sudo docker images --format "table {{.Repository}}\\t{{.Tag}}\\t{{.ID}}\\t{{.Size}}"'
     p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Added the output of "show platform summary", "uptime", and "sudo decode-syseeprom -s" to get the serial number of the device.   I did this to include information most network engineers expect when running show version.

**- How I did it**
I added a function (run_command_save) to save the output of an existing command and then used that output to add the additional info into "show version".

**- How to verify it**
Just run "show version" on the CLI.

**- Previous command output (if the output of a command-line utility has changed)**
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/show$ show version 
SONiC Software Version: SONiC.HEAD.534-8af9b8c
Distribution: Debian 9.8
Kernel: 4.9.0-8-2-amd64
Build commit: 8af9b8c
Build date: Tue Mar 12 13:44:27 UTC 2019
Built by: sonicbld@jenkins-slave-phx-2

Docker images:
REPOSITORY                 TAG                 IMAGE ID            SIZE
docker-syncd-brcm          HEAD.534-8af9b8c    0a7d6c56458e        362MB
docker-syncd-brcm          latest              0a7d6c56458e        362MB
docker-orchagent-brcm      HEAD.534-8af9b8c    dfc9c6cb6108        287MB
docker-orchagent-brcm      latest              dfc9c6cb6108        287MB
docker-lldp-sv2            HEAD.534-8af9b8c    d8e51b7b6676        275MB
docker-lldp-sv2            latest              d8e51b7b6676        275MB
docker-dhcp-relay          HEAD.534-8af9b8c    fdda30109e55        257MB
docker-dhcp-relay          latest              fdda30109e55        257MB
docker-database            HEAD.534-8af9b8c    00aee8121f92        280MB
docker-database            latest              00aee8121f92        280MB
docker-snmp-sv2            HEAD.534-8af9b8c    1f35adf26b49        295MB
docker-snmp-sv2            latest              1f35adf26b49        295MB
docker-teamd               HEAD.534-8af9b8c    da308d77b4dd        275MB
docker-teamd               latest              da308d77b4dd        275MB
docker-sonic-telemetry     HEAD.534-8af9b8c    853b1b6d0c47        300MB
docker-sonic-telemetry     latest              853b1b6d0c47        300MB
docker-router-advertiser   HEAD.534-8af9b8c    c35df28e2b2f        279MB
docker-router-advertiser   latest              c35df28e2b2f        279MB
docker-platform-monitor    HEAD.534-8af9b8c    be2125ca403a        288MB
docker-platform-monitor    latest              be2125ca403a        288MB
docker-fpm-quagga          HEAD.534-8af9b8c    097a67eff5fa        282MB
docker-fpm-quagga          latest              097a67eff5fa        282MB

admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/show$ 

**- New command output (if the output of a command-line utility has changed)**

admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/show$ show version 

SONiC Software Version: SONiC.HEAD.534-8af9b8c
Distribution: Debian 9.8
Kernel: 4.9.0-8-2-amd64
Build commit: 8af9b8c
Build date: Tue Mar 12 13:44:27 UTC 2019
Built by: sonicbld@jenkins-slave-phx-2

Platform: x86_64-dell_s6000_s1220-r0
HwSKU: Force10-S6000
ASIC: broadcom
Serial Number: BQBRX42
Uptime:  21:06:36 up 2 days, 23:49,  4 users,  load average: 1.48, 1.27, 0.88

Docker images:
REPOSITORY                 TAG                 IMAGE ID            SIZE
docker-syncd-brcm          HEAD.534-8af9b8c    0a7d6c56458e        362MB
docker-syncd-brcm          latest              0a7d6c56458e        362MB
docker-orchagent-brcm      HEAD.534-8af9b8c    dfc9c6cb6108        287MB
docker-orchagent-brcm      latest              dfc9c6cb6108        287MB
docker-lldp-sv2            HEAD.534-8af9b8c    d8e51b7b6676        275MB
docker-lldp-sv2            latest              d8e51b7b6676        275MB
docker-dhcp-relay          HEAD.534-8af9b8c    fdda30109e55        257MB
docker-dhcp-relay          latest              fdda30109e55        257MB
docker-database            HEAD.534-8af9b8c    00aee8121f92        280MB
docker-database            latest              00aee8121f92        280MB
docker-snmp-sv2            HEAD.534-8af9b8c    1f35adf26b49        295MB
docker-snmp-sv2            latest              1f35adf26b49        295MB
docker-teamd               HEAD.534-8af9b8c    da308d77b4dd        275MB
docker-teamd               latest              da308d77b4dd        275MB
docker-sonic-telemetry     HEAD.534-8af9b8c    853b1b6d0c47        300MB
docker-sonic-telemetry     latest              853b1b6d0c47        300MB
docker-router-advertiser   HEAD.534-8af9b8c    c35df28e2b2f        279MB
docker-router-advertiser   latest              c35df28e2b2f        279MB
docker-platform-monitor    HEAD.534-8af9b8c    be2125ca403a        288MB
docker-platform-monitor    latest              be2125ca403a        288MB
docker-fpm-quagga          HEAD.534-8af9b8c    097a67eff5fa        282MB
docker-fpm-quagga          latest              097a67eff5fa        282MB

admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/show$ 
-->

