### PR TITLE
[warm-reboot] add docker upgrade --warm option and roll back support

### DIFF
--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -8,6 +8,7 @@ import sys
 import time
 import click
 import urllib
+import syslog
 import subprocess
 from swsssdk import ConfigDBConnector
 from swsssdk import SonicV2Connector
@@ -265,6 +266,37 @@ def abort_if_false(ctx, param, value):
     if not value:
         ctx.abort()
 
+def get_container_image_name(container_name):
+    # example image: docker-lldp-sv2:latest
+    cmd = "docker inspect --format '{{.Config.Image}}' " + container_name
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+    (out, err) = proc.communicate()
+    if proc.returncode != 0:
+        sys.exit(proc.returncode)
+    image_latest = out.rstrip()
+
+    # example image_name: docker-lldp-sv2
+    cmd = "echo " + image_latest + " | cut -d ':' -f 1"
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+    image_name = proc.stdout.read().rstrip()
+    return image_name
+
+def get_container_image_id(image_tag):
+    # TODO: extract commond docker info fetching functions
+    # this is image_id for image with tag, like 'docker-teamd:latest'
+    cmd = "docker images --format '{{.ID}}' " + image_tag
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+    image_id = proc.stdout.read().rstrip()
+    return image_id
+
+def get_container_image_id_all(image_name):
+    # All images id under the image name like 'docker-teamd'
+    cmd = "docker images --format '{{.ID}}' " + image_name
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+    image_id_all = proc.stdout.read()
+    image_id_all = image_id_all.splitlines()
+    image_id_all = set(image_id_all)
+    return image_id_all
 
 # Main entrypoint
 @click.group()
@@ -433,27 +465,19 @@ def cleanup():
 @cli.command()
 @click.option('-y', '--yes', is_flag=True, callback=abort_if_false,
         expose_value=False, prompt='New docker image will be installed, continue?')
-@click.option('--cleanup_image', is_flag=True, help="Clean up old docker image(s)")
-@click.option('--enforce_check', is_flag=True, help="Enforce pending task check for docker upgrade")
+@click.option('--cleanup_image', is_flag=True, help="Clean up old docker image")
+@click.option('--skip_check', is_flag=True, help="Skip task check for docker upgrade")
 @click.option('--tag', type=str, help="Tag for the new docker image")
+@click.option('--warm', is_flag=True, help="Perform warm upgrade")
 @click.argument('container_name', metavar='<container_name>', required=True,
-    type=click.Choice(["swss", "snmp", "lldp", "bgp", "pmon", "dhcp_relay", "telemetry", "teamd"]))
+    type=click.Choice(["swss", "snmp", "lldp", "bgp", "pmon", "dhcp_relay", "telemetry", "teamd", "radv", "amon"]))
 @click.argument('url')
-def upgrade_docker(container_name, url, cleanup_image, enforce_check, tag):
+def upgrade_docker(container_name, url, cleanup_image, skip_check, tag, warm):
     """ Upgrade docker image from local binary or URL"""
 
-    # example image: docker-lldp-sv2:latest
-    cmd = "docker inspect --format '{{.Config.Image}}' " + container_name
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
-    (out, err) = proc.communicate()
-    if proc.returncode != 0:
-        sys.exit(proc.returncode)
-    image_latest = out.rstrip()
-
-    # example image_name: docker-lldp-sv2
-    cmd = "echo " + image_latest + " | cut -d ':' -f 1"
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
-    image_name = proc.stdout.read().rstrip()
+    image_name = get_container_image_name(container_name)
+    image_latest = image_name + ":latest"
+    image_id_previous = get_container_image_id(image_latest)
 
     DEFAULT_IMAGE_PATH = os.path.join("/tmp/", image_name)
     if url.startswith('http://') or url.startswith('https://'):
@@ -474,7 +498,7 @@ def upgrade_docker(container_name, url, cleanup_image, enforce_check, tag):
         click.echo("Image file '{}' does not exist or is not a regular file. Aborting...".format(image_path))
         raise click.Abort()
 
