### PR TITLE
Changinging "show runningconfiguration interface" to "show runningconfiguration ports"

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -2958,7 +2958,7 @@ This sub-section explains the show commands for displaying the running configura
 4) snmp
 5) all
 6) acl
-7) interface
+7) ports
 
 **show runningconfiguration all**
 
@@ -3038,21 +3038,21 @@ This command displays the running configuration of the snmp module.
   admin@sonic:~$ show runningconfiguration acl
   ```
 
- **show runningconfiguration interface <interfacename>**
+ **show runningconfiguration ports <portname>**
 
  This command displays the running configuration of the ports
 
    - Usage:
-    show runningconfiguration interface <interfacename>
+    show runningconfiguration ports <portname>
 
 
  - Example:
   ```
-  admin@sonic:~$ show runningconfiguration interface
+  admin@sonic:~$ show runningconfiguration ports
   ```
 
    ```
-  admin@sonic:~$ show runningconfiguration interface <interfacename>
+  admin@sonic:~$ show runningconfiguration ports <portname>
   ```
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Startup--Running-Configuration)

--- a/show/main.py
+++ b/show/main.py
@@ -1388,7 +1388,7 @@ def acl(verbose):
 @runningconfiguration.command()
 @click.argument('portname', required=False)
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
-def interface(interfacename, verbose):
+def ports(interfacename, verbose):
     """Show port running configuration"""
     cmd = "sonic-cfggen -d --var-json PORT"
 

--- a/show/main.py
+++ b/show/main.py
@@ -1384,16 +1384,16 @@ def acl(verbose):
     run_command(cmd, display_cmd=verbose)
 
 
-# 'interface' subcommand ("show runningconfiguration interface <interfacename>")
+# 'ports' subcommand ("show runningconfiguration ports <portname>")
 @runningconfiguration.command()
-@click.argument('interfacename', required=False)
+@click.argument('portname', required=False)
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def interface(interfacename, verbose):
     """Show port running configuration"""
     cmd = "sonic-cfggen -d --var-json PORT"
 
-    if interfacename is not None:
-        cmd += " {0} {1}".format("--interface", interfacename)
+    if portname is not None:
+        cmd += " {0} {1}".format("--port", portname)
 
     run_command(cmd, display_cmd=verbose)
 

--- a/show/main.py
+++ b/show/main.py
@@ -1389,7 +1389,7 @@ def acl(verbose):
 @click.argument('portname', required=False)
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def ports(interfacename, verbose):
-    """Show port running configuration"""
+    """Show ports running configuration"""
     cmd = "sonic-cfggen -d --var-json PORT"
 
     if portname is not None:


### PR DESCRIPTION


Signed-off-by: Vasant Patil <vapatil@linkedin.com>


Testing:
```
[
admin@lnos-x1-a-csw06:~$ show runningconfiguration ?
Usage: show runningconfiguration [OPTIONS] COMMAND [ARGS]...

  Show current running configuration information

Options:
  -?, -h, --help  Show this message and exit.

Commands:
  acl         Show acl running configuration
  all         Show full running configuration
  bgp         Show BGP running configuration
  interfaces  Show interfaces running configuration
  ntp         Show NTP running configuration
  ports       Show ports running configuration
  snmp        Show SNMP information
admin@lnos-x1-a-csw06:~$ show runningconfiguration ports
{
    "Ethernet0": {
        "admin_status": "up", 
        "alias": "Eth1", 
        "index": "1", 
        "lanes": "65,66,67,68", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet4": {
        "admin_status": "up", 
        "alias": "Eth2", 
        "index": "2", 
        "lanes": "69,70,71,72", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet8": {
        "admin_status": "up", 
        "alias": "Eth3", 
        "index": "3", 
        "lanes": "73,74,75,76", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet12": {
        "admin_status": "up", 
        "alias": "Eth4", 
        "index": "4", 
        "lanes": "77,78,79,80", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet16": {
        "admin_status": "up", 
        "alias": "Eth5", 
        "index": "5", 
        "lanes": "33,34,35,36", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet20": {
        "admin_status": "up", 
        "alias": "Eth6", 
        "index": "6", 
        "lanes": "37,38,39,40", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet24": {
        "admin_status": "up", 
        "alias": "Eth7", 
        "index": "7", 
        "lanes": "41,42,43,44", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet28": {
        "admin_status": "up", 
        "alias": "Eth8", 
        "index": "8", 
        "lanes": "45,46,47,48", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet32": {
        "admin_status": "up", 
        "alias": "Eth9", 
        "index": "9", 
        "lanes": "49,50,51,52", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet36": {
        "admin_status": "up", 
        "alias": "Eth10", 
        "index": "10", 
        "lanes": "53,54,55,56", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet40": {
        "admin_status": "up", 
        "alias": "Eth11", 
        "index": "11", 
        "lanes": "57,58,59,60", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet44": {
        "admin_status": "up", 
        "alias": "Eth12", 
        "index": "12", 
        "lanes": "61,62,63,64", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet48": {
        "admin_status": "up", 
        "alias": "Eth13", 
        "index": "13", 
        "lanes": "81,82,83,84", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet52": {
        "admin_status": "up", 
        "alias": "Eth14", 
        "index": "14", 
        "lanes": "85,86,87,88", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet56": {
        "admin_status": "up", 
        "alias": "Eth15", 
        "index": "15", 
        "lanes": "89,90,91,92", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet60": {
        "admin_status": "up", 
        "alias": "Eth16", 
        "index": "16", 
        "lanes": "93,94,95,96", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet64": {
        "admin_status": "up", 
        "alias": "Eth17", 
        "index": "17", 
        "lanes": "97,98,99,100", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet68": {
        "admin_status": "up", 
        "alias": "Eth18", 
        "index": "18", 
        "lanes": "101,102,103,104", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet72": {
        "admin_status": "up", 
        "alias": "Eth19", 
        "index": "19", 
        "lanes": "105,106,107,108", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet76": {
        "admin_status": "up", 
        "alias": "Eth20", 
        "index": "20", 
        "lanes": "109,110,111,112", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet80": {
        "admin_status": "up", 
        "alias": "Eth21", 
        "index": "21", 
        "lanes": "1,2,3,4", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet84": {
        "admin_status": "up", 
        "alias": "Eth22", 
        "index": "22", 
        "lanes": "5,6,7,8", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet88": {
        "admin_status": "up", 
        "alias": "Eth23", 
        "index": "23", 
        "lanes": "9,10,11,12", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet92": {
        "admin_status": "up", 
        "alias": "Eth24", 
        "index": "24", 
        "lanes": "13,14,15,16", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet96": {
        "admin_status": "up", 
        "alias": "Eth25", 
        "index": "25", 
        "lanes": "17,18,19,20", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet100": {
        "admin_status": "up", 
        "alias": "Eth26", 
        "index": "26", 
        "lanes": "21,22,23,24", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet104": {
        "admin_status": "up", 
        "alias": "Eth27", 
        "index": "27", 
        "lanes": "25,26,27,28", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet108": {
        "admin_status": "up", 
        "alias": "Eth28", 
        "index": "28", 
        "lanes": "29,30,31,32", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet112": {
        "admin_status": "up", 
        "alias": "Eth29", 
        "index": "29", 
        "lanes": "113,114,115,116", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet116": {
        "admin_status": "up", 
        "alias": "Eth30", 
        "index": "30", 
        "lanes": "117,118,119,120", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet120": {
        "admin_status": "up", 
        "alias": "Eth31", 
        "index": "31", 
        "lanes": "121,122,123,124", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet124": {
        "admin_status": "up", 
        "alias": "Eth32", 
        "index": "32", 
        "lanes": "125,126,127,128", 
        "mtu": "9100", 
        "speed": "100000"
    }
}](url)
```
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

