### PR TITLE
Generate interface table to have an entry for default VRF

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -948,10 +948,13 @@ def add(ctx, interface_name, ip_addr):
 
     if interface_name.startswith("Ethernet"):
         config_db.set_entry("INTERFACE", (interface_name, ip_addr), {"NULL": "NULL"})
+        config_db.set_entry("INTERFACE", interface_name, {"NULL": "NULL"})
     elif interface_name.startswith("PortChannel"):
         config_db.set_entry("PORTCHANNEL_INTERFACE", (interface_name, ip_addr), {"NULL": "NULL"})
+        config_db.set_entry("PORTCHANNEL_INTERFACE", interface_name, {"NULL": "NULL"})
     elif interface_name.startswith("Vlan"):
         config_db.set_entry("VLAN_INTERFACE", (interface_name, ip_addr), {"NULL": "NULL"})
+        config_db.set_entry("VLAN_INTERFACE", interface_name, {"NULL": "NULL"})
 
 #
 # 'del' subcommand
@@ -969,12 +972,29 @@ def remove(ctx, interface_name, ip_addr):
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
+    if_table = ""
     if interface_name.startswith("Ethernet"):
         config_db.set_entry("INTERFACE", (interface_name, ip_addr), None)
+        if_table = "INTERFACE"
     elif interface_name.startswith("PortChannel"):
         config_db.set_entry("PORTCHANNEL_INTERFACE", (interface_name, ip_addr), None)
+        if_table = "PORTCHANNEL_INTERFACE"
     elif interface_name.startswith("Vlan"):
         config_db.set_entry("VLAN_INTERFACE", (interface_name, ip_addr), None)
+        if_table = "VLAN_INTERFACE"
+
+    exists = False
+    if if_table:
+        interfaces = config_db.get_table(if_table)
+        for key in interfaces.keys():
+            if not isinstance(key, tuple):
+                continue
+            if interface_name in key:
+                exists = True
+                break
+
+    if not exists:
+        config_db.set_entry(if_table, interface_name, None)
 
 #
 # 'acl' group ('config acl ...')

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -51,6 +51,34 @@ class DBMigrator():
         self.configDB.delete_table('PFC_WD_TABLE')
 
 
