### PR TITLE
[PR template] Add reminder to update Command Line Reference Guide if modifying user-facing commands

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,11 @@ If this is a bug fix, make sure your description includes "closes #xxxx",
 "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
 issue when the PR is merged
 
+If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
+subcommand, or you are adding a new subcommand, please make sure you also
+update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
+your changes.
+
 Please provide the following information:
 -->
 


### PR DESCRIPTION
Add a reminder in the GitHub pull request template to update Command Line Reference Guide if modifying user-facing commands to ensure contributors keep the documentation up-to-date with new changes.