### PR TITLE
Revert "Removed 'show interfaces alias'. (#412)"

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -427,6 +427,43 @@ def interfaces():
     """Show details of the network interfaces"""
     pass
 
+# 'alias' subcommand ("show interfaces alias")
+@interfaces.command()
+@click.argument('interfacename', required=False)
+def alias(interfacename):
+    """Show Interface Name/Alias Mapping"""
+
+    cmd = 'sonic-cfggen -d --var-json "PORT"'
+    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+
+    port_dict = json.loads(p.stdout.read())
+
+    header = ['Name', 'Alias']
+    body = []
+
+    if interfacename is not None:
+        if get_interface_mode() == "alias":
+            interfacename = iface_alias_converter.alias_to_name(interfacename)
+
+        # If we're given an interface name, output name and alias for that interface only
+        if interfacename in port_dict:
+            if 'alias' in port_dict[interfacename]:
+                body.append([interfacename, port_dict[interfacename]['alias']])
+            else:
+                body.append([interfacename, interfacename])
+        else:
+            click.echo("Invalid interface name, '{0}'".format(interfacename))
+            return
+    else:
+        # Output name and alias for all interfaces
+        for port_name in natsorted(port_dict.keys()):
+            if 'alias' in port_dict[port_name]:
+                body.append([port_name, port_dict[port_name]['alias']])
+            else:
+                body.append([port_name, port_name])
+
+    click.echo(tabulate(body, header))
+
 #
 # 'neighbor' group ###
 #
@@ -486,7 +523,6 @@ def expected(interfacename):
                          neighbor_metadata_dict['DEVICE_NEIGHBOR_METADATA'][device]['type']])
 
     click.echo(tabulate(body, header))
-
 
 @interfaces.group(cls=AliasedGroup, default_if_no_args=False)
 def transceiver():


### PR DESCRIPTION
This partially reverts commit 3d03c130023eb03901f078369f238bd0a559e29b.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
```
admin@str-s6100-acs-2:~$ show interfaces alias
Name        Alias
----------  ---------------
Ethernet0   fortyGigE1/1/1
Ethernet1   fortyGigE1/1/2
Ethernet2   fortyGigE1/1/3
Ethernet3   fortyGigE1/1/4
Ethernet4   fortyGigE1/1/5
Ethernet5   fortyGigE1/1/6
Ethernet6   fortyGigE1/1/7
Ethernet7   fortyGigE1/1/8
Ethernet8   fortyGigE1/1/9
Ethernet9   fortyGigE1/1/10
Ethernet10  fortyGigE1/1/11
Ethernet11  fortyGigE1/1/12
Ethernet12  fortyGigE1/1/13
Ethernet13  fortyGigE1/1/14
Ethernet14  fortyGigE1/1/15
Ethernet15  fortyGigE1/1/16
Ethernet16  fortyGigE1/2/1
Ethernet17  fortyGigE1/2/2
Ethernet18  fortyGigE1/2/3
Ethernet19  fortyGigE1/2/4
Ethernet20  fortyGigE1/2/5
Ethernet21  fortyGigE1/2/6
Ethernet22  fortyGigE1/2/7
Ethernet23  fortyGigE1/2/8
Ethernet24  fortyGigE1/2/9
Ethernet25  fortyGigE1/2/10
Ethernet26  fortyGigE1/2/11
Ethernet27  fortyGigE1/2/12
Ethernet28  fortyGigE1/2/13
Ethernet29  fortyGigE1/2/14
Ethernet30  fortyGigE1/2/15
Ethernet31  fortyGigE1/2/16
Ethernet32  fortyGigE1/3/1
Ethernet33  fortyGigE1/3/2
Ethernet34  fortyGigE1/3/3
Ethernet35  fortyGigE1/3/4
Ethernet36  fortyGigE1/3/5
Ethernet37  fortyGigE1/3/6
Ethernet38  fortyGigE1/3/7
Ethernet39  fortyGigE1/3/8
Ethernet40  fortyGigE1/3/9
Ethernet41  fortyGigE1/3/10
Ethernet42  fortyGigE1/3/11
Ethernet43  fortyGigE1/3/12
Ethernet44  fortyGigE1/3/13
Ethernet45  fortyGigE1/3/14
Ethernet46  fortyGigE1/3/15
Ethernet47  fortyGigE1/3/16
Ethernet48  fortyGigE1/4/1
Ethernet49  fortyGigE1/4/2
Ethernet50  fortyGigE1/4/3
Ethernet51  fortyGigE1/4/4
Ethernet52  fortyGigE1/4/5
Ethernet53  fortyGigE1/4/6
Ethernet54  fortyGigE1/4/7
Ethernet55  fortyGigE1/4/8
Ethernet56  fortyGigE1/4/9
Ethernet57  fortyGigE1/4/10
Ethernet58  fortyGigE1/4/11
Ethernet59  fortyGigE1/4/12
Ethernet60  fortyGigE1/4/13
Ethernet61  fortyGigE1/4/14
Ethernet62  fortyGigE1/4/15
Ethernet63  fortyGigE1/4/16
admin@str-s6100-acs-2:~$ show version

SONiC Software Version: SONiC.20181130.37
Distribution: Debian 9.9
Kernel: 4.9.0-9-amd64
Build commit: d508f60
Build date: Fri Aug  9 06:40:08 UTC 2019
Built by: sonicbld@jenkins-slave-phx-3

Platform: x86_64-dell_s6100_c2538-r0
HwSKU: Force10-S6100
ASIC: broadcom
Serial Number: DWMQG02
Uptime: 16:21:27 up  1:25,  1 user,  load average: 0.95, 0.87, 0.96

Docker images:
REPOSITORY                 TAG                 IMAGE ID            SIZE
docker-fpm-quagga          20181130.37         4d218628f62e        283MB
docker-fpm-quagga          latest              4d218628f62e        283MB
docker-snmp-sv2            20181130.37         4283cbf8c12f        291MB
docker-snmp-sv2            latest              4283cbf8c12f        291MB
docker-orchagent-brcm      20181130.37         2b8f442108d1        288MB
docker-orchagent-brcm      latest              2b8f442108d1        288MB
docker-teamd               20181130.37         993ed066db03        276MB
docker-teamd               latest              993ed066db03        276MB
docker-lldp-sv2            20181130.37         8fbaa76f7cdc        276MB
docker-lldp-sv2            latest              8fbaa76f7cdc        276MB
docker-platform-monitor    20181130.37         17903a6131fa        289MB
docker-platform-monitor    latest              17903a6131fa        289MB
docker-syncd-brcm          20181130.37         86fd82bdd738        369MB
docker-syncd-brcm          latest              86fd82bdd738        369MB
docker-dhcp-relay          20181130.37         6a9be4685f43        260MB
docker-dhcp-relay          latest              6a9be4685f43        260MB
docker-router-advertiser   20181130.37         512edc06a2f7        256MB
docker-router-advertiser   latest              512edc06a2f7        256MB
docker-database            20181130.37         862e0124ca13        257MB
docker-database            latest              862e0124ca13        257MB
```
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

