### PR TITLE
Add TACACS accounting support

### DIFF
--- a/config/aaa.py
+++ b/config/aaa.py
@@ -93,6 +93,28 @@ def login(auth_protocol):
         add_table_kv('AAA', 'authentication', 'login', val)
 authentication.add_command(login)
 
+# cmd: aaa accounting
+@click.group()
+def accounting():
+    """User accounting"""
+    pass
+aaa.add_command(accounting)
+
+# cmd: aaa accounting session [tacacs+|default]
+@click.command()
+@click.argument('acct_protocol', nargs=-1, type=click.Choice(["tacacs+", "default"]))
+def session(acct_protocol):
+    """Switch session accounting [ tacacs+ | default ]"""
+    if len(acct_protocol) is 0:
+        print 'Not support empty argument'
+        return
+
+    if 'default' in acct_protocol:
+        del_table_key('AAA', 'accounting', 'session')
+    else:
+        val = acct_protocol[0]
+        add_table_kv('AAA', 'accounting', 'session', val)
+accounting.add_command(session)
 
 @click.group()
 def tacacs():

--- a/show/main.py
+++ b/show/main.py
@@ -1575,10 +1575,15 @@ def aaa():
             'login': 'local (default)',
             'failthrough': 'True (default)',
             'fallback': 'True (default)'
+        },
+        'accounting': {
+            'session': 'none (default)'
         }
     }
     if 'authentication' in data:
         aaa['authentication'].update(data['authentication'])
+    if 'accounting' in data:
+        aaa['accounting'].update(data['accounting'])
     for row in aaa:
         entry = aaa[row]
         for key in entry:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Add user command for "aaa accounting"

**- How I did it**
Implement command in "/config/aaa.py"

Together with "Support TACACS Accounting #2762"
files/image_config/hostcfgd/common-session-sonic.j2
files/image_config/hostcfgd/hostcfgd

**- How to verify it**
root@SONiC-Inventec-d7054:# config aaa accounting session tacacs+
root@SONiC-Inventec-d7054:# config aaa authentication login local tacacs+
root@SONiC-Inventec-d7054:# config save

[Check config_db.json]
"AAA": {
    "accounting": {
        "session": "tacacs+"
    },
    "authentication": {
        "login": "local,tacacs+"
    }
},

**- Previous command output (if the output of a command-line utility has changed)**
N/A
**- New command output (if the output of a command-line utility has changed)**
N/A


