### PR TITLE
[config]: Flush the neighbor table when removing the router interface

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1064,9 +1064,12 @@ def remove(ctx, interface_name, ip_addr):
             config_db.set_entry("LOOPBACK_INTERFACE", (interface_name, ip_addr), None)
         else:
             ctx.fail("'interface_name' is not valid. Valid names [Ethernet/PortChannel/Vlan/Loopback]")
+
+        command = "ip neigh flush {}".format(ip_addr)
+        run_command(command)
     except ValueError:
         ctx.fail("'ip_addr' is not valid.")
-    
+
     exists = False
     if if_table:
         interfaces = config_db.get_table(if_table)


### PR DESCRIPTION
Manually trigger the flush command to remove the deprecated
neighbors that are associated with the removed router interface.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>