### PR TITLE
load_minigraph: restart hostcfgd

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -294,6 +294,7 @@ def _stop_services():
         'pmon',
         'bgp',
         'teamd',
+        'hostcfgd',
     ]
     for service in services:
         try:
@@ -315,6 +316,7 @@ def _restart_services():
         'lldp',
         'snmp',
         'dhcp_relay',
+        'hostcfgd',
     ]
     for service in services:
         try:

--- a/show/main.py
+++ b/show/main.py
@@ -1576,8 +1576,7 @@ def aaa():
     aaa = {
         'authentication': {
             'login': 'local (default)',
-            'failthrough': 'True (default)',
-            'fallback': 'True (default)'
+            'failthrough': 'False (default)'
         }
     }
     if 'authentication' in data:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Add hostcfgd as one of the services to restart upon load_minigraph, as load_minigraph does flush_db and creates the DB from scratch.
Even if we may get into flush_db to ensure  proper DB updates on 'deletes' to subscribers, when starting config from scratch it is more clean with less loop-holes if we could restart the subscribers.

**- How I did it**

**- How to verify it**
1) Setup TACACS auth and see it reflect in /etc/pam.d/common-auth-sonic
2) sudo config load_minigraph
3) View /etc/pam.d/common-auth-sonic to find those TACACS servers not there anymore, as load_minigraph should have removed them.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

