### PR TITLE
Enhancing port utilization percentage calculation for all port speeds

### DIFF
--- a/scripts/portstat
+++ b/scripts/portstat
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 #####################################################################
 #
 # portstat is a tool for summarizing network statistics. 
@@ -57,6 +56,8 @@ COUNTERS_PORT_NAME_MAP = "COUNTERS_PORT_NAME_MAP"
 PORT_STATUS_TABLE_PREFIX = "PORT_TABLE:"
 PORT_OPER_STATUS_FIELD = "oper_status"
 PORT_ADMIN_STATUS_FIELD = "admin_status"
+PORT_TABLE_PREFIX = "PORT|"
+PORT_SPEED_FIELD = "speed"
 PORT_STATUS_VALUE_UP = 'UP'
 PORT_STATUS_VALUE_DOWN = 'DOWN'
 
@@ -67,6 +68,7 @@ PORT_STATE_DISABLED = 'X'
 class Portstat(object):
     def __init__(self):
         self.db = swsssdk.SonicV2Connector(host='127.0.0.1')
+        self.db.connect(self.db.CONFIG_DB)
         self.db.connect(self.db.COUNTERS_DB)
         self.db.connect(self.db.APPL_DB)
 
@@ -117,6 +119,17 @@ class Portstat(object):
             return PORT_STATE_DOWN
         else:
             return STATUS_NA
+    
+    def get_port_speed(self, port_name):
+        """
+            Get the port speed
+        """
+        full_table_id = PORT_TABLE_PREFIX + port_name
+        port_speed = self.db.get(self.db.CONFIG_DB, full_table_id, PORT_SPEED_FIELD)
+        if port_speed is None:
+             return STATUS_NA
+        else:
+            return port_speed
 
     def cnstat_diff_print(self, cnstat_new_dict, cnstat_old_dict, use_json=False, print_all=False):
         """
@@ -143,14 +156,14 @@ class Portstat(object):
                               ns_diff(cntr.rx_ok, old_cntr.rx_ok),
                               ns_brate(cntr.rx_byt, old_cntr.rx_byt, time_gap),
                               ns_prate(cntr.rx_ok, old_cntr.rx_ok, time_gap),
-                              ns_util(cntr.rx_byt, old_cntr.rx_byt, time_gap),
+                              ns_util(cntr.rx_byt, old_cntr.rx_byt, time_gap, self.get_port_speed(key)),
                               ns_diff(cntr.rx_err, old_cntr.rx_err),
                               ns_diff(cntr.rx_drop, old_cntr.rx_drop),
                               ns_diff(cntr.rx_ovr, old_cntr.rx_ovr),
                               ns_diff(cntr.tx_ok, old_cntr.tx_ok),
                               ns_brate(cntr.tx_byt, old_cntr.tx_byt, time_gap),
                               ns_prate(cntr.tx_ok, old_cntr.tx_ok, time_gap),
-                              ns_util(cntr.tx_byt, old_cntr.tx_byt, time_gap),
+                              ns_util(cntr.tx_byt, old_cntr.tx_byt, time_gap, self.get_port_speed(key)),
                               ns_diff(cntr.tx_err, old_cntr.tx_err),
                               ns_diff(cntr.tx_drop, old_cntr.tx_drop),
                               ns_diff(cntr.tx_ovr, old_cntr.tx_ovr)))
@@ -158,13 +171,13 @@ class Portstat(object):
                 table.append((key, self.get_port_state(key),
                               ns_diff(cntr.rx_ok, old_cntr.rx_ok),
                               ns_brate(cntr.rx_byt, old_cntr.rx_byt, time_gap),
-                              ns_util(cntr.rx_byt, old_cntr.rx_byt, time_gap),
+                              ns_util(cntr.rx_byt, old_cntr.rx_byt, time_gap, self.get_port_speed(key)),
                               ns_diff(cntr.rx_err, old_cntr.rx_err),
                               ns_diff(cntr.rx_drop, old_cntr.rx_drop),
                               ns_diff(cntr.rx_ovr, old_cntr.rx_ovr),
                               ns_diff(cntr.tx_ok, old_cntr.tx_ok),
                               ns_brate(cntr.tx_byt, old_cntr.tx_byt, time_gap),
-                              ns_util(cntr.tx_byt, old_cntr.tx_byt, time_gap),
+                              ns_util(cntr.tx_byt, old_cntr.tx_byt, time_gap, self.get_port_speed(key)),
                               ns_diff(cntr.tx_err, old_cntr.tx_err),
                               ns_diff(cntr.tx_drop, old_cntr.tx_drop),
                               ns_diff(cntr.tx_ovr, old_cntr.tx_ovr)))

--- a/utilities_common/netstat.py
+++ b/utilities_common/netstat.py
@@ -3,7 +3,6 @@
 import json
 
 STATUS_NA = 'N/A'
-PORT_RATE = 40
 
 def ns_diff(newstr, oldstr):
     """
@@ -41,15 +40,15 @@ def ns_prate(newstr, oldstr, delta):
         rate = int(ns_diff(newstr, oldstr).replace(',',''))/delta
         return "{:.2f}".format(rate)+'/s'
 
-def ns_util(newstr, oldstr, delta):
+def ns_util(newstr, oldstr, delta, port_rate):
     """
         Calculate the util.
     """
-    if newstr == STATUS_NA or oldstr == STATUS_NA:
+    if newstr == STATUS_NA or oldstr == STATUS_NA or port_rate == STATUS_NA:
         return STATUS_NA
     else:
         rate = int(ns_diff(newstr, oldstr).replace(',',''))/delta
-        util = rate/(PORT_RATE*1024*1024*1024/8.0)*100
+        util = rate/(int(port_rate)*1000*1000/8.0)*100
         return "{:.2f}%".format(util)
 
 def table_as_json(table, header):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
The utilization percentage calculation for interfaces is been updated to address all the port speeds. It was calculated for 40G alone previously.
**- How I did it**
The utilization percentage is based on the port speed. It should be the percentage of traffic rate with respect to the port speed. So the formula is been updated to take the actual port speed instead of 40Gbps. 
10Gbps is 1000000 bits per second, NOT 10*1024*1024*1024 bps. This is also fixed in utilization formula.

**- How to verify it**
show interface counters 
This command can be used to verify the utilization percentage at different traffic rates.
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->
