### PR TITLE
Align PSU DB count field with the schema Spec

### DIFF
--- a/scripts/psushow
+++ b/scripts/psushow
@@ -24,7 +24,7 @@ def psu_status_show(index):
     # Currently set chassis_num to 1, need to improve it once new platform API is implemented
     chassis_num = 1
     chassis_name = "chassis {}".format(chassis_num)
-    num_psus = db.get(db.STATE_DB, 'CHASSIS_INFO|{}'.format(chassis_name), 'num_psus')
+    num_psus = db.get(db.STATE_DB, 'CHASSIS_INFO|{}'.format(chassis_name), 'psu_num')
     if not num_psus:
         print "Error! Failed to get the number of PSUs!"
         return -1

--- a/sonic-utilities-tests/mock_tables/state_db.json
+++ b/sonic-utilities-tests/mock_tables/state_db.json
@@ -33,7 +33,7 @@
         "tx4power": "N/A"
     },
     "CHASSIS_INFO|chassis 1": {
-        "num_psus": "2"
+        "psu_num": "2"
     },
     "PSU_INFO|PSU 1": {
         "presence": "true",


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

**- What I did**
* Aligned PSU DB 'num_psus' with the schema Spec

**- How I did it**
* N/A

**- How to verify it**
1. show platform psustatus

**- Previous command output (if the output of a command-line utility has changed)**
```
root@sonic:/home/admin# show platform psustatus
Error! Failed to get the number of PSUs!
Error: fail to get psu status from state DB
```

**- New command output (if the output of a command-line utility has changed)**
```
root@sonic:/home/admin# show platform psustatus
PSU    Status
-----  --------
PSU 1  OK
PSU 2  OK
```