### PR TITLE
sfpshow: prevent 'show int trans eeprom --dom' from crashing

### DIFF
--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -75,7 +75,7 @@ class SFPShow(object):
         out_put=''
         ident = '        '
         for key in sorted_key_table:
-            if dom_info_dict[key] != 'N/A':
+            if dom_info_dict is not None and dom_info_dict[key] != 'N/A':
                 if dom_info_dict[key] == 'Unknown':
                     out_put = out_put + ident + ident + channel_monitor_map[key] + ': ' + dom_info_dict[key] + '\n'
                 else:


### PR DESCRIPTION
When some specific 25G DAC attached to the system, the 'dom_info_dict'
could be a None object, as a result, the 'show int transceiver eeprom --dom'
will crash.

And thus, in this commit, we'll add an additional checker for the None object.

Signed-off-by: Dante (Kuo-Jung) Su <dante.su@broadcom.com>
Change-Id: Ic2b5eb38ddf98b98cce7eddf161595013a19c720

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Add a None object checker to prevent CLI from crashing

**- How I did it**
Add a None object checker

**- How to verify it**
Attach a 25G DAC to the system

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

