### PR TITLE
[intfutil] Fix error when <interface name> specified in show interface related commands

### DIFF
--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -87,7 +87,7 @@ def appl_db_keys_get(appl_db, front_panel_ports_list, intf_name):
     if intf_name is None:
         appl_db_keys = appl_db.keys(appl_db.APPL_DB, "PORT_TABLE:*")
     elif intf_name in front_panel_ports_list:
-        appl_db_keys = db.keys(appl_db.APPL_DB, "PORT_TABLE:%s" % intf_name)
+        appl_db_keys = appl_db.keys(appl_db.APPL_DB, "PORT_TABLE:%s" % intf_name)
     else:
         return None
     return appl_db_keys


### PR DESCRIPTION
**What I did**
show interface status Ethernet0 and show interface description Ethernet0. And the error message is dump

**Why I did it**
Use an incorrect variable db to get APP_DB. The correct variable should be appl_db

**How I verified it**
After modifying correct variable, the show interface status <interface name> would show correct value