### PR TITLE
IP Address validation check

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -10,6 +10,7 @@ import re
 import syslog
 
 import sonic_device_util
+import ipaddress
 from swsssdk import ConfigDBConnector
 from swsssdk import SonicV2Connector
 from minigraph import parse_device_desc_xml
@@ -946,15 +947,20 @@ def add(ctx, interface_name, ip_addr):
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
-    if interface_name.startswith("Ethernet"):
-        config_db.set_entry("INTERFACE", (interface_name, ip_addr), {"NULL": "NULL"})
-    elif interface_name.startswith("PortChannel"):
-        config_db.set_entry("PORTCHANNEL_INTERFACE", (interface_name, ip_addr), {"NULL": "NULL"})
-    elif interface_name.startswith("Vlan"):
-        config_db.set_entry("VLAN_INTERFACE", (interface_name, ip_addr), {"NULL": "NULL"})
-    elif interface_name.startswith("Loopback"):
-        config_db.set_entry("LOOPBACK_INTERFACE", (interface_name, ip_addr), {"NULL": "NULL"})
-
+    try:
+        ipaddress.ip_network(unicode(ip_addr), strict=False)
+        if interface_name.startswith("Ethernet"):
+            config_db.set_entry("INTERFACE", (interface_name, ip_addr), {"NULL": "NULL"})
+        elif interface_name.startswith("PortChannel"):
+            config_db.set_entry("PORTCHANNEL_INTERFACE", (interface_name, ip_addr), {"NULL": "NULL"})
+        elif interface_name.startswith("Vlan"):
+            config_db.set_entry("VLAN_INTERFACE", (interface_name, ip_addr), {"NULL": "NULL"})
+        elif interface_name.startswith("Loopback"):
+            config_db.set_entry("LOOPBACK_INTERFACE", (interface_name, ip_addr), {"NULL": "NULL"})
+        else:
+            ctx.fail("'interface_name' is not valid. Valid names [Ethernet/PortChannel/Vlan/Loopback]")
+    except ValueError:
+        ctx.fail("'ip_addr' is not valid.")
 
 #
 # 'del' subcommand
@@ -972,15 +978,20 @@ def remove(ctx, interface_name, ip_addr):
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
-    if interface_name.startswith("Ethernet"):
-        config_db.set_entry("INTERFACE", (interface_name, ip_addr), None)
-    elif interface_name.startswith("PortChannel"):
-        config_db.set_entry("PORTCHANNEL_INTERFACE", (interface_name, ip_addr), None)
-    elif interface_name.startswith("Vlan"):
-        config_db.set_entry("VLAN_INTERFACE", (interface_name, ip_addr), None)
-    elif interface_name.startswith("Loopback"):
-        config_db.set_entry("LOOPBACK_INTERFACE", (interface_name, ip_addr), None)
-
+    try:
+        ipaddress.ip_network(unicode(ip_addr), strict=False)
+        if interface_name.startswith("Ethernet"):
+            config_db.set_entry("INTERFACE", (interface_name, ip_addr), None)
+        elif interface_name.startswith("PortChannel"):
+            config_db.set_entry("PORTCHANNEL_INTERFACE", (interface_name, ip_addr), None)
+        elif interface_name.startswith("Vlan"):
+            config_db.set_entry("VLAN_INTERFACE", (interface_name, ip_addr), None)
+        elif interface_name.startswith("Loopback"):
+            config_db.set_entry("LOOPBACK_INTERFACE", (interface_name, ip_addr), None)
+        else:
+            ctx.fail("'interface_name' is not valid. Valid names [Ethernet/PortChannel/Vlan/Loopback]")
+    except ValueError:
+        ctx.fail("'ip_addr' is not valid.")
 #
 # 'acl' group ('config acl ...')
 #


### PR DESCRIPTION
**- What I did**
IP Add CLI do not do any IP Address validation check. It accepts and inserts any string as IP address.
Added IP Address validation check.

**- How I did it**
Checking for valid IP v4/v6 as part of CLI configuration. Throw error if IP is not valid.

**- How to verify it**
Configure IP Add/Del with invalid IP address should throw error.

**- Previous command output (if the output of a command-line utility has changed)**
No change in CLI syntax.

Log before change :
admin@sonic:$ sudo config interface ip add Vlan100 ?
admin@sonic:$ sudo config interface ip add Vlan100 21.1.1.2/24

admin@sonic:$ show run all
{
"VLAN_INTERFACE": {
"Vlan100|21.1.1.2/24": {}, 
"Vlan100|?": {}
},

**- New command output (if the output of a command-line utility has changed)**
No change in CLI syntax.

Log after change 

root@sonic:/home/admin# config interface ip add Vlan100 ?
Usage: config interface ip add [OPTIONS] <interface_name> <ip_addr> 

Error: 'ip_addr' is not valid.
root@sonic:/home/admin# config interface ip add Vlan100 1.2.3.4/24 

