### PR TITLE
[acl_loader]: Fix show table binding when bound to only one entry

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -517,7 +517,7 @@ class AclLoader(object):
                 services = natsorted(val["services"])
                 data.append([key, val["type"], services[0], val["policy_desc"]])
 
-                if len(services) > 1:
+                if "," in services:
                     for service in services[1:]:
                         data.append(["", "", service, ""])
             else:
@@ -527,7 +527,7 @@ class AclLoader(object):
                     ports = natsorted(val["ports"])
                     data.append([key, val["type"], ports[0], val["policy_desc"]])
 
-                    if len(ports) > 1:
+                    if "," in ports:
                         for port in ports[1:]:
                             data.append(["", "", port, ""])
 


### PR DESCRIPTION
the string length is always larger than 1, causing the display format
gets corrupted

check if the deliminator is in the string instead of checking the length
of the variable

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>