### PR TITLE
[portstat] Fix portstat show RX_UTIL over 100% for 100G

### DIFF
--- a/scripts/portstat
+++ b/scripts/portstat
@@ -59,6 +59,7 @@ PORT_OPER_STATUS_FIELD = "oper_status"
 PORT_ADMIN_STATUS_FIELD = "admin_status"
 PORT_STATUS_VALUE_UP = 'UP'
 PORT_STATUS_VALUE_DOWN = 'DOWN'
+PORT_SPEED_FIELD = "speed"
 
 PORT_STATE_UP = 'U'
 PORT_STATE_DOWN = 'D'
@@ -100,6 +101,19 @@ class Portstat(object):
             cnstat_dict[port] = get_counters(counter_port_name_map[port]) 
         return cnstat_dict
 
+    def get_port_speed(self, port_name):
+        """
+            Get the port speed
+        """
+        # Get speed from APPL_DB
+        full_table_id = PORT_STATUS_TABLE_PREFIX + port_name
+        speed = self.db.get(self.db.APPL_DB, full_table_id, PORT_SPEED_FIELD)
+        if speed is None:
+            speed = PORT_RATE
+        else:
+            speed = int(speed)/1000
+        return speed
+
     def get_port_state(self, port_name):
         """
             Get the port state
@@ -137,20 +151,20 @@ class Portstat(object):
                 old_cntr = cnstat_old_dict.get(key)
             else:
                 old_cntr = NStats._make([0] * BUCKET_NUM)
-
+            port_speed = self.get_port_speed(key)
             if print_all:
                 table.append((key, self.get_port_state(key),
                               ns_diff(cntr.rx_ok, old_cntr.rx_ok),
                               ns_brate(cntr.rx_byt, old_cntr.rx_byt, time_gap),
                               ns_prate(cntr.rx_ok, old_cntr.rx_ok, time_gap),
-                              ns_util(cntr.rx_byt, old_cntr.rx_byt, time_gap),
+                              ns_util(cntr.rx_byt, old_cntr.rx_byt, time_gap, port_speed),
                               ns_diff(cntr.rx_err, old_cntr.rx_err),
                               ns_diff(cntr.rx_drop, old_cntr.rx_drop),
                               ns_diff(cntr.rx_ovr, old_cntr.rx_ovr),
                               ns_diff(cntr.tx_ok, old_cntr.tx_ok),
                               ns_brate(cntr.tx_byt, old_cntr.tx_byt, time_gap),
                               ns_prate(cntr.tx_ok, old_cntr.tx_ok, time_gap),
-                              ns_util(cntr.tx_byt, old_cntr.tx_byt, time_gap),
+                              ns_util(cntr.tx_byt, old_cntr.tx_byt, time_gap, port_speed),
                               ns_diff(cntr.tx_err, old_cntr.tx_err),
                               ns_diff(cntr.tx_drop, old_cntr.tx_drop),
                               ns_diff(cntr.tx_ovr, old_cntr.tx_ovr)))
@@ -158,13 +172,13 @@ class Portstat(object):
                 table.append((key, self.get_port_state(key),
                               ns_diff(cntr.rx_ok, old_cntr.rx_ok),
                               ns_brate(cntr.rx_byt, old_cntr.rx_byt, time_gap),
-                              ns_util(cntr.rx_byt, old_cntr.rx_byt, time_gap),
+                              ns_util(cntr.rx_byt, old_cntr.rx_byt, time_gap, port_speed),
                               ns_diff(cntr.rx_err, old_cntr.rx_err),
                               ns_diff(cntr.rx_drop, old_cntr.rx_drop),
                               ns_diff(cntr.rx_ovr, old_cntr.rx_ovr),
                               ns_diff(cntr.tx_ok, old_cntr.tx_ok),
                               ns_brate(cntr.tx_byt, old_cntr.tx_byt, time_gap),
-                              ns_util(cntr.tx_byt, old_cntr.tx_byt, time_gap),
+                              ns_util(cntr.tx_byt, old_cntr.tx_byt, time_gap, port_speed),
                               ns_diff(cntr.tx_err, old_cntr.tx_err),
                               ns_diff(cntr.tx_drop, old_cntr.tx_drop),
                               ns_diff(cntr.tx_ovr, old_cntr.tx_ovr)))

--- a/utilities_common/netstat.py
+++ b/utilities_common/netstat.py
@@ -41,7 +41,7 @@ def ns_prate(newstr, oldstr, delta):
         rate = int(ns_diff(newstr, oldstr).replace(',',''))/delta
         return "{:.2f}".format(rate)+'/s'
 
-def ns_util(newstr, oldstr, delta):
+def ns_util(newstr, oldstr, delta, port_rate=PORT_RATE):
     """
         Calculate the util.
     """
@@ -49,7 +49,7 @@ def ns_util(newstr, oldstr, delta):
         return STATUS_NA
     else:
         rate = int(ns_diff(newstr, oldstr).replace(',',''))/delta
-        util = rate/(PORT_RATE*1024*1024*1024/8.0)*100
+        util = rate/(port_rate*1024*1024*1024/8.0)*100
         return "{:.2f}%".format(util)
 
 def table_as_json(table, header):


### PR DESCRIPTION
           When calc the RX_UTIL, currently it use hardcode 40G,
           now change to get the real port speed via APP DB

Signed-off-by: Richard Wu <wutong23@baidu.com>

**- What I did**
When test the RX_UTIL when 100G port with line rate, the RX_UTIL shows over 100%. port stats use default 40G to calc the RX_UTIL, now change to get the real time speed via APP DB
**- How I did it**

**- How to verify it**

