### PR TITLE
[fast-reboot] Stop services after killing containers to prevent automatic restart

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -377,18 +377,30 @@ docker exec -i bgp pkill -9 zebra
 docker exec -i bgp pkill -9 bgpd || [ $? == 1 ]
 debug "Stopped  bgp ..."
 
-# Kill lldp, otherwise it sends informotion about reboot
+# Kill lldp, otherwise it sends informotion about reboot.
+# We call `docker kill lldp` to ensure the container stops as quickly as possible,
+# then immediately call `systemctl stop lldp` to prevent the service from
+# restarting the container automatically.
 docker kill lldp > /dev/null
+systemctl stop lldp
 
 if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
     # Kill teamd, otherwise it gets down all LAGs
+    # We call `docker kill teamd` to ensure the container stops as quickly as possible,
+    # then immediately call `systemctl stop teamd` to prevent the service from
+    # restarting the container automatically.
     # Note: teamd must be killed before syncd, because it will send the last packet through CPU port
     # TODO: stop teamd gracefully to allow teamd to send last valid update to be sure we'll have 90 seconds reboot time
     docker kill teamd > /dev/null
+    systemctl stop teamd
 fi
 
-# Kill swss dockers
+# Kill swss Docker container
+# We call `docker kill swss` to ensure the container stops as quickly as possible,
+# then immediately call `systemctl stop swss` to prevent the service from
+# restarting the container automatically.
 docker kill swss > /dev/null
+systemctl stop swss
 
 # Pre-shutdown syncd
 if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; then
@@ -425,7 +437,13 @@ systemctl stop syncd
 debug "Stopped  syncd ..."
 
 # Kill other containers to make the reboot faster
-docker ps -q | xargs docker kill > /dev/null
+# We call `docker kill ...` to ensure the container stops as quickly as possible,
+# then immediately call `systemctl stop ...` to prevent the service from
+# restarting the container automatically.
+for CONTAINER_NAME in $(docker ps --format '{{.Names}}'); do
+    docker kill $CONTAINER_NAME > /dev/null
+    systemctl stop $CONTAINER_NAME
+done
 
 # Stop the docker container engine. Otherwise we will have a broken docker storage
 systemctl stop docker.service


### PR DESCRIPTION
**- What I did**

Explicitly stop corresponding services after killing Docker containers to prevent the service from automatically restarting the container during fast-/warm-reboot.

We are beginning to configure the services which control Docker containers to automatically restart the service and all dependent services if the container should ever stop. In the case of fast-/warm-reboot, stopping the service could require up to 10 seconds to stop the container (due to the behavior of the underlying `docker stop` command). This could take too long, so in this script we call `docker kill`, which will work faster. However, after killing the container, the service which controls the container (once configured to restart) will restart the container after the specified interval, but we do not want the behavior under these fast-/warm-reboot circumstances. The services will be restarted after completing the reboot. Therefore, we stop the service immediately after killing the corresponding container to ensure the service cannot automatically restart the container.