### PR TITLE
[show] Add 'show boot' command

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -382,6 +382,21 @@ This command displays the current date and time configured on the system
   Mon Mar 25 20:25:16 UTC 2019
   ```
 
+**show boot**
+This command displays the current OS image, the image loaded on next reboot, and the lists the available images on the system
+
+-  Usage:
+   show boot
+
+- Example:
+  ```
+  admin@sonic:~$ show boot
+  Current: SONiC-OS-20181130.31
+  Next: SONiC-OS-20181130.31
+  Available: 
+  SONiC-OS-20181130.31
+  ```
+
 **show environment**
 This command displays the platform environmentals, such as voltages, temperatures and fan speeds
 

--- a/show/main.py
+++ b/show/main.py
@@ -1860,6 +1860,17 @@ def ecn():
     click.echo(proc.stdout.read())
 
 
+#
+# 'boot' command ("show boot")
+#
+@cli.command('boot')
+def boot():
+    """Show boot configuration"""
+    cmd = "sudo sonic_installer list"
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+    click.echo(proc.stdout.read())
+
+
 # 'mmu' command ("show mmu")
 #
 @cli.command('mmu')


### PR DESCRIPTION
**- What I did**
I added the "show boot" command to the CLI.

**- How I did it**
I updated the show/main.py file to add the command. 

**- How to verify it**
run "show boot"

**- Previous command output (if the output of a command-line utility has changed)**
None 

**- New command output (if the output of a command-line utility has changed)**
```
admin@str-s6000-acs-11:~$ show boot
Current: SONiC-OS-20181130.31
Next: SONiC-OS-20181130.31
Available: 
SONiC-OS-20181130.31
```


