### PR TITLE
[config] Add commands to remove BGP neighbor configuration

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -238,24 +238,24 @@ def _change_bgp_session_status(ipaddr_or_hostname, status, verbose):
     for ip_addr in ip_addrs:
         _change_bgp_session_status_by_addr(ip_addr, status, verbose)
 
-def _validate_bgp_neighbor_ip(neighbor):
+def _validate_bgp_neighbor_ip(neighbor_ip_or_hostname):
     """validates whether the given ip or host name is a BGP neighbor
     """
     ip_addrs = []
-    if _is_neighbor_ipaddress(neighbor.lower()):
-        ip_addrs.append(neighbor.lower())
+    if _is_neighbor_ipaddress(neighbor_ip_or_hostname.lower()):
+        ip_addrs.append(neighbor_ip_or_hostname.lower())
     else:
-        ip_addrs = _get_neighbor_ipaddress_list_by_hostname(neighbor.upper())
+        ip_addrs = _get_neighbor_ipaddress_list_by_hostname(neighbor_ip_or_hostname.upper())
 
     if not ip_addrs:
-        click.get_current_context().fail("Could not locate neighbor '{}'".format(neighbor))
+        click.get_current_context().fail("Could not locate neighbor '{}'".format(neighbor_ip_or_hostname))
 
     return ip_addrs
 
-def _remove_bgp_neighbor_config(neighbor_ip):
+def _remove_bgp_neighbor_config(neighbor_ip_or_hostname):
     """Removes BGP configuration of the given neighbor
     """
-    ip_addrs = _validate_bgp_neighbor_ip(neighbor_ip)
+    ip_addrs = _validate_bgp_neighbor_ip(neighbor_ip_or_hostname)
     config_db = ConfigDBConnector()
     config_db.connect()
 

--- a/config/main.py
+++ b/config/main.py
@@ -241,6 +241,10 @@ def _change_bgp_session_status(ipaddr_or_hostname, status, verbose):
 def _remove_bgp_neighbor_config(neighbor_ip):
     """Removes BGP configuration of the given neighbor
     """
+    neighbor_ip = neighbor_ip.lower()
+    if not is_ipaddress(neighbor_ip):
+        click.echo("{} is not a valid neighbor address".format(neighbor_ip))
+        return
     config_db = ConfigDBConnector()
     config_db.connect()
     config_db.mod_entry('bgp_neighbor', neighbor_ip, None)
@@ -979,7 +983,7 @@ def remove_neighbor_with_ip(neighbor_ip):
 @click.argument('neighbor_name', metavar='<neighbor_name>', required=True)
 def remove_neighbor_with_name(neighbor_name):
     """Deletes BGP neighbor configuration of given hostname from devices"""
-    bgp_neighbor_ip_list = _get_neighbor_ipaddress_list_by_hostname(neighbor_name)
+    bgp_neighbor_ip_list = _get_neighbor_ipaddress_list_by_hostname(neighbor_name.upper())
     for ipaddress in bgp_neighbor_ip_list:
         _remove_bgp_neighbor_config(ipaddress)
 

--- a/config/main.py
+++ b/config/main.py
@@ -238,7 +238,7 @@ def _change_bgp_session_status(ipaddr_or_hostname, status, verbose):
     for ip_addr in ip_addrs:
         _change_bgp_session_status_by_addr(ip_addr, status, verbose)
 
-def _validate_bgp_neighbor_ip(neighbor_ip_or_hostname):
+def _validate_bgp_neighbor(neighbor_ip_or_hostname):
     """validates whether the given ip or host name is a BGP neighbor
     """
     ip_addrs = []
@@ -255,7 +255,7 @@ def _validate_bgp_neighbor_ip(neighbor_ip_or_hostname):
 def _remove_bgp_neighbor_config(neighbor_ip_or_hostname):
     """Removes BGP configuration of the given neighbor
     """
-    ip_addrs = _validate_bgp_neighbor_ip(neighbor_ip_or_hostname)
+    ip_addrs = _validate_bgp_neighbor(neighbor_ip_or_hostname)
     config_db = ConfigDBConnector()
     config_db.connect()
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -1531,7 +1531,7 @@ This command is used to remove particular IPv4 or IPv6 BGP neighbor configuratio
 This command is used to remove particular neighbor device's IPv4 and IPv6 BGP configuration.
 
   - Usage:
