### PR TITLE
[warm-reboot] initialize warm reboot state table before warm rebooting

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -106,6 +106,18 @@ function clear_warm_boot()
     fi
 }
 
+function init_warm_reboot_states()
+{
+    # If the current running instanace was booted up with warm reboot. Then
+    # the current DB contents will likely mark warm reboot is done.
+    # Clear these states so that the next boot up image won't ge confused.
+    if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; then
+        for key in `/usr/bin/redis-cli -n 6 keys "WARM_RESTART_TABLE|*"`; do
+            /usr/bin/redis-cli -n 6 hdel $key "state" > /dev/null
+        done
+    fi
+}
+
 function initialize_pre_shutdown()
 {
     debug "Initialize pre-shutdown ..."
@@ -284,6 +296,8 @@ if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
     mkdir -p /host/fast-reboot
     /usr/bin/fast-reboot-dump.py -t /host/fast-reboot
 fi
+
+init_warm_reboot_states
 
 setup_control_plane_assistant
 

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -112,9 +112,11 @@ function init_warm_reboot_states()
     # the current DB contents will likely mark warm reboot is done.
     # Clear these states so that the next boot up image won't get confused.
     if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; then
-        for key in `/usr/bin/redis-cli -n 6 keys "WARM_RESTART_TABLE|*"`; do
-            /usr/bin/redis-cli -n 6 hdel $key "state" > /dev/null
-        done
+        redis-cli -n 6 eval "
+            for _, key in ipairs(redis.call('keys', 'WARM_RESTART_TABLE|*')) do
+                redis.call('hdel', key, 'state')
+            end
+        " 0 >/dev/null
     fi
 }
 

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -110,7 +110,7 @@ function init_warm_reboot_states()
 {
     # If the current running instanace was booted up with warm reboot. Then
     # the current DB contents will likely mark warm reboot is done.
-    # Clear these states so that the next boot up image won't ge confused.
+    # Clear these states so that the next boot up image won't get confused.
     if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; then
         for key in `/usr/bin/redis-cli -n 6 keys "WARM_RESTART_TABLE|*"`; do
             /usr/bin/redis-cli -n 6 hdel $key "state" > /dev/null


### PR DESCRIPTION
**- What I did**

Make sure that when the new image boots up, the component state won't
be 'reconciled'.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- How to verify it**
continuous warm reboot.

admin@str-7260cx3-acs-1:~$ show warm_restart state ; uptime
name             restore_count  state
-------------  ---------------  ----------------------
syncd                       83
vlanmgrd                    83
neighsyncd                  83  reconciled
portsyncd                   83
teammgrd                    83
bgp                         83  reconciled
warm-shutdown                0  pre-shutdown-succeeded
orchagent                   83  reconciled
teamsyncd                   83
 16:13:00 up 6 min,  1 user,  load average: 2.81, 1.54, 0.76
admin@str-7260cx3-acs-1:~$ show warm_restart state ; uptime
name             restore_count  state
-------------  ---------------  -------
syncd                       83
vlanmgrd                    83
neighsyncd                  83
portsyncd                   83
teammgrd                    83
bgp                         83
warm-shutdown                0
orchagent                   83
teamsyncd                   83
 16:13:08 up 6 min,  1 user,  load average: 2.61, 1.53, 0.77