### PR TITLE
[config] add support to configure mtu on interface

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -907,6 +907,34 @@ def speed(ctx, interface_name, interface_speed, verbose):
     run_command(command, display_cmd=verbose)
 
 #
+# 'mtu' subcommand
+#
+
+@interface.command()
+@click.pass_context
+@click.argument('interface_name', metavar='<interface_name>', required=True)
+@click.argument('interface_mtu', metavar='<interface_mtu>', required=True)
+@click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
+def mtu(ctx, interface_name, interface_mtu, verbose):
+    """Set interface mtu"""
+    config_db = ctx.obj['config_db']
+    if get_interface_naming_mode() == "alias":
+        interface_name = interface_alias_to_name(interface_name)
+        if interface_name is None:
+            ctx.fail("'interface_name' is None!")
+
+    if interface_name_is_valid(interface_name) is False:
+        ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
+
+    if interface_name.startswith("Ethernet"):
+        command = "portconfig -p {} -m {}".format(interface_name, interface_mtu)
+        if verbose:
+            command += " -vv"
+        run_command(command, display_cmd=verbose)
+    elif interface_name.startswith("PortChannel"):
+        config_db.mod_entry("PORTCHANNEL", interface_name, {"mtu": interface_mtu})
+
+#
 # 'ip' subgroup ('config interface ip ...')
 #
 

--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -2,7 +2,7 @@
 """
 portconfig is the utility to show and change ECN configuration
 
-usage: portconfig [-h] [-v] [-s] [-f] [-p PROFILE] [-gmin GREEN_MIN]
+usage: portconfig [-h] [-v] [-s] [-f] [-m] [-p PROFILE] [-gmin GREEN_MIN]
                  [-gmax GREEN_MAX] [-ymin YELLOW_MIN] [-ymax YELLOW_MAX]
                  [-rmin RED_MIN] [-rmax RED_MAX] [-vv]
 
@@ -13,6 +13,7 @@ optional arguments:
   -p     --port                port name
   -s     --speed               port speed in Mbits
   -f     --fec                 port fec mode
+  -m     --mtu                 port mtu in Uint
 """
 from __future__ import print_function
 
@@ -25,6 +26,7 @@ import swsssdk
 PORT_TABLE_NAME = "PORT"
 PORT_SPEED_CONFIG_FIELD_NAME = "speed"
 PORT_FEC_CONFIG_FIELD_NAME = "fec"
