### PR TITLE
[fast reboot] stop removing opennsl module before reboot

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -430,15 +430,6 @@ docker ps -q | xargs docker kill > /dev/null
 # Stop the docker container engine. Otherwise we will have a broken docker storage
 systemctl stop docker.service
 
-if [[ "$REBOOT_TYPE" != "warm-reboot" ]]; then
-    # Stop opennsl modules for Broadcom platform
-    if [[ "$sonic_asic_type" = 'broadcom' ]];
-    then
-      service_name=$(systemctl list-units --plain --no-pager --no-legend --type=service | grep opennsl | cut -f 1 -d' ')
-      systemctl stop "$service_name"
-    fi
-fi
-
 # Stop kernel modules for Nephos platform
 if [[ "$sonic_asic_type" = 'nephos' ]];
 then


### PR DESCRIPTION
**- What I did**

We have been running warm reboot test without removing opennsl for
10k+ iterations and not having issue.

The kexec reboot part is the same for warm reboot and fast reboot. It
should be safe for us to skip this during fast reboot to save some
time too.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
