### PR TITLE
[show interface neighbor expected] Support 'alias' interface naming mode

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -460,6 +460,7 @@ def expected(interfacename):
     body = []
     if interfacename:
         for device in natsorted(neighbor_metadata_dict.keys()):
+            if device2interface_dict[device]['localPort'] == interfacename:
                 body.append([device2interface_dict[device]['localPort'],
                              device,
                              device2interface_dict[device]['neighborPort'],

--- a/show/main.py
+++ b/show/main.py
@@ -450,13 +450,16 @@ def expected(interfacename):
     #Swap Key and Value from interface: name to name: interface
     device2interface_dict = {}
     for port in natsorted(neighbor_dict.keys()):
+        temp_port = port
+        if get_interface_mode() == "alias":
+            port = iface_alias_converter.name_to_alias(port)
+            neighbor_dict[port] = neighbor_dict.pop(temp_port)
         device2interface_dict[neighbor_dict[port]['name']] = {'localPort': port, 'neighborPort': neighbor_dict[port]['port']}
 
     header = ['LocalPort', 'Neighbor', 'NeighborPort', 'NeighborLoopback', 'NeighborMgmt', 'NeighborType']
     body = []
     if interfacename:
         for device in natsorted(neighbor_metadata_dict.keys()):
-            if device2interface_dict[device]['localPort'] == interfacename:
                 body.append([device2interface_dict[device]['localPort'],
                              device,
                              device2interface_dict[device]['neighborPort'],


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**

I updated the "show interface neighbor expected" command to be able to work with Alias mode. 


**- How I did it**

**- How to verify it**

Verify the interface naming mode and then switch between them to verify the command. 

```
sudo config interface_naming_mode alias
logout
<log back in to device>
show ip interfaces
<confirm output now contains interface aliases>

sudo config interface_naming_mode default
logout
<log back in to device>
show ip interfaces
<confirm output now contains SONiC port names>
```

**- Previous command output (if the output of a command-line utility has changed)**

```
admin@str-s6000-acs-11:~$ show int naming_mode 
default
admin@str-s6000-acs-11:~$ show int neigh exp
LocalPort    Neighbor    NeighborPort    NeighborLoopback    NeighborMgmt    NeighborType
-----------  ----------  --------------  ------------------  --------------  --------------
Ethernet64   ARISTA01T0  Ethernet1       None                172.16.130.112  ToRRouter
Ethernet0    ARISTA01T2  Ethernet1       None                172.16.130.96   SpineRouter
Ethernet68   ARISTA02T0  Ethernet1       None                172.16.130.113  ToRRouter
Ethernet4    ARISTA02T2  Ethernet1       None                172.16.130.97   SpineRouter
Ethernet72   ARISTA03T0  Ethernet1       None                172.16.130.114  ToRRouter
Ethernet8    ARISTA03T2  Ethernet1       None                172.16.130.98   SpineRouter
Ethernet76   ARISTA04T0  Ethernet1       None                172.16.130.115  ToRRouter
Ethernet12   ARISTA04T2  Ethernet1       None                172.16.130.99   SpineRouter
Ethernet80   ARISTA05T0  Ethernet1       None                172.16.130.116  ToRRouter
Ethernet16   ARISTA05T2  Ethernet1       None                172.16.130.100  SpineRouter
Ethernet84   ARISTA06T0  Ethernet1       None                172.16.130.117  ToRRouter
Ethernet20   ARISTA06T2  Ethernet1       None                172.16.130.101  SpineRouter
Ethernet88   ARISTA07T0  Ethernet1       None                172.16.130.118  ToRRouter
Ethernet24   ARISTA07T2  Ethernet1       None                172.16.130.102  SpineRouter
Ethernet92   ARISTA08T0  Ethernet1       None                172.16.130.119  ToRRouter
Ethernet28   ARISTA08T2  Ethernet1       None                172.16.130.103  SpineRouter
Ethernet96   ARISTA09T0  Ethernet1       None                172.16.130.120  ToRRouter
Ethernet32   ARISTA09T2  Ethernet1       None                172.16.130.104  SpineRouter
Ethernet100  ARISTA10T0  Ethernet1       None                172.16.130.121  ToRRouter
Ethernet36   ARISTA10T2  Ethernet1       None                172.16.130.105  SpineRouter
Ethernet104  ARISTA11T0  Ethernet1       None                172.16.130.122  ToRRouter
Ethernet40   ARISTA11T2  Ethernet1       None                172.16.130.106  SpineRouter
Ethernet108  ARISTA12T0  Ethernet1       None                172.16.130.123  ToRRouter
Ethernet44   ARISTA12T2  Ethernet1       None                172.16.130.107  SpineRouter
Ethernet112  ARISTA13T0  Ethernet1       None                172.16.130.124  ToRRouter
Ethernet48   ARISTA13T2  Ethernet1       None                172.16.130.108  SpineRouter
Ethernet116  ARISTA14T0  Ethernet1       None                172.16.130.125  ToRRouter
Ethernet52   ARISTA14T2  Ethernet1       None                172.16.130.109  SpineRouter
Ethernet120  ARISTA15T0  Ethernet1       None                172.16.130.126  ToRRouter
Ethernet56   ARISTA15T2  Ethernet1       None                172.16.130.110  SpineRouter
Ethernet124  ARISTA16T0  Ethernet1       None                172.16.130.127  ToRRouter
Ethernet60   ARISTA16T2  Ethernet1       None                172.16.130.111  SpineRouter
admin@str-s6000-acs-11:~$ sudo config interface_naming_mode alias
Please logout and log back in for changes take effect.
admin@str-s6000-acs-11:~$ logout
Connection to 10.3.147.239 closed.
trvanduy@nettools2-co1:~$ ssh admin@10.3.147.239
admin@10.3.147.239's password: 
Linux str-s6000-acs-11 4.9.0-8-2-amd64 #1 SMP Debian 4.9.110-3+deb9u6 (2015-12-19) x86_64
You are on
  ____   ___  _   _ _  ____
 / ___| / _ \| \ | (_)/ ___|
 \___ \| | | |  \| | | |
  ___) | |_| | |\  | | |___
 |____/ \___/|_| \_|_|\____|

-- Software for Open Networking in the Cloud --

Unauthorized access and/or use are prohibited.
All access and/or use are subject to monitoring.

Help:      http://azure.github.io/SONiC/
Wiki:      https://microsoft.sharepoint.com/teams/WAG/AzureNetworking/Wiki/SONiC.aspx
On-Call:   https://icm.ad.msft.net/imp/CurrentOnCall.aspx?teamId=26162
Dashboard: https://aka.ms/sonic-dri
Contact:   sonicdev@microsoft.com

Last login: Tue Apr  2 17:29:14 2019 from 10.20.30.97
admin@str-s6000-acs-11:~$ show int naming_mode 
alias
admin@str-s6000-acs-11:~$ show int neigh exp
LocalPort    Neighbor    NeighborPort    NeighborLoopback    NeighborMgmt    NeighborType
-----------  ----------  --------------  ------------------  --------------  --------------
Ethernet64   ARISTA01T0  Ethernet1       None                172.16.130.112  ToRRouter
Ethernet0    ARISTA01T2  Ethernet1       None                172.16.130.96   SpineRouter
Ethernet68   ARISTA02T0  Ethernet1       None                172.16.130.113  ToRRouter
Ethernet4    ARISTA02T2  Ethernet1       None                172.16.130.97   SpineRouter
Ethernet72   ARISTA03T0  Ethernet1       None                172.16.130.114  ToRRouter
Ethernet8    ARISTA03T2  Ethernet1       None                172.16.130.98   SpineRouter
Ethernet76   ARISTA04T0  Ethernet1       None                172.16.130.115  ToRRouter
Ethernet12   ARISTA04T2  Ethernet1       None                172.16.130.99   SpineRouter
Ethernet80   ARISTA05T0  Ethernet1       None                172.16.130.116  ToRRouter
Ethernet16   ARISTA05T2  Ethernet1       None                172.16.130.100  SpineRouter
Ethernet84   ARISTA06T0  Ethernet1       None                172.16.130.117  ToRRouter
Ethernet20   ARISTA06T2  Ethernet1       None                172.16.130.101  SpineRouter
Ethernet88   ARISTA07T0  Ethernet1       None                172.16.130.118  ToRRouter
Ethernet24   ARISTA07T2  Ethernet1       None                172.16.130.102  SpineRouter
Ethernet92   ARISTA08T0  Ethernet1       None                172.16.130.119  ToRRouter
Ethernet28   ARISTA08T2  Ethernet1       None                172.16.130.103  SpineRouter
Ethernet96   ARISTA09T0  Ethernet1       None                172.16.130.120  ToRRouter
Ethernet32   ARISTA09T2  Ethernet1       None                172.16.130.104  SpineRouter
Ethernet100  ARISTA10T0  Ethernet1       None                172.16.130.121  ToRRouter
Ethernet36   ARISTA10T2  Ethernet1       None                172.16.130.105  SpineRouter
Ethernet104  ARISTA11T0  Ethernet1       None                172.16.130.122  ToRRouter
Ethernet40   ARISTA11T2  Ethernet1       None                172.16.130.106  SpineRouter
Ethernet108  ARISTA12T0  Ethernet1       None                172.16.130.123  ToRRouter
Ethernet44   ARISTA12T2  Ethernet1       None                172.16.130.107  SpineRouter
Ethernet112  ARISTA13T0  Ethernet1       None                172.16.130.124  ToRRouter
Ethernet48   ARISTA13T2  Ethernet1       None                172.16.130.108  SpineRouter
Ethernet116  ARISTA14T0  Ethernet1       None                172.16.130.125  ToRRouter
Ethernet52   ARISTA14T2  Ethernet1       None                172.16.130.109  SpineRouter
Ethernet120  ARISTA15T0  Ethernet1       None                172.16.130.126  ToRRouter
Ethernet56   ARISTA15T2  Ethernet1       None                172.16.130.110  SpineRouter
Ethernet124  ARISTA16T0  Ethernet1       None                172.16.130.127  ToRRouter
Ethernet60   ARISTA16T2  Ethernet1       None                172.16.130.111  SpineRouter
admin@str-s6000-acs-11:~$ 
```
**- New command output (if the output of a command-line utility has changed)**
```
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/show$ show int nam
default
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/show$ show int neigh exp
LocalPort    Neighbor    NeighborPort    NeighborLoopback    NeighborMgmt    NeighborType
-----------  ----------  --------------  ------------------  --------------  --------------
Ethernet64   ARISTA01T0  Ethernet1       None                172.16.130.112  ToRRouter
Ethernet0    ARISTA01T2  Ethernet1       None                172.16.130.96   SpineRouter
Ethernet68   ARISTA02T0  Ethernet1       None                172.16.130.113  ToRRouter
Ethernet4    ARISTA02T2  Ethernet1       None                172.16.130.97   SpineRouter
Ethernet72   ARISTA03T0  Ethernet1       None                172.16.130.114  ToRRouter
Ethernet8    ARISTA03T2  Ethernet1       None                172.16.130.98   SpineRouter
Ethernet76   ARISTA04T0  Ethernet1       None                172.16.130.115  ToRRouter
Ethernet12   ARISTA04T2  Ethernet1       None                172.16.130.99   SpineRouter
Ethernet80   ARISTA05T0  Ethernet1       None                172.16.130.116  ToRRouter
Ethernet16   ARISTA05T2  Ethernet1       None                172.16.130.100  SpineRouter
Ethernet84   ARISTA06T0  Ethernet1       None                172.16.130.117  ToRRouter
Ethernet20   ARISTA06T2  Ethernet1       None                172.16.130.101  SpineRouter
Ethernet88   ARISTA07T0  Ethernet1       None                172.16.130.118  ToRRouter
Ethernet24   ARISTA07T2  Ethernet1       None                172.16.130.102  SpineRouter
Ethernet92   ARISTA08T0  Ethernet1       None                172.16.130.119  ToRRouter
Ethernet28   ARISTA08T2  Ethernet1       None                172.16.130.103  SpineRouter
Ethernet96   ARISTA09T0  Ethernet1       None                172.16.130.120  ToRRouter
Ethernet32   ARISTA09T2  Ethernet1       None                172.16.130.104  SpineRouter
Ethernet100  ARISTA10T0  Ethernet1       None                172.16.130.121  ToRRouter
Ethernet36   ARISTA10T2  Ethernet1       None                172.16.130.105  SpineRouter
Ethernet104  ARISTA11T0  Ethernet1       None                172.16.130.122  ToRRouter
Ethernet40   ARISTA11T2  Ethernet1       None                172.16.130.106  SpineRouter
Ethernet108  ARISTA12T0  Ethernet1       None                172.16.130.123  ToRRouter
Ethernet44   ARISTA12T2  Ethernet1       None                172.16.130.107  SpineRouter
Ethernet112  ARISTA13T0  Ethernet1       None                172.16.130.124  ToRRouter
Ethernet48   ARISTA13T2  Ethernet1       None                172.16.130.108  SpineRouter
Ethernet116  ARISTA14T0  Ethernet1       None                172.16.130.125  ToRRouter
Ethernet52   ARISTA14T2  Ethernet1       None                172.16.130.109  SpineRouter
Ethernet120  ARISTA15T0  Ethernet1       None                172.16.130.126  ToRRouter
Ethernet56   ARISTA15T2  Ethernet1       None                172.16.130.110  SpineRouter
Ethernet124  ARISTA16T0  Ethernet1       None                172.16.130.127  ToRRouter
Ethernet60   ARISTA16T2  Ethernet1       None                172.16.130.111  SpineRouter
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/show$ sudo config interface_naming_mode alias
Please logout and log back in for changes take effect.
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/show$ logout
Connection to 10.3.147.239 closed.
trvanduy@nettools2-co1:~$ ssh admin@10.3.147.239
admin@10.3.147.239's password: 
Linux str-s6000-acs-11 4.9.0-8-2-amd64 #1 SMP Debian 4.9.110-3+deb9u6 (2015-12-19) x86_64
You are on
  ____   ___  _   _ _  ____
 / ___| / _ \| \ | (_)/ ___|
 \___ \| | | |  \| | | |
  ___) | |_| | |\  | | |___
 |____/ \___/|_| \_|_|\____|

-- Software for Open Networking in the Cloud --

Unauthorized access and/or use are prohibited.
All access and/or use are subject to monitoring.

Help:      http://azure.github.io/SONiC/
Wiki:      https://microsoft.sharepoint.com/teams/WAG/AzureNetworking/Wiki/SONiC.aspx
On-Call:   https://icm.ad.msft.net/imp/CurrentOnCall.aspx?teamId=26162
Dashboard: https://aka.ms/sonic-dri
Contact:   sonicdev@microsoft.com

Last login: Tue Apr  2 19:04:32 2019 from 10.20.48.209
admin@str-s6000-acs-11:~$ show int nam
alias
admin@str-s6000-acs-11:~$ show int neigh exp
LocalPort       Neighbor    NeighborPort    NeighborLoopback    NeighborMgmt    NeighborType
--------------  ----------  --------------  ------------------  --------------  --------------
fortyGigE0/64   ARISTA01T0  Ethernet1       None                172.16.130.112  ToRRouter
fortyGigE0/0    ARISTA01T2  Ethernet1       None                172.16.130.96   SpineRouter
fortyGigE0/68   ARISTA02T0  Ethernet1       None                172.16.130.113  ToRRouter
fortyGigE0/4    ARISTA02T2  Ethernet1       None                172.16.130.97   SpineRouter
fortyGigE0/72   ARISTA03T0  Ethernet1       None                172.16.130.114  ToRRouter
fortyGigE0/8    ARISTA03T2  Ethernet1       None                172.16.130.98   SpineRouter
fortyGigE0/76   ARISTA04T0  Ethernet1       None                172.16.130.115  ToRRouter
fortyGigE0/12   ARISTA04T2  Ethernet1       None                172.16.130.99   SpineRouter
fortyGigE0/80   ARISTA05T0  Ethernet1       None                172.16.130.116  ToRRouter
fortyGigE0/16   ARISTA05T2  Ethernet1       None                172.16.130.100  SpineRouter
fortyGigE0/84   ARISTA06T0  Ethernet1       None                172.16.130.117  ToRRouter
fortyGigE0/20   ARISTA06T2  Ethernet1       None                172.16.130.101  SpineRouter
fortyGigE0/88   ARISTA07T0  Ethernet1       None                172.16.130.118  ToRRouter
fortyGigE0/24   ARISTA07T2  Ethernet1       None                172.16.130.102  SpineRouter
fortyGigE0/92   ARISTA08T0  Ethernet1       None                172.16.130.119  ToRRouter
fortyGigE0/28   ARISTA08T2  Ethernet1       None                172.16.130.103  SpineRouter
fortyGigE0/96   ARISTA09T0  Ethernet1       None                172.16.130.120  ToRRouter
fortyGigE0/32   ARISTA09T2  Ethernet1       None                172.16.130.104  SpineRouter
fortyGigE0/100  ARISTA10T0  Ethernet1       None                172.16.130.121  ToRRouter
fortyGigE0/36   ARISTA10T2  Ethernet1       None                172.16.130.105  SpineRouter
fortyGigE0/104  ARISTA11T0  Ethernet1       None                172.16.130.122  ToRRouter
fortyGigE0/40   ARISTA11T2  Ethernet1       None                172.16.130.106  SpineRouter
fortyGigE0/108  ARISTA12T0  Ethernet1       None                172.16.130.123  ToRRouter
fortyGigE0/44   ARISTA12T2  Ethernet1       None                172.16.130.107  SpineRouter
fortyGigE0/112  ARISTA13T0  Ethernet1       None                172.16.130.124  ToRRouter
fortyGigE0/48   ARISTA13T2  Ethernet1       None                172.16.130.108  SpineRouter
fortyGigE0/116  ARISTA14T0  Ethernet1       None                172.16.130.125  ToRRouter
fortyGigE0/52   ARISTA14T2  Ethernet1       None                172.16.130.109  SpineRouter
fortyGigE0/120  ARISTA15T0  Ethernet1       None                172.16.130.126  ToRRouter
fortyGigE0/56   ARISTA15T2  Ethernet1       None                172.16.130.110  SpineRouter
fortyGigE0/124  ARISTA16T0  Ethernet1       None                172.16.130.127  ToRRouter
fortyGigE0/60   ARISTA16T2  Ethernet1       None                172.16.130.111  SpineRouter
admin@str-s6000-acs-11:~$
```
-->

