### PR TITLE
[generate_dump] system dump improvements

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -18,6 +18,8 @@ V=
 NOOP=false
 DO_COMPRESS=true
 CMD_PREFIX=
+SINCE_DATE=
+REFERENCE_FILE=/tmp/reference
 BASE=sonic_dump_`hostname`_`date +%Y%m%d_%H%M%S`
 DUMPDIR=/var/dump
 TARDIR=$DUMPDIR/$BASE
@@ -217,6 +219,35 @@ save_file() {
 }
 
 ###############################################################################
+# find_logs routine
+# Globals:
+#  SINCE_DATE: list files only newer than given date
+#  REFERENCE_FILE: the file to be created as a reference to compare modification time
+# Arguments:
+#  directory: directory to search files in
+# Returns:
+#  None
+###############################################################################
+find_logs() {
+    local -r directory=$1
+    local newer_than=""
+
+    if [[ ! -z "${SINCE_DATE}" ]]; then
+        ${CMD_PREFIX}touch --date="${SINCE_DATE}" "${REFERENCE_FILE}"
+        newer_than="${REFERENCE_FILE}"
+    fi
+
+    local find_command="find -L $directory -type f"
+
+    if [[ ! -z "${newer_than}" ]]; then
+        find_command+=" -newer ${REFERENCE_FILE}"
+    fi
+
+    echo $($find_command)
+}
+
+
+###############################################################################
 # Main generate_dump routine
 # Globals:
 #  All of them.
@@ -340,7 +371,7 @@ main() {
         && $RM $V -rf $TARDIR
 
     # gzip up all log files individually before placing them in the incremental tarball
-    for file in $(find -L /var/log -type f); do
+    for file in $(find_logs "/var/log/"); do
         # ignore the sparse file lastlog
         if [ "$file" = "/var/log/lastlog" ]; then
             continue
@@ -354,7 +385,7 @@ main() {
     done
 
     # archive core dump files
-    for file in $(find -L /var/core -type f); do
+    for file in $(find_logs "/var/core/"); do
         # don't gzip already-gzipped log files :)
         if [ -z "${file##*.gz}" ]; then
             save_file $file core false
@@ -422,10 +453,15 @@ OPTIONS
         Noop mode. Don't actually create anything, just echo what would happen
     -z
         Don't compress the tar at the end.
+    -s DATE
+        Collect logs since DATE;
+        The argument is a mostly free format human readable string such as
+        "24 March", "yesterday", etc.
+
 EOF
 }
 
-while getopts ":xnvhz" opt; do
+while getopts ":xnvhzs:" opt; do
     case $opt in
         x)
             # enable bash debugging
@@ -454,6 +490,11 @@ while getopts ":xnvhz" opt; do
             ;;
         z)
             DO_COMPRESS=false
+            ;;
+        s)
+            SINCE_DATE="${OPTARG}"
+            # validate date expression
+            date --date="${SINCE_DATE}" &> /dev/null || abort 10 "Invalid date expression passed: '${SINCE_DATE}'"
             ;;
         /?)
             echo "Invalid option: -$OPTARG" >&2

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -370,6 +370,8 @@ main() {
         --exclude="*/etc/ssh*" \
         --exclude="*get_creds*" \
         --exclude="*snmpd.conf*" \
+        --exclude="/etc/mlnx" \
+        --exclude="/etc/mft" \
         $BASE/etc \
         || abort "${ERROR_TAR_FAILED}" "Tar append operation failed. Aborting for safety.") \
         && $RM $V -rf $TARDIR

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -18,6 +18,7 @@ GZIP=gzip
 CP=cp
 MV=mv
 GREP=grep
+TOUCH=touch
 V=
 NOOP=false
 DO_COMPRESS=true
@@ -223,7 +224,7 @@ save_file() {
 }
 
 ###############################################################################
-# find_logs routine
+# find_files routine
 # Globals:
 #  SINCE_DATE: list files only newer than given date
 #  REFERENCE_FILE: the file to be created as a reference to compare modification time
