### PR TITLE
Fixing the expected neighbor command due to change in output format under sonic-buildimage/pull/3036

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -449,32 +449,32 @@ def expected(interfacename):
 
     #Swap Key and Value from interface: name to name: interface
     device2interface_dict = {}
-    for port in natsorted(neighbor_dict.keys()):
+    for port in natsorted(neighbor_dict['DEVICE_NEIGHBOR'].keys()):
         temp_port = port
         if get_interface_mode() == "alias":
             port = iface_alias_converter.name_to_alias(port)
-            neighbor_dict[port] = neighbor_dict.pop(temp_port)
-        device2interface_dict[neighbor_dict[port]['name']] = {'localPort': port, 'neighborPort': neighbor_dict[port]['port']}
+            neighbor_dict['DEVICE_NEIGHBOR'][port] = neighbor_dict['DEVICE_NEIGHBOR'].pop(temp_port)
+        device2interface_dict[neighbor_dict['DEVICE_NEIGHBOR'][port]['name']] = {'localPort': port, 'neighborPort': neighbor_dict['DEVICE_NEIGHBOR'][port]['port']}
 
     header = ['LocalPort', 'Neighbor', 'NeighborPort', 'NeighborLoopback', 'NeighborMgmt', 'NeighborType']
     body = []
     if interfacename:
-        for device in natsorted(neighbor_metadata_dict.keys()):
+        for device in natsorted(neighbor_metadata_dict['DEVICE_NEIGHBOR_METADATA'].keys()):
             if device2interface_dict[device]['localPort'] == interfacename:
                 body.append([device2interface_dict[device]['localPort'],
                              device,
                              device2interface_dict[device]['neighborPort'],
-                             neighbor_metadata_dict[device]['lo_addr'],
-                             neighbor_metadata_dict[device]['mgmt_addr'],
-                             neighbor_metadata_dict[device]['type']])
+                             neighbor_metadata_dict['DEVICE_NEIGHBOR_METADATA'][device]['lo_addr'],
+                             neighbor_metadata_dict['DEVICE_NEIGHBOR_METADATA'][device]['mgmt_addr'],
+                             neighbor_metadata_dict['DEVICE_NEIGHBOR_METADATA'][device]['type']])
     else:
-        for device in natsorted(neighbor_metadata_dict.keys()):
+        for device in natsorted(neighbor_metadata_dict['DEVICE_NEIGHBOR_METADATA'].keys()):
             body.append([device2interface_dict[device]['localPort'],
                          device,
                          device2interface_dict[device]['neighborPort'],
-                         neighbor_metadata_dict[device]['lo_addr'],
-                         neighbor_metadata_dict[device]['mgmt_addr'],
-                         neighbor_metadata_dict[device]['type']])
+                         neighbor_metadata_dict['DEVICE_NEIGHBOR_METADATA'][device]['lo_addr'],
+                         neighbor_metadata_dict['DEVICE_NEIGHBOR_METADATA'][device]['mgmt_addr'],
+                         neighbor_metadata_dict['DEVICE_NEIGHBOR_METADATA'][device]['type']])
 
     click.echo(tabulate(body, header))
 


### PR DESCRIPTION
Please provide the following information:
-->

**- What I did**
Fixed show interface neigh expected which was broken because of https://github.com/Azure/sonic-buildimage/pull/3036

**- How I did it**
There was a change in the output format for --var-json option in sonic-config-engine,changes had to be done for show commands as well.

**- How to verify it**
Build the sonic-utilities debian package after applying these changes or for quick test smash /usr/lib/python2.7/dist-packages/show/main.py with the file with these changes.

**Test Data**


admin@lnos-x1-a-csw02:~$ sonic-cfggen -d --var-json "DEVICE_NEIGHBOR"
{
    "DEVICE_NEIGHBOR": {
        "Ethernet112": {
            "name": "lsg1-p27-csw01.nw",
            "port": "Eth0"
        },
        "Ethernet114": {
            "name": "lsg1-p27-csw02.nw",
            "port": "Eth0"
        }
    }
}
admin@lnos-x1-a-csw02:~$ sonic-cfggen -d --var-json "DEVICE_NEIGHBOR_METADATA"
{
    "DEVICE_NEIGHBOR_METADATA": {
        "Device1": {
            "lo_addr": "127.0.0.1",
            "mgmt_addr": "10.0.0.1",
            "type": "test1"
        },
        "Device2": {
            "lo_addr": "127.0.0.2",
            "mgmt_addr": "10.0.0.2",
            "type": "test2"
        }
    }
}
admin@lnos-x1-a-csw02:~$


admin@lnos-x1-a-csw02:~$ show interfaces neighbor expected
LocalPort    Neighbor           NeighborPort    NeighborLoopback    NeighborMgmt    NeighborType
-----------  -----------------  --------------  ------------------  --------------  --------------
Ethernet112  Device1  Eth0            127.0.0.1           10.0.0.1        test1
Ethernet114  Device2  Eth0            127.0.0.2           10.0.0.2        test2
admin@lnos-x1-a-csw02:~$




