### PR TITLE
[config] Add commands for adding/removing syslog servers

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1332,13 +1332,18 @@ def add_syslog_server(ctx, syslog_ip_address):
     if not is_ipaddress(syslog_ip_address):
         ctx.fail('Invalid ip address')
     db = ctx.obj['db']
-    db.set_entry('SYSLOG_SERVER', syslog_ip_address, {'NULL': 'NULL'})
-    click.echo("Syslog server {} added to configuration".format(syslog_ip_address))
-    try:
-        click.echo("Restarting rsyslog-config service...")
-        run_command("systemctl restart rsyslog-config", display_cmd=False)
-    except SystemExit as e:
-        ctx.fail("Restart service rsyslog-config failed with error {}".format(e))
+    syslog_servers = db.get_table("SYSLOG_SERVER")
+    if syslog_ip_address in syslog_servers:
+        click.echo("Syslog server {} is already configured".format(syslog_ip_address))
+        return
+    else: 
+        db.set_entry('SYSLOG_SERVER', syslog_ip_address, {'NULL': 'NULL'})
+        click.echo("Syslog server {} added to configuration".format(syslog_ip_address))
+        try:
+            click.echo("Restarting rsyslog-config service...")
+            run_command("systemctl restart rsyslog-config", display_cmd=False)
+        except SystemExit as e:
+            ctx.fail("Restart service rsyslog-config failed with error {}".format(e))
 
 @syslog.command('del')
 @click.argument('syslog_ip_address', metavar='<syslog_ip_address>', required=True)

--- a/config/main.py
+++ b/config/main.py
@@ -1312,6 +1312,49 @@ def naming_mode_alias():
     """Set CLI interface naming mode to ALIAS (Vendor port alias)"""
     set_interface_naming_mode('alias')
 
+#
+# 'syslog' group ('config syslog ...')
+#
+@config.group()
+@click.pass_context
+def syslog(ctx):
+    """Syslog server configuration tasks"""
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    ctx.obj = {'db': config_db}
+    pass
+
+@syslog.command('add')
+@click.argument('syslog_ip_address', metavar='<syslog_ip_address>', required=True)
+@click.pass_context
+def add_syslog_server(ctx, syslog_ip_address):
+    """ Add syslog server IP """
+    if not is_ipaddress(syslog_ip_address):
+        ctx.fail('Invalid ip address')
+    db = ctx.obj['db']
+    db.set_entry('SYSLOG_SERVER', syslog_ip_address, {'NULL': 'NULL'})
+    click.echo("Syslog server {} added to configuration".format(syslog_ip_address))
+    try:
+        click.echo("Restarting rsyslog-config service...")
+        run_command("systemctl restart rsyslog-config", display_cmd=False)
+    except SystemExit as e:
+        ctx.fail("Restart service rsyslog-config failed with error {}".format(e))
+
+@syslog.command('del')
+@click.argument('syslog_ip_address', metavar='<syslog_ip_address>', required=True)
+@click.pass_context
+def del_syslog_server(ctx, syslog_ip_address):
+    """ Delete syslog server IP """
+    if not is_ipaddress(syslog_ip_address):
+        ctx.fail('Invalid IP address')
+    db = ctx.obj['db']
+    db.set_entry('SYSLOG_SERVER', '{}'.format(syslog_ip_address), None)
+    click.echo("Syslog server {} removed from configuration".format(syslog_ip_address))
+    try:
+        click.echo("Restarting rsyslog-config service...")
+        run_command("systemctl restart rsyslog-config", display_cmd=False)
+    except SystemExit as e:
+        ctx.fail("Restart service rsyslog-config failed with error {}".format(e))
 
 if __name__ == '__main__':
     config()

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -4079,4 +4079,35 @@ This command displays the routing policy that takes precedence over the other ro
 		Exit routemap
   ```
 
+**Syslog config commands 
+
+This sub-section of commands is used to add or remove the configured syslog servers.
+
+**config syslog add 
+
+This command is used to add a SYSLOG server to the syslog server list.  Note that more that one syslog server can be added in the device.
+
+- Usage: config syslog add <ip-address>
+- Example: 
+  ```
+  admin@str-s6000-acs-11:~$ sudo config syslog add 1.1.1.1
+  Syslog server 1.1.1.1 added to configuration
+  Restarting rsyslog-config service...
+  admin@str-s6000-acs-11:~$
+  ```
+
+**config syslog delete
+
+This command is used to delete the syslog server configured. 
+
+- Usage: config syslog del <ip-address>
+- Example:
+  ```
+  admin@str-s6000-acs-11:~$ sudo config syslog del 1.1.1.1
+  Syslog server 1.1.1.1 removed from configuration
+  Restarting rsyslog-config service...
+  admin@str-s6000-acs-11:~$
+  ```
+  
+
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Quagga-BGP-Show-Commands)

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -4083,7 +4083,7 @@ This command displays the routing policy that takes precedence over the other ro
 
 This sub-section of commands is used to add or remove the configured syslog servers.
 
-**config syslog add 
+**config syslog add** 
 
 This command is used to add a SYSLOG server to the syslog server list.  Note that more that one syslog server can be added in the device.
 
@@ -4096,7 +4096,7 @@ This command is used to add a SYSLOG server to the syslog server list.  Note tha
   admin@str-s6000-acs-11:~$
   ```
 
