### PR TITLE
[sonic-utilities] Add fstrim to reboot

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -73,6 +73,7 @@ clear_warm_boot
 # cause of the previous reboot
 echo "User issued 'reboot' command [User: ${REBOOT_USER}, Time: ${REBOOT_TIME}]" > ${REBOOT_CAUSE_FILE}
 sync
+/sbin/fstrim -av
 sleep 3
 
 # sync the current system time to CMOS


### PR DESCRIPTION
This commit added fstrim to reboot script between
sync and sleep 3.
MERGE this PR before MERGING the following PR
https://github.com/Azure/sonic-buildimage/pull/2912

Signed-off-by: Harish Venkatraman <harish_venkatraman@dell.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

