### PR TITLE
[fast/warm reboot] add some sanity check before warm reboot

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -13,9 +13,15 @@ REBOOT_METHOD="/sbin/kexec -e"
 ASSISTANT_IP_LIST=""
 ASSISTANT_SCRIPT="/usr/bin/neighbor_advertiser"
 
+# Require 100M available on the hard drive for warm reboot temp files,
+# Size is in 1K blocks:
+MIN_HD_SPACE_NEEDED=100000
+
 EXIT_SUCCESS=0
 EXIT_FAILURE=1
 EXIT_NOT_SUPPORTED=2
+EXIT_FILE_SYSTEM_FULL=3
+EXIT_NEXT_IMAGE_NOT_EXISTS=4
 EXIT_ORCHAGENT_SHUTDOWN=10
 EXIT_SYNCD_SHUTDOWN=11
 
@@ -207,8 +213,8 @@ function setup_reboot_variables()
 {
     # Kernel and initrd image
     NEXT_SONIC_IMAGE=$(sonic_installer list | grep "Next: " | cut -d ' ' -f 2)
+    IMAGE_PATH="/host/image-${NEXT_SONIC_IMAGE#SONiC-OS-}"
     if grep -q aboot_platform= /host/machine.conf; then
-        IMAGE_PATH="/host/image-${NEXT_SONIC_IMAGE#SONiC-OS-}"
         KERNEL_IMAGE="$(ls $IMAGE_PATH/boot/vmlinuz-*)"
         BOOT_OPTIONS="$(cat "$IMAGE_PATH/kernel-cmdline" | tr '\n' ' ') SONIC_BOOT_TYPE=${BOOT_TYPE_ARG}"
     elif grep -q onie_platform= /host/machine.conf; then
@@ -220,6 +226,29 @@ function setup_reboot_variables()
         exit "${EXIT_NOT_SUPPORTED}"
     fi
     INITRD=$(echo $KERNEL_IMAGE | sed 's/vmlinuz/initrd.img/g')
+}
+
+function reboot_pre_check()
+{
+    # Make sure that the file system is normal: read-write able
+    filename="/host/test-`date +%Y%m%d-%H%M%S`"
+    if [[ ! -f ${filename} ]]; then
+        touch ${filename}
+    fi
+    rm ${filename}
+
+    # Make sure /host has enough space for warm reboot temp files
+    avail=$(df -k /host | tail -1 | awk '{ print $4 }')
+    if [[ ${avail} -lt ${MIN_HD_SPACE_NEEDED} ]]; then
+        debug "/host has ${avail} bytes availalbe, not enough for warm reboot."
+        exit ${EXIT_FILE_SYSTEM_FULL}
+    fi
+
+    # Make sure that the next image exists
+    if [[ ! -d ${IMAGE_PATH} ]]; then
+        debug "Next image ${NEXT_SONIC_IMAGE} doesn't exist ..."
+        exit ${EXIT_NEXT_IMAGE_NOT_EXISTS}
+    fi
 }
 
 # main starts here
@@ -267,6 +296,8 @@ then
 fi
 
 setup_reboot_variables
+
+reboot_pre_check
 
 # Install new FW for mellanox platforms before control plane goes down
 # So on boot switch will not spend time to upgrade FW increasing the CP downtime

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -19,13 +19,6 @@ EXIT_NOT_SUPPORTED=2
 EXIT_ORCHAGENT_SHUTDOWN=10
 EXIT_SYNCD_SHUTDOWN=11
 
-# Check root privileges
-if [[ "$EUID" -ne 0 ]]
-then
-    echo "This command must be run as root" >&2
-    exit "${EXIT_FAILURE}"
-fi
-
 function error()
 {
     echo $@ >&2
@@ -81,8 +74,6 @@ function parseOptions()
         esac
     done
 }
-
-sonic_asic_type=$(sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)
 
 function clear_fast_boot()
 {
@@ -231,7 +222,17 @@ function setup_reboot_variables()
     INITRD=$(echo $KERNEL_IMAGE | sed 's/vmlinuz/initrd.img/g')
 }
 
+# main starts here
 parseOptions $@
+
+# Check root privileges
+if [[ "$EUID" -ne 0 ]]
+then
+    echo "This command must be run as root" >&2
+    exit "${EXIT_FAILURE}"
+fi
+
+sonic_asic_type=$(sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)
 
 # Check reboot type supported
 BOOT_TYPE_ARG="cold"

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -240,7 +240,7 @@ function reboot_pre_check()
     # Make sure /host has enough space for warm reboot temp files
     avail=$(df -k /host | tail -1 | awk '{ print $4 }')
     if [[ ${avail} -lt ${MIN_HD_SPACE_NEEDED} ]]; then
