### PR TITLE
[show vlan brief] Support 'alias' interface naming mode

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1472,8 +1472,12 @@ def brief(verbose):
         ports_value = str(key[1])
         ports_tagging = vlan_ports_data[key]['tagging_mode']
         if ports_key in vlan_ports_dict:
+            if get_interface_mode() == "alias":
+                ports_value = iface_alias_converter.name_to_alias(ports_value)
             vlan_ports_dict[ports_key].append(ports_value)
         else:
+            if get_interface_mode() == "alias":
+                ports_value = iface_alias_converter.name_to_alias(ports_value)
             vlan_ports_dict[ports_key] = [ports_value]
         if ports_key in vlan_tagging_dict:
             vlan_tagging_dict[ports_key].append(ports_tagging)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
I updated the "show vlan brief" command to be able to work with Alias mode.

**- How I did it**


**- How to verify it**
Verify the interface naming mode and then switch between them to verify the command.

```
sudo config interface_naming_mode alias
logout
<log back in to device>
show vlan brief
<confirm output now contains interface aliases>

sudo config interface_naming_mode default
logout
<log back in to device>
show vlan brief
<confirm output now contains SONiC port names>
```

**- Previous command output (if the output of a command-line utility has changed)**

```
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/show$ show vlan brief
+-----------+--------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address   | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+==============+============+================+=======================+
|         3 |              | Ethernet44 | tagged         |                       |
+-----------+--------------+------------+----------------+-----------------------+
|         4 |              | Ethernet12 | tagged         | 102.103.104.105       |
+-----------+--------------+------------+----------------+-----------------------+
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/show$ show int nam
alias
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/show$ sudo config interface_naming_mode default
Please logout and log back in for changes take effect.
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/show$ logout 
Connection to 10.3.147.239 closed.
trvanduy@nettools2-co1:~$ ssh admin@10.3.147.239
admin@10.3.147.239's password: 
Linux str-s6000-acs-11 4.9.0-8-2-amd64 #1 SMP Debian 4.9.110-3+deb9u6 (2015-12-19) x86_64
You are on
  ____   ___  _   _ _  ____
 / ___| / _ \| \ | (_)/ ___|
 \___ \| | | |  \| | | |
  ___) | |_| | |\  | | |___
 |____/ \___/|_| \_|_|\____|

-- Software for Open Networking in the Cloud --

Unauthorized access and/or use are prohibited.
All access and/or use are subject to monitoring.

Help:      http://azure.github.io/SONiC/
Wiki:      https://microsoft.sharepoint.com/teams/WAG/AzureNetworking/Wiki/SONiC.aspx
On-Call:   https://icm.ad.msft.net/imp/CurrentOnCall.aspx?teamId=26162
Dashboard: https://aka.ms/sonic-dri
Contact:   sonicdev@microsoft.com

Last login: Wed Apr  3 21:18:04 2019 from 10.20.48.211
admin@str-s6000-acs-11:~$ show int nam
default
admin@str-s6000-acs-11:~$ show vlan brief
+-----------+--------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address   | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+==============+============+================+=======================+
|         3 |              | Ethernet44 | tagged         |                       |
+-----------+--------------+------------+----------------+-----------------------+
|         4 |              | Ethernet12 | tagged         | 102.103.104.105       |
+-----------+--------------+------------+----------------+-----------------------+
admin@str-s6000-acs-11:~$ 
```

**- New command output (if the output of a command-line utility has changed)**
```
admin@str-s6000-acs-11:~$ show int nam
default
admin@str-s6000-acs-11:~$ show vlan brief
+-----------+--------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address   | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+==============+============+================+=======================+
|         3 |              | Ethernet44 | tagged         |                       |
+-----------+--------------+------------+----------------+-----------------------+
|         4 |              | Ethernet12 | tagged         | 102.103.104.105       |
+-----------+--------------+------------+----------------+-----------------------+
admin@str-s6000-acs-11:~$ sudo config interface_naming_mode alias
Please logout and log back in for changes take effect.
admin@str-s6000-acs-11:~$ logout
Connection to 10.3.147.239 closed.
trvanduy@nettools2-co1:~$ ssh admin@10.3.147.239
admin@10.3.147.239's password: 
Linux str-s6000-acs-11 4.9.0-8-2-amd64 #1 SMP Debian 4.9.110-3+deb9u6 (2015-12-19) x86_64
You are on
  ____   ___  _   _ _  ____
 / ___| / _ \| \ | (_)/ ___|
 \___ \| | | |  \| | | |
  ___) | |_| | |\  | | |___
 |____/ \___/|_| \_|_|\____|

-- Software for Open Networking in the Cloud --

Unauthorized access and/or use are prohibited.
All access and/or use are subject to monitoring.

Help:      http://azure.github.io/SONiC/
Wiki:      https://microsoft.sharepoint.com/teams/WAG/AzureNetworking/Wiki/SONiC.aspx
On-Call:   https://icm.ad.msft.net/imp/CurrentOnCall.aspx?teamId=26162
Dashboard: https://aka.ms/sonic-dri
Contact:   sonicdev@microsoft.com

Last login: Wed Apr  3 18:56:30 2019 from 10.20.30.97
admin@str-s6000-acs-11:~$ show int nam
alias
admin@str-s6000-acs-11:~$ show vlan brief
+-----------+--------------+---------------+----------------+-----------------------+
|   VLAN ID | IP Address   | Ports         | Port Tagging   | DHCP Helper Address   |
+===========+==============+===============+================+=======================+
|         3 |              | fortyGigE0/44 | tagged         |                       |
+-----------+--------------+---------------+----------------+-----------------------+
|         4 |              | fortyGigE0/12 | tagged         | 102.103.104.105       |
+-----------+--------------+---------------+----------------+-----------------------+
admin@str-s6000-acs-11:~$ 
```
-->

