### PR TITLE
sonic_installer: fix read-only filesystem support for firmware update

### DIFF
--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -327,7 +327,7 @@ def install(url, force):
             run_command("/usr/bin/unzip -od /tmp %s boot0" % image_path)
             run_command("swipath=%s target_path=/host sonic_upgrade=1 . /tmp/boot0" % image_path)
         else:
-            run_command("bash -C " + image_path)
+            run_command("bash " + image_path)
             run_command('grub-set-default --boot-directory=' + HOST_PATH + ' 0')
         run_command("rm -rf /host/old_config")
         # copy directories and preserve original file structure, attributes and associated metadata

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -327,7 +327,14 @@ def install(url, force):
             run_command("/usr/bin/unzip -od /tmp %s boot0" % image_path)
             run_command("swipath=%s target_path=/host sonic_upgrade=1 . /tmp/boot0" % image_path)
         else:
-            os.chmod(image_path, stat.S_IXUSR)
+            try:
+                os.chmod(image_path, stat.S_IXUSR)
+            except Exception:
+                # Upon chmod failure, copy the image to /tmp directory
+                # and then resume the following operations
+                run_command("cp -f " + image_path + " " + DEFAULT_IMAGE_PATH)
+                image_path = DEFAULT_IMAGE_PATH
+                os.chmod(image_path, stat.S_IXUSR)
             run_command(image_path)
             run_command('grub-set-default --boot-directory=' + HOST_PATH + ' 0')
         run_command("rm -rf /host/old_config")

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -327,15 +327,7 @@ def install(url, force):
             run_command("/usr/bin/unzip -od /tmp %s boot0" % image_path)
             run_command("swipath=%s target_path=/host sonic_upgrade=1 . /tmp/boot0" % image_path)
         else:
-            try:
-                os.chmod(image_path, stat.S_IXUSR)
-            except Exception:
-                # Upon chmod failure, copy the image to /tmp directory
-                # and then resume the following operations
-                run_command("cp -f " + image_path + " " + DEFAULT_IMAGE_PATH)
-                image_path = DEFAULT_IMAGE_PATH
-                os.chmod(image_path, stat.S_IXUSR)
-            run_command(image_path)
+            run_command("bash -C " + image_path)
             run_command('grub-set-default --boot-directory=' + HOST_PATH + ' 0')
         run_command("rm -rf /host/old_config")
         # copy directories and preserve original file structure, attributes and associated metadata


### PR DESCRIPTION
It's possible that users will either store the SONIC image in a NTFS
formatted USB disk, or make it read-only by a USB lock.

Unfortunately the sonic_installer always tries to make the image executable
during the 'sonic_installer install' process, and then fail in these cases.

And thus, in this commit, we'll copy the image to /tmp upon chmod failure,
and then resume the following operations

Signed-off-by: Dante (Kuo-Jung) Su <dante.su@broadcom.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Enable 'sonic_installer install' to update the SONIC from an image stored in NTFS formatted USB disk or a read-only filesystem

**- How I did it**
Copy the image to /tmp upon chmod failure, and then resume the following operations

**- How to verify it**
1. Copy the SONIC image to a NTFS formatted USB, or simply make it read-only by switching the USB lock
2. Attach the USB stick into SONIC
3. Issue following command to initiate SONIC firmware update
   $ sonic_installer install "path-to-the-image"

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

