### PR TITLE
[show] Add BGP neighbor info to 'show ip/ipv6 interfaces' command output

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -2043,16 +2043,16 @@ The type of interfaces include the following.
 - Example:
   ```
 	admin@sonic:~$ show ip interfaces
-  Interface      IPv4 address/mask    Admin/Oper    Neighbor    PeerIp
-  -------------  -------------------  ------------  ----------  ---------
-  PortChannel01  10.0.0.56/31         up/down       DEVICE1     10.0.0.57
-  PortChannel02  10.0.0.58/31         up/down       DEVICE2     10.0.0.59
-  PortChannel03  10.0.0.60/31         up/down       DEVICE3     10.0.0.61
-  PortChannel04  10.0.0.62/31         up/down       DEVICE4     10.0.0.63
-  Vlan100        10.168.0.1/27        up/up         N/A         N/A
-  docker0        240.127.1.1/24       up/down       N/A         N/A
-  eth0           10.3.147.252/23      up/up         N/A         N/A
-  lo             127.0.0.1/8          up/up         N/A         N/A
+    Interface      IPv4 address/mask    Admin/Oper    Neighbor    PeerIp
+    -------------  -------------------  ------------  ----------  ---------
+    PortChannel01  10.0.0.56/31         up/down       DEVICE1     10.0.0.57
+    PortChannel02  10.0.0.58/31         up/down       DEVICE2     10.0.0.59
+    PortChannel03  10.0.0.60/31         up/down       DEVICE3     10.0.0.61
+    PortChannel04  10.0.0.62/31         up/down       DEVICE4     10.0.0.63
+    Vlan100        10.168.0.1/27        up/up         N/A         N/A
+    docker0        240.127.1.1/24       up/down       N/A         N/A
+    eth0           10.3.147.252/23      up/up         N/A         N/A
+    lo             127.0.0.1/8          up/up         N/A         N/A
   ```
 
 
