### PR TITLE
Asym PFC configuration fix

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1293,14 +1293,17 @@ def pfc(ctx):
 #
 
 @pfc.command()
+@click.argument('interface_name', metavar='<interface_name>', required=True)
 @click.argument('status', type=click.Choice(['on', 'off']))
 @click.pass_context
-def asymmetric(ctx, status):
+def asymmetric(ctx, interface_name, status):
     """Set asymmetric PFC configuration."""
-    config_db = ctx.obj["config_db"]
-    interface = ctx.obj["interface_name"]
+    if get_interface_naming_mode() == "alias":
+        interface_name = interface_alias_to_name(interface_name)
+        if interface_name is None:
+            ctx.fail("'interface_name' is None!")
 
-    run_command("pfc config asymmetric {0} {1}".format(status, interface))
+    run_command("pfc config asymmetric {0} {1}".format(status, interface_name))
 
 #
 # 'platform' group ('config platform ...')


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

**- What I did**
* Fixed Asym PFC configuration 

**- How I did it**
* Added missing argument

**- How to verify it**
1. root@sonic:/home/admin# config interface pfc asymmetric Ethernet0 off
2. root@sonic:/home/admin# config interface pfc asymmetric Ethernet0 on

**- Previous command output (if the output of a command-line utility has changed)**
```bash
root@sonic:/home/admin# config interface Ethernet0 pfc asymmetric off
Usage: config interface [OPTIONS] COMMAND [ARGS]...

Error: No such command "Ethernet0".

root@sonic:/home/admin# config interface pfc asymmetric Ethernet0 off
Usage: config interface pfc asymmetric [OPTIONS] STATUS

Error: Invalid value for "status": invalid choice: Ethernet0. (choose from on, off)

root@sonic:/home/admin# config interface pfc asymmetric off Ethernet0
Usage: config interface pfc asymmetric [OPTIONS] STATUS

Error: Got unexpected extra argument (Ethernet0)
```

**- New command output (if the output of a command-line utility has changed)**
```bash
root@sonic:/home/admin# config interface pfc asymmetric Ethernet0 off
```