### PR TITLE
[fast/warm reboot] kill radv docker before stopping BGP

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -374,6 +374,7 @@ fi
 # Kill radv before stopping BGP service to prevent annoucing our departure.
 debug "Stopping radv ..."
 docker kill radv &>/dev/null || [ $? == 1 ]
+systemctl stop radv
 
 # Kill bgpd to start the bgp graceful restart procedure
 debug "Stopping bgp ..."

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -371,6 +371,10 @@ if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; t
     fi
 fi
 
+# Kill radv before stopping BGP service to prevent annoucing our departure.
+debug "Stopping radv ..."
+docker kill radv &>/dev/null || [ $? == 1 ]
+
 # Kill bgpd to start the bgp graceful restart procedure
 debug "Stopping bgp ..."
 docker exec -i bgp pkill -9 zebra


### PR DESCRIPTION
**- What I did**

Kill radv docker before stopping BGP. Otherwise it will announce our
departure and cause hosts to lose default gateway.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- How to verify it**
warm reboot with IPv6 IO going through.