-    warm = False
+    warm_configured = False
     # warm restart enable/disable config is put in stateDB, not persistent across cold reboot, not saved to config_DB.json file
     state_db = SonicV2Connector(host='127.0.0.1')
     state_db.connect(state_db.STATE_DB, False)
@@ -482,40 +506,46 @@ def upgrade_docker(container_name, url, cleanup_image, enforce_check, tag):
     prefix = 'WARM_RESTART_ENABLE_TABLE' + TABLE_NAME_SEPARATOR
     _hash = '{}{}'.format(prefix, container_name)
     if state_db.get(state_db.STATE_DB, _hash, "enable") == "true":
-        warm = True
+        warm_configured = True
     state_db.close(state_db.STATE_DB)
 
+    if container_name == "swss" or container_name == "bgp" or container_name == "teamd":
+        if warm_configured == False and warm:
+           run_command("config warm_restart enable %s" % container_name)
+
+    warm_app_names = []
     # warm restart specific procssing for swss, bgp and teamd dockers.
-    if warm == True:
+    if warm_configured == True or warm:
         # make sure orchagent is in clean state if swss is to be upgraded
         if container_name == "swss":
-            skipPendingTaskCheck = " -s"
-            if enforce_check:
-                skipPendingTaskCheck = ""
+            skipPendingTaskCheck = ""
+            if skip_check:
+                skipPendingTaskCheck = " -s"
 
-            cmd = "docker exec -i swss orchagent_restart_check -w 1000 " + skipPendingTaskCheck
-            for i in range(1, 6):
-                proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
-                (out, err) = proc.communicate()
-                if proc.returncode != 0:
-                    if enforce_check:
-                        click.echo("Orchagent is not in clean state, RESTARTCHECK failed {}".format(i))
-                        if i == 5:
-                            sys.exit(proc.returncode)
-                    else:
-                        click.echo("Orchagent is not in clean state, upgrading it anyway")
-                        break
+            cmd = "docker exec -i swss orchagent_restart_check -w 2000 -r 5 " + skipPendingTaskCheck
+
+            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+            (out, err) = proc.communicate()
+            if proc.returncode != 0:
+                if not skip_check:
+                    click.echo("Orchagent is not in clean state, RESTARTCHECK failed")
+                    # Restore orignal config before exit
+                    if warm_configured == False and warm:
+                        run_command("config warm_restart disable %s" % container_name)
+                    sys.exit(proc.returncode)
                 else:
-                    click.echo("Orchagent is in clean state and frozen for warm upgrade")
-                    break
-                run_command("sleep 1")
+                    click.echo("Orchagent is not in clean state, upgrading it anyway")
+            else:
+                click.echo("Orchagent is in clean state and frozen for warm upgrade")
+
+            warm_app_names = ["orchagent", "neighsyncd"]
 
         elif container_name == "bgp":
             # Kill bgpd to restart the bgp graceful restart procedure
             click.echo("Stopping bgp ...")
             run_command("docker exec -i bgp pkill -9 zebra")
             run_command("docker exec -i bgp pkill -9 bgpd")
-            run_command("sleep 2") # wait 2 seconds for bgp to settle down
+            warm_app_names = ["bgp"]
             click.echo("Stopped  bgp ...")
 
         elif container_name == "teamd":
@@ -523,12 +553,16 @@ def upgrade_docker(container_name, url, cleanup_image, enforce_check, tag):
             # Send USR1 signal to all teamd instances to stop them
             # It will prepare teamd for warm-reboot
             run_command("docker exec -i teamd pkill -USR1 teamd > /dev/null")
-            run_command("sleep 2") # wait 2 seconds for teamd to settle down
+            warm_app_names = ["teamsyncd"]
             click.echo("Stopped  teamd ...")
 
