### PR TITLE
[Mellanox] Improve the prompt of the Mellanox sdk sniffer command.

### DIFF
--- a/config/mlnx.py
+++ b/config/mlnx.py
@@ -198,21 +198,32 @@ def sniffer():
 
 
 # 'sdk' subgroup
-@sniffer.command()
-@click.option('-y', '--yes', is_flag=True, callback=_abort_if_false, expose_value=False,
-              prompt='To change SDK sniffer status, swss service will be restarted, continue?')
-@click.argument('option', type=click.Choice(["enable", "disable"]))
-def sdk(option):
+@sniffer.group()
+def sdk():
     """SDK Sniffer - Command Line to enable/disable SDK sniffer"""
-    if option == 'enable':
-        sdk_sniffer_enable()
-    elif option == 'disable':
-        sdk_sniffer_disable()
+    pass
+
+
+@sdk.command()
+@click.option('-y', '--yes', is_flag=True, callback=_abort_if_false, expose_value=False,
+              prompt='To turn on the SDK sniffer, swss service will be restarted and it can excessively consume storage space, continue?')
+def enable():
+    """Enable SDK Sniffer"""
+    print "Enabling SDK sniffer"
+    sdk_sniffer_enable()
+
+
+@sdk.command()
+@click.option('-y', '--yes', is_flag=True, callback=_abort_if_false, expose_value=False,
+              prompt='To turn off the SDK sniffer, swss service will be restarted, continue?')
+def disable():
+    """Disable SDK Sniffer"""
+    print "Disabling SDK sniffer"
+    sdk_sniffer_disable()
 
 
 def sdk_sniffer_enable():
     """Enable SDK Sniffer"""
-    print "Enabling SDK sniffer"
     sdk_sniffer_filename = sniffer_filename_generate(SDK_SNIFFER_TARGET_PATH,
                                                      SDK_SNIFFER_FILENAME_PREFIX,
                                                      SDK_SNIFFER_FILENAME_EXT)
@@ -238,7 +249,6 @@ def sdk_sniffer_enable():
 
 def sdk_sniffer_disable():
     """Disable SDK Sniffer"""
-    print "Disabling SDK sniffer"
 
     ignore = sniffer_env_variable_set(enable=False, env_variable_name=ENV_VARIABLE_SX_SNIFFER)
     if not ignore:

--- a/config/mlnx.py
+++ b/config/mlnx.py
@@ -206,16 +206,17 @@ def sdk():
 
 @sdk.command()
 @click.option('-y', '--yes', is_flag=True, callback=_abort_if_false, expose_value=False,
-              prompt='To turn on the SDK sniffer, swss service will be restarted and it can excessively consume storage space, continue?')
+              prompt='Swss service will be restarted, continue?')
 def enable():
     """Enable SDK Sniffer"""
     print "Enabling SDK sniffer"
     sdk_sniffer_enable()
+    print "Note: the sniffer file may exhaust the space on /var/log, please disable it when you are done with this sniffering."
 
 
 @sdk.command()
 @click.option('-y', '--yes', is_flag=True, callback=_abort_if_false, expose_value=False,
-              prompt='To turn off the SDK sniffer, swss service will be restarted, continue?')
+              prompt='Swss service will be restarted, continue?')
 def disable():
     """Disable SDK Sniffer"""
     print "Disabling SDK sniffer"
@@ -242,7 +243,7 @@ def sdk_sniffer_enable():
         err = restart_swss()
         if err is not 0:
             return
-        print 'Enabled SDK sniffer, recording file is %s' % sdk_sniffer_filename
+        print 'SDK sniffer is Enabled, recording file is %s.' % sdk_sniffer_filename
     else:
         pass
 
@@ -255,7 +256,7 @@ def sdk_sniffer_disable():
         err = restart_swss()
         if err is not 0:
             return
-        print "Disabled SDK sniffer"
+        print "SDK sniffer is Disabled."
     else:
         pass
 


### PR DESCRIPTION
**- What I did**
Prompt the risk of excessive consumption of disk space when user intends to turn on the sdk sniffer.
The SDK sniffer is a diagnosis feature, introduced with a view to recording all the operations to SDK into the sniffer file which the low-level team can replay and investigate. Only the sniffer file contains all the operations from SWSS restart does it help. To handle it in a way like log-rotate to limit its size can hurt its integrity since the operating records can be lost during rotating and to address this requires a big effort.
So we just add a prompt of that risk for now.

**- Previous command output (if the output of a command-line utility has changed)**

    admin@arc-mtbc-1001:~$ sudo config platform mlnx sniffer sdk enable
    To change SDK sniffer status, swss service will be restarted, continue? [y/N]: y
    Enabling SDK sniffer
    Enabled SDK sniffer, recording file is /var/log/mellanox/sniffer/sx_sdk_sniffer_20190530012428.pcap
    admin@arc-mtbc-1001:~$ sudo config platform mlnx sniffer sdk disable
    To change SDK sniffer status, swss service will be restarted, continue? [y/N]: y
    Disabling SDK sniffer
    Disabled SDK sniffer

**- New command output (if the output of a command-line utility has changed)**

    admin@mtbc-sonic-01-2410:~$ sudo config platform mlnx sniffer sdk enable 
    Swss service will be restarted, continue? [y/N]: y
    Enabling SDK sniffer
    SDK sniffer is Enabled, recording file is /var/log/mellanox/sniffer/sx_sdk_sniffer_20190601091204.pcap.
    Note: the sniffer file may exhaust the space on /var/log, please disable it when you are done with this sniffering.
    admin@mtbc-sonic-01-2410:~$ sudo config platform mlnx sniffer sdk disable 
    Swss service will be restarted, continue? [y/N]: y
    Disabling SDK sniffer
    SDK sniffer is Disabled.

Signed-off-by: Stephen Sun <stephens@mellanox.com>
