### PR TITLE
[FastReboot]: Send SIGINT to all teamd before stop

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -407,12 +407,13 @@ docker kill lldp > /dev/null
 systemctl stop lldp
 
 if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
+    # Kill teamd processes inside of teamd container with SIGINT to allow them to send last LACP frames
     # Kill teamd, otherwise it gets down all LAGs
     # We call `docker kill teamd` to ensure the container stops as quickly as possible,
     # then immediately call `systemctl stop teamd` to prevent the service from
     # restarting the container automatically.
     # Note: teamd must be killed before syncd, because it will send the last packet through CPU port
-    # TODO: stop teamd gracefully to allow teamd to send last valid update to be sure we'll have 90 seconds reboot time
+    docker exec -i teamd pkill -INT teamd
     docker kill teamd > /dev/null
     systemctl stop teamd
 fi

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -413,7 +413,7 @@ if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
     # then immediately call `systemctl stop teamd` to prevent the service from
     # restarting the container automatically.
     # Note: teamd must be killed before syncd, because it will send the last packet through CPU port
-    docker exec -i teamd pkill -INT teamd
+    docker exec -i teamd pkill -INT teamd || [ $? == 1 ]
     docker kill teamd > /dev/null
     systemctl stop teamd
 fi

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -414,6 +414,9 @@ if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
     # restarting the container automatically.
     # Note: teamd must be killed before syncd, because it will send the last packet through CPU port
     docker exec -i teamd pkill -INT teamd || [ $? == 1 ]
+    while docker exec -i teamd pgrep teamd > /dev/null; do
+      sleep 0.05
+    done
     docker kill teamd > /dev/null
     systemctl stop teamd
 fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Added sending of SIGINT signal to all active teamd processes before Fast-Reboot

**- How I did it**
using pkill utility

**- How to verify it**
Put the changes from this PR to your DUT.
Then use `fast-reboot` on your dut while capturing packets on one of the portchannel member interfaces of DUT

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

