### PR TITLE
When Port channel configured, MAC address table is not showing up the macs though hardware has MACs.

### DIFF
--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -76,11 +76,20 @@ class FdbShow(object):
             if br_port_id not in self.if_br_oid_map:
                 continue
             port_id = self.if_br_oid_map[br_port_id]
-            if_name = self.if_oid_map[port_id]
+            #FIXME: When if_name not mapped to port_id in DB, using port_id as if_name in the display.
+            try:
+                if_name = self.if_oid_map[port_id]
+            except :
+                if_name = port_id
+
+            #FIXME: When VLAN Id for fdb entry not present in DB, then not displaying the fdb entry.
             if 'vlan' in fdb:
                 vlan_id = fdb["vlan"]
             elif 'bvid' in fdb:
-                vlan_id = port_util.get_vlan_id_from_bvid(self.db, fdb["bvid"])
+                try:
+                    vlan_id = port_util.get_vlan_id_from_bvid(self.db, fdb["bvid"])
+                except :
+                    continue
             self.bridge_mac_list.append((int(vlan_id),) + (fdb["mac"],) + (if_name,) + (fdb_type,))
 
         self.bridge_mac_list.sort(key = lambda x: x[0])

--- a/scripts/nbrshow
+++ b/scripts/nbrshow
@@ -84,11 +84,19 @@ class NbrBase(object):
             if br_port_id not in self.if_br_oid_map:
                 continue
             port_id = self.if_br_oid_map[br_port_id]
-            if_name = self.if_oid_map[port_id]
+            #FIXME: When if_name not mapped to port_id in DB, using port_id as if_name in the display.
+            try:
+                if_name = self.if_oid_map[port_id]
+            except:
+                if_name = port_id
+            #FIXME: When VLAN Id for fdb entry not present in DB, then not displaying the fdb entry.
             if 'vlan' in fdb:
                 vlan_id = fdb["vlan"]
             elif 'bvid' in fdb:
-                vlan_id = port_util.get_vlan_id_from_bvid(self.db, fdb["bvid"])
+                try:
+                    vlan_id = port_util.get_vlan_id_from_bvid(self.db, fdb["bvid"])
+                except :
+                    continue
             self.bridge_mac_list.append((int(vlan_id),) + (fdb["mac"],) + (if_name,))
 
         return


### PR DESCRIPTION
**- What I did**
When PortChannel is configured, the port_id is not mapped to if_name in the radis DB. 
In this case 'show mac' or 'show arp' commands are failing to display the MAC entries.
In this case display the port_id in place of if_name. 

**- How I did it**
When interface to OID map failed for port channel mac entries, keyerror exception occurred.
Here considering the OID as interface name and updating bridge mac list.

**- How to verify it**
Configure port channel and verify mac entries are learned.
When display mac entries via 'show mac' or 'show arp' the mac entried should be displayed.

admin@sonic:~$ show mac 
  No. Vlan MacAddress Port Type 
----- ------ ----------------- ------------- ------- 
    1 3000 00:00:0A:00:04:0F Ethernet0 Dynamic 
    2 3000 00:00:0A:00:04:04 Ethernet0 Dynamic 
    3 3000 00:00:0A:00:04:09 Ethernet0 Dynamic 
    4 3000 00:00:0A:00:04:0E Ethernet0 Dynamic 
    5 3000 00:00:0A:00:04:06 Ethernet0 Dynamic 
    6 3000 00:00:0A:00:04:01 Ethernet0 Dynamic 
    7 3000 00:00:0A:00:04:05 Ethernet0 Dynamic 
    8 3000 CC:37:AB:17:7B:76 2000000000ce4 Dynamic 
    9 3000 00:00:0A:00:04:0C Ethernet0 Dynamic 
   10 3000 00:00:0A:00:04:03 Ethernet0 Dynamic 
   11 3000 00:00:0A:00:04:0B Ethernet0 Dynamic 
   12 3000 00:00:0A:00:04:0D Ethernet0 Dynamic 
   13 3000 00:00:0A:00:04:07 Ethernet0 Dynamic 
   14 3000 00:00:0A:00:04:02 Ethernet0 Dynamic 
   15 3000 00:00:0A:00:04:00 Ethernet0 Dynamic 
   16 3000 00:00:0A:00:04:0A Ethernet0 Dynamic 
   17 3000 00:00:0A:00:04:08 Ethernet0 Dynamic 
Total number of entries 17 

Without fix:

The output doesn't contain any MAC entries, but MAC entries present in hardware.
admin@sonic:~$ show mac
200000000060e
 

