### PR TITLE
updated "show ntp" to use cgexec when management vrf is enabled

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1542,7 +1542,28 @@ def bgp(verbose):
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def ntp(verbose):
     """Show NTP information"""
-    cmd = "ntpq -p -n"
+    cmd = 'sonic-cfggen -d --var-json "MGMT_VRF_CONFIG"'
+
+    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocc
+ess.PIPE)
+    res = p.communicate()
+    if p.returncode == 0 :
+        p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subb
+process.PIPE)
+        mvrf_dict = json.loads(p.stdout.read())
+
+        # if the mgmtVrfEnabled attribute is configured, check the value
+        # and print Enabled or Disabled accordingly.
+        if 'mgmtVrfEnabled' in mvrf_dict['vrf_global']:
+            if (mvrf_dict['vrf_global']['mgmtVrfEnabled'] == "true"):
+                #ManagementVRF is enabled. Call ntpq using cgexec
+                cmd = "cgexec -g l3mdev:mgmt ntpq -p -n"
+            else:
+                #ManagementVRF is disabled. Call ntpq without cgexec
+                cmd = "ntpq -p -n"
+        else:
+            cmd = "ntpq -p -n"
+
     run_command(cmd, display_cmd=verbose)
 
 

--- a/show/main.py
+++ b/show/main.py
@@ -1539,19 +1539,18 @@ def bgp(verbose):
 #
 
 @cli.command()
+@click.pass_context
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
-def ntp(verbose):
+def ntp(ctx, verbose):
     """Show NTP information"""
     ntpcmd = "ntpq -p -n"
     if ctx.invoked_subcommand is None:
         cmd = 'sonic-cfggen -d --var-json "MGMT_VRF_CONFIG"'
 
-        p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subb
-process.PIPE)
+        p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         res = p.communicate()
         if p.returncode == 0 :
-            p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderrr
-=subprocess.PIPE)
+            p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             mvrf_dict = json.loads(p.stdout.read())
 
             # if the mgmtVrfEnabled attribute is configured, check the value

--- a/show/main.py
+++ b/show/main.py
@@ -1542,8 +1542,26 @@ def bgp(verbose):
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def ntp(verbose):
     """Show NTP information"""
-    cmd = "ntpq -p -n"
-    run_command(cmd, display_cmd=verbose)
+    ntpcmd = "ntpq -p -n"
+    if ctx.invoked_subcommand is None:
+        cmd = 'sonic-cfggen -d --var-json "MGMT_VRF_CONFIG"'
+
+        p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subb
+process.PIPE)
+        res = p.communicate()
+        if p.returncode == 0 :
+            p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderrr
+=subprocess.PIPE)
+            mvrf_dict = json.loads(p.stdout.read())
+
+            # if the mgmtVrfEnabled attribute is configured, check the value
+            # and print Enabled or Disabled accordingly.
+            if 'mgmtVrfEnabled' in mvrf_dict['vrf_global']:
+                if (mvrf_dict['vrf_global']['mgmtVrfEnabled'] == "true"):
+                    #ManagementVRF is enabled. Call ntpq using cgexec
+                    ntpcmd = "cgexec -g l3mdev:mgmt ntpq -p -n"
+    run_command(ntpcmd, display_cmd=verbose)
+
 
 
 #

--- a/show/main.py
+++ b/show/main.py
@@ -1542,28 +1542,7 @@ def bgp(verbose):
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def ntp(verbose):
     """Show NTP information"""
-    cmd = 'sonic-cfggen -d --var-json "MGMT_VRF_CONFIG"'
-
-    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocc
-ess.PIPE)
-    res = p.communicate()
-    if p.returncode == 0 :
-        p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subb
-process.PIPE)
-        mvrf_dict = json.loads(p.stdout.read())
-
-        # if the mgmtVrfEnabled attribute is configured, check the value
-        # and print Enabled or Disabled accordingly.
-        if 'mgmtVrfEnabled' in mvrf_dict['vrf_global']:
-            if (mvrf_dict['vrf_global']['mgmtVrfEnabled'] == "true"):
-                #ManagementVRF is enabled. Call ntpq using cgexec
-                cmd = "cgexec -g l3mdev:mgmt ntpq -p -n"
-            else:
-                #ManagementVRF is disabled. Call ntpq without cgexec
-                cmd = "ntpq -p -n"
-        else:
-            cmd = "ntpq -p -n"
-
+    cmd = "ntpq -p -n"
     run_command(cmd, display_cmd=verbose)
 
 


### PR DESCRIPTION
When management VRF is enabled, the linux command/exe "ntpq" should be called using "cgexec -g l3mdev:mgmt".
"show ntp" is updated for the same.
Result of "show ntp" after enabling management VRF using "config vrf add mgmt" is as follows.
root@sonic:~# show ntp
     remote           refid      st t when poll reach   delay   offset  jitter
================================================================
 23.92.29.245    .STEP.          16 u    -  256    0    0.000    0.000   0.000
*204.2.134.164   44.24.199.34     3 u   31   64  377  201.063    0.444   0.514
root@sonic:~# 