-    sudo config bgp remove neighbor_ip <neighbor_name>
+    sudo config bgp remove neighbor_name <neighbor_name>
 
 - Examples:
   ```

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -1451,6 +1451,9 @@ The list of possible BGP config commands are given below.
         startup
             all
             neighbor
+        remove
+            neighbor_ip
+            neighbor_name
 
 **config bgp shut down all**
 
@@ -1507,6 +1510,32 @@ This command is used to start up the particular IPv4 or IPv6 BGP neighbor using 
   ```
   ```
   admin@sonic:~$ sudo config bgp startup neighbor SONIC02SPINE
+  ```
+
+
+**config bgp remove neighbor_ip <neighbor_ip>**
+
+This command is used to remove particular IPv4 or IPv6 BGP neighbor configuration.
+
+  - Usage:
+    sudo config bgp remove neighbor_ip <neighbor_ip>
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp remove neighbor_ip 192.168.1.124
+  ```
+
+
+**config bgp remove neighbor_name <neighbor_name>**
+
+This command is used to remove particular neighbor device's IPv4 and IPv6 BGP configuration.
+
+  - Usage:
+    sudo config bgp remove neighbor_ip <neighbor_name>
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp remove neighbor_name SONIC02SPINE
   ```
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#BGP-Configuration-And-Show-Commands)

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -1467,8 +1467,7 @@ The list of possible BGP config commands are given below.
             all
             neighbor
         remove
-            neighbor_ip
-            neighbor_name
+            neighbor
 
 **config bgp shut down all**
 
@@ -1528,30 +1527,24 @@ This command is used to start up the particular IPv4 or IPv6 BGP neighbor using 
   ```
 
 
-**config bgp remove neighbor_ip <neighbor_ip>**
+**config bgp remove neighbor <neighbor_ip_or_hostname>**
 
-This command is used to remove particular IPv4 or IPv6 BGP neighbor configuration.
+This command is used to remove particular IPv4 or IPv6 BGP neighbor configuration using either the IP address or hostname.
 
   - Usage:
-    sudo config bgp remove neighbor_ip <neighbor_ip>
+    sudo config bgp remove neighbor <neighbor_ip_or_hostname>
 
 - Examples:
   ```
-  admin@sonic:~$ sudo config bgp remove neighbor_ip 192.168.1.124
+  admin@sonic:~$ sudo config bgp remove neighbor 192.168.1.124
   ```
-
-
-**config bgp remove neighbor_name <neighbor_name>**
-
-This command is used to remove particular neighbor device's IPv4 and IPv6 BGP configuration.
-
-  - Usage:
-    sudo config bgp remove neighbor_name <neighbor_name>
-
-- Examples:
   ```
-  admin@sonic:~$ sudo config bgp remove neighbor_name SONIC02SPINE
+  admin@sonic:~$ sudo config bgp remove neighbor 2603:10b0:b0f:346::4a
   ```
+  ```
+  admin@sonic:~$ sudo config bgp remove neighbor SONIC02SPINE
+  ``` 
+
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#BGP-Configuration-And-Show-Commands)
 


### PR DESCRIPTION
**- What I did**
I have added commands to remove BGP neighbor configuration
**- How I did it**
Added some new methods to the config/main.py file to support removing BGP neighbor configuration.
**- How to verify it**
```
admin@Test_Device1:~$ show ip bgp summary
BGP router identifier 10.10.1.1, local AS number 65534
RIB entries 1, using 112 bytes of memory
Peers 42, using 191 KiB of memory
Peer groups 1, using 56 bytes of memory

Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
... 
10.10.193.43    4 64521       0       0        0    0    0 never    Idle       
10.10.193.45    4 64522       0       0        0    0    0 never    Idle       
10.10.193.47    4 64523       0       0        0    0    0 never    Idle       
10.106.8.240    4 64524       0       0        0    0    0 never    Idle       
10.106.12.240   4 64525       0       0        0    0    0 never    Idle       

Total number of neighbors 21

admin@Test_Device1:~$ redis-cli -n 4 hgetall "BGP_NEIGHBOR|10.106.12.240"        
 1) "rrclient"
 2) "0"
 3) "name"
 4) "Test_T2"
 5) "local_addr"
 6) "10.106.12.241"
 7) "nhopself"
 8) "0"
 9) "holdtime"
10) "10"
11) "asn"
12) "64525"
13) "keepalive"
14) "3"
admin@Test_Device1:~$ 