-    run_command("systemctl stop %s" % container_name)
+        # clean app reconcilation state from last warm start if exists
+        for warm_app_name in warm_app_names:
+            cmd = "docker exec -i database redis-cli -n 6 hdel 'WARM_RESTART_TABLE|" + warm_app_name + "' state"
+            run_command(cmd)
+
+    run_command("docker kill %s > /dev/null" % container_name)
     run_command("docker rm %s " % container_name)
-    run_command("docker rmi %s " % image_latest)
     run_command("docker load < %s" % image_path)
     if tag == None:
         # example image: docker-lldp-sv2:latest
@@ -536,25 +570,85 @@ def upgrade_docker(container_name, url, cleanup_image, enforce_check, tag):
     run_command("docker tag %s:latest %s:%s" % (image_name, image_name, tag))
     run_command("systemctl restart %s" % container_name)
 
-    # Clean up old docker images
-    if cleanup_image:
-        # All images id under the image name
-        cmd = "docker images --format '{{.ID}}' " + image_name
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
-        image_id_all = proc.stdout.read()
-        image_id_all = image_id_all.splitlines()
-        image_id_all = set(image_id_all)
+    # All images id under the image name
+    image_id_all = get_container_image_id_all(image_name)
 
-        # this is image_id for image with "latest" tag
-        cmd = "docker images --format '{{.ID}}' " + image_latest
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
-        image_id_latest = proc.stdout.read().rstrip()
+    # this is image_id for image with "latest" tag
+    image_id_latest = get_container_image_id(image_latest)
 
-        for id in image_id_all:
-            if id != image_id_latest:
-                run_command("docker rmi -f %s" % id)
+    for id in image_id_all:
+        if id != image_id_latest:
+            # Unless requested, the previoud docker image will be preserved
+            if not cleanup_image and id == image_id_previous:
+                continue
+            run_command("docker rmi -f %s" % id)
 
-    run_command("sleep 5") # wait 5 seconds for application to sync
+    exp_state = "reconciled"
+    state = ""
+    # post warm restart specific procssing for swss, bgp and teamd dockers, wait for reconciliation state.
+    if warm_configured == True or warm:
+        count = 0
+        for warm_app_name in warm_app_names:
+            state = ""
+            cmd = "docker exec -i database redis-cli -n 6 hget 'WARM_RESTART_TABLE|" + warm_app_name + "' state"
+            # Wait up to 180 seconds for reconciled state
+            while state != exp_state and count < 90:
+                sys.stdout.write("\r  {}: ".format(warm_app_name))
+                sys.stdout.write("[%-s" % ('='*count))
+                sys.stdout.flush()
+                count += 1
+                time.sleep(2)
+                proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+                state = proc.stdout.read().rstrip()
+                syslog.syslog("%s reached %s state"%(warm_app_name, state))
+            sys.stdout.write("]\n\r")
+            if state != exp_state:
+                click.echo("%s failed to reach %s state"%(warm_app_name, exp_state))
+                syslog.syslog(syslog.LOG_ERR, "%s failed to reach %s state"%(warm_app_name, exp_state))
+    else:
+        exp_state = ""  # this is cold upgrade
+
+    # Restore to previous cold restart setting
+    if warm_configured == False and warm:
+        if container_name == "swss" or container_name == "bgp" or container_name == "teamd":
+            run_command("config warm_restart disable %s" % container_name)
+
+    if state == exp_state:
+        click.echo('Done')
+    else:
+        click.echo('Failed')
+        sys.exit(1)
+
+# rollback docker image
+@cli.command()
+@click.option('-y', '--yes', is_flag=True, callback=abort_if_false,
+        expose_value=False, prompt='Docker image will be rolled back, continue?')
+@click.argument('container_name', metavar='<container_name>', required=True,
+    type=click.Choice(["swss", "snmp", "lldp", "bgp", "pmon", "dhcp_relay", "telemetry", "teamd", "radv", "amon"]))
+def rollback_docker(container_name):
+    """ Rollback docker image to previous version"""
+    image_name = get_container_image_name(container_name)
+    # All images id under the image name
+    image_id_all = get_container_image_id_all(image_name)
+    if len(image_id_all) != 2:
+        click.echo("Two images required, but there are '{}' images for '{}'. Aborting...".format(len(image_id_all), image_name))
+        raise click.Abort()
+
+    image_latest = image_name + ":latest"
+    image_id_previous = get_container_image_id(image_latest)
+
+    version_tag = ""
+    for id in image_id_all:
+        if id != image_id_previous:
+            version_tag = get_docker_tag_name(id)
+
+    # make previous image as latest
+    run_command("docker tag %s:%s %s:latest" % (image_name, version_tag, image_name))
+    if container_name == "swss" or container_name == "bgp" or container_name == "teamd":
+        click.echo("Cold reboot is required to restore system state after '{}' rollback !!".format(container_name))
+    else:
+        run_command("systemctl restart %s" % container_name)
+
     click.echo('Done')
 
 if __name__ == '__main__':


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**- What I did**
Add --warm option for docker upgrade to automatically enable warm restart before image upgrade and disable it after upgrade is done.
Added docker image version rollback tool.

