### PR TITLE
[config]: fix the runtime error of the 'show line' command  (#595)

### DIFF
--- a/consutil/main.py
+++ b/consutil/main.py
@@ -11,7 +11,9 @@ try:
     import pexpect
     import re
     import subprocess
+    import sys
     from tabulate import tabulate
+    from lib import *
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
 


### PR DESCRIPTION
[config]: fix the runtime error of the 'show line' command  (#595)
Signed-off-by: wangshengjun <wangshengjun@asterfusion.com>

**What I did**
Fix the runtime error of the 'show line' command 
**Why I did it**
the command of 'show line' executes fail.
**How I verified it**
Recompile the debian package and execute the 'show line' command.

**Before the change**
admin@48S:~$ show line      
Traceback (most recent call last):
  File "/usr/bin/consutil", line 8, in <module>
    from consutil.main import consutil
ImportError: No module named consutil.main

admin@48S:~$ show line              // add the  '__init__.py ' file 
Traceback (most recent call last):
  File "/usr/bin/consutil", line 12, in <module>
    Root privileges are required for this operation
sys.exit(consutil())
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1063, in invoke
    Command.invoke(self, ctx)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/consutil/main.py", line 24, in consutil
    sys.exit(1)
NameError: global name 'sys' is not defined

**After the change**
admin@48S:~$ show line 
Root privileges are required for this operation
admin@48S-222:~$ sudo show line
Command resulted in error: ls: cannot access '/dev/ttyUSB*': No such file or directory