@@ -232,9 +233,9 @@ save_file() {
 # Returns:
 #  None
 ###############################################################################
-find_logs() {
+find_files() {
     local -r directory=$1
-    ${CMD_PREFIX}touch --date="${SINCE_DATE}" "${REFERENCE_FILE}"
+    $TOUCH --date="${SINCE_DATE}" "${REFERENCE_FILE}"
     local -r find_command="find -L $directory -type f -newer ${REFERENCE_FILE}"
 
     echo $($find_command)
@@ -395,7 +396,7 @@ main() {
     trap enable_logrotate HUP INT QUIT TERM KILL ABRT ALRM
 
     # gzip up all log files individually before placing them in the incremental tarball
-    for file in $(find_logs "/var/log/"); do
+    for file in $(find_files "/var/log/"); do
         # ignore the sparse file lastlog
         if [ "$file" = "/var/log/lastlog" ]; then
             continue
@@ -411,7 +412,7 @@ main() {
     enable_logrotate
 
     # archive core dump files
-    for file in $(find_logs "/var/core/"); do
+    for file in $(find_files "/var/core/"); do
         # don't gzip already-gzipped log files :)
         if [ -z "${file##*.gz}" ]; then
             save_file $file core false
@@ -512,6 +513,7 @@ while getopts ":xnvhzs:" opt; do
             CMD_PREFIX="echo "
             MV="echo mv"
             CP="echo cp"
+            TOUCH="echo touch"
             NOOP=true
             ;;
         z)

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -357,6 +357,13 @@ main() {
         docker exec -it syncd saisdkdump -f $sai_dump_filename
         docker exec syncd tar Ccf $(dirname $sai_dump_filename) - $(basename $sai_dump_filename) | tar Cxf /tmp/ -
         save_file $sai_dump_filename sai_sdk_dump true
+
+        local mst_dump_filename="/tmp/mstdump"
+        local max_dump_count="3"
+        for i in $(seq 1 $max_dump_count); do
+            /usr/bin/mstdump /dev/mst/mt*conf0 > "${mst_dump_filename}${i}"
+            save_file "${mst_dump_filename}${i}" mstdump true
+        done
     fi
 
     local asic="$(/usr/local/bin/sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)"

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -23,7 +23,7 @@ V=
 NOOP=false
 DO_COMPRESS=true
 CMD_PREFIX=
-SINCE_DATE="@0" # epoch
+SINCE_DATE="@0" # default is set to January 1, 1970 at 00:00:00 GMT
 REFERENCE_FILE=/tmp/reference
 BASE=sonic_dump_`hostname`_`date +%Y%m%d_%H%M%S`
 DUMPDIR=/var/dump
@@ -354,14 +354,14 @@ main() {
     local platform="$(/usr/local/bin/sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)"
     if [[ $platform == *"mlnx"* ]]; then
         local sai_dump_filename="/tmp/sai_sdk_dump_$(date +"%m_%d_%Y_%I_%M_%p")"
-        docker exec -it syncd saisdkdump -f $sai_dump_filename
-        docker exec syncd tar Ccf $(dirname $sai_dump_filename) - $(basename $sai_dump_filename) | tar Cxf /tmp/ -
+        ${CMD_PREFIX}docker exec -it syncd saisdkdump -f $sai_dump_filename
+        ${CMD_PREFIX}docker exec syncd tar Ccf $(dirname $sai_dump_filename) - $(basename $sai_dump_filename) | tar Cxf /tmp/ -
         save_file $sai_dump_filename sai_sdk_dump true
 
         local mst_dump_filename="/tmp/mstdump"
         local max_dump_count="3"
         for i in $(seq 1 $max_dump_count); do
-            /usr/bin/mstdump /dev/mst/mt*conf0 > "${mst_dump_filename}${i}"
+            ${CMD_PREFIX}/usr/bin/mstdump /dev/mst/mt*conf0 > "${mst_dump_filename}${i}"
             save_file "${mst_dump_filename}${i}" mstdump true
         done
     fi

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -22,7 +22,7 @@ V=
 NOOP=false
 DO_COMPRESS=true
 CMD_PREFIX=
-SINCE_DATE=
+SINCE_DATE="@0" # epoch
 REFERENCE_FILE=/tmp/reference
 BASE=sonic_dump_`hostname`_`date +%Y%m%d_%H%M%S`
 DUMPDIR=/var/dump
@@ -234,18 +234,8 @@ save_file() {
 ###############################################################################
 find_logs() {
     local -r directory=$1
-    local newer_than=""
-
-    if [[ ! -z "${SINCE_DATE}" ]]; then
-        ${CMD_PREFIX}touch --date="${SINCE_DATE}" "${REFERENCE_FILE}"
-        newer_than="${REFERENCE_FILE}"
-    fi
-
-    local find_command="find -L $directory -type f"
-
-    if [[ ! -z "${newer_than}" ]]; then
-        find_command+=" -newer ${REFERENCE_FILE}"
-    fi
+    ${CMD_PREFIX}touch --date="${SINCE_DATE}" "${REFERENCE_FILE}"
+    local -r find_command="find -L $directory -type f -newer ${REFERENCE_FILE}"
 
     echo $($find_command)
 }

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -6,6 +6,10 @@
 
 set -u
 
+ERROR_TAR_FAILED=5
+ERROR_PROCFS_SAVE_FAILED=6
+ERROR_INVALID_ARGUMENT=10
+
 TAR=tar
 MKDIR=mkdir
 RM=rm
@@ -74,7 +78,7 @@ save_cmd() {
         fi
     fi
     ($TAR $V -rhf $TARFILE -C $DUMPDIR "$tarpath" \
-        || abort 5 "tar append operation failed. Aborting to prevent data loss.") \
+        || abort "${ERROR_TAR_FAILED}" "tar append operation failed. Aborting to prevent data loss.") \
         && $RM $V -rf "$filepath"
 }
 
@@ -214,7 +218,7 @@ save_file() {
         fi
     fi
     ($TAR $V -rhf $TARFILE -C $DUMPDIR "$tar_path" \
-        || abort 5 "tar append operation failed. Aborting to prevent data loss.") \
+        || abort "${ERROR_PROCFS_SAVE_FAILED}" "tar append operation failed. Aborting to prevent data loss.") \
         && $RM $V -f "$gz_path"
 }
 
@@ -282,7 +286,7 @@ main() {
         /proc/softirqs /proc/stat /proc/swaps /proc/sysvipc /proc/timer_list \
         /proc/uptime /proc/version /proc/vmallocinfo /proc/vmstat \
         /proc/zoneinfo \
-        || abort 6 "Proc saving operation failed. Aborting for safety."
+        || abort "${ERROR_PROCFS_SAVE_FAILED}" "Proc saving operation failed. Aborting for safety."
 
     save_cmd "show version" "version"
     save_cmd "show platform summary" "platform.summary"
@@ -367,7 +371,7 @@ main() {
         --exclude="*get_creds*" \
         --exclude="*snmpd.conf*" \
         $BASE/etc \
-        || abort 5 "Tar append operation failed. Aborting for safety.") \
+        || abort "${ERROR_TAR_FAILED}" "Tar append operation failed. Aborting for safety.") \
         && $RM $V -rf $TARDIR
 
     # gzip up all log files individually before placing them in the incremental tarball
@@ -494,7 +498,7 @@ while getopts ":xnvhzs:" opt; do
         s)
             SINCE_DATE="${OPTARG}"
             # validate date expression
-            date --date="${SINCE_DATE}" &> /dev/null || abort 10 "Invalid date expression passed: '${SINCE_DATE}'"
+            date --date="${SINCE_DATE}" &> /dev/null || abort "${ERROR_INVALID_ARGUMENT}" "Invalid date expression passed: '${SINCE_DATE}'"
             ;;
         /?)
             echo "Invalid option: -$OPTARG" >&2

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -157,7 +157,7 @@ save_proc() {
     local procfiles="$@"
     $MKDIR $V -p $TARDIR/proc \
         && $CP $V -r $procfiles $TARDIR/proc \
-        && $TAR $V -rhf $TARFILE -C $DUMPDIR --mode=+r $BASE/proc \
+        && $TAR $V -rhf $TARFILE -C $DUMPDIR --mode=+rw $BASE/proc \
         && $RM $V -rf $TARDIR/proc
 }
 
@@ -386,7 +386,7 @@ main() {
     $MKDIR $V -p $LOGDIR
     $LN $V -s /etc $TARDIR/etc
 
-    ($TAR $V -rhf $TARFILE -C $DUMPDIR --mode=+r \
+    ($TAR $V -rhf $TARFILE -C $DUMPDIR --mode=+rw \
         --exclude="etc/alternatives" \
         --exclude="*/etc/passwd*" \
         --exclude="*/etc/shadow*" \

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -250,6 +250,31 @@ find_logs() {
     echo $($find_command)
 }
 
+###############################################################################
+# disable_logrotate routine
+# Globals:
+#  None
+# Arguments:
+#  None
+# Returns:
+#  None
+###############################################################################
+disable_logrotate() {
+    sed -i '/logrotate/s/^/#/g' /etc/cron.d/logrotate
+}
+
+###############################################################################
+# enable_logrotate routine
+# Globals:
+#  None
+# Arguments:
+#  None
+# Returns:
+#  None
+###############################################################################
+enable_logrotate() {
+    sed -i '/logrotate/s/^#*//g' /etc/cron.d/logrotate
+}
 
 ###############################################################################
 # Main generate_dump routine
@@ -376,6 +401,9 @@ main() {
         || abort "${ERROR_TAR_FAILED}" "Tar append operation failed. Aborting for safety.") \
         && $RM $V -rf $TARDIR
 
+    disable_logrotate
+    trap enable_logrotate HUP INT QUIT TERM KILL ABRT ALRM
+
     # gzip up all log files individually before placing them in the incremental tarball
     for file in $(find_logs "/var/log/"); do
         # ignore the sparse file lastlog
@@ -389,6 +417,8 @@ main() {
             save_file $file log true
         fi
     done
+
+    enable_logrotate
 
     # archive core dump files
     for file in $(find_logs "/var/core/"); do

--- a/show/main.py
+++ b/show/main.py
@@ -1276,10 +1276,13 @@ def users(verbose):
 #
 
 @cli.command()
+@click.option('--since', required=False, help="Collect logs and core files since given date")
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
-def techsupport(verbose):
+def techsupport(since, verbose):
     """Gather information for troubleshooting"""
     cmd = "sudo generate_dump -v"
+    if since:
+        cmd += " -s {}".format(since)
     run_command(cmd, display_cmd=verbose)
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
I added new option to ```show techsupport``` to specify ```--since``` parameter, e.g:
```
show techsupport --since=yesterday
```
When specified, the command will generated dump and include only logs and core files created since given date.
Also I added mstdump for mellanox to the script

**- How I did it**

**- How to verify it**
execute:
```
show techsupport --since=yesterday
```

**- Previous command output (if the output of a command-line utility has changed)**
```
admin@sonic:~$ show techsupport -h
Usage: show techsupport [OPTIONS]

  Gather information for troubleshooting

Options:
  --verbose       Enable verbose output
  -?, -h, --help  Show this message and exit.
```

**- New command output (if the output of a command-line utility has changed)**
```
admin@sonic:~$ show techsupport -h
Usage: show techsupport [OPTIONS]

  Gather information for troubleshooting

Options:
  --since TEXT    Collect logs and core files since given date
  --verbose       Enable verbose output
  -?, -h, --help  Show this message and exit.
```

-->

