### PR TITLE
sonic_utilities: Support for DOM Threshold values for EEPROM dump

### DIFF
--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -39,8 +39,45 @@ qsfp_data_map = {'modelname': 'Vendor PN', 'vendor_oui': 'Vendor OUI',
                  }
 
 sfp_dom_channel_monitor_map = {'rx1power': 'RXPower',
-                               'tx1bias':  'TXBias',
+                               'tx1bias': 'TXBias',
                                'tx1power': 'TXPower'}
+
+sfp_dom_channel_threshold_map = {
+                                  'txpowerhighalarm':   'TxPowerHighAlarm',
+                                  'txpowerlowalarm':    'TxPowerLowAlarm',
+                                  'txpowerhighwarning': 'TxPowerHighWarning',
+                                  'txpowerlowwarning':  'TxPowerLowWarning',
+                                  'rxpowerhighalarm':   'RxPowerHighAlarm',
+                                  'rxpowerlowalarm':    'RxPowerLowAlarm',
+                                  'rxpowerhighwarning': 'RxPowerHighWarning',
+                                  'rxpowerlowwarning':  'RxPowerLowWarning',
+                                  'txbiashighalarm':    'TxBiasHighAlarm',
+                                  'txbiaslowalarm':     'TxBiasLowAlarm',
+                                  'txbiashighwarning':  'TxBiasHighWarning',
+                                  'txbiaslowwarning':   'TxBiasLowWarning',
+                                 }
+
+qsfp_dom_channel_threshold_map = {
+                                   'rxpowerhighalarm':   'RxPowerHighAlarm',
+                                   'rxpowerlowalarm':    'RxPowerLowAlarm',
+                                   'rxpowerhighwarning': 'RxPowerHighWarning',
+                                   'rxpowerlowwarning':  'RxPowerLowWarning',
+                                   'txbiashighalarm':    'TxBiasHighAlarm',
+                                   'txbiaslowalarm':     'TxBiasLowAlarm',
+                                   'txbiashighwarning':  'TxBiasHighWarning',
+                                   'txbiaslowwarning':   'TxBiasLowWarning',
+                                 }
+
+dom_module_threshold_map = {
+                             'temphighalarm':  'TempHighAlarm',
+                             'templowalarm':   'TempLowAlarm',
+                             'temphighwarning':'TempHighWarning',
+                             'templowwarning': 'TempLowWarning',
+                             'vcchighalarm':   'VccHighAlarm',
+                             'vcclowalarm':    'VccLowAlarm',
+                             'vcchighwarning': 'VccHighWarning',
+                             'vcclowwarning':  'VccLowWarning'
+                           }
 
 qsfp_dom_channel_monitor_map = {'rx1power': 'RX1Power', 'rx2power': 'RX2Power',
                                 'rx3power': 'RX3Power', 'rx4power': 'RX4Power',
@@ -51,39 +88,22 @@ qsfp_dom_channel_monitor_map = {'rx1power': 'RX1Power', 'rx2power': 'RX2Power',
 
 dom_module_monitor_map = {'temperature': 'Temperature', 'voltage': 'Vcc'}
 
-
-qsfp_dom_channel_threshold_map = {'rxpowerhighalarm':   'RxPowerHighAlarm',
-                                  'rxpowerlowalarm':    'RxPowerLowAlarm',
-                                  'rxpowerhighwarning': 'RxPowerHighWarning',
-                                  'rxpowerlowwarning':  'RxPowerLowWarning',
-                                  'txbiashighalarm':    'TxBiasHighAlarm',
-                                  'txbiaslowalarm':     'TxBiasLowAlarm',
-                                  'txbiashighwarning':  'TxBiasHighWarning',
-                                  'txbiaslowwarning':   'TxBiasLowWarning',
+dom_channel_threshold_unit_map = {
+                                   'txpowerhighalarm':   'dBm',
+                                   'txpowerlowalarm':    'dBm',
+                                   'txpowerhighwarning': 'dBm',
+                                   'txpowerlowwarning':  'dBm',
+                                   'rxpowerhighalarm':   'dBm',
+                                   'rxpowerlowalarm':    'dBm',
+                                   'rxpowerhighwarning': 'dBm',
+                                   'rxpowerlowwarning':  'dBm',
+                                   'txbiashighalarm':    'mA',
+                                   'txbiaslowalarm':     'mA',
+                                   'txbiashighwarning':  'mA',
+                                   'txbiaslowwarning':   'mA',
                                  }
 
-qsfp_dom_module_threshold_map = {'temphighalarm':  'TempHighAlarm',
-                                 'templowalarm':   'TempLowAlarm',
-                                 'temphighwarning':'TempHighWarning',
-                                 'templowwarning': 'TempLowWarning',
-                                 'vcchighalarm':   'VccHighAlarm',
-                                 'vcclowalarm':    'VccLowAlarm',
-                                 'vcchighwarning': 'VccHighWarning',
-                                 'vcclowwarning':  'VccLowWarning'
-                                }
-
-qsfp_dom_channel_threshold_unit_map = {
-                                  'rxpowerhighalarm':   'dBm',
-                                  'rxpowerlowalarm':    'dBm',
-                                  'rxpowerhighwarning': 'dBm',
-                                  'rxpowerlowwarning':  'dBm',
-                                  'txbiashighalarm':    'mA',
-                                  'txbiaslowalarm':     'mA',
-                                  'txbiashighwarning':  'mA',
-                                  'txbiaslowwarning':   'mA',
-                                 }
-
-qsfp_dom_module_threshold_unit_map = {
+dom_module_threshold_unit_map = {
                                  'temphighalarm':   'C',
                                  'templowalarm':    'C',
                                  'temphighwarning': 'C',
@@ -94,8 +114,6 @@ qsfp_dom_module_threshold_unit_map = {
                                  'vcclowwarning':   'Volts'
                                 }
 
-
-
 dom_value_unit_map = {'rx1power': 'dBm', 'rx2power': 'dBm',
                       'rx3power': 'dBm', 'rx4power': 'dBm',
                       'tx1bias': 'mA', 'tx2bias': 'mA',
@@ -103,6 +121,7 @@ dom_value_unit_map = {'rx1power': 'dBm', 'rx2power': 'dBm',
                       'tx1power': 'dBm', 'tx2power': 'dBm',
                       'tx3power': 'dBm', 'tx4power': 'dBm',
                       'temperature': 'C', 'voltage': 'Volts'}
+
 
 
 class SFPShow(object):
@@ -163,7 +182,7 @@ class SFPShow(object):
             out_put_channel_threshold = self.format_dict_value_to_string(
                                          sorted_key_table, dom_info_dict,
                                          qsfp_dom_channel_threshold_map,
-                                         qsfp_dom_channel_threshold_unit_map,
+                                         dom_channel_threshold_unit_map,
                                          channel_threshold_align)
             out_put_dom = out_put_dom + out_put_channel_threshold
 
@@ -180,11 +199,11 @@ class SFPShow(object):
             #Module Threshold
             out_put_dom = (out_put_dom + ident + 'ModuleThresholdValues'
                                                              + newline_ident)
-            sorted_key_table = natsorted(qsfp_dom_module_threshold_map)
+            sorted_key_table = natsorted(dom_module_threshold_map)
             out_put_module_threshold = self.format_dict_value_to_string(
                                          sorted_key_table, dom_info_dict,
-                                         qsfp_dom_module_threshold_map,
-                                         qsfp_dom_module_threshold_unit_map,
+                                         dom_module_threshold_map,
+                                         dom_module_threshold_unit_map,
                                          module_threshold_align)
             out_put_dom = out_put_dom + out_put_module_threshold
 
@@ -203,6 +222,26 @@ class SFPShow(object):
                                             dom_module_monitor_map,
                                             dom_value_unit_map)
             out_put_dom = out_put_dom + out_put_module
+
+            out_put_dom = (out_put_dom + ident + 'ThresholdData'
+                                                             + newline_ident)
+            #Module Threshold
+            sorted_key_table = natsorted(dom_module_threshold_map)
+            out_put_module_threshold = self.format_dict_value_to_string(
+                                         sorted_key_table, dom_info_dict,
+                                         dom_module_threshold_map,
+                                         dom_module_threshold_unit_map,
+                                         module_threshold_align)
+            out_put_dom = out_put_dom + out_put_module_threshold
+
+            #Channel Threshold
+            sorted_key_table = natsorted(sfp_dom_channel_threshold_map)
+            out_put_channel_threshold = self.format_dict_value_to_string(
+                                         sorted_key_table, dom_info_dict,
+                                         sfp_dom_channel_threshold_map,
+                                         dom_channel_threshold_unit_map,
+                                         channel_threshold_align)
+            out_put_dom = out_put_dom + out_put_channel_threshold
 
         return out_put_dom
 

--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -38,16 +38,63 @@ qsfp_data_map = {'modelname': 'Vendor PN', 'vendor_oui': 'Vendor OUI',
                  'encoding': 'Encoding', 'Connector': 'Connector' 
                  }
 
-sfp_dom_channel_monitor_map = {'rx1power': 'RXPower', 'tx1bias': 'TXBias', 'tx1power': 'TXPower'}
+sfp_dom_channel_monitor_map = {'rx1power': 'RXPower',
+                               'tx1bias':  'TXBias',
+                               'tx1power': 'TXPower'}
 
 qsfp_dom_channel_monitor_map = {'rx1power': 'RX1Power', 'rx2power': 'RX2Power',
                                 'rx3power': 'RX3Power', 'rx4power': 'RX4Power',
-                                'tx1bias': 'TX1Bias', 'tx2bias': 'TX2Bias',
-                                'tx3bias': 'TX3Bias', 'tx4bias': 'TX4Bias',
+                                'tx1bias':  'TX1Bias',  'tx2bias':  'TX2Bias',
+                                'tx3bias':  'TX3Bias',  'tx4bias':  'TX4Bias',
                                 'tx1power': 'TX1Power', 'tx2power': 'TX2Power',
                                 'tx3power': 'TX3Power', 'tx4power': 'TX4Power'}
 
 dom_module_monitor_map = {'temperature': 'Temperature', 'voltage': 'Vcc'}
+
+
+qsfp_dom_channel_threshold_map = {'rxpowerhighalarm':   'RxPowerHighAlarm',
+                                  'rxpowerlowalarm':    'RxPowerLowAlarm',
+                                  'rxpowerhighwarning': 'RxPowerHighWarning',
+                                  'rxpowerlowwarning':  'RxPowerLowWarning',
+                                  'txbiashighalarm':    'TxBiasHighAlarm',
+                                  'txbiaslowalarm':     'TxBiasLowAlarm',
+                                  'txbiashighwarning':  'TxBiasHighWarning',
+                                  'txbiaslowwarning':   'TxBiasLowWarning',
+                                 }
+
+qsfp_dom_module_threshold_map = {'temphighalarm':  'TempHighAlarm',
+                                 'templowalarm':   'TempLowAlarm',
+                                 'temphighwarning':'TempHighWarning',
+                                 'templowwarning': 'TempLowWarning',
+                                 'vcchighalarm':   'VccHighAlarm',
+                                 'vcclowalarm':    'VccLowAlarm',
+                                 'vcchighwarning': 'VccHighWarning',
+                                 'vcclowwarning':  'VccLowWarning'
+                                }
+
+qsfp_dom_channel_threshold_unit_map = {
+                                  'rxpowerhighalarm':   'dBm',
+                                  'rxpowerlowalarm':    'dBm',
+                                  'rxpowerhighwarning': 'dBm',
+                                  'rxpowerlowwarning':  'dBm',
+                                  'txbiashighalarm':    'mA',
+                                  'txbiaslowalarm':     'mA',
+                                  'txbiashighwarning':  'mA',
+                                  'txbiaslowwarning':   'mA',
+                                 }
+
+qsfp_dom_module_threshold_unit_map = {
+                                 'temphighalarm':   'C',
+                                 'templowalarm':    'C',
+                                 'temphighwarning': 'C',
+                                 'templowwarning':  'C',
+                                 'vcchighalarm':    'Volts',
+                                 'vcclowalarm':     'Volts',
+                                 'vcchighwarning':  'Volts',
+                                 'vcclowwarning':   'Volts'
+                                }
+
+
 
 dom_value_unit_map = {'rx1power': 'dBm', 'rx2power': 'dBm',
                       'rx3power': 'dBm', 'rx4power': 'dBm',
@@ -56,7 +103,6 @@ dom_value_unit_map = {'rx1power': 'dBm', 'rx2power': 'dBm',
                       'tx1power': 'dBm', 'tx2power': 'dBm',
                       'tx3power': 'dBm', 'tx4power': 'dBm',
                       'temperature': 'C', 'voltage': 'Volts'}
-
 
 
 class SFPShow(object):
@@ -70,39 +116,93 @@ class SFPShow(object):
         self.sdb.connect(self.sdb.STATE_DB)
         return
 
-    # Convert channel monitor values to cli output string
-    def convert_channel_monitor_value_to_output_string(self, sorted_key_table, dom_info_dict, channel_monitor_map):
+    # Convert dict values to cli output string
+    def format_dict_value_to_string(self, sorted_key_table,
+                                    dom_info_dict, dom_value_map,
+                                    dom_unit_map, alignment = 0):
         out_put=''
         ident = '        '
+        seperator = ": "
         for key in sorted_key_table:
             if dom_info_dict[key] != 'N/A':
+                current_val = (ident + ident +
+                        dom_value_map[key])
+                current_val = (current_val + seperator.rjust(len(seperator) +
+                               alignment - len(dom_value_map[key])))
                 if dom_info_dict[key] == 'Unknown':
-                    out_put = out_put + ident + ident + channel_monitor_map[key] + ': ' + dom_info_dict[key] + '\n'
+                    current_val = (current_val + dom_info_dict[key])
                 else:
-                    out_put = out_put + ident + ident + channel_monitor_map[key] + ': ' + dom_info_dict[key] + dom_value_unit_map[key] + '\n'
+                    current_val = (current_val + dom_info_dict[key] +
+                               dom_unit_map[key])
+                out_put  = out_put + current_val + '\n'
         return out_put
      
     # Convert dom sensor info in DB to cli output string
     def convert_dom_to_output_string(self, sfp_type, dom_info_dict):
         ident = '        '
         out_put_dom = ''
+        newline_ident = ': ' + '\n'
+        channel_threshold_align = 18
+        module_threshold_align = 15
+
         if sfp_type.startswith('QSFP'):
-            out_put_dom = out_put_dom + ident + 'ChannelMonitorValues' + ': ' + '\n'
-            sorted_dom_channel_monitor_info_key_table = natsorted(qsfp_dom_channel_monitor_map)
-            out_put_channel = self.convert_channel_monitor_value_to_output_string(sorted_dom_channel_monitor_info_key_table, dom_info_dict, qsfp_dom_channel_monitor_map)
+            #Channel Monitor
+            out_put_dom = (out_put_dom + ident + 'ChannelMonitorValues'
+                                                             + newline_ident)
+            sorted_key_table = natsorted(qsfp_dom_channel_monitor_map)
+            out_put_channel = self.format_dict_value_to_string(
+                                            sorted_key_table, dom_info_dict,
+                                            qsfp_dom_channel_monitor_map,
+                                            dom_value_unit_map)
             out_put_dom = out_put_dom + out_put_channel
 
-            out_put_dom = out_put_dom + ident + 'ModuleMonitorValues' + ': ' + '\n'
+            #Channel Threshold
+            out_put_dom = (out_put_dom + ident + 'ChannelThresholdValues'
+                                                             + newline_ident)
+            sorted_key_table = natsorted(qsfp_dom_channel_threshold_map)
+            out_put_channel_threshold = self.format_dict_value_to_string(
+                                         sorted_key_table, dom_info_dict,
+                                         qsfp_dom_channel_threshold_map,
+                                         qsfp_dom_channel_threshold_unit_map,
+                                         channel_threshold_align)
+            out_put_dom = out_put_dom + out_put_channel_threshold
+
+            # Module Monitor
+            out_put_dom = (out_put_dom + ident + 'ModuleMonitorValues'
+                                                             + newline_ident)
+            sorted_key_table = natsorted(dom_module_monitor_map)
+            out_put_module = self.format_dict_value_to_string(
+                                            sorted_key_table, dom_info_dict,
+                                            dom_module_monitor_map,
+                                            dom_value_unit_map)
+            out_put_dom = out_put_dom + out_put_module
+
+            #Module Threshold
+            out_put_dom = (out_put_dom + ident + 'ModuleThresholdValues'
+                                                             + newline_ident)
+            sorted_key_table = natsorted(qsfp_dom_module_threshold_map)
+            out_put_module_threshold = self.format_dict_value_to_string(
+                                         sorted_key_table, dom_info_dict,
+                                         qsfp_dom_module_threshold_map,
+                                         qsfp_dom_module_threshold_unit_map,
+                                         module_threshold_align)
+            out_put_dom = out_put_dom + out_put_module_threshold
 
         else:
-            out_put_dom = out_put_dom + ident + 'MonitorData' + ': ' + '\n'
-            sorted_dom_channel_monitor_info_key_table = natsorted(sfp_dom_channel_monitor_map)
-            out_put_channel = self.convert_channel_monitor_value_to_output_string(sorted_dom_channel_monitor_info_key_table, dom_info_dict, sfp_dom_channel_monitor_map)
+            out_put_dom = out_put_dom + ident + 'MonitorData' + newline_ident
+            sorted_key_table = natsorted(sfp_dom_channel_monitor_map)
+            out_put_channel = self.format_dict_value_to_string(
+                                            sorted_key_table, dom_info_dict,
+                                            sfp_dom_channel_monitor_map,
+                                            dom_value_unit_map)
             out_put_dom = out_put_dom + out_put_channel
 
-        sorted_dom_module_monitor_info_key_table = natsorted(dom_module_monitor_map)
-        out_put_module = self.convert_channel_monitor_value_to_output_string(sorted_dom_module_monitor_info_key_table, dom_info_dict, dom_module_monitor_map)
-        out_put_dom = out_put_dom + out_put_module
+            sorted_key_table = natsorted(dom_module_monitor_map)
+            out_put_module = self.format_dict_value_to_string(
+                                            sorted_key_table, dom_info_dict,
+                                            dom_module_monitor_map,
+                                            dom_value_unit_map)
+            out_put_dom = out_put_dom + out_put_module
 
         return out_put_dom
 

--- a/sonic-utilities-tests/mock_tables/state_db.json
+++ b/sonic-utilities-tests/mock_tables/state_db.json
@@ -30,7 +30,23 @@
         "tx1power": "N/A",
         "tx2power": "N/A",
         "tx3power": "N/A",
-        "tx4power": "N/A"
+        "tx4power": "N/A",
+        "rxpowerhighalarm": "3.4001",
+        "rxpowerhighwarning": "2.4000",
+        "rxpowerlowalarm": "-13.5067",
+        "rxpowerlowwarning": "-9.5001",
+        "txbiashighalarm": "10.0000",
+        "txbiashighwarning": "9.5000",
+        "txbiaslowalarm": "0.5000",
+        "txbiaslowwarning": "1.0000",
+        "temphighalarm": "75.0000",
+        "temphighwarning": "70.0000",
+        "templowalarm": "-5.0000",
+        "templowwarning": "0.0000",
+        "vcchighalarm": "3.6300",
+        "vcchighwarning": "3.4650",
+        "vcclowalarm": "2.9700",
+        "vcclowwarning": "3.1349"
     },
     "CHASSIS_INFO|chassis 1": {
         "psu_num": "2"

--- a/sonic-utilities-tests/sfp_test.py
+++ b/sonic-utilities-tests/sfp_test.py
@@ -60,9 +60,27 @@ Ethernet200  Not present
                 TX2Bias: 6.7500mA
                 TX3Bias: 6.7500mA
                 TX4Bias: 6.7500mA
+        ChannelThresholdValues: 
+                RxPowerHighAlarm  : 3.4001dBm
+                RxPowerHighWarning: 2.4000dBm
+                RxPowerLowAlarm   : -13.5067dBm
+                RxPowerLowWarning : -9.5001dBm
+                TxBiasHighAlarm   : 10.0000mA
+                TxBiasHighWarning : 9.5000mA
+                TxBiasLowAlarm    : 0.5000mA
+                TxBiasLowWarning  : 1.0000mA
         ModuleMonitorValues: 
                 Temperature: 30.9258C
                 Vcc: 3.2824Volts
+        ModuleThresholdValues: 
+                TempHighAlarm  : 75.0000C
+                TempHighWarning: 70.0000C
+                TempLowAlarm   : -5.0000C
+                TempLowWarning : 0.0000C
+                VccHighAlarm   : 3.6300Volts
+                VccHighWarning : 3.4650Volts
+                VccLowAlarm    : 2.9700Volts
+                VccLowWarning  : 3.1349Volts
 
 """
         assert result.output == expected
@@ -100,4 +118,3 @@ Ethernet200  Not present
         os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])
         os.environ["UTILITIES_UNIT_TESTING"] = "0"
 
-        


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Added support to dump Dom Threshold values along with other dom values as per EEPROM sff8436 standard.
**- How I did it**
Read the eeprom,  save the redis transceiver_dom table with threshold values.

**- How to verify it**
sfpshow eeprom --dom
**- Previous command output (if the output of a command-line utility has changed)**
Ethernet124: SFP EEPROM detected
        Connector: MPOx12
        Encoding: 64B66B
        Extended Identifier: Power Class 1(1.5W max)
        Extended RateSelect Compliance: QSFP+ Rate Select Version 1
        Identifier: QSFP+ or later
        Length OM3(2m): 50
        Nominal Bit Rate(100Mbs): 103
        Specification compliance:
                10/40G Ethernet Compliance Code: 40GBASE-SR4
        Vendor Date Code(YYYY-MM-DD Lot): 2010-09-01
        Vendor Name: AVAGO
        Vendor OUI: 00-17-6a
        Vendor PN: AFBR-79E4Z-D
        Vendor Rev: 01
        Vendor SN: QA340092
        ChannelMonitorValues:
                RX1Power: -16.3827dBm
                RX2Power: -infdBm
                RX3Power: -15.5284dBm
                RX4Power: -infdBm
                TX1Bias: 5.9720mA
                TX2Bias: 5.3740mA
                TX3Bias: 5.3800mA
                TX4Bias: 6.0540mA
        ModuleMonitorValues:
                Temperature: 32.4688C
                Vcc: 3.3458Volts


**- New command output (if the output of a command-line utility has changed)**
Ethernet124: SFP EEPROM detected
        Connector: MPOx12
        Encoding: 64B66B
        Extended Identifier: Power Class 1(1.5W max)
        Extended RateSelect Compliance: QSFP+ Rate Select Version 1
        Identifier: QSFP+ or later
        Length OM3(2m): 50
        Nominal Bit Rate(100Mbs): 103
        Specification compliance:
                10/40G Ethernet Compliance Code: 40GBASE-SR4
        Vendor Date Code(YYYY-MM-DD Lot): 2010-09-01
        Vendor Name: AVAGO
        Vendor OUI: 00-17-6a
        Vendor PN: AFBR-79E4Z-D
        Vendor Rev: 01
        Vendor SN: QA340092
        ChannelMonitorValues:
                RX1Power: -16.3827dBm
                RX2Power: -infdBm
                RX3Power: -15.5284dBm
                RX4Power: -infdBm
                TX1Bias: 5.9720mA
                TX2Bias: 5.3740mA
                TX3Bias: 5.3800mA
                TX4Bias: 6.0540mA
        ChannelThresholdValues:
                RxPowerHighAlarm    : 3.4001dBm
                RxPowerHighWarning: 2.4000dBm
                RxPowerLowAlarm     : -13.5067dBm
                RxPowerLowWarning : -9.5001dBm
                TxBiasHighAlarm        : 10.0000mA
                TxBiasHighWarning    : 9.5000mA
                TxBiasLowAlarm         : 0.5000mA
                TxBiasLowWarning     : 1.0000mA
        ModuleMonitorValues:
                Temperature: 32.4688C
                Vcc: 3.3458Volts
        ModuleThresholdValues:
                TempHighAlarm    : 75.0000C
                TempHighWarning: 70.0000C
                TempLowAlarm     : -5.0000C
                TempLowWarning : 0.0000C
                VccHighAlarm       : 3.6300Volts
                VccHighWarning   : 3.4650Volts
                VccLowAlarm        : 2.9700Volts
                VccLowWarning    : 3.1349Volts


-->