+PORT_MTU_CONFIG_FIELD_NAME = "mtu"
 
 class portconfig(object):
     """
@@ -57,6 +59,11 @@ class portconfig(object):
             print("Setting fec %s on port %s" % (fec, port))
         self.db.mod_entry(PORT_TABLE_NAME, port, {PORT_FEC_CONFIG_FIELD_NAME: fec})
 
+    def set_mtu(self, port, mtu):
+        if self.verbose:
+            print("Setting mtu %s on port %s" % (mtu, port))
+        self.db.mod_entry(PORT_TABLE_NAME, port, {PORT_MTU_CONFIG_FIELD_NAME: mtu})
+
 def main():
     parser = argparse.ArgumentParser(description='Set SONiC port parameters',
                          version='1.0.0',
@@ -65,6 +72,7 @@ def main():
     parser.add_argument('-l', '--list', action='store_true', help='list port parametars', default=False)
     parser.add_argument('-s', '--speed', type=int, help='port speed value in Mbit', default=None)
     parser.add_argument('-f', '--fec', type=str, help='port fec mode value in (none, rs, fc)', default=None)
+    parser.add_argument('-m', '--mtu', type=str, help='port mtu value in Uint', default=None)
     parser.add_argument('-vv', '--verbose', action='store_true', help='Verbose output', default=False)
     args = parser.parse_args()
 
@@ -72,11 +80,13 @@ def main():
         port = portconfig(args.verbose, args.port)
         if args.list:
             port.list_params(args.port)
-        elif args.speed or args.fec:
+        elif args.speed or args.fec or args.mtu:
             if args.speed:
                 port.set_speed(args.port, args.speed)
             if args.fec:
                 port.set_fec(args.port, args.fec)
+            if args.mtu:
+                port.set_mtu(args.port, args.mtu)
         else:
             parser.print_help()
             sys.exit(1)


### PR DESCRIPTION
Signed-off-by: leo.li <leo.li@nephosinc.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Interface mtu configuration support

**- How I did it**
Python scripts `scripts/portconfig` and `config/main.py` modified

**- How to verify it**
Using `sudo conifg interface mtu` command and check port status

**- Previous command output (if the output of a command-line utility has changed)**
```
admin@sonic:~$ sudo portconfig --help
usage: portconfig [-h] [-v] -p PORT [-l] [-s SPEED] [-f FEC] [-vv]

Set SONiC port parameters

optional arguments:
  -h, --help            show this help message and exit
  -v, --version         show program's version number and exit
  -p PORT, --port PORT  port name (e.g. Ethernet0)
  -l, --list            list port parametars
  -s SPEED, --speed SPEED
                        port speed value in Mbit
  -f FEC, --fec FEC     port fec mode value in (none, rs, fc)
  -vv, --verbose        Verbose output
admin@sonic:~$
admin@sonic:~$ sudo config interface --help
Usage: config interface [OPTIONS] <interface_name> COMMAND [ARGS]...

  Interface-related configuration tasks

Options:
  --help  Show this message and exit.

Commands:
  ip        Add or remove IP address
  pfc       Set PFC configuration.
  shutdown  Shut down interface
  speed     Set interface speed
  startup   Start up interface
admin@sonic:~$
```
**- New command output (if the output of a command-line utility has changed)**
```
admin@sonic:~$ sudo portconfig --help
usage: portconfig [-h] [-v] -p PORT [-l] [-s SPEED] [-f FEC] [-m MTU] [-vv]

Set SONiC port parameters

optional arguments:
  -h, --help            show this help message and exit
  -v, --version         show program's version number and exit
  -p PORT, --port PORT  port name (e.g. Ethernet0)
  -l, --list            list port parametars
  -s SPEED, --speed SPEED
                        port speed value in Mbit
  -f FEC, --fec FEC     port fec mode value in (none, rs, fc)
  -m MTU, --mtu MTU     port mtu value in Uint
  -vv, --verbose        Verbose output
admin@sonic:~$
admin@sonic:~$ sudo config interface --help
Usage: config interface [OPTIONS] COMMAND [ARGS]...

  Interface-related configuration tasks

Options:
  --help  Show this message and exit.

Commands:
  ip        Add or remove IP address
  mtu       Set interface mtu
  pfc       Set PFC configuration.
  shutdown  Shut down interface
  speed     Set interface speed
  startup   Start up interface
admin@sonic:~$
```
**- Logs**
```
admin@sonic:~$ sudo config interface mtu Ethernet120 300

Apr 16 07:22:30.029695 sonic NOTICE swss#orchagent: :- doPortTask: Set port Ethernet120 MTU to 300
Apr 16 07:22:30.029695 sonic NOTICE swss#orchagent: :- setRouterIntfsMtu: Set router interface Ethernet120 MTU to 300
Apr 16 07:22:30.032236 sonic NOTICE swss#portmgrd: :- doTask: Configure Ethernet120 MTU to 300
```
```
admin@sonic:~$ ip link show Ethernet120
49: Ethernet120: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 300 qdisc pfifo_fast state UP mode DEFAULT group default qlen 1000
    link/ether 6c:ec:5a:08:2a:b9 brd ff:ff:ff:ff:ff:ff
admin@sonic:~$
```
```
admin@sonic:~$ sudo config interface mtu PortChannel0001 300

Apr 16 07:26:08.943151 sonic NOTICE swss#orchagent: :- setRouterIntfsMtu: Set router interface PortChannel0001 MTU to 300
Apr 16 07:26:08.944256 sonic NOTICE teamd#teammgrd: :- setLagMtu: Set port channel PortChannel0001 MTU to 300
```
```
admin@sonic:~$ ip link show PortChannel0001
6: PortChannel0001: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 300 qdisc noqueue master Bridge state UP mode DEFAULT group default qlen 1000
    link/ether 6c:ec:5a:08:2a:b9 brd ff:ff:ff:ff:ff:ff
admin@sonic:~$
```