admin@Test_Device1:~$ 
admin@Test_Device1:~$ sudo config bgp remove neighbor 10.106.12.240
Removed configuration of BGP neighbor 10.106.12.240
admin@Test_Device1:~$ 

admin@Test_Device1:~$ redis-cli -n 4 hgetall "BGP_NEIGHBOR|10.106.12.240" 
(empty list or set)
admin@Test_Device1:~$ 

admin@Test_Device1:~$ show ip bgp summary 
BGP router identifier 10.10.1.1, local AS number 65534
RIB entries 1, using 112 bytes of memory
Peers 42, using 191 KiB of memory
Peer groups 1, using 56 bytes of memory

Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
... 
10.10.193.43    4 64521       0       0        0    0    0 never    Idle       
10.10.193.45    4 64522       0       0        0    0    0 never    Idle       
10.10.193.47    4 64523       0       0        0    0    0 never    Idle       
10.106.8.240    4 64524       0       0        0    0    0 never    Idle              

Total number of neighbors 20

-------------

admin@Test_Device1:/usr/lib/python2.7/dist-packages$ show ipv6 bgp summary 
BGP router identifier 10.10.1.1, local AS number 65534
RIB entries 1, using 112 bytes of memory
Peers 42, using 191 KiB of memory
Peer groups 1, using 56 bytes of memory

Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
...
2603:10b0:b0f:346::4e
                4 65515       0       0        0    0    0 never    Active     
2603:10b0:b0f:346::52
                4 65516       0       0        0    0    0 never    Active     
2603:10b0:b0f:346::56
                4 65517       0       0        0    0    0 never    Active     
2603:10b0:b0f:346::5a
                4 65518       0       0        0    0    0 never    Active     
2603:10b0:b0f:346::5e
                4 65519       0       0        0    0    0 never    Active     

Total number of neighbors 21

admin@Test_Device1:~$ redis-cli -n 4 hgetall "BGP_NEIGHBOR|2603:10b0:b0f:346::5e"
 1) "rrclient"
 2) "0"
 3) "name"
 4) "TestT0"
 5) "local_addr"
 6) "2603:10b0:b0f:346::5d"
 7) "nhopself"
 8) "0"
 9) "holdtime"
10) "10"
11) "asn"
12) "65519"
13) "keepalive"
14) "3"
admin@Test_Device1:~$ 
admin@Test_Device1:~$ 
admin@Test_Device1:~$ sudo config bgp remove neighbor 2603:10b0:b0f:346::5e
Removed configuration of BGP neighbor 2603:10b0:b0f:346::5e
admin@Test_Device1:~$ 
admin@Test_Device1:~$ redis-cli -n 4 hgetall "BGP_NEIGHBOR|2603:10b0:b0f:346::5e"
(empty list or set)
admin@Test_Device1:~$ 

admin@Test_Device1:/usr/lib/python2.7/dist-packages$ show ipv6 bgp summary 
BGP router identifier 10.10.1.1, local AS number 65534
RIB entries 1, using 112 bytes of memory
Peers 42, using 191 KiB of memory
Peer groups 1, using 56 bytes of memory

Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
...
2603:10b0:b0f:346::4e
                4 65515       0       0        0    0    0 never    Active     
2603:10b0:b0f:346::52
                4 65516       0       0        0    0    0 never    Active     
2603:10b0:b0f:346::56
                4 65517       0       0        0    0    0 never    Active     
2603:10b0:b0f:346::5a
                4 65518       0       0        0    0    0 never    Active      

Total number of neighbors 20

-------------
admin@Test_Device1:~$ 
admin@Test_Device1:~$ show run bgp | grep Test_Device0
 neighbor 10.10.193.31 description Test_Device0
 neighbor 2603:10b0:b0f:346::42 description Test_Device0
admin@Test_Device1:~$ 

admin@Test_Device1:~$ 
admin@Test_Device1:~$ sudo config bgp remove neighbor Test_Device0
Removed configuration of BGP neighbor 2603:10b0:b0f:346::42
Removed configuration of BGP neighbor 10.10.193.31
admin@Test_Device1:~$ 
admin@Test_Device1:~$ 
```
**- Previous command output (if the output of a command-line utility has changed)**
The output on the command doesn't change. It just removes the neighbor details when you run the "show ip bgp summary" / "show ipv6 bgp summary" command
**- New command output (if the output of a command-line utility has changed)**
The output on the command doesn't change. It just removes the neighbor details when you run the "show ip bgp summary" / "show ipv6 bgp summary" command
-->

