### PR TITLE
[show] Don't abort in InterfaceAliasConverter ctor if PORT table doesn't exist

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -58,8 +58,8 @@ class InterfaceAliasConverter(object):
         self.port_dict = config_db.get_table('PORT')
 
         if not self.port_dict:
-            click.echo("Warning: port_dict is None!")
-            return
+            click.echo("Warning: failed to retrieve PORT table from ConfigDB!")
+            self.port_dict = {}
 
         for port_name in self.port_dict.keys():
             try:

--- a/show/main.py
+++ b/show/main.py
@@ -58,7 +58,7 @@ class InterfaceAliasConverter(object):
         self.port_dict = config_db.get_table('PORT')
 
         if not self.port_dict:
-            click.echo("Warning: failed to retrieve PORT table from ConfigDB!")
+            click.echo(message="Warning: failed to retrieve PORT table from ConfigDB!", err=True)
             self.port_dict = {}
 
         for port_name in self.port_dict.keys():

--- a/show/main.py
+++ b/show/main.py
@@ -58,8 +58,8 @@ class InterfaceAliasConverter(object):
         self.port_dict = config_db.get_table('PORT')
 
         if not self.port_dict:
-            click.echo("port_dict is None!")
-            raise click.Abort()
+            click.echo("Warning: port_dict is None!")
+            return
 
         for port_name in self.port_dict.keys():
             try:


### PR DESCRIPTION
When the show command is run, don't abort if InterfaceAliasConverter fails to create port_dict. Instead, print a warning message and continue execution.

Without this change, no show commands will work if there is no PORT table in ConfigDB (e.g., if the device is freshly imaged, but unconfigured. In this situation, one cannot get any system info, as all show commands abort (e.g., `show version`, `show platform summary`, etc.). These commands should work whether or not the device is configured.