@@ -2153,16 +2153,16 @@ The type of interfaces include the following.
 - Example:
   ```
 	admin@sonic:~$ show ipv6 interfaces
-  Interface      IPv6 address/mask                         Admin/Oper    BGP Neighbor    Neighbor IP
-  -------------  ----------------------------------------  ------------  --------------  -------------
-  Bridge         fe80::7c45:1dff:fe08:cdd%Bridge/64        up/up         N/A             N/A
-  PortChannel01  fc00::71/126                              up/down       DEVICE1         fc00::72
-  PortChannel02  fc00::75/126                              up/down       DEVICE2         fc00::76
-  PortChannel03  fc00::79/126                              up/down       DEVICE3         fc00::7a
-  PortChannel04  fc00::7d/126                              up/down       DEVICE4         fc00::7e
-  Vlan100        fe80::eef4:bbff:fefe:880a%Vlan100/64      up/up         N/A             N/A
-  eth0           fe80::eef4:bbff:fefe:880a%eth0/64         up/up         N/A             N/A
-  lo             fc00:1::32/128                            up/up         N/A             N/A
+    Interface      IPv6 address/mask                         Admin/Oper    BGP Neighbor    Neighbor IP
+    -------------  ----------------------------------------  ------------  --------------  -------------
+    Bridge         fe80::7c45:1dff:fe08:cdd%Bridge/64        up/up         N/A             N/A
+    PortChannel01  fc00::71/126                              up/down       DEVICE1         fc00::72
+    PortChannel02  fc00::75/126                              up/down       DEVICE2         fc00::76
+    PortChannel03  fc00::79/126                              up/down       DEVICE3         fc00::7a
+    PortChannel04  fc00::7d/126                              up/down       DEVICE4         fc00::7e
+    Vlan100        fe80::eef4:bbff:fefe:880a%Vlan100/64      up/up         N/A             N/A
+    eth0           fe80::eef4:bbff:fefe:880a%eth0/64         up/up         N/A             N/A
+    lo             fc00:1::32/128                            up/up         N/A             N/A
   ```
 
 **show ipv6 protocol**

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -2043,16 +2043,16 @@ The type of interfaces include the following.
 - Example:
   ```
 	admin@sonic:~$ show ip interfaces
-	Interface      IPv4 address/mask    Admin/Oper    Neighbor    PeerIp
-	-------------  -------------------  ------------  ----------  ---------
-	PortChannel01  10.0.0.56/31         up/down       DEVICE1     10.0.0.57
-	PortChannel02  10.0.0.58/31         up/down       DEVICE2     10.0.0.59
-	PortChannel03  10.0.0.60/31         up/down       DEVICE3     10.0.0.61
-	PortChannel04  10.0.0.62/31         up/down       DEVICE4     10.0.0.63
-	Vlan100        10.168.0.1/27        up/up         N/A         N/A
-	docker0        240.127.1.1/24       up/down       N/A         N/A
-	eth0           10.3.147.252/23      up/up         N/A         N/A
-	lo             127.0.0.1/8          up/up         N/A         N/A
+	Interface      IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
+	-------------  -------------------  ------------  --------------  -------------
+	PortChannel01  10.0.0.56/31         up/down       DEVICE1         10.0.0.57
+	PortChannel02  10.0.0.58/31         up/down       DEVICE2         10.0.0.59
+	PortChannel03  10.0.0.60/31         up/down       DEVICE3         10.0.0.61
+	PortChannel04  10.0.0.62/31         up/down       DEVICE4         10.0.0.63
+	Vlan1000       192.168.0.1/27       up/up         N/A             N/A
+	docker0        240.127.1.1/24       up/down       N/A             N/A
+	eth0           10.3.147.252/23      up/up         N/A             N/A
+	lo             127.0.0.1/8          up/up         N/A             N/A
   ```
 
 **show ip protocol**

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -2043,19 +2043,16 @@ The type of interfaces include the following.
 - Example:
   ```
 	admin@sonic:~$ show ip interfaces
-	Interface        IPv4 address/mask    Admin/Oper
-	---------------  -------------------  ------------
-	Ethernet112      10.1.1.0/31          up/up
-	Ethernet116      10.1.1.2/31          up/up
-	PortChannel0001  10.0.1.1/31          up/down
-	PortChannel0002  10.0.1.3/31          up/down
-	Vlan100          1.1.2.2/16           up/down
-	docker0          240.127.1.1/24       up/down
-	eth0             10.11.162.42/24      up/up
-	lo               127.0.0.1/8          up/up
-					 10.1.0.1/32
-					 10.1.0.32/32
-					 10.12.0.102/32
+  Interface      IPv4 address/mask    Admin/Oper    Neighbor    PeerIp
+  -------------  -------------------  ------------  ----------  ---------
+  PortChannel01  10.0.0.56/31         up/down       DEVICE1     10.0.0.57
+  PortChannel02  10.0.0.58/31         up/down       DEVICE2     10.0.0.59
+  PortChannel03  10.0.0.60/31         up/down       DEVICE3     10.0.0.61
+  PortChannel04  10.0.0.62/31         up/down       DEVICE4     10.0.0.63
+  Vlan100        10.168.0.1/27        up/up         N/A         N/A
+  docker0        240.127.1.1/24       up/down       N/A         N/A
+  eth0           10.3.147.252/23      up/up         N/A         N/A
+  lo             127.0.0.1/8          up/up         N/A         N/A
   ```
 
 
@@ -2156,23 +2153,16 @@ The type of interfaces include the following.
 - Example:
   ```
 	admin@sonic:~$ show ipv6 interfaces
-	Interface        IPv6 address/mask                            Admin/Oper
-	---------------  -------------------------------------------  ------------
-	Bridge           fe80::d494:dcff:fe37:535e%Bridge/64          up/down
-	Ethernet112      2018:2001::1/126                             up/up
-					 fe80::3617:ebff:fe38:100%Ethernet112/64
-	Ethernet116      2018:2002::1/126                             up/up
-					 fe80::3617:ebff:fe38:100%Ethernet116/64
-	PortChannel0001  2018:1002::2/126                             up/down
-	PortChannel0002  2018:1002::6/126                             up/down
-	PortChannel0011  fe80::3617:ebff:fe38:100%PortChannel0011/64  up/up
-	Vlan100          fe80::3617:ebff:fe38:100%Vlan100/64          up/down
-	eth0             fc00:2::102/128                              up/up
-					 fe80::3617:ebff:fe38:100%eth0/64
-	lo               fc00:1::102/128                              up/up
-					 fc00:1::32/128
-					 ::1/128
-
+  Interface      IPv6 address/mask                         Admin/Oper    BGP Neighbor    Neighbor IP
+  -------------  ----------------------------------------  ------------  --------------  -------------
+  Bridge         fe80::7c45:1dff:fe08:cdd%Bridge/64        up/up         N/A             N/A
+  PortChannel01  fc00::71/126                              up/down       DEVICE1         fc00::72
+  PortChannel02  fc00::75/126                              up/down       DEVICE2         fc00::76
+  PortChannel03  fc00::79/126                              up/down       DEVICE3         fc00::7a
+  PortChannel04  fc00::7d/126                              up/down       DEVICE4         fc00::7e
+  Vlan100        fe80::eef4:bbff:fefe:880a%Vlan100/64      up/up         N/A             N/A
+  eth0           fe80::eef4:bbff:fefe:880a%eth0/64         up/up         N/A             N/A
+  lo             fc00:1::32/128                            up/up         N/A             N/A
   ```
 
 **show ipv6 protocol**

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -2043,19 +2043,17 @@ The type of interfaces include the following.
 - Example:
   ```
 	admin@sonic:~$ show ip interfaces
-    Interface      IPv4 address/mask    Admin/Oper    Neighbor    PeerIp
-    -------------  -------------------  ------------  ----------  ---------
-    PortChannel01  10.0.0.56/31         up/down       DEVICE1     10.0.0.57
-    PortChannel02  10.0.0.58/31         up/down       DEVICE2     10.0.0.59
-    PortChannel03  10.0.0.60/31         up/down       DEVICE3     10.0.0.61
-    PortChannel04  10.0.0.62/31         up/down       DEVICE4     10.0.0.63
-    Vlan100        10.168.0.1/27        up/up         N/A         N/A
-    docker0        240.127.1.1/24       up/down       N/A         N/A
-    eth0           10.3.147.252/23      up/up         N/A         N/A
-    lo             127.0.0.1/8          up/up         N/A         N/A
+	Interface      IPv4 address/mask    Admin/Oper    Neighbor    PeerIp
+	-------------  -------------------  ------------  ----------  ---------
+	PortChannel01  10.0.0.56/31         up/down       DEVICE1     10.0.0.57
+	PortChannel02  10.0.0.58/31         up/down       DEVICE2     10.0.0.59
+	PortChannel03  10.0.0.60/31         up/down       DEVICE3     10.0.0.61
+	PortChannel04  10.0.0.62/31         up/down       DEVICE4     10.0.0.63
+	Vlan100        10.168.0.1/27        up/up         N/A         N/A
+	docker0        240.127.1.1/24       up/down       N/A         N/A
+	eth0           10.3.147.252/23      up/up         N/A         N/A
+	lo             127.0.0.1/8          up/up         N/A         N/A
   ```
-
-
 
 **show ip protocol**
 
@@ -2153,16 +2151,16 @@ The type of interfaces include the following.
 - Example:
   ```
 	admin@sonic:~$ show ipv6 interfaces
-    Interface      IPv6 address/mask                         Admin/Oper    BGP Neighbor    Neighbor IP
-    -------------  ----------------------------------------  ------------  --------------  -------------
-    Bridge         fe80::7c45:1dff:fe08:cdd%Bridge/64        up/up         N/A             N/A
-    PortChannel01  fc00::71/126                              up/down       DEVICE1         fc00::72
-    PortChannel02  fc00::75/126                              up/down       DEVICE2         fc00::76
-    PortChannel03  fc00::79/126                              up/down       DEVICE3         fc00::7a
-    PortChannel04  fc00::7d/126                              up/down       DEVICE4         fc00::7e
-    Vlan100        fe80::eef4:bbff:fefe:880a%Vlan100/64      up/up         N/A             N/A
-    eth0           fe80::eef4:bbff:fefe:880a%eth0/64         up/up         N/A             N/A
-    lo             fc00:1::32/128                            up/up         N/A             N/A
+	Interface      IPv6 address/mask                         Admin/Oper    BGP Neighbor    Neighbor IP
+	-------------  ----------------------------------------  ------------  --------------  -------------
+	Bridge         fe80::7c45:1dff:fe08:cdd%Bridge/64        up/up         N/A             N/A
+	PortChannel01  fc00::71/126                              up/down       DEVICE1         fc00::72
+	PortChannel02  fc00::75/126                              up/down       DEVICE2         fc00::76
+	PortChannel03  fc00::79/126                              up/down       DEVICE3         fc00::7a
+	PortChannel04  fc00::7d/126                              up/down       DEVICE4         fc00::7e
+	Vlan100        fe80::eef4:bbff:fefe:880a%Vlan100/64      up/up         N/A             N/A
+	eth0           fe80::eef4:bbff:fefe:880a%eth0/64         up/up         N/A             N/A
+	lo             fc00:1::32/128                            up/up         N/A             N/A
   ```
 
 **show ipv6 protocol**

