### PR TITLE
[show] Fail to show interface status after creating portchannel if portchannel members don't speed information.

### DIFF
--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -228,17 +228,25 @@ def po_speed_dict(po_int_dict, appl_db):
             po_list.append(key)
             if len(value) == 1:
                 interface_speed = appl_db.get(appl_db.APPL_DB, "PORT_TABLE:" + value[0], "speed")
-                interface_speed = '{}G'.format(interface_speed[:-3])
-                po_list.append(interface_speed)
+                if interface_speed:
+                    interface_speed = '{}G'.format(interface_speed[:-3])
+                    po_list.append(interface_speed)
+                else:
+                    po_list.append("N/A")
             elif len(value) > 1:
+                interface_speed = 0
                 for intf in value:
                     temp_speed = appl_db.get(appl_db.APPL_DB, "PORT_TABLE:" + intf, "speed")
-                    temp_speed = int(temp_speed)
-                    agg_speed_list.append(temp_speed)
-                    interface_speed = sum(agg_speed_list)
-                    interface_speed = str(interface_speed)
-                    interface_speed = '{}G'.format(interface_speed[:-3])
-                po_list.append(interface_speed)
+                    if temp_speed:
+                        temp_speed = int(temp_speed)
+                        agg_speed_list.append(temp_speed)
+                        interface_speed = sum(agg_speed_list)
+                        interface_speed = str(interface_speed)
+                        interface_speed = '{}G'.format(interface_speed[:-3])
+                if interface_speed == 0:
+                    po_list.append("N/A")
+                else:
+                    po_list.append(interface_speed)
             po_speed_dict = dict(po_list[i:i+2] for i in range(0, len(po_list), 2))
         return po_speed_dict
     else:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
The port may not have speed information, we should consider this case when we calculate portchannel speed.
**- How I did it**
If all portchannel members don't speed information, display N/A 

**- How to verify it**
> 
    root@sonic:~# show interfaces status
      Interface    Lanes    Speed    MTU      Alias    Vlan    Oper    Admin            Type    Asym PFC
    -----------  -------  -------  -----  ---------  ------  ------  -------  --------------  ----------
      Ethernet0       13      N/A   9100   tenGigE0  routed      up       up  SFP/SFP+/SFP28         N/A
      Ethernet1       14      N/A   9100   tenGigE1  routed      up       up  SFP/SFP+/SFP28         N/A
    ... 

    root@sonic:~# config portchannel add PortChannel1
    root@sonic:~# config portchannel member add PortChannel1 Ethernet0
    root@sonic:~# config portchannel member add PortChannel1 Ethernet1
**- Previous command output (if the output of a command-line utility has changed)**

> 
    root@sonic:~# show interfaces status
    Traceback (most recent call last):
    File "/usr/bin/intfutil", line 424, in <module>
    main(sys.argv[1:])
    File "/usr/bin/intfutil", line 417, in main
    interface_stat = IntfStatus(intf_name)
    File "/usr/bin/intfutil", line 345, in _init_
    self.portchannel_speed_dict = po_speed_dict(self.po_int_dict, self.appl_db)
    File "/usr/bin/intfutil", line 231, in po_speed_dict
    interface_speed = '{}G'.format(interface_speed[:-3])
    TypeError: 'NoneType' object has no attribute '_getitem_'

**- New command output (if the output of a command-line utility has changed)**

> 

    root@sonic:~# show interfaces status
       Interface    Lanes    Speed    MTU      Alias          Vlan    Oper    Admin            Type    Asym PFC
    ------------  -------  -------  -----  ---------  ------------  ------  -------  --------------  ----------
       Ethernet0       13      N/A   9100   tenGigE0  PortChannel1      up       up  SFP/SFP+/SFP28         N/A
       Ethernet1       14      N/A   9100   tenGigE1  PortChannel1      up       up  SFP/SFP+/SFP28         N/A
    ......
    PortChannel1      N/A      N/A   9100        N/A        routed      up       up             N/A         N/A


Signed-off-by: kelly_chen@edge-core.com