<1> upgrade bgp and teamd docker
```
admin@vlab-01:~$ show warm_restart config
name    enable    timer_name    timer_duration
------  --------  ------------  ----------------
admin@vlab-01:~$ show warm_restart state
name          restore_count  state
----------  ---------------  -------
neighsyncd                0
bgp                       0
vlanmgrd                  0
orchagent                 0
teammgrd                  0
syncd                     0
teamsyncd                 0
portsyncd                 0
admin@vlab-01:~$ sonic_installer upgrade_docker bgp docker-fpm-frr.gz --warm
Root privileges required for this operation
admin@vlab-01:~$ sudo sonic_installer upgrade_docker bgp docker-fpm-frr.gz --warm
New docker image will be installed, continue? [y/N]: y
Command: config warm_restart enable bgp

Stopping bgp ...
Command: docker exec -i bgp pkill -9 zebra

Command: docker exec -i bgp pkill -9 bgpd

Stopped  bgp ...
Command: docker exec -i database redis-cli -n 6 hdel 'WARM_RESTART_TABLE|bgp' state
0

Command: docker kill  bgp > /dev/null

Command: docker rm bgp 
bgp

Command: docker load < ./docker-fpm-frr.gz
Loaded image: docker-fpm-frr:latest

Command: docker tag docker-fpm-frr:latest docker-fpm-frr:HEAD.18-dd0f005b

Command: systemctl restart bgp

Command: docker rmi -f 6cbbff760d65
Untagged: docker-fpm-frr:master.0-dirty-20190621.231403
Deleted: sha256:6cbbff760d65710dd8d13b90ce61176591deee621d196806755e68ed3be077cf
Deleted: sha256:fa9cdad4a07a16d0b28108d70e951d956a7f689afdbb48062b416840ec22a778

  bgp: [======================================================]
Command: config warm_restart disable bgp

Done
admin@vlab-01:~$ show warm_restart config
name    enable    timer_name    timer_duration
------  --------  ------------  ----------------
bgp     false     NULL          NULL
admin@vlab-01:~$ show warm_restart state
name          restore_count  state
----------  ---------------  ----------
neighsyncd                0
bgp                       1  reconciled
vlanmgrd                  0
orchagent                 0
teammgrd                  0
syncd                     0
teamsyncd                 0
portsyncd                 0
admin@vlab-01:~$ 
admin@vlab-01:~$ 
admin@vlab-01:~$ sudo sonic_installer upgrade_docker teamd docker-teamd.gz --warm
New docker image will be installed, continue? [y/N]: y
Command: config warm_restart enable teamd

Stopping teamd ...
Command: docker exec -i teamd pkill -USR1 teamd > /dev/null

Stopped  teamd ...
Command: docker exec -i database redis-cli -n 6 hdel 'WARM_RESTART_TABLE|teamsyncd' state
0

Command: docker kill  teamd > /dev/null

Command: docker rm teamd 
teamd

Command: docker load < ./docker-teamd.gz
The image docker-teamd:latest already exists, renaming the old one with ID sha256:3bba6febaa8e7dd3019fbaa71883a2a0ecea87da6c6a6e1f0e63a1fdd6cbaa46 to empty string
Loaded image: docker-teamd:latest

Command: docker tag docker-teamd:latest docker-teamd:HEAD.18-dd0f005b

Command: systemctl restart teamd

  teamsyncd: [============================]
Command: config warm_restart disable teamd

Done

```

