### PR TITLE
Fix reboot command for booting to other OS

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -8,6 +8,7 @@ DEVPATH="/usr/share/sonic/device"
 PLAT_REBOOT="platform_reboot"
 REBOOT_CAUSE_FILE="/host/reboot-cause/reboot-cause.txt"
 VERBOSE=no
+FORCE=no
 EXIT_NEXT_IMAGE_NOT_EXISTS=4
 
 function debug()
@@ -50,6 +51,8 @@ function show_help_and_exit()
     echo " "
     echo "    Available options:"
     echo "        -h, -? : getting this help"
+    echo "        -v : verbose mode"
+    echo "        -f : forcing to reboot even without pre-check success"
 
     exit 0
 }
@@ -73,7 +76,7 @@ function reboot_pre_check()
     rm ${filename}
 
     # Make sure that the next image exists
-    if [[ ! -d ${IMAGE_PATH} ]]; then
+    if [[ ! -d ${IMAGE_PATH} ]] && [[ x"$FORCE" != x"yes" ]]; then
         VERBOSE=yes debug "Next image ${NEXT_SONIC_IMAGE} doesn't exist ..."
         exit ${EXIT_NEXT_IMAGE_NOT_EXISTS}
     fi
@@ -81,13 +84,15 @@ function reboot_pre_check()
 
 function parse_options()
 {
-    while getopts "h?v" opt; do
+    while getopts "h?vf" opt; do
         case ${opt} in
             h|\? )
                 show_help_and_exit
                 ;;
             v )
                 VERBOSE=yes
+                ;;
+            f ) FORCE=yes
                 ;;
         esac
     done

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -175,9 +175,12 @@ def get_current_image():
 # Returns name of next boot image
 def get_next_image():
     if get_running_image_type() == IMAGE_TYPE_ABOOT:
-        config = open(HOST_PATH + ABOOT_BOOT_CONFIG, 'r')
-        next_image = re.search("SWI=flash:(\S+)/", config.read()).group(1).replace(IMAGE_DIR_PREFIX, IMAGE_PREFIX)
-        config.close()
+        with open(HOST_PATH + ABOOT_BOOT_CONFIG, 'r') as f:
+            config = f.read()
+            match = re.search("SWI=flash:(\S+)/", config)
+            if match is None:
+                match = re.search("SWI=flash:/?(\S+)", config)
+            next_image = match.group(1).replace(IMAGE_DIR_PREFIX, IMAGE_PREFIX)
     else:
         images = get_installed_images()
         grubenv = subprocess.check_output(["/usr/bin/grub-editenv", HOST_PATH + "/grub/grubenv", "list"])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
The reboot command may not be able boot to some OS other than SONiC for the exception in reboot_pre_check(), as a result of "sonic_installer list" throwing exception when the image path of the next OS does not satisfy the pattern of SONiC. 

Add an option '-f' to the reboot command to override the exception in reboot_pre_check(), which can  be used for rebooting regardless of the availability of the next image. Besides, fix the line of 'Next: ' in the output of "sonic_install list", for the case that SONiC is not the next image under the Aboot condition.

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

