### PR TITLE
[acl_loader]:Fix show mirror_session error

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -48,7 +48,8 @@ class AclLoader(object):
     ACL_RULE = "ACL_RULE"
     ACL_TABLE_TYPE_MIRROR = "MIRROR"
     ACL_TABLE_TYPE_CTRLPLANE = "CTRLPLANE"
-    MIRROR_SESSION = "MIRROR_SESSION"
+    CFG_MIRROR_SESSION_TABLE = "MIRROR_SESSION"
+    STATE_MIRROR_SESSION_TABLE = "MIRROR_SESSION_TABLE"
     SESSION_PREFIX = "everflow"
 
     min_priority = 1
@@ -118,9 +119,9 @@ class AclLoader(object):
         Read ACL tables information from Config DB
         :return:
         """
-        self.sessions_db_info = self.configdb.get_table(self.MIRROR_SESSION)
+        self.sessions_db_info = self.configdb.get_table(self.CFG_MIRROR_SESSION_TABLE)
         for key in self.sessions_db_info.keys():
-            state_db_info = self.statedb.get_all(self.statedb.STATE_DB, "{}|{}".format(self.MIRROR_SESSION, key))
+            state_db_info = self.statedb.get_all(self.statedb.STATE_DB, "{}|{}".format(self.STATE_MIRROR_SESSION_TABLE, key))
             if state_db_info:
                 status = state_db_info.get("status", "inactive")
             else:


### PR DESCRIPTION
Signed-off-by: Jared.Liu <Jared.Liu@nephosinc.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
when execute command "show mirror_session", the status display error.
admin@sonic:~$ show mirror_session
Name       Status    SRC IP        DST IP       GRE       DSCP    TTL  Queue
---------  --------  ------------  -----------  ------  ------  -----  -------
everflow0  error     14.14.14.149  192.192.2.2  0x6558      50     64 
there is some code error in acl_loader/main.py.
**- How I did it**
when get mirror session information from state_db, use MIRROR_SESSION_TABLE instead of MIRROR_SESSION
**- How to verify it**
After fix, the status display correct.
admin@sonic:~$ show mirror_session
Name       Status    SRC IP        DST IP       GRE       DSCP    TTL  Queue    Policer
---------  --------  ------------  -----------  ------  ------  -----  -------  ---------
everflow0  active    14.14.14.149  192.192.2.2  0x6558      50     64 
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