<2> warm restart state and docker image version

```
admin@vlab-01:~$ show warm_restart state
name          restore_count  state
----------  ---------------  ----------
neighsyncd                0
bgp                       1  reconciled
vlanmgrd                  0
orchagent                 0
teammgrd                  1
syncd                     0
teamsyncd                 1  reconciled
portsyncd                 0
admin@vlab-01:~$ show version

SONiC Software Version: SONiC.master.0-dirty-20190621.231403
Distribution: Debian 9.9
Kernel: 4.9.0-9-2-amd64
Build commit: f4d07dc0
Build date: Sat Jun 22 06:34:29 UTC 2019
Built by: jipan@dockerhost05

Platform: x86_64-kvm_x86_64-r0
HwSKU: Force10-S6000
ASIC: vs
/usr/bin/decode-syseeprom : ERROR : cannot load module: /usr/share/sonic/device/x86_64-kvm_x86_64-r0/plugins/eeprom.py
Serial Number: 
Uptime: 12:29:27 up 13 min,  3 users,  load average: 0.61, 2.14, 2.10

Docker images:
REPOSITORY                 TAG                              IMAGE ID            SIZE
docker-fpm-frr             HEAD.18-dd0f005b                 bdf8903da57f        319MB
docker-fpm-frr             latest                           bdf8903da57f        319MB
docker-teamd               HEAD.18-dd0f005b                 d2c1896be540        301MB
docker-teamd               latest                           d2c1896be540        301MB
docker-orchagent           latest                           fd2c776d3668        387MB
docker-orchagent           master.0-dirty-20190621.231403   fd2c776d3668        387MB
docker-database            latest                           df035c8fd43b        352MB
docker-database            master.0-dirty-20190621.231403   df035c8fd43b        352MB
docker-teamd               master.0-dirty-20190621.231403   3bba6febaa8e        374MB
docker-sonic-telemetry     latest                           477b1450b3d5        375MB
docker-sonic-telemetry     master.0-dirty-20190621.231403   477b1450b3d5        375MB
docker-snmp-sv2            latest                           9e216648e2a3        384MB
docker-snmp-sv2            master.0-dirty-20190621.231403   9e216648e2a3        384MB
docker-lldp-sv2            latest                           e1f7f9c9df17        370MB
docker-lldp-sv2            master.0-dirty-20190621.231403   e1f7f9c9df17        370MB
docker-syncd-vs            latest                           8f3b873a3ff9        354MB
docker-syncd-vs            master.0-dirty-20190621.231403   8f3b873a3ff9        354MB
docker-dhcp-relay          latest                           e91fad0252a2        357MB
docker-dhcp-relay          master.0-dirty-20190621.231403   e91fad0252a2        357MB
docker-router-advertiser   latest                           904024b06841        352MB
docker-router-advertiser   master.0-dirty-20190621.231403   904024b06841        352MB
docker-platform-monitor    latest                           5db67e5f9f5d        390MB
docker-platform-monitor    master.0-dirty-20190621.231403   5db67e5f9f5d        390MB

```

<3>docker image rollback test

```
admin@vlab-01:~/17$ sudo sonic_installer upgrade_docker teamd docker-teamd.gz --warm
New docker image will be installed, continue? [y/N]: y
Command: config warm_restart enable teamd

Stopping teamd ...
Command: docker exec -i teamd pkill -USR1 teamd > /dev/null

Stopped  teamd ...
Command: docker exec -i database redis-cli -n 6 hdel 'WARM_RESTART_TABLE|teamsyncd' state
1

Command: docker kill  teamd > /dev/null

Command: docker rm teamd 
teamd

Command: docker load < ./docker-teamd.gz
The image docker-teamd:latest already exists, renaming the old one with ID sha256:d2c1896be5401f4fc8939a6fa4c7bbadb3d55bc473c4877804daaec726fece4a to empty string
Loaded image: docker-teamd:latest

Command: docker tag docker-teamd:latest docker-teamd:HEAD.17-34e790bf

Command: systemctl restart teamd

  teamsyncd: [=============================]
Command: config warm_restart disable teamd

Done
admin@vlab-01:~/17$ show version

SONiC Software Version: SONiC.master.0-dirty-20190621.231403
Distribution: Debian 9.9
Kernel: 4.9.0-9-2-amd64
Build commit: f4d07dc0
Build date: Sat Jun 22 06:34:29 UTC 2019
Built by: jipan@dockerhost05

Platform: x86_64-kvm_x86_64-r0
HwSKU: Force10-S6000
ASIC: vs
/usr/bin/decode-syseeprom : ERROR : cannot load module: /usr/share/sonic/device/x86_64-kvm_x86_64-r0/plugins/eeprom.py
Serial Number: 
Uptime: 12:57:08 up 41 min,  2 users,  load average: 0.36, 1.17, 1.41

Docker images:
REPOSITORY                 TAG                              IMAGE ID            SIZE
docker-fpm-frr             HEAD.18-dd0f005b                 bdf8903da57f        319MB
docker-fpm-frr             latest                           bdf8903da57f        319MB
docker-teamd               HEAD.18-dd0f005b                 d2c1896be540        301MB
docker-teamd               HEAD.17-34e790bf                 cd09d29975d5        301MB
docker-teamd               latest                           cd09d29975d5        301MB
docker-orchagent           latest                           fd2c776d3668        387MB
docker-orchagent           master.0-dirty-20190621.231403   fd2c776d3668        387MB
docker-database            latest                           df035c8fd43b        352MB
docker-database            master.0-dirty-20190621.231403   df035c8fd43b        352MB
docker-sonic-telemetry     latest                           477b1450b3d5        375MB
docker-sonic-telemetry     master.0-dirty-20190621.231403   477b1450b3d5        375MB
docker-snmp-sv2            latest                           9e216648e2a3        384MB
docker-snmp-sv2            master.0-dirty-20190621.231403   9e216648e2a3        384MB
docker-lldp-sv2            latest                           e1f7f9c9df17        370MB
docker-lldp-sv2            master.0-dirty-20190621.231403   e1f7f9c9df17        370MB
docker-syncd-vs            latest                           8f3b873a3ff9        354MB
docker-syncd-vs            master.0-dirty-20190621.231403   8f3b873a3ff9        354MB
docker-dhcp-relay          latest                           e91fad0252a2        357MB
docker-dhcp-relay          master.0-dirty-20190621.231403   e91fad0252a2        357MB
docker-router-advertiser   latest                           904024b06841        352MB
docker-router-advertiser   master.0-dirty-20190621.231403   904024b06841        352MB
docker-platform-monitor    latest                           5db67e5f9f5d        390MB
docker-platform-monitor    master.0-dirty-20190621.231403   5db67e5f9f5d        390MB

admin@vlab-01:~/17$ show warm_restart state
name          restore_count  state
----------  ---------------  ----------
neighsyncd                0
bgp                       2  reconciled
vlanmgrd                  0
orchagent                 0
teammgrd                  3
syncd                     0
teamsyncd                 3  reconciled
portsyncd                 0
admin@vlab-01:~/17$ sudo sonic_installer rollback_docker teamd
Docker image will be rolled back, continue? [y/N]: y
Command: docker tag docker-teamd:HEAD.18-dd0f005b docker-teamd:latest

Cold reboot is required to restore system state after 'teamd' rollback !!
Done

```

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

