### PR TITLE
[fast-reboot] Check if ASIC config has changed before warm reboot

### DIFF
--- a/scripts/asic_config_check
+++ b/scripts/asic_config_check
@@ -19,7 +19,8 @@ function debug()
 
 # Retrieve the source ASIC config checksum from the source image
 # Exits with error SRC_ASIC_CONFIG_NOT_FOUND if the checksum is not found
-function GetSourceASICConfigChecksum() {
+function GetSourceASICConfigChecksum()
+{
     if [[ ! -f "/etc/sonic/asic_config_checksum" ]]; then
             error "ASIC config not found in src image, can't verify changes"
             exit "${SRC_ASIC_CONFIG_NOT_FOUND}"
@@ -28,7 +29,8 @@ function GetSourceASICConfigChecksum() {
 
 # Retrieve the destination ASIC config checksum from the destination image
 # Exits with error DST_ASIC_CONFIG_NOT_FOUND if the checksum is not found
-function GetDestinationASICConfigChecksum() {
+function GetDestinationASICConfigChecksum()
+{
     DST_IMAGE_PATH="/host/image-${DST_SONIC_IMAGE#SONiC-OS-}"
     FS_PATH="${DST_IMAGE_PATH}/fs.squashfs"
     FS_MOUNTPOINT="/tmp/image-${DST_SONIC_IMAGE#SONiC-OS-}-fs"
@@ -56,7 +58,8 @@ function GetDestinationASICConfigChecksum() {
 
 # Confirm that the src and dst ASIC config checksums match
 # Exits with ASIC_CONFIG_CHANGED if the checksums differ
-function ConfirmASICConfigChecksumsMatch() {
+function ConfirmASICConfigChecksumsMatch()
+{
     SRC_CONFIG_CHECKSUM=$(cat /etc/sonic/asic_config_checksum)
     DST_CONFIG_CHECKSUM=$(cat /tmp/dst_asic_config_checksum)
     if [[ "${SRC_CONFIG_CHECKSUM}" != "${DST_CONFIG_CHECKSUM}" ]]; then

--- a/scripts/asic_config_check
+++ b/scripts/asic_config_check
@@ -10,7 +10,6 @@ DST_ASIC_CONFIG_NOT_FOUND=3
 function error()
 {
     logger -p user.err "$@"
-    echo $@ >&2
 }
 
 function debug()

--- a/scripts/asic_config_check
+++ b/scripts/asic_config_check
@@ -1,0 +1,83 @@
+#!/bin/bash -e
+
+# Exit codes
+ASIC_CONFIG_UNCHANGED=0
+ASIC_CONFIG_CHANGED=1
+SRC_ASIC_CONFIG_NOT_FOUND=2
+DST_ASIC_CONFIG_NOT_FOUND=3
+
+# Logging utilities
+function error()
+{
+    logger -p user.err "$@"
+}
+
+function debug()
+{
+    logger -p user.info "$@"
+}
+
+# Retrieve the source ASIC config checksum from the source image
+# Exits with error SRC_ASIC_CONFIG_NOT_FOUND if the checksum is not found
+function GetSourceASICConfigChecksum() {
+    if [[ ! -f "/etc/sonic/asic_config_checksum" ]]; then
+            error "ASIC config not found in src image, can't verify changes"
+            exit "${SRC_ASIC_CONFIG_NOT_FOUND}"
+    fi
+}
+
+# Retrieve the destination ASIC config checksum from the destination image
+# Exits with error DST_ASIC_CONFIG_NOT_FOUND if the checksum is not found
+function GetDestinationASICConfigChecksum() {
+    DST_IMAGE_PATH="/host/image-${DST_SONIC_IMAGE#SONiC-OS-}"
+    FS_PATH="${DST_IMAGE_PATH}/fs.squashfs"
+    FS_MOUNTPOINT="/tmp/image-${DST_SONIC_IMAGE#SONiC-OS-}-fs"
+
+    # Verify that the destination image exists
+    if [[ ! -d ${DST_IMAGE_PATH} ]]; then
+        error "ASIC config not found in dst image, can't verify changes"
+        exit "${DST_ASIC_CONFIG_NOT_FOUND}"
+    fi
+
+    mkdir "${FS_MOUNTPOINT}"
+    mount -t squashfs "${FS_PATH}" "${FS_MOUNTPOINT}"
+
+    if [[ ! -f "${FS_MOUNTPOINT}/etc/sonic/asic_config_checksum" ]]; then
+        error "ASIC config not found in dst image, can't verify changes"
+        umount "${FS_MOUNTPOINT}"
+        rm -rf "${FS_MOUNTPOINT}"
+        exit "${DST_ASIC_CONFIG_NOT_FOUND}"
+    fi
+
+    cp "${FS_MOUNTPOINT}/etc/sonic/asic_config_checksum" /tmp/dst_asic_config_checksum
+    umount "${FS_MOUNTPOINT}"
+    rm -rf "${FS_MOUNTPOINT}"
+}
+
+# Confirm that the src and dst ASIC config checksums match
+# Exits with ASIC_CONFIG_CHANGED if the checksums differ
+function ConfirmASICConfigChecksumsMatch() {
+    SRC_CONFIG_CHECKSUM=$(cat /etc/sonic/asic_config_checksum)
+    DST_CONFIG_CHECKSUM=$(cat /tmp/dst_asic_config_checksum)
+    if [[ "${SRC_CONFIG_CHECKSUM}" != "${DST_CONFIG_CHECKSUM}" ]]; then
+        error "ASIC config may have changed, checksum failed"
+        exit "${ASIC_CONFIG_CHANGED}"
+    fi
+}
+
+# Main starts here
+debug "Checking if ASIC config has changed"
+
+SRC_SONIC_IMAGE="$(sonic_installer list | grep "Current: " | cut -f2 -d' ')"
+DST_SONIC_IMAGE="$(sonic_installer list | grep "Next: " | cut -f2 -d' ')"
+if [[ "${SRC_SONIC_IMAGE}" == "${DST_SONIC_IMAGE}" ]]; then
+    debug "ASIC config unchanged, src and dst SONiC version are the same"
+    exit "${ASIC_CONFIG_UNCHANGED}"
+fi
+
+GetSourceASICConfigChecksum
+GetDestinationASICConfigChecksum
+ConfirmASICConfigChecksumsMatch
+
+debug "ASIC config unchanged, checksum passed"
+exit "${ASIC_CONFIG_UNCHANGED}"

--- a/scripts/asic_config_check
+++ b/scripts/asic_config_check
@@ -10,6 +10,7 @@ DST_ASIC_CONFIG_NOT_FOUND=3
 function error()
 {
     logger -p user.err "$@"
+    echo $@ >&2
 }
 
 function debug()
@@ -69,7 +70,7 @@ function ConfirmASICConfigChecksumsMatch()
 }
 
 # Main starts here
-debug "Checking if ASIC config has changed"
+debug "Checking that ASIC configuration has not changed"
 
 SRC_SONIC_IMAGE="$(sonic_installer list | grep "Current: " | cut -f2 -d' ')"
 DST_SONIC_IMAGE="$(sonic_installer list | grep "Next: " | cut -f2 -d' ')"

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -253,14 +253,7 @@ function reboot_pre_check()
     
     # Make sure ASIC configuration has not changed between images
     ASIC_CONFIG_CHECK_SCRIPT="/usr/bin/asic_config_check"
-    ASIC_CONFIG_CHECK_SUCCESS=0
-
-    debug "Checking that ASIC configuration has not changed"
-    ${ASIC_CONFIG_CHECK_SCRIPT} || ASIC_CONFIG_CHECK_EXIT_CODE=$?
-    if [[ "${ASIC_CONFIG_CHECK_EXIT_CODE}" != "${ASIC_CONFIG_CHECK_SUCCESS}" ]]; then
-        error "ASIC config may have changed: errno=${ASIC_CONFIG_CHECK_EXIT_CODE}"
-        exit "${EXIT_FAILURE}"
-    fi
+    ${ASIC_CONFIG_CHECK_SCRIPT}
 }
 
 function unload_kernel()

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -250,6 +250,17 @@ function reboot_pre_check()
         debug "Next image ${NEXT_SONIC_IMAGE} doesn't exist ..."
         exit ${EXIT_NEXT_IMAGE_NOT_EXISTS}
     fi
+    
+    # Make sure ASIC configuration has not changed between images
+    ASIC_CONFIG_CHECK_SCRIPT="/usr/bin/asic_config_check"
+    ASIC_CONFIG_CHECK_SUCCESS=0
+
+    debug "Checking that ASIC configuration has not changed"
+    ${ASIC_CONFIG_CHECK_SCRIPT} || ASIC_CONFIG_CHECK_EXIT_CODE=$?
+    if [[ "${ASIC_CONFIG_CHECK_EXIT_CODE}" != "${ASIC_CONFIG_CHECK_SUCCESS}" ]]; then
+        error "ASIC config may have changed: errno=${ASIC_CONFIG_CHECK_EXIT_CODE}"
+        exit "${EXIT_FAILURE}"
+    fi
 }
 
 function unload_kernel()

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -253,7 +253,22 @@ function reboot_pre_check()
     
     # Make sure ASIC configuration has not changed between images
     ASIC_CONFIG_CHECK_SCRIPT="/usr/bin/asic_config_check"
-    ${ASIC_CONFIG_CHECK_SCRIPT}
+    ASIC_CONFIG_CHECK_SUCCESS=0
+    if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; then
+        set +e
+        ${ASIC_CONFIG_CHECK_SCRIPT}
+        ASIC_CONFIG_CHECK_EXIT_CODE=$?
+        set -e
+
+        if [[ "${ASIC_CONFIG_CHECK_EXIT_CODE}" != "${ASIC_CONFIG_CHECK_SUCCESS}" ]]; then
+            if [[ x"${FORCE}" == x"yes" ]]; then
+                debug "Ignoring ASIC config checksum failure..."
+            else
+                error "ASIC config may have changed: errno=${ASIC_CONFIG_CHECK_EXIT_CODE}"
+                exit "${EXIT_FAILURE}"
+            fi
+        fi
+    fi
 }
 
 function unload_kernel()

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -255,10 +255,8 @@ function reboot_pre_check()
     ASIC_CONFIG_CHECK_SCRIPT="/usr/bin/asic_config_check"
     ASIC_CONFIG_CHECK_SUCCESS=0
     if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; then
-        set +e
-        ${ASIC_CONFIG_CHECK_SCRIPT}
-        ASIC_CONFIG_CHECK_EXIT_CODE=$?
-        set -e
+        ASIC_CONFIG_CHECK_EXIT_CODE=0
+        ${ASIC_CONFIG_CHECK_SCRIPT} || ASIC_CONFIG_CHECK_EXIT_CODE=$?
 
         if [[ "${ASIC_CONFIG_CHECK_EXIT_CODE}" != "${ASIC_CONFIG_CHECK_SUCCESS}" ]]; then
             if [[ x"${FORCE}" == x"yes" ]]; then

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
     },
     scripts=[
         'scripts/aclshow',
+        'scripts/asic_config_check',
         'scripts/boot_part',
         'scripts/coredump-compress',
         'scripts/db_migrator.py',


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
I modified the fast-reboot script to check that certain ASIC configurations haven't changed between the source and destination SONiC image before performing the warm reboot.

**- How I did it**
Azure/sonic-buildimage#3384 adds the relevant checksums at build time. I wrote a script to fetch these checksums from the filesystem and check that they match. This script is called as a pre-check in the warm reboot script.

**- How to verify it**
I built two SONiC images with the same checksum and verified that warm reboot proceeded normally. I also built a third image with a different checksum and verified that warm reboot was aborted when attempting to boot from one of the other two images.

**- Previous command output (if the output of a command-line utility has changed)**
N/A

**- New command output (if the output of a command-line utility has changed)**
N/A

-->
DEPENDS Azure/sonic-buildimage#3384