### PR TITLE
[Mellanox] Update FW if needed before fast-reboot

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -42,7 +42,7 @@ if [[ "$sonic_asic_type" == "mellanox" ]]; then
     echo "Prepare MLNX ASIC to fast reboot: install new FW if required"
 
     MLNX_EXIT_SUCCESS="0"
-    MLNX_EXIT_ERROR="1"
+    MLNX_EXIT_FW_ERROR=100
 
     MLNX_FW_UPGRADE_SCRIPT="/usr/bin/mlnx-fw-upgrade.sh"
 
@@ -50,7 +50,7 @@ if [[ "$sonic_asic_type" == "mellanox" ]]; then
     MLNX_EXIT_CODE="$?"
     if [[ "${MLNX_EXIT_CODE}" != "${MLNX_EXIT_SUCCESS}" ]]; then
         echo "Failed to burn MLNX FW: errno=${MLNX_EXIT_CODE}"
-        exit "${MLNX_EXIT_ERROR}"
+        exit "${MLNX_EXIT_FW_ERROR}"
     fi
 fi
 

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -1,9 +1,13 @@
 #!/bin/bash
 
+REBOOT_USER=$(logname)
+REBOOT_TIME=$(date)
+REBOOT_CAUSE_FILE="/var/cache/sonic/reboot-cause.txt"
+
 # Check root privileges
 if [[ "$EUID" -ne 0 ]]
 then
-  echo "Please run as root"
+  echo "This command must be run as root" >&2
   exit
 fi
 
@@ -32,6 +36,24 @@ INITRD=$(echo $KERNEL_IMAGE | sed 's/vmlinuz/initrd.img/g')
 
 sonic_asic_type=$(sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)
 
+# Install new FW for mellanox platforms before control plane goes down
+# So on boot switch will not spend time to upgrade FW increasing the CP downtime
+if [[ "$sonic_asic_type" == "mellanox" ]]; then
+    echo "Prepare MLNX ASIC to fast reboot: install new FW if required"
+
+    MLNX_EXIT_SUCCESS="0"
+    MLNX_EXIT_ERROR="1"
+
+    MLNX_FW_UPGRADE_SCRIPT="/usr/bin/mlnx-fw-upgrade.sh"
+
+    ${MLNX_FW_UPGRADE_SCRIPT} --upgrade
+    MLNX_EXIT_CODE="$?"
+    if [[ "${MLNX_EXIT_CODE}" != "${MLNX_EXIT_SUCCESS}" ]]; then
+        echo "Failed to burn MLNX FW: errno=${MLNX_EXIT_CODE}"
+        exit "${MLNX_EXIT_ERROR}"
+    fi
+fi
+
 # Load kernel into the memory
 /sbin/kexec -l "$KERNEL_IMAGE" --initrd="$INITRD" --append="$BOOT_OPTIONS"
 
@@ -50,7 +72,7 @@ docker kill lldp > /dev/null
 # Kill teamd, otherwise it gets down all LAGs
 docker kill teamd > /dev/null
 
-# syncd graceful stop is supported only for Broadcoms platforms only for now
+# syncd graceful stop is supported only for Broadcom platforms only for now
 if [[ "$sonic_asic_type" = 'broadcom' ]];
 then
     # Gracefully stop syncd
@@ -82,6 +104,11 @@ then
   systemctl stop nps-modules-`uname -r`.service
 fi
 
+# Update the reboot cause file to reflect that user issued 'fast-reboot' command
+# Upon next boot, the contents of this file will be used to determine the
+# cause of the previous reboot
+echo "User issued 'fast-reboot' command [User: ${REBOOT_USER}, Time: ${REBOOT_TIME}]" > ${REBOOT_CAUSE_FILE}
+
 # Wait until all buffers synced with disk
 sync
 sleep 1
@@ -89,4 +116,9 @@ sync
 
 # Reboot: explicity call Linux native reboot under sbin
 echo "Rebooting to $NEXT_SONIC_IMAGE..."
-/sbin/reboot
+exec /sbin/reboot
+
+# Should never reach here
+echo "fast-reboot failed!" >&2
+exit 1
+


### PR DESCRIPTION
This change aligns fast-reboot script with the master
at point 42582872ac0285fed53141d9e4b9a1a5652bb132
Unfortunatelly cannot be cherry-picked because original
commits also change other files

