### PR TITLE
BIOS upgrade support in sonic_installer

### DIFF
--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -10,7 +10,6 @@ import click
 import urllib
 import tempfile
 import subprocess
-import sonic_platform.chassis
 from swsssdk import ConfigDBConnector
 from swsssdk import SonicV2Connector
 import collections
@@ -287,8 +286,6 @@ def install(url, force):
     """ Install image from local binary or URL"""
 
     cleanup_image = False
-    component_name = "BIOS"
-    chassis = sonic_platform.chassis.Chassis()
 
     if get_running_image_type() == IMAGE_TYPE_ABOOT:
         DEFAULT_IMAGE_PATH = ABOOT_DEFAULT_IMAGE_PATH
@@ -341,21 +338,30 @@ def install(url, force):
         run_command("cp -ar /etc/sonic /host/old_config")
 
     # Check Latest BIOS availability
-    next_image = get_next_image()
-    squashfs_path = HOST_PATH + '/' + \
-            next_image.replace(IMAGE_PREFIX, IMAGE_DIR_PREFIX) + \
-            '/' + 'fs.squashfs'
-    if squashfs_path:
-        tmpdir = tempfile.mkdtemp()
-        run_command(
-            'mount ' + squashfs_path + ' ' + tmpdir + ' -t squashfs -o loop')
-        status = chassis.install_component_firmware(component_name, tmpdir)
+    try:
+        import sonic_platform.chassis
+        component_name = "BIOS"
+        chassis = sonic_platform.chassis.Chassis()
 
-        if not status:
-            click.echo("BIOS upgrade failed!")
+        next_image = get_next_image()
+        squashfs_path = HOST_PATH + '/' + \
+                next_image.replace(IMAGE_PREFIX, IMAGE_DIR_PREFIX) + \
+                '/' + 'fs.squashfs'
+        if squashfs_path:
+            tmpdir = tempfile.mkdtemp()
+            run_command(
+                'mount ' + squashfs_path + ' ' + tmpdir + \
+                ' -t squashfs -o loop')
+            status = chassis.install_component_firmware(component_name, tmpdir)
 
-        run_command('umount ' + tmpdir)
-        os.rmdir(tmpdir)
+            if not status:
+                click.echo("BIOS upgrade failed!")
+
+            run_command('umount ' + tmpdir)
+            os.rmdir(tmpdir)
+
+    except ImportError:
+        pass
 
     # Finally, sync filesystem
     run_command("sync;sync;sync")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
- Added BIOS upgrade support in sonic_installer

**- How I did it**
-  "sonic_installer install sonic-broadcom.bin" --> Post installation of the new image, fetch the next_image version and mount sqashfs filesystem.
- With the help of install_component_firmware() pass component name as "BIOS" and mount location.
- Respective vendor API fetch the BIOS image from mounted location and take appropriate decisions (upgrade/Downgrade/Nochange) respectively. 

**- How to verify it**
 - sonic_installer install sonic-broadcom.bin

**- New command output (if the output of a command-line utility has changed)**
```
--------Upgrade BIOS------------------------------------------------------------
   creating: /host/image-master.0-dirty-20190703.033247/platform/x86_64-dell_s6000_s1220-r0/
  inflating: /host/image-master.0-dirty-20190703.033247/platform/x86_64-dell_s6000_s1220-r0/platform-modules-s6000_1.1_amd64.deb
   creating: /host/image-master.0-dirty-20190703.033247/platform/x86_64-accton_as7312_54x-r0/
  inflating: /host/image-master.0-dirty-20190703.033247/platform/x86_64-accton_as7312_54x-r0/sonic-platform-accton-as7312-54x_1.1_amd64.deb
  inflating: /host/image-master.0-dirty-20190703.033247/fs.squashfs
Installed SONiC base image SONiC-OS successfully

Command: grub-set-default --boot-directory=/host 0

Command: rm -rf /host/old_config

Command: cp -ar /etc/sonic /host/old_config

Command: mount /host/image-master.0-dirty-20190703.033247/fs.squashfs /tmp/tmpQEjjBC -t squashfs -o loop


        ********************************************************************
        * Warning - Upgrading BIOS is inherently risky and should only be  *
        * attempted when necessary.  A failure at this upgrade may cause   *
        * a board RMA.  Proceed with caution !                             *
        ********************************************************************

New BIOS image 3.25.0.2-7 available to install, continue? [y/N]: y
Command: /usr/local/bin/flashrom -p internal -w /tmp/tmpQEjjBC/usr/share/sonic/device/x86_64-dell_s6100_c2538-r0/bin/S6100-BIOS-3.25.0.2-7.bin
Erasing and writing flash chip... Erase/write done.
Verifying flash... VERIFIED.

Command: umount /tmp/tmpQEjjBC

Command: sync;sync;sync

Command: sleep 3

Done
```

-->



