### PR TITLE
updated show ipv6 interface for alias mode

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -998,6 +998,8 @@ def interfaces():
                     oper = get_if_oper_state(iface)
                 else:
                     oper = "down"
+                if get_interface_mode() == "alias":
+                    iface = iface_alias_converter.name_to_alias(iface)
                 data.append([iface, ifaddresses[0][1], admin + "/" + oper])
             for ifaddr in ifaddresses[1:]:
                 data.append(["", ifaddr[1], ""])


### PR DESCRIPTION
**- What I did**

Add support for 'alias' interface naming mode to the show ipv6 interface command.

**- How I did it**

Added these two lines to the function for "show ipv6 interfaces"
if get_interface_mode() == "alias":
    iface = iface_alias_converter.name_to_alias(iface)

This is the same as what Joe did for PR 486. 
https://github.com/Azure/sonic-utilities/pull/486
Only just updated for IPv6.

**- How to verify it**

```
sudo config interface_naming_mode alias
logout
<log back in to device>
show ip interfaces
<confirm output now contains interface aliases>
```

```
sudo config interface_naming_mode default
logout
<log back in to device>
show ip interfaces
<confirm output now contains SONiC port names
```

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**
```
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/show$ show interface naming_mode 
alias
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/show$ show ipv6 interface
Interface       IPv6 address/mask                         Admin/Oper
--------------  ----------------------------------------  ------------
Bridge          fe80::483b:52ff:fecf:ef35%Bridge/64       up/up
fortyGigE0/0    fc00::1/126                               up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet0/64
fortyGigE0/4    fc00::5/126                               up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet4/64
fortyGigE0/8    fc00::9/126                               up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet8/64
fortyGigE0/12   fc00::d/126                               up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet12/64
fortyGigE0/16   fc00::11/126                              up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet16/64
fortyGigE0/20   fc00::15/126                              up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet20/64
fortyGigE0/24   fc00::19/126                              up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet24/64
fortyGigE0/28   fc00::1d/126                              up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet28/64
fortyGigE0/32   fc00::21/126                              up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet32/64
fortyGigE0/36   fc00::25/126                              up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet36/64
fortyGigE0/40   fc00::29/126                              up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet40/64
fortyGigE0/44   fc00::2d/126                              up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet44/64
fortyGigE0/48   fc00::31/126                              up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet48/64
fortyGigE0/52   fc00::35/126                              up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet52/64
fortyGigE0/56   fc00::39/126                              up/down
fortyGigE0/60   fc00::3d/126                              up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet60/64
fortyGigE0/64   fc00::41/126                              up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet64/64
fortyGigE0/68   fc00::45/126                              up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet68/64
fortyGigE0/72   fc00::49/126                              up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet72/64
fortyGigE0/76   fc00::4d/126                              up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet76/64
fortyGigE0/80   fc00::51/126                              up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet80/64
fortyGigE0/84   fc00::55/126                              up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet84/64
fortyGigE0/88   fc00::59/126                              up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet88/64
fortyGigE0/92   fc00::5d/126                              up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet92/64
fortyGigE0/96   fc00::61/126                              up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet96/64
fortyGigE0/100  fc00::65/126                              up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet100/64
fortyGigE0/104  fc00::69/126                              up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet104/64
fortyGigE0/108  fc00::6d/126                              up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet108/64
fortyGigE0/112  fc00::71/126                              up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet112/64
fortyGigE0/116  fc00::75/126                              up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet116/64
fortyGigE0/120  fc00::79/126                              up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet120/64
fortyGigE0/124  fc00::7d/126                              up/up
                fe80::eef4:bbff:fefe:80a1%Ethernet124/64
Vlan3           fe80::eef4:bbff:fefe:80a1%Vlan3/64        up/up
Vlan4           fe80::eef4:bbff:fefe:80a1%Vlan4/64        up/up
eth0            fc00:2::32/64                             up/up
                fe80::eef4:bbff:fefe:80a1%eth0/64
lo              fc00:1::32/128                            up/up
                ::1/128
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/show$ 
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/show$ sudo config interface_naming_mode default
Please logout and log back in for changes take effect.
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/show$ logout
Connection to 10.3.147.239 closed.
trvanduy@nettools2-co1:~$ ssh admin@10.3.147.239
admin@10.3.147.239's password: 
Linux str-s6000-acs-11 4.9.0-8-2-amd64 #1 SMP Debian 4.9.110-3+deb9u6 (2015-12-19) x86_64
You are on
  ____   ___  _   _ _  ____
 / ___| / _ \| \ | (_)/ ___|
 \___ \| | | |  \| | | |
  ___) | |_| | |\  | | |___
 |____/ \___/|_| \_|_|\____|

-- Software for Open Networking in the Cloud --

Unauthorized access and/or use are prohibited.
All access and/or use are subject to monitoring.

Help:      http://azure.github.io/SONiC/
Wiki:      https://microsoft.sharepoint.com/teams/WAG/AzureNetworking/Wiki/SONiC.aspx
On-Call:   https://icm.ad.msft.net/imp/CurrentOnCall.aspx?teamId=26162
Dashboard: https://aka.ms/sonic-dri
Contact:   sonicdev@microsoft.com

Last login: Mon Apr  1 20:29:18 2019 from 10.20.48.212
admin@str-s6000-acs-11:~$ show interface namin
default
admin@str-s6000-acs-11:~$ show ipv6 interface
Interface    IPv6 address/mask                         Admin/Oper
-----------  ----------------------------------------  ------------
Bridge       fe80::483b:52ff:fecf:ef35%Bridge/64       up/up
Ethernet0    fc00::1/126                               up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet0/64
Ethernet4    fc00::5/126                               up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet4/64
Ethernet8    fc00::9/126                               up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet8/64
Ethernet12   fc00::d/126                               up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet12/64
Ethernet16   fc00::11/126                              up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet16/64
Ethernet20   fc00::15/126                              up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet20/64
Ethernet24   fc00::19/126                              up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet24/64
Ethernet28   fc00::1d/126                              up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet28/64
Ethernet32   fc00::21/126                              up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet32/64
Ethernet36   fc00::25/126                              up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet36/64
Ethernet40   fc00::29/126                              up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet40/64
Ethernet44   fc00::2d/126                              up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet44/64
Ethernet48   fc00::31/126                              up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet48/64
Ethernet52   fc00::35/126                              up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet52/64
Ethernet56   fc00::39/126                              up/down
Ethernet60   fc00::3d/126                              up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet60/64
Ethernet64   fc00::41/126                              up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet64/64
Ethernet68   fc00::45/126                              up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet68/64
Ethernet72   fc00::49/126                              up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet72/64
Ethernet76   fc00::4d/126                              up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet76/64
Ethernet80   fc00::51/126                              up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet80/64
Ethernet84   fc00::55/126                              up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet84/64
Ethernet88   fc00::59/126                              up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet88/64
Ethernet92   fc00::5d/126                              up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet92/64
Ethernet96   fc00::61/126                              up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet96/64
Ethernet100  fc00::65/126                              up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet100/64
Ethernet104  fc00::69/126                              up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet104/64
Ethernet108  fc00::6d/126                              up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet108/64
Ethernet112  fc00::71/126                              up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet112/64
Ethernet116  fc00::75/126                              up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet116/64
Ethernet120  fc00::79/126                              up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet120/64
Ethernet124  fc00::7d/126                              up/up
             fe80::eef4:bbff:fefe:80a1%Ethernet124/64
Vlan3        fe80::eef4:bbff:fefe:80a1%Vlan3/64        up/up
Vlan4        fe80::eef4:bbff:fefe:80a1%Vlan4/64        up/up
eth0         fc00:2::32/64                             up/up
             fe80::eef4:bbff:fefe:80a1%eth0/64
lo           fc00:1::32/128                            up/up
             ::1/128
admin@str-s6000-acs-11:~$ 
```

