### PR TITLE
[config] Add commands for adding/removing NTP servers

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1445,8 +1445,12 @@ def del_ntp_server(ctx, ntp_ip_address):
     if not is_ipaddress(ntp_ip_address):
         ctx.fail('Invalid IP address')
     db = ctx.obj['db']
-    db.set_entry('NTP_SERVER', '{}'.format(ntp_ip_address), None)
-    click.echo("NTP server {} removed from configuration".format(ntp_ip_address))
+    ntp_servers = db.get_table("NTP_SERVER")
+    if ntp_ip_address in ntp_servers:
+        db.set_entry('NTP_SERVER', '{}'.format(ntp_ip_address), None)
+        click.echo("NTP server {} removed from configuration".format(ntp_ip_address))
+    else: 
+        ctx.fail("NTP server {} is not configured.".format(ntp_ip_address))
     try:
         click.echo("Restarting ntp-config service...")
         run_command("systemctl restart ntp-config", display_cmd=False)

--- a/config/main.py
+++ b/config/main.py
@@ -1404,5 +1404,54 @@ def del_syslog_server(ctx, syslog_ip_address):
     except SystemExit as e:
         ctx.fail("Restart service rsyslog-config failed with error {}".format(e))
 
+#
+# 'ntp' group ('config ntp ...')
+#
+@config.group()
+@click.pass_context
+def ntp(ctx):
+    """NTP server configuration tasks"""
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    ctx.obj = {'db': config_db}
+    pass
+
+@ntp.command('add')
+@click.argument('ntp_ip_address', metavar='<ntp_ip_address>', required=True)
+@click.pass_context
+def add_ntp_server(ctx, ntp_ip_address):
+    """ Add NTP server IP """
+    if not is_ipaddress(ntp_ip_address):
+        ctx.fail('Invalid ip address')
+    db = ctx.obj['db']
+    ntp_servers = db.get_table("NTP_SERVER")
+    if ntp_ip_address in ntp_servers:
+        click.echo("NTP server {} is already configured".format(ntp_ip_address))
+        return
+    else: 
+        db.set_entry('NTP_SERVER', ntp_ip_address, {'NULL': 'NULL'})
+        click.echo("NTP server {} added to configuration".format(ntp_ip_address))
+        try:
+            click.echo("Restarting ntp-config service...")
+            run_command("systemctl restart ntp-config", display_cmd=False)
+        except SystemExit as e:
+            ctx.fail("Restart service ntp-config failed with error {}".format(e))
+
+@ntp.command('del')
+@click.argument('ntp_ip_address', metavar='<ntp_ip_address>', required=True)
+@click.pass_context
+def del_ntp_server(ctx, ntp_ip_address):
+    """ Delete NTP server IP """
+    if not is_ipaddress(ntp_ip_address):
+        ctx.fail('Invalid IP address')
+    db = ctx.obj['db']
+    db.set_entry('NTP_SERVER', '{}'.format(ntp_ip_address), None)
+    click.echo("NTP server {} removed from configuration".format(ntp_ip_address))
+    try:
+        click.echo("Restarting ntp-config service...")
+        run_command("systemctl restart ntp-config", display_cmd=False)
+    except SystemExit as e:
+        ctx.fail("Restart service ntp-config failed with error {}".format(e))
+
 if __name__ == '__main__':
     config()

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -4140,5 +4140,34 @@ This command is used to delete a configured DHCP Relay Destination IP address fr
   Running command: systemctl restart dhcp_relay
   admin@str-s6000-acs-11:~$ 
   
+# NTP Server Configuration Commands 
+
+This sub-section of commands is used to add or remove the configured NTP servers.
+
+**config ntp add** 
+
+This command is used to add a NTP server IP address to the NTP server list.  Note that more that one NTP server IP address can be added in the device.
+
+- Usage: config ntp add <ip-address>
+- Example: 
+  ```
+  admin@str-s6000-acs-11:~$ sudo config ntp add 9.9.9.9
+  NTP server 9.9.9.9 added to configuration
+  Restarting ntp-config service...
+  admin@str-s6000-acs-11:~$
+  ```
+
+**config ntp delete**
+
+This command is used to delete a configured NTP server IP address. 
+
+- Usage: config ntp del <ip-address>
+- Example:
+  ```
+  admin@str-s6000-acs-11:~$ sudo config ntp del 9.9.9.9
+  NTP server 9.9.9.9 removed from configuration
+  Restarting ntp-config service...
+  admin@str-s6000-acs-11:~$
+  ```
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Quagga-BGP-Show-Commands)

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -4139,6 +4139,7 @@ This command is used to delete a configured DHCP Relay Destination IP address fr
   Restarting DHCP relay service...
   Running command: systemctl restart dhcp_relay
   admin@str-s6000-acs-11:~$ 
+  ```
   
 # NTP Server Configuration Commands 
 


### PR DESCRIPTION
**- What I did**
I've added config commands to add/del NTP servers from the device.

**- How I did it**
```
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/config$ redis-cli -n 4 keys "*" | grep -i ntp 
NTP_SERVER|10.3.149.170
NTP_SERVER|6.6.6.6
NTP_SERVER|10.3.149.171
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/config$ sudo config ntp add 8.8.8.8
NTP server 8.8.8.8 added to configuration
Restarting ntp-config service...
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/config$ redis-cli -n 4 keys "*" | grep -i ntp 
NTP_SERVER|10.3.149.170
NTP_SERVER|8.8.8.8
NTP_SERVER|6.6.6.6
NTP_SERVER|10.3.149.171
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/config$ sudo config ntp del 8.8.8.8
NTP server 8.8.8.8 removed from configuration
Restarting ntp-config service...
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/config$ redis-cli -n 4 keys "*" | grep -i ntp 
NTP_SERVER|10.3.149.170
NTP_SERVER|6.6.6.6
NTP_SERVER|10.3.149.171
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/config$
```

**- How to verify it**
```
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/config$ redis-cli -n 4 keys "*" | grep -i ntp 
NTP_SERVER|10.3.149.170
NTP_SERVER|6.6.6.6
NTP_SERVER|10.3.149.171
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/config$
```

**- Previous command output (if the output of a command-line utility has changed)**
There was no previous command to add or remove syslog servers.

**- New command output (if the output of a command-line utility has changed)**
```
config add ntp command:
admin@str-s6000-acs-11:~$ sudo config ntp add 9.9.9.9
NTP server 9.9.9.9 added to configuration
Restarting ntp-config service...
admin@str-s6000-acs-11:~$ 

config del ntp command:
admin@str-s6000-acs-11:~$ sudo config ntp del 9.9.9.9
NTP server 9.9.9.9 removed from configuration
Restarting ntp-config service...
admin@str-s6000-acs-11:~$ 
```
-->