-**config syslog delete
+**config syslog delete**
 
 This command is used to delete the syslog server configured. 
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -4079,7 +4079,7 @@ This command displays the routing policy that takes precedence over the other ro
 		Exit routemap
   ```
 
-**Syslog config commands 
+# Syslog Server Configuration Commands 
 
 This sub-section of commands is used to add or remove the configured syslog servers.
 


### PR DESCRIPTION
**- What I did**
I've added config commands to add/del syslog servers from the device.

**- How I did it**
```
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/config$ redis-cli -n 4 keys "*" | grep syslog  -i
SYSLOG_SERVER|100.127.20.21
SYSLOG_SERVER|10.3.145.8
SYSLOG_SERVER|4.4.4.4
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/config$ sudo config syslog add 5.5.5.5
Syslog server 5.5.5.5 added to configuration
Restarting rsyslog-config service...
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/config$ redis-cli -n 4 keys "*" | grep syslog  -i
SYSLOG_SERVER|100.127.20.21
SYSLOG_SERVER|10.3.145.8
SYSLOG_SERVER|4.4.4.4
SYSLOG_SERVER|5.5.5.5
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/config$ sudo config syslog del 5.5.5.5
Syslog server 5.5.5.5 removed from configuration
Restarting rsyslog-config service...
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/config$ redis-cli -n 4 keys "*" | grep syslog  -i
SYSLOG_SERVER|100.127.20.21
SYSLOG_SERVER|10.3.145.8
SYSLOG_SERVER|4.4.4.4
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/config$ 

```
**- How to verify it**
```
There are two ways: 
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/config$ redis-cli -n 4 keys "*" | grep syslog  -i
SYSLOG_SERVER|100.127.20.21
SYSLOG_SERVER|10.3.145.8
SYSLOG_SERVER|4.4.4.4

Or 
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/config$ show run all | grep -i syslog -A4
    "SYSLOG_SERVER": {
        "4.4.4.4": {}, 
        "10.3.145.8": {}, 
        "100.127.20.21": {}
    }, 
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/config$ sudo config syslog add 5.5.5.5
Syslog server 5.5.5.5 added to configuration
Restarting rsyslog-config service...
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/config$ show run all | grep -i syslog -A4
    "SYSLOG_SERVER": {
        "4.4.4.4": {}, 
        "5.5.5.5": {}, 
        "10.3.145.8": {}, 
        "100.127.20.21": {}
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/config$ 
```
**- Previous command output (if the output of a command-line utility has changed)**
There was no previous command to add or remove syslog servers. 
**- New command output (if the output of a command-line utility has changed)**
```
config add syslog command:
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/config$ sudo config syslog add 5.5.5.5
Syslog server 5.5.5.5 added to configuration
Restarting rsyslog-config service...
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/config$

config del syslog command: 
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/config$ sudo config syslog del 5.5.5.5
Syslog server 5.5.5.5 removed from configuration
Restarting rsyslog-config service...
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/config$ 
```
-->