+    def migrate_interface_table(self):
+        # Migrate all data entries for Interface table
+        if_db = []
+        if_tables = {
+                     'INTERFACE',
+                     'PORTCHANNEL_INTERFACE',
+                     'VLAN_INTERFACE'
+                    }
+        for table in if_tables:
+            data = self.configDB.get_table(table)
+            for key in data.keys():
+                if not isinstance(key, tuple):
+                    if_db.append(key)
+                    continue
+
+        log_info('Existing interface objects ')
+        log_info(' '.join(if_db))
+
+        for table in if_tables:
+            data = self.configDB.get_table(table)
+            for key in data.keys():
+                if not isinstance(key, tuple) or key[0] in if_db:
+                    continue
+                log_info('Migrating interface table for ' + key[0])
+                self.configDB.set_entry(table, key[0], data[key])
+                if_db.append(key[0])
+
+
     def version_unknown(self):
         """
         version_unknown tracks all SONiC versions that doesn't have a version
@@ -69,6 +97,7 @@ class DBMigrator():
         #       If new DB version is added in the future, the incremental
         #       upgrade will take care of the subsequent migrations.
         # self.migrate_pfc_wd_table()
+        self.migrate_interface_table()
         # self.set_version('version_1_0_1')
         # return 'version_1_0_1'
 

--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -110,12 +110,21 @@ def extract_ip_ver_addr(ip_prefix):
     return (ver, addr)
 
 
+def is_ip_prefix_in_key(key):
+    '''
+    Function to check if IP address is present in the key. If it
+    is present, then the key would be a tuple or else, it shall be
+    be string
+    '''
+    return (isinstance(key, tuple))
+
+
 def get_loopback_addr(ip_ver):
     loopback_intfs = config_db.get_table('LOOPBACK_INTERFACE')
     loopback_addr = ''
 
     for intf in loopback_intfs.keys():
-        if not isinstance(intf, tuple):
+        if not is_ip_prefix_in_key(intf):
              continue
         if 'Loopback0' in intf:
             intf_ip_prefix = intf[1]
@@ -172,7 +181,7 @@ def get_vlan_addr(vlan_intf_name, ip_ver):
     vlan_addr = []
 
     for intf in vlan_intfs.keys():
-        if not isinstance(intf, tuple):
+        if not is_ip_prefix_in_key(intf):
              continue
         if vlan_intf_name in intf:
             intf_ip_prefix = intf[1]

--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -115,6 +115,8 @@ def get_loopback_addr(ip_ver):
     loopback_addr = ''
 
     for intf in loopback_intfs.keys():
+        if not isinstance(intf, tuple):
+             continue
         if 'Loopback0' in intf:
             intf_ip_prefix = intf[1]
             (intf_ip_ver, intf_ip_addr) = extract_ip_ver_addr(intf_ip_prefix)
@@ -165,6 +167,8 @@ def get_vlan_addr(vlan_intf_name, ip_ver):
     vlan_addr = []
 
     for intf in vlan_intfs.keys():
+        if not isinstance(intf, tuple):
+             continue
         if vlan_intf_name in intf:
             intf_ip_prefix = intf[1]
             (intf_ip_ver, intf_ip_addr) = extract_ip_ver_addr(intf_ip_prefix)

--- a/scripts/pcmping
+++ b/scripts/pcmping
@@ -92,7 +92,7 @@ def get_portchannel_ipv4(portchannel_name):
     config = configdb.get_config()
     portchannel_interfaces = config["PORTCHANNEL_INTERFACE"]
     for key in portchannel_interfaces.keys():
-        if len(key) == 1:
+        if not isinstance(key, tuple):
             continue
         pc, ip = key
         ip = ip.split("/")[0]

--- a/scripts/pcmping
+++ b/scripts/pcmping
@@ -86,13 +86,21 @@ def get_portchannel(interface):
     sys.stderr.write("Interface %s is not a portchannel member. Please Check!\n" % interface)
     sys.exit(1)
 
+def is_ip_prefix_in_key(key):
+    '''
+    Function to check if IP address is present in the key. If it
+    is present, then the key would be a tuple or else, it shall be
+    be string
+    '''
+    return (isinstance(key, tuple))
+
 def get_portchannel_ipv4(portchannel_name):
     configdb = swsssdk.ConfigDBConnector()
     configdb.connect()
     config = configdb.get_config()
     portchannel_interfaces = config["PORTCHANNEL_INTERFACE"]
     for key in portchannel_interfaces.keys():
-        if not isinstance(key, tuple):
+        if not is_ip_prefix_in_key(key):
             continue
         pc, ip = key
         ip = ip.split("/")[0]

--- a/show/main.py
+++ b/show/main.py
@@ -200,6 +200,15 @@ def get_interface_mode():
     return mode
 
 
+def is_ip_prefix_in_key(key):
+    '''
+    Function to check if IP address is present in the key. If it
+    is present, then the key would be a tuple or else, it shall be
+    be string
+    '''
+    return (isinstance(key, tuple))
+
+
 # Global class instance for SONiC interface name to alias conversion
 iface_alias_converter = InterfaceAliasConverter()
 
@@ -1480,7 +1489,7 @@ def brief(verbose):
 
     # Parsing VLAN Gateway info
     for key in natsorted(vlan_ip_data.keys()):
-        if not isinstance(key, tuple):
+        if not is_ip_prefix_in_key(key):
             continue
         interface_key = str(key[0].strip("Vlan"))
         interface_value = str(key[1])

--- a/show/main.py
+++ b/show/main.py
@@ -1462,7 +1462,7 @@ def brief(verbose):
 
     # Parsing VLAN Gateway info
     for key in natsorted(vlan_ip_data.keys()):
-        if len(key) == 1:
+        if not isinstance(key, tuple):
             continue
         interface_key = str(key[0].strip("Vlan"))
         interface_value = str(key[1])


### PR DESCRIPTION
**- What I did**
Generate interface table to have an entry designated to default VRF during config reload. This is when the interface is not configured to be part of any VRFs.  This is a placeholder PR to be merged along with https://github.com/Azure/sonic-buildimage/pull/2848

Current:
```
    "VLAN_INTERFACE": {
        "Vlan1000|192.168.0.1/21": {}
    },
```

Proposed:
```
    "VLAN_INTERFACE": {
        "Vlan1000": {},
        "Vlan1000|192.168.0.1/21": {}
    },
```
**- How I did it**
DB migrator modified to migrate interface table during config reload

**- How to verify it**
Run config reload and verify for entries without prefix in config_db
```
 2) "LOOPBACK_INTERFACE|Loopback0|FC00:1::32/128"
 3) "MGMT_INTERFACE|eth0|FC00:2::32/64"
 4) "PORTCHANNEL_INTERFACE|PortChannel0002|FC00::75/126"
 5) "PORTCHANNEL_INTERFACE|PortChannel0001|FC00::71/126"
 6) "PORTCHANNEL_INTERFACE|PortChannel0004|10.0.0.62/31"
 7) "PORTCHANNEL_INTERFACE|PortChannel0001"
 8) "PORTCHANNEL_INTERFACE|PortChannel0004|FC00::7D/126"
 9) "PORTCHANNEL_INTERFACE|PortChannel0003|10.0.0.60/31"
10) "PORTCHANNEL_INTERFACE|PortChannel0003"
11) "PORTCHANNEL_INTERFACE|PortChannel0004"
12) "PORTCHANNEL_INTERFACE|PortChannel0003|FC00::79/126"
13) "VLAN_INTERFACE|Vlan1000|192.168.0.1/21"
14) "LOOPBACK_INTERFACE|Loopback0|10.1.0.32/32"
15) "PORTCHANNEL_INTERFACE|PortChannel0001|10.0.0.56/31"
16) "MGMT_INTERFACE|eth0|10.3.147.47/23"
17) "VLAN_INTERFACE|Vlan1000"
18) "PORTCHANNEL_INTERFACE|PortChannel0002|10.0.0.58/31
```

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

