### PR TITLE
[neighbor_advertiser] Use full vlan name for vxlan tunnel map programming

### DIFF
--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -376,7 +376,7 @@ def add_vxlan_tunnel_map():
     for (index, vlan_intf_name) in enumerate(get_vlan_interfaces(), 1):
         vxlan_tunnel_map_info = {
             'vni': get_vlan_interface_vxlan_id(vlan_intf_name),
-            'vlan': get_vlan_interface_vlan_id(vlan_intf_name)
+            'vlan': vlan_intf_name
         }
 
         config_db.set_entry('VXLAN_TUNNEL_MAP', (VXLAN_TUNNEL_NAME, VXLAN_TUNNEL_MAP_PREFIX + str(index)), vxlan_tunnel_map_info)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

**- How I did it**
Fixed a bug which caused incorrect programming of vxlan tunnel map.

**- How to verify it**
Run the script and check that syslog doesn't have any errors.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

