### PR TITLE
[config] Do not stop or restart dependent services when reloading config

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -288,13 +288,10 @@ def _abort_if_false(ctx, param, value):
 
 def _stop_services():
     services = [
-        'dhcp_relay',
         'swss',
-        'snmp',
         'lldp',
         'pmon',
         'bgp',
-        'teamd',
         'hostcfgd',
     ]
     for service in services:
@@ -312,11 +309,8 @@ def _restart_services():
         'rsyslog-config',
         'swss',
         'bgp',
-        'teamd',
         'pmon',
         'lldp',
-        'snmp',
-        'dhcp_relay',
         'hostcfgd',
     ]
     for service in services:


### PR DESCRIPTION
**- What I did**

Remove explicit calls to stop/restart services which are now dependent on SwSS.

As of https://github.com/Azure/sonic-buildimage/pull/2546, teamd, snmp and dhcp_relay services will be stopped/started/restarted along with swss when it is stopped/started/restarted, respectively.

This prevents issues due to double restarts (e.g., this script would call `systemctl restart swss`, which would now cause teamd to restart, then shortly thereafter it would call `systemctl restart teamd`, which could lead to instability).

Now, stopping/starting/restarting swss will also stop/start/restart teamd, snmp, dhcp_relay and radv services, so we should no longer be stopping/starting/restarting them along with swss.