### PR TITLE
Fix TODO to get/set ecn status on active ports only

### DIFF
--- a/scripts/ecnconfig
+++ b/scripts/ecnconfig
@@ -68,11 +68,12 @@ WRED_CONFIG_FIELDS = {
     "rdrop": "red_drop_probability"
 }
 
-PORT_TABLE_NAME         = "PORT"
-QUEUE_TABLE_NAME        = "QUEUE"
-FIELD                   = "wred_profile"
-ON                      = "[WRED_PROFILE|AZURE_LOSSLESS]"
-OFF                     = "[]"
+PORT_TABLE_NAME            = "PORT"
+QUEUE_TABLE_NAME           = "QUEUE"
+DEVICE_NEIGHBOR_TABLE_NAME = "DEVICE_NEIGHBOR"
+FIELD                      = "wred_profile"
+ON                         = "[WRED_PROFILE|AZURE_LOSSLESS]"
+OFF                        = "[]"
 
 lossless_queues         = ['3', '4']
 
@@ -153,10 +154,9 @@ class EcnQ(object):
             if q not in lossless_queues:
                 sys.exit('Invalid queue index: %s' % q)
 
-    # TODO: Change to use active ports only
     def gen_ports_key(self):
         if self.ports_key is not None:
-            port_table = self.config_db.get_table(PORT_TABLE_NAME)
+            port_table = self.config_db.get_table(DEVICE_NEIGHBOR_TABLE_NAME)
             self.ports_key = port_table.keys()
 
             self.ports_key.sort(key = lambda k: int(k[8:]))


### PR DESCRIPTION
BUG: on t0 topo, if Ethernet0 is disabled, ecnconfig -q 3 will return the ecn status to be off on active ports.

Signed-off-by: Wenda Ni <wenni@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Operate (get & set) ecn on/off status on active ports only. 
**- How I did it**

**- How to verify it**

on brcm dut

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

