### PR TITLE
[config] add support for command "config interface pfc asymmetric EthernetXXX on/off"

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1069,14 +1069,13 @@ def pfc(ctx):
 #
 
 @pfc.command()
-@click.argument('status', type=click.Choice(['on', 'off']))
 @click.pass_context
-def asymmetric(ctx, status):
+@click.argument('interface_name', metavar='<interface_name>', required=True)
+@click.argument('status', type=click.Choice(['on', 'off']))
+def asymmetric(ctx, interface_name, status):
     """Set asymmetric PFC configuration."""
-    config_db = ctx.obj["config_db"]
-    interface = ctx.obj["interface_name"]
 
-    run_command("pfc config asymmetric {0} {1}".format(status, interface))
+    run_command("pfc config asymmetric {0} {1}".format(status, interface_name))
 
 #
 # 'platform' group ('config platform ...')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Add support for command "config interface pfc asymmetric EthernetXXX on/off".

**- How I did it**
Modify subcommand ``pfc asymmetric`` according to the adjustment of the command ``interface group``.

**- How to verify it**
1. First execute the command and observe the print;
2. Then use the command ``pfc show asymmetric`` to view the results.

**- Previous command output (if the output of a command-line utility has changed)**
```
admin@sonic:~$ sudo config interface pfc asymmetric Ethernet0 on
Usage: config interface pfc asymmetric [OPTIONS] STATUS

Error: Invalid value for "status": invalid choice: Ethernet0. (choose from on, off)
admin@sonic:~$
admin@sonic:~$ pfc show asymmetric Ethernet0


Interface    Asymmetric
-----------  ------------
Ethernet0    N/A


admin@sonic:~$

```
**- New command output (if the output of a command-line utility has changed)**
```
admin@sonic:~$ sudo config interface pfc asymmetric Ethernet0 on
admin@sonic:~$
admin@sonic:~$ pfc show asymmetric Ethernet0


Interface    Asymmetric
-----------  ------------
Ethernet0    on


admin@sonic:~$
admin@sonic:~$ sudo config interface pfc asymmetric Ethernet0 off
admin@sonic:~$
admin@sonic:~$ pfc show asymmetric Ethernet0


Interface    Asymmetric
-----------  ------------
Ethernet0    off


admin@sonic:~$

```

Signed-off-by: leo.li <leo.li@nephosinc.com>