--- a/show/main.py
+++ b/show/main.py
@@ -906,15 +906,16 @@ def get_if_oper_state(iface):
 #
 # 'show ip interfaces' command
 #
-# Display all interfaces with an IPv4 address and their admin/oper states.
+# Display all interfaces with an IPv4 address, admin/oper states, their BGP neighbor name and peer ip.
 # Addresses from all scopes are included. Interfaces with no addresses are
 # excluded.
 #
 @ip.command()
 def interfaces():
     """Show interfaces IPv4 address"""
-    header = ['Interface', 'IPv4 address/mask', 'Admin/Oper']
+    header = ['Interface', 'IPv4 address/mask', 'Admin/Oper', 'BGP Neighbor', 'Neighbor IP']
     data = []
+    bgp_peer = get_bgp_peer()
 
     interfaces = natsorted(netifaces.interfaces())
 
@@ -924,8 +925,16 @@ def interfaces():
         if netifaces.AF_INET in ipaddresses:
             ifaddresses = []
             for ipaddr in ipaddresses[netifaces.AF_INET]:
+                neighbor_name = 'N/A'
+                neighbor_ip = 'N/A'
+                local_ip = str(ipaddr['addr'])
                 netmask = netaddr.IPAddress(ipaddr['netmask']).netmask_bits()
-                ifaddresses.append(["", str(ipaddr['addr']) + "/" + str(netmask)])
+                ifaddresses.append(["", local_ip + "/" + str(netmask)])
+                try:
+                    neighbor_name = bgp_peer[local_ip][0]
+                    neighbor_ip = bgp_peer[local_ip][1]
+                except:
+                    pass
 
             if len(ifaddresses) > 0:
                 admin = get_if_admin_state(iface)
@@ -937,13 +946,32 @@ def interfaces():
                 if get_interface_mode() == "alias":
                     iface = iface_alias_converter.name_to_alias(iface)
 
-                data.append([iface, ifaddresses[0][1], admin + "/" + oper])
+                data.append([iface, ifaddresses[0][1], admin + "/" + oper, neighbor_name, neighbor_ip])
 
             for ifaddr in ifaddresses[1:]:
                 data.append(["", ifaddr[1], ""])
 
     print tabulate(data, header, tablefmt="simple", stralign='left', missingval="")
 
+# get bgp peering info
+def get_bgp_peer():
+    """
+    collects local and bgp neighbor ip along with device name in below format
+    {
+     'local_addr1':['neighbor_device1_name', 'neighbor_device1_ip'],
+     'local_addr2':['neighbor_device2_name', 'neighbor_device2_ip']
+     }
+    """
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    data = config_db.get_table('BGP_NEIGHBOR')
+    bgp_peer = {}
+
+    for neighbor_ip in data.keys():
+        local_addr = data[neighbor_ip]['local_addr']
+        neighbor_name = data[neighbor_ip]['name']
+        bgp_peer.setdefault(local_addr,[neighbor_name,neighbor_ip])
+    return bgp_peer
 
 #
 # 'route' subcommand ("show ip route")
@@ -1002,7 +1030,7 @@ def ipv6():
 #
 # 'show ipv6 interfaces' command
 #
-# Display all interfaces with an IPv6 address and their admin/oper states.
+# Display all interfaces with an IPv6 address, admin/oper states, their BGP neighbor name and peer ip.
 # Addresses from all scopes are included. Interfaces with no addresses are
 # excluded.
 #
@@ -1011,6 +1039,7 @@ def interfaces():
     """Show interfaces IPv6 address"""
     header = ['Interface', 'IPv6 address/mask', 'Admin/Oper']
     data = []
+    bgp_peer = get_bgp_peer()
 
     interfaces = natsorted(netifaces.interfaces())
 
@@ -1020,8 +1049,16 @@ def interfaces():
         if netifaces.AF_INET6 in ipaddresses:
             ifaddresses = []
             for ipaddr in ipaddresses[netifaces.AF_INET6]:
+                neighbor_name = 'N/A'
+                neighbor_ip = 'N/A'
+                local_ip = str(ipaddr['addr'])
                 netmask = ipaddr['netmask'].split('/', 1)[-1]
-                ifaddresses.append(["", str(ipaddr['addr']) + "/" + str(netmask)])
+                ifaddresses.append(["", local_ip + "/" + str(netmask)])
+                try:
+                    neighbor_name = bgp_peer[local_ip][0]
+                    neighbor_ip = bgp_peer[local_ip][1]
+                except:
+                    pass
 
             if len(ifaddresses) > 0:
                 admin = get_if_admin_state(iface)
@@ -1031,7 +1068,7 @@ def interfaces():
                     oper = "down"
                 if get_interface_mode() == "alias":
                     iface = iface_alias_converter.name_to_alias(iface)
-                data.append([iface, ifaddresses[0][1], admin + "/" + oper])
+                data.append([iface, ifaddresses[0][1], admin + "/" + oper], neighbor_name, neighbor_ip)
             for ifaddr in ifaddresses[1:]:
                 data.append(["", ifaddr[1], ""])
 

--- a/show/main.py
+++ b/show/main.py
@@ -970,7 +970,7 @@ def get_bgp_peer():
     for neighbor_ip in data.keys():
         local_addr = data[neighbor_ip]['local_addr']
         neighbor_name = data[neighbor_ip]['name']
-        bgp_peer.setdefault(local_addr,[neighbor_name,neighbor_ip])
+        bgp_peer.setdefault(local_addr, [neighbor_name, neighbor_ip])
     return bgp_peer
 
 #


### PR DESCRIPTION
**- What I did**
Added BGP neighbor and BGP neighbor ip to 'show ip interfaces' and 'show ipv6 interfaces' command output
**- How I did it**
By getting the neighbor info from the CONFIG DB BGP_NEIGHBOR table
**- How to verify it**
Run show ip interfaces or show ipv6 interfaces in the hardware box
**- Previous command output (if the output of a command-line utility has changed)**

**show ip interfaces**
```
Interface      IPv4 address/mask    Admin/Oper  
-------------  -------------------  ------------
PortChannel01  10.0.0.56/31         up/down     
PortChannel02  10.0.0.58/31         up/down     
PortChannel03  10.0.0.60/31         up/down     
PortChannel04  10.0.0.62/31         up/down     
Vlan100        10.168.0.1/27        up/up       
docker0        240.127.1.1/24       up/down     
eth0           10.3.147.252/23      up/up       
lo             127.0.0.1/8          up/up       
```

**show ipv6 interfaces**
```
Interface      IPv6 address/mask                         Admin/Oper  
-------------  ----------------------------------------  ------------
Bridge         fe80::7c45:1dff:fe08:cdd%Bridge/64        up/up       
PortChannel01  fc00::71/126                              up/down     
PortChannel02  fc00::75/126                              up/down     
PortChannel03  fc00::79/126                              up/down     
PortChannel04  fc00::7d/126                              up/down     
Vlan100        fe80::eef4:bbff:fefe:880a%Vlan100/64      up/up       
eth0           fe80::eef4:bbff:fefe:880a%eth0/64         up/up       
lo             fc00:1::32/128                            up/up       
```

**- New command output (if the output of a command-line utility has changed)**

**show ip interfaces**
```
Interface      IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
-------------  -------------------  ------------  --------------  -------------
PortChannel01  10.0.0.56/31         up/down       DEVICE1         10.0.0.57
PortChannel02  10.0.0.58/31         up/down       DEVICE2         10.0.0.59
PortChannel03  10.0.0.60/31         up/down       DEVICE3         10.0.0.61
PortChannel04  10.0.0.62/31         up/down       DEVICE4         10.0.0.63
Vlan1000       192.168.0.1/27       up/up         N/A             N/A
docker0        240.127.1.1/24       up/down       N/A             N/A
eth0           10.3.147.252/23      up/up         N/A             N/A
lo             127.0.0.1/8          up/up         N/A             N/A
```
**show ipv6 interfaces**
```
Interface      IPv6 address/mask                         Admin/Oper    BGP Neighbor    Neighbor IP
-------------  ----------------------------------------  ------------  --------------  -------------
Bridge         fe80::7c45:1dff:fe08:cdd%Bridge/64        up/up         N/A             N/A
PortChannel01  fc00::71/126                              up/down       DEVICE1         fc00::72
PortChannel02  fc00::75/126                              up/down       DEVICE2         fc00::76
PortChannel03  fc00::79/126                              up/down       DEVICE3         fc00::7a
PortChannel04  fc00::7d/126                              up/down       DEVICE4         fc00::7e
Vlan100        fe80::eef4:bbff:fefe:880a%Vlan100/64      up/up         N/A             N/A
eth0           fe80::eef4:bbff:fefe:880a%eth0/64         up/up         N/A             N/A
lo             fc00:1::32/128                            up/up         N/A             N/A
```