Signed-off-by: Andriy Moroz <c_andriym@mellanox.com>

**- What I did**
Updated fast-reboot script to update firmware before reboot

**- How I did it**
Used version from 201811 (latest before warm-reboot)

**- How to verify it**
Tested upgrade to 201811 with fast-reboot
See log below

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**
```
root@mts-sonic-dut:/home/admin# mlxfwmanager
Querying Mellanox devices firmware ...

Device #1:
----------

  Device Type:      Spectrum
  Part Number:      MSN2700-CxxxO_Ax_Bx
  Description:      Spectrum based 100GbE 1U Open Switch with ONIE; 32 QSFP28 ports; x86 CPU; RoHS6
  PSID:             MT_2750111033
  PCI Device Name:  /dev/mst/mt52100_pci_cr0
  Base MAC:         7cfe90f53640
  Versions:         Current        Available
     FW             13.1620.0234   N/A

  Status:           No matching image found

root@mts-sonic-dut:/home/admin# sonic_installer list
Current: SONiC-OS-20180330.99
Next: SONiC-OS-HEAD.46-bed716e
Available:
SONiC-OS-HEAD.46-bed716e
SONiC-OS-20180330.99
716e@mts-sonic-dut:/home/admin# sonic_installer set_default SONiC-OS-HEAD.46-bed
Command: grub-set-default --boot-directory=/host 0

root@mts-sonic-dut:/home/admin# fast-reboot
Prepare MLNX ASIC to fast reboot: install new FW if required
Mellanox firmware upgrade is required. Installing compatible version...
Querying Mellanox devices firmware ...

Device #1:
----------

  Device Type:      Spectrum
  Part Number:      MSN2700-CxxxO_Ax_Bx
  Description:      Spectrum based 100GbE 1U Open Switch with ONIE; 32 QSFP28 ports; x86 CPU; RoHS6
  PSID:             MT_2750111033
  PCI Device Name:  /dev/mst/mt52100_pci_cr0
  Base MAC:         7cfe90f53640
  Versions:         Current        Available
     FW             13.1620.0234   13.1910.0920

  Status:           Update required

---------
Found 1 device(s) requiring firmware update...

Device #1: Updating FW ...                                                                                                 Done

Restart needed for updates to take effect.
Rebooting to SONiC-OS-HEAD.46[ 1206.510911] Starting new kernel
[    7.539245] rc.local[1660]: + sonic-cfggen -y /etc/sonic/sonic_version.yml -v build_version
[    9.672832] rc.local[1660]: + SONIC_VERSION=HEAD.46-bed716e
[    9.744782] rc.local[1660]: + FIRST_BOOT_FILE=/host/image-HEAD.46-bed716e/platform/firsttime
[    9.864322] rc.local[1660]: + process_reboot_cause
[    9.924373] rc.local[1660]: + REBOOT_CAUSE_DIR=/host/reboot-cause
[   10.000385] rc.local[1660]: + REBOOT_CAUSE_FILE=/host/reboot-cause/reboot-cause.txt
[   10.104437] rc.local[1660]: + PREVIOUS_REBOOT_CAUSE_FILE=/host/reboot-cause/previous-reboot-cause.txt
[   10.224441] rc.local[1660]: + mkdir -p /host/reboot-cause
[   10.296392] rc.local[1660]: + [ -f /host/image-HEAD.46-bed716e/platform/firsttime ]
[   10.392577] rc.local[1660]: + [ -f /host/reboot-cause/reboot-cause.txt ]
[   10.480576] rc.local[1660]: + mv -f /host/reboot-cause/reboot-cause.txt /host/reboot-cause/previous-reboot-cause.txt
[   10.615816] rc.local[1660]: + cat /host/reboot-cause/previous-reboot-cause.txt
[   10.721284] rc.local[1660]: + logger Previous reboot cause: User issued 'fast-reboot' command [User: admin, Time: Tue Apr 16 09:20:47 UTC 2019]
[   10.880442] rc.local[1660]: + echo Unexpected reboot
[   10.940545] rc.local[1660]: + [ ! -e /host/machine.conf ]
[   11.012412] rc.local[1660]: + . /host/machine.conf
[   11.072447] rc.local[1660]: + onie_arch=x86_64
[   11.132464] rc.local[1660]: + onie_bin=
[   11.188481] rc.local[1660]: + onie_boot_reason=rescue
[   11.260435] rc.local[1660]: + onie_build_date=2018-05-21T14:16+0000
[   11.336427] rc.local[1660]: + onie_cli_static_parms=
[   11.396413] rc.local[1660]: + onie_cli_static_url=sonic-mellanox-201811.bin
[   11.484412] rc.local[1660]: + onie_config_version=1
[   11.544413] rc.local[1660]: + onie_dev=/dev/sda2
[   11.604488] rc.local[1660]: + onie_exec_url=sonic-mellanox-201811.bin
[   11.692404] rc.local[1660]: + onie_firmware=auto
[   11.752403] rc.local[1660]: + onie_initrd_tmp=/
[   11.812516] rc.local[1660]: + onie_installer=/var/tmp/installer
[   11.888644] rc.local[1660]: + onie_kernel_version=4.9.95
[   11.960494] rc.local[1660]: + onie_machine=mlnx_msn2700
[   12.032426] rc.local[1660]: + onie_machine_rev=0
[   12.092415] rc.local[1660]: + onie_partition_type=gpt
[   12.164441] rc.local[1660]: + onie_platform=x86_64-mlnx_msn2700-r0
[   12.240444] rc.local[1660]: + onie_root_dir=/mnt/onie-boot/onie
[   12.320408] rc.local[1660]: + onie_skip_ethmgmt_macs=yes
[   12.392427] rc.local[1660]: + onie_switch_asic=mlnx
[   12.452428] rc.local[1660]: + onie_uefi_arch=x64
[   12.512426] rc.local[1660]: + onie_uefi_boot_loader=grubx64.efi
[   12.588532] rc.local[1660]: + onie_vendor_id=33049
[   12.648426] rc.local[1660]: + onie_version=2018.05-5.2.0004-9600
[   12.724512] rc.local[1660]: + program_console_speed
[   12.788082] rc.local[1660]: + cut -d , -f2
[   12.853263] rc.local[1660]: + grep -Eo console=ttyS[0-9]+,[0-9]+
[   12.931346] rc.local[1660]: + cat /proc/cmdline
[   12.993960] rc.local[1660]: + speed=9600
[   13.049069] rc.local[1660]: + [ -z 9600 ]
[   13.104412] rc.local[1660]: + CONSOLE_SPEED=9600
[   13.164436] rc.local[1660]: + sed -i s|\-\-keep\-baud .* %I| 9600 %I|g /lib/systemd/system/serial-getty@.service
[   13.292429] rc.local[1660]: + systemctl daemon-reload
[   13.364504] rc.local[1660]: + [ -f /host/image-HEAD.46-bed716e/platform/firsttime ]
[   13.468717] rc.local[1660]: + exit 0

Debian GNU/Linux 9 mts-sonic-dut ttyS0

mts-sonic-dut login: admin
Password:
Last login: Tue Apr 16 09:40:00 UTC 2019 on ttyS0
Linux mts-sonic-dut 4.9.0-8-amd64 #1 SMP Debian 4.9.110-3+deb9u6 (2015-12-19) x86_64
You are on
  ____   ___  _   _ _  ____
 / ___| / _ \| \ | (_)/ ___|
 \___ \| | | |  \| | | |
  ___) | |_| | |\  | | |___
 |____/ \___/|_| \_|_|\____|

-- Software for Open Networking in the Cloud --

Unauthorized access and/or use are prohibited.
All access and/or use are subject to monitoring.

Help:    http://azure.github.io/SONiC/

admin@mts-sonic-dut:~$ sudo su
root@mts-sonic-dut:/home/admin# mlxfwmanager
Querying Mellanox devices firmware ...

Device #1:
----------

  Device Type:      Spectrum
  Part Number:      MSN2700-CxxxO_Ax_Bx
  Description:      Spectrum based 100GbE 1U Open Switch with ONIE; 32 QSFP28 ports; x86 CPU; RoHS6
  PSID:             MT_2750111033
  PCI Device Name:  /dev/mst/mt52100_pci_cr0
  Base MAC:         7cfe90f53640
  Versions:         Current        Available
     FW             13.1910.0920   N/A

  Status:           No matching image found

root@mts-sonic-dut:/home/admin#
```