-        debug "/host has ${avail} bytes availalbe, not enough for warm reboot."
+        debug "/host has ${avail}K bytes available, not enough for warm reboot."
         exit ${EXIT_FILE_SYSTEM_FULL}
     fi
 

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -212,6 +212,25 @@ function teardown_control_plane_assistant()
     fi
 }
 
+function setup_reboot_variables()
+{
+    # Kernel and initrd image
+    NEXT_SONIC_IMAGE=$(sonic_installer list | grep "Next: " | cut -d ' ' -f 2)
+    if grep -q aboot_platform= /host/machine.conf; then
+        IMAGE_PATH="/host/image-${NEXT_SONIC_IMAGE#SONiC-OS-}"
+        KERNEL_IMAGE="$(ls $IMAGE_PATH/boot/vmlinuz-*)"
+        BOOT_OPTIONS="$(cat "$IMAGE_PATH/kernel-cmdline" | tr '\n' ' ') SONIC_BOOT_TYPE=${BOOT_TYPE_ARG}"
+    elif grep -q onie_platform= /host/machine.conf; then
+        KERNEL_OPTIONS=$(cat /host/grub/grub.cfg | sed "/$NEXT_SONIC_IMAGE'/,/}/"'!'"g" | grep linux)
+        KERNEL_IMAGE="/host$(echo $KERNEL_OPTIONS | cut -d ' ' -f 2)"
+        BOOT_OPTIONS="$(echo $KERNEL_OPTIONS | sed -e 's/\s*linux\s*/BOOT_IMAGE=/') SONIC_BOOT_TYPE=${BOOT_TYPE_ARG}"
+    else
+        error "Unknown bootloader. ${REBOOT_TYPE} is not supported."
+        exit "${EXIT_NOT_SUPPORTED}"
+    fi
+    INITRD=$(echo $KERNEL_IMAGE | sed 's/vmlinuz/initrd.img/g')
+}
+
 parseOptions $@
 
 # Check reboot type supported
@@ -246,21 +265,7 @@ then
     /sbin/kexec -u
 fi
 
-# Kernel and initrd image
-NEXT_SONIC_IMAGE=$(sonic_installer list | grep "Next: " | cut -d ' ' -f 2)
-if grep -q aboot_platform= /host/machine.conf; then
-    IMAGE_PATH="/host/image-${NEXT_SONIC_IMAGE#SONiC-OS-}"
-    KERNEL_IMAGE="$(ls $IMAGE_PATH/boot/vmlinuz-*)"
-    BOOT_OPTIONS="$(cat "$IMAGE_PATH/kernel-cmdline" | tr '\n' ' ') SONIC_BOOT_TYPE=${BOOT_TYPE_ARG}"
-elif grep -q onie_platform= /host/machine.conf; then
-    KERNEL_OPTIONS=$(cat /host/grub/grub.cfg | sed "/$NEXT_SONIC_IMAGE'/,/}/"'!'"g" | grep linux)
-    KERNEL_IMAGE="/host$(echo $KERNEL_OPTIONS | cut -d ' ' -f 2)"
-    BOOT_OPTIONS="$(echo $KERNEL_OPTIONS | sed -e 's/\s*linux\s*/BOOT_IMAGE=/') SONIC_BOOT_TYPE=${BOOT_TYPE_ARG}"
-else
-    error "Unknown bootloader. ${REBOOT_TYPE} is not supported."
-    exit "${EXIT_NOT_SUPPORTED}"
-fi
-INITRD=$(echo $KERNEL_IMAGE | sed 's/vmlinuz/initrd.img/g')
+setup_reboot_variables
 
 # Install new FW for mellanox platforms before control plane goes down
 # So on boot switch will not spend time to upgrade FW increasing the CP downtime


### PR DESCRIPTION
**- What I did**
- Refactoring some code into functions, and making main start point more visible.
- Add sanity checks for warm reboot (some check might be useful for reboot script too. Will create another PR when this one is in).
  - Make sure that the next boot image is available.
  - Make sure that /host is write-able and has enough space.

**- How to verify it**
- continuous warm reboot
- reduce /host space available to at 100M and passed.
- further reduce /host space available and warm-reboot will abort.
- file system read-only test: have to change script to test with path /host/test and mount /host/test as read-only:
  host> mount -t tmpfs -r -o size=100M tmpfs /host/test/
  host> warm-reboot -v
  touch: cannot touch '/host/test/test-20190412-223147': Read-only file system
  Fri Apr 12 22:31:47 UTC 2019 warm-reboot failure (1) cleanup ...
  Fri Apr 12 22:31:48 UTC 2019 Cancel warm-reboot: code (1)