### PR TITLE
Change ip-helper address in CLI and show to verify

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -721,28 +721,28 @@ def helper_ip(ctx, helper_ip, vid):
 
     if vid is None:
         if not vlan_table_dict:
-		ctx.fail("No VLAN is configured yet")
-	else:
-		for vkey in vlan_table_dict.keys():
-			if 'dhcp_servers' in vlan_table_dict[vkey]:
-				db.mod_entry('VLAN', '{}'.format(vkey), {'dhcp_servers@': '{}'.format(helper_ip)})
-			else:
-				db.set_entry('VLAN', '{}'.format(vkey), {'dhcp_servers@': '{}'.format(helper_ip)})
+	    ctx.fail("No VLAN is configured yet")
+        else:
+            for vkey in vlan_table_dict.keys():
+                if 'dhcp_servers' in vlan_table_dict[vkey]:
+                    db.mod_entry('VLAN', '{}'.format(vkey), {'dhcp_servers@': '{}'.format(helper_ip)})
+                else:
+                    db.set_entry('VLAN', '{}'.format(vkey), {'dhcp_servers@': '{}'.format(helper_ip)})
 
     else:
-	vlan_name = 'Vlan{}'.format(vid)
-	vlan_entry = db.get_entry('VLAN', vlan_name)
-	if len(vlan_entry) == 0:
-		ctx.fail("{} doesn't exist".format(vlan_name))
-	elif 'dhcp_servers' in vlan_entry:
-		db.mod_entry('VLAN', 'Vlan{}'.format(vid), {'dhcp_servers@': '{}'.format(helper_ip)})
-	else:
-		db.set_entry('VLAN', 'Vlan{}'.format(vid), {'dhcp_servers@': '{}'.format(helper_ip)})
+        vlan_name = 'Vlan{}'.format(vid)
+        vlan_entry = db.get_entry('VLAN', vlan_name)
+        if len(vlan_entry) == 0:
+            ctx.fail("{} doesn't exist".format(vlan_name))
+        elif 'dhcp_servers' in vlan_entry:
+            db.mod_entry('VLAN', 'Vlan{}'.format(vid), {'dhcp_servers@': '{}'.format(helper_ip)})
+        else:
+             db.set_entry('VLAN', 'Vlan{}'.format(vid), {'dhcp_servers@': '{}'.format(helper_ip)})
 
     try:
-	run_command("service dhcp_relay restart", display_cmd=True)
+        run_command("service dhcp_relay restart", display_cmd=True)
     except SystemExit as e:
-	click.echo("Restarting dhcp_relay service failed with error {}".format(e))
+        click.echo("Restarting dhcp_relay service failed with error {}".format(e))
         raise
 
 #

--- a/show/main.py
+++ b/show/main.py
@@ -1236,6 +1236,36 @@ def version(verbose):
     click.echo(p.stdout.read())
 
 #
+# 'dhcp_relay' command ("show dhcp_relay")
+#
+
+@cli.group(cls=AliasedGroup, default_if_no_args=False)
+def dhcp_relay():
+    """Show dhcp-relay helper ip for all vlan"""
+    pass
+
+@dhcp_relay.command()
+@click.argument('vid', metavar='<vid>', required=False, type=int)
+@click.option('--verbose', is_flag=True, help="Enable verbose output")
+def vlan(vid, verbose):
+    """Show dhcp-relay helper ip for a vlan"""
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    vlan_dict = config_db.get_table('VLAN')
+
+    header = ['VLAN ID', 'HELPER IP']
+    body = []
+    if vid is not None:
+        vlan = 'Vlan'+str(vid)
+        if vlan in vlan_dict.keys():
+                body.append([vlan, vlan_dict[vlan]['dhcp_servers'][0].encode("utf-8")])
+    else:
+        for vlan in vlan_dict.keys():
+                body.append([vlan, vlan_dict[vlan]['dhcp_servers'][0].encode("utf-8")])
+
+    click.echo(tabulate(body, header))
+
+#
 # 'environment' command ("show environment")
 #
 


### PR DESCRIPTION
Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>


**- What I did**
Introducing **dhcp_relay** subbcommand under vlan command to change dhcp-relay ip-helper address via **config** CLI and verify using **show** CLI command.

**- How I did it**
using config db
**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**
                     Introducing new subcommands. N/A
**- New command output (if the output of a command-line utility has changed)**


**admin@lnos-x1-a-csw04:/usr/lib/python2.7/dist-packages$ sudo config vlan dhcp_relay --help**
Usage: config vlan dhcp_relay [OPTIONS] <helper_ip> <vid>
Options:
  --help  Show this message and exit.

_if vid is mentioned , it will take particular vlan id. Otherwise, it will consider for all vlans by default._
```
**admin@lnos-x1-a-csw04:~$ show dhcp_relay vlan**   _---> Before the changing helper ip address_
VLAN ID    HELPER IP
Vlan100    10.189.64.1
Vlan777    10.189.64.1
```

**Changed ip-helper address of one vlan specifying vlan id (i.e. 100) using config command CLI**
```
admin@lnos-x1-a-csw04:/usr/lib/python2.7/dist-packages$ sudo config vlan dhcp_relay 1.2.3.4 100
Running command: service dhcp_relay restart

### Verification
admin@lnos-x1-a-csw04:/usr/lib/python2.7/dist-packages$ show dhcp_relay vlan
VLAN ID    HELPER IP
Vlan100    1.2.3.4
Vlan777    10.189.64.1
```
**Changed ip-helper address of all vlans present in config db using config command CLI.**
```
**_admin@lnos-x1-a-csw04:/usr/lib/python2.7/dist-packages$ sudo config vlan dhcp_relay 10.10.11.11_**
Running command: service dhcp_relay restart

### Verification
**_admin@lnos-x1-a-csw04:/usr/lib/python2.7/dist-packages$ show dhcp_relay vlan_**
VLAN ID    HELPER IP
Vlan100    10.10.11.11
Vlan777    10.10.11.11
```

### Verification of  show commands
```
admin@lnos-x1-a-csw04:~$ show dhcp_relay
Usage: show dhcp_relay [OPTIONS] COMMAND [ARGS]...
Show dhcp-relay helper ip for all vlan

Options:
  -?, -h, --help  Show this message and exit.
Commands:
  vlan  Show dhcp-relay helper ip for a vlan


### show dhcp_relay command
**admin@lnos-x1-a-csw04:~$ show dhcp_relay vlan**
VLAN ID    HELPER IP
Vlan100    10.10.11.11
Vlan777    10.10.11.11

admin@lnos-x1-a-csw04:~$ show dhcp_relay vlan 100
VLAN ID    HELPER IP
Vlan100    10.10.11.11

admin@lnos-x1-a-csw04:~$ show dhcp_relay vlan 777
VLAN ID    HELPER IP
Vlan777    10.10.11.11
```
### Result of test case when the user-specified VLAN does not exist ->
```
admin@lnos-x1-a-csw04:~$ sudo config vlan dhcp_relay 1.1.1.1 300
Usage: config vlan dhcp_relay [OPTIONS] <helper_ip> <vid>

Error: Vlan300 doesn't exist

### Result of test case for no VLAN configured ->

admin@lnos-x1-a-csw04:/usr/lib/python2.7/dist-packages$ sudo config vlan dhcp_relay 1.1.1.1
Usage: config vlan dhcp_relay [OPTIONS] <helper_ip> <vid>

Error: No VLAN is configured yet

```