### PR TITLE
[show] Call teamshow using sudo in 'show interfaces portchannel'

### DIFF
--- a/scripts/teamshow
+++ b/scripts/teamshow
@@ -19,6 +19,7 @@
 """
 
 import json
+import os
 import re
 import swsssdk
 import subprocess
@@ -127,6 +128,9 @@ class Teamshow(object):
         print tabulate(output, header)
 
 def main():
+    if os.geteuid() != 0:
+        exit("This utility must be run as root")
+
     try:
         team = Teamshow()
         team.get_portchannel_names()
@@ -134,8 +138,7 @@ def main():
         team.get_teamshow_result()
         team.display_summary()
     except Exception as e:
-        print e.message
-        sys.exit(1)
+        sys.exit(e.message)
 
 if __name__ == "__main__":
     main()

--- a/show/main.py
+++ b/show/main.py
@@ -617,7 +617,7 @@ def rif(interface, period, verbose):
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def portchannel(verbose):
     """Show PortChannel information"""
-    cmd = "teamshow"
+    cmd = "sudo teamshow"
     run_command(cmd, display_cmd=verbose)
 
 #


### PR DESCRIPTION
- Also modify teamshow to print a message and exit if it is not run as root.

- NOTE: This change will also require a modification to the sudoers file in sonic-buildimage to be complete.