### PR TITLE
Bring queue storm status to 'pfcwd show stats'

### DIFF
--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -27,7 +27,7 @@ CONFIG_DESCRIPTION = [
     ('RESTORATION TIME', 'restoration_time', 'infinite')
 ]
 
-STATS_HEADER = ('QUEUE',) + zip(*STATS_DESCRIPTION)[0]
+STATS_HEADER = ('QUEUE', 'STATUS',) + zip(*STATS_DESCRIPTION)[0]
 CONFIG_HEADER = ('PORT',) + zip(*CONFIG_DESCRIPTION)[0]
 
 CONFIG_DB_PFC_WD_TABLE_NAME = 'PFC_WD'
@@ -84,7 +84,7 @@ def stats(empty, queues):
             line = stats.get(stat[1], '0') + '/' + stats.get(stat[2], '0')
             stats_list.append(line)
         if stats_list != ['0/0'] * len(STATS_DESCRIPTION) or empty:
-            table.append([queue] + stats_list)
+            table.append([queue, stats['PFC_WD_STATUS']] + stats_list)
 
     click.echo(tabulate(table, STATS_HEADER, stralign='right', numalign='right', tablefmt='simple'))
 


### PR DESCRIPTION

$ pfcwd show stats
       QUEUE       STATUS    STORM DETECTED/RESTORED    TX OK/DROP    RX OK/DROP    TX LAST OK/DROP    RX LAST OK/DROP
------------  -----------  -------------------------  ------------  ------------  -----------------  -----------------
Ethernet36:3  operational                       18/9        0/1800        0/1800              0/100              0/100
Ethernet36:4  operational                       18/9        0/1800        0/1800              0/100              0/100
Ethernet96:3  operational                       18/9        0/1800        0/1800              0/100              0/100
Ethernet96:4  operational                       18/9        0/1700        0/1700              0/100              0/100


$ pfcwd show stats
       QUEUE       STATUS    STORM DETECTED/RESTORED    TX OK/DROP    RX OK/DROP    TX LAST OK/DROP    RX LAST OK/DROP
------------  -----------  -------------------------  ------------  ------------  -----------------  -----------------
Ethernet36:3  operational                       18/9        0/1800        0/1800              0/100              0/100
Ethernet36:4  operational                       18/9        0/1800        0/1800              0/100              0/100
Ethernet96:3      stormed                       19/9        0/1900        0/1900              0/100              0/100
Ethernet96:4      stormed                       19/9        0/1800        0/1800              0/100              0/100


$ pfcwd show stats
       QUEUE    STATUS    STORM DETECTED/RESTORED    TX OK/DROP    RX OK/DROP    TX LAST OK/DROP    RX LAST OK/DROP
------------  --------  -------------------------  ------------  ------------  -----------------  -----------------
Ethernet36:3   stormed                       19/9        0/1900        0/1900              0/100              0/100
Ethernet36:4   stormed                       19/9        0/1900        0/1900              0/100              0/100
Ethernet96:3   stormed                       19/9        0/1900        0/1900              0/100              0/100
Ethernet96:4   stormed                       19/9        0/1800        0/1800              0/100              0/100

Signed-off-by: Wenda Ni <wenni@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
On brcm dut
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

