### PR TITLE
[neighbor_advertiser]: Change the ICMPv6 type to 135

### DIFF
--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -363,7 +363,7 @@ def add_mirror_acl_rule():
 
     acl_rule_info = {
         'PRIORITY': '8887',
-        'ICMPV6_TYPE': '128',
+        'ICMPV6_TYPE': '135',
         'mirror_action': MIRROR_SESSION_NAME
     }
 


### PR DESCRIPTION
Need to mirror the neighbor solicitation packets - type 135.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>