### PR TITLE
[Command Reference] Add config commands for DHCP relay destination address

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -4108,6 +4108,37 @@ This command is used to delete the syslog server configured.
   Restarting rsyslog-config service...
   admin@str-s6000-acs-11:~$
   ```
+
+# DHCP Relay Destination Server Configuration Commands 
+
+This sub-section of commands is used to add or remove the DHCP Relay Destination Servers on a VLAN interface.
+
+**config vlan dhcp_relay add** 
+
+This command is used to add a DHCP Relay Destination server to the a VLAN.  Note that more that one DHCP Relay Destination server can be added on a VLAN interface.
+
+- Usage: config vlan dhcp_relay add <vlan-id> <dhcp_relay_destination_ip>
+- Example: 
+  ```
+  admin@str-s6000-acs-11:~$ sudo config vlan dhcp_relay add 1000 7.7.7.7
+  Added DHCP relay destination address 7.7.7.7 to Vlan1000
+  Restarting DHCP relay service...
+  Running command: systemctl restart dhcp_relay
+  admin@str-s6000-acs-11:~$ 
+  ```
+
+**config vlan dhcp_relay delete**
+
+This command is used to delete the DHCP Relay Destination server configured on a VLAN interface. 
+
+- Usage: config vlan dhcp_relay del <vlan-id> <dhcp_relay_destination_ip>
+- Example:
+  ```
+  admin@str-s6000-acs-11:~$ sudo config vlan dhcp_relay del 1000 7.7.7.7
+  Removed DHCP relay destination address 7.7.7.7 from Vlan1000
+  Restarting DHCP relay service...
+  Running command: systemctl restart dhcp_relay
+  admin@str-s6000-acs-11:~$ 
   
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Quagga-BGP-Show-Commands)

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -4109,13 +4109,13 @@ This command is used to delete the syslog server configured.
   admin@str-s6000-acs-11:~$
   ```
 
-# DHCP Relay Destination Server Configuration Commands 
+# DHCP Relay Destination IP address Configuration Commands 
 
-This sub-section of commands is used to add or remove the DHCP Relay Destination Servers on a VLAN interface.
+This sub-section of commands is used to add or remove the DHCP Relay Destination IP address on a VLAN interface.
 
 **config vlan dhcp_relay add** 
 
-This command is used to add a DHCP Relay Destination server to the a VLAN.  Note that more that one DHCP Relay Destination server can be added on a VLAN interface.
+This command is used to add a DHCP Relay Destination IP address to the a VLAN.  Note that more that one DHCP Relay Destination IP address can be added on a VLAN interface.
 
 - Usage: config vlan dhcp_relay add <vlan-id> <dhcp_relay_destination_ip>
 - Example: 
@@ -4129,7 +4129,7 @@ This command is used to add a DHCP Relay Destination server to the a VLAN.  Note
 
 **config vlan dhcp_relay delete**
 
-This command is used to delete the DHCP Relay Destination server configured on a VLAN interface. 
+This command is used to delete the DHCP Relay Destination IP address configured on a VLAN interface. 
 
 - Usage: config vlan dhcp_relay del <vlan-id> <dhcp_relay_destination_ip>
 - Example:

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -4111,7 +4111,7 @@ This command is used to delete the syslog server configured.
 
 # DHCP Relay Destination IP address Configuration Commands 
 
-This sub-section of commands is used to add or remove the DHCP Relay Destination IP address on a VLAN interface.
+This sub-section of commands is used to add or remove the DHCP Relay Destination IP address(es) for a VLAN interface.
 
 **config vlan dhcp_relay add** 
 
@@ -4129,7 +4129,7 @@ This command is used to add a DHCP Relay Destination IP address to the a VLAN.  
 
 **config vlan dhcp_relay delete**
 
-This command is used to delete the DHCP Relay Destination IP address configured on a VLAN interface. 
+This command is used to delete a configured DHCP Relay Destination IP address from a VLAN interface. 
 
 - Usage: config vlan dhcp_relay del <vlan-id> <dhcp_relay_destination_ip>
 - Example:


### PR DESCRIPTION
**- What I did**
I already committed the change for updating the DHCP Relay Destination IP address but I didn't update the Command-Reference.md

**- How I did it**
Since I wrote and merged this change:
https://github.com/Azure/sonic-utilities/pull/585

The PR is only to update the documentation.

**- How to verify it**
Just look at the Command-Reference.md.

**- Previous command output (if the output of a command-line utility has changed)**
None
**- New command output (if the output of a command-line utility has changed)**
None
-->

