### PR TITLE
[config]: add the vid range check for creating vlan.

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -742,11 +742,14 @@ def vlan(ctx, redis_unix_socket_path):
 @click.argument('vid', metavar='<vid>', required=True, type=int)
 @click.pass_context
 def add_vlan(ctx, vid):
-    db = ctx.obj['db']
-    vlan = 'Vlan{}'.format(vid)
-    if len(db.get_entry('VLAN', vlan)) != 0:
-        ctx.fail("{} already exists".format(vlan))
-    db.set_entry('VLAN', vlan, {'vlanid': vid})
+    if vid >= 1 and vid <= 4094:
+        db = ctx.obj['db']
+        vlan = 'Vlan{}'.format(vid)
+        if len(db.get_entry('VLAN', vlan)) != 0:
+            ctx.fail("{} already exists".format(vlan))
+        db.set_entry('VLAN', vlan, {'vlanid': vid})
+    else :
+        ctx.fail("Invalid VLAN ID {} (1-4094)".format(vid))
 
 @vlan.command('del')
 @click.argument('vid', metavar='<vid>', required=True, type=int)


### PR DESCRIPTION
Signed-off-by: wangshengjun <wangshengjun@asterfusion.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
When adding vlan through the CLI,  the corresponding api 'add_vlan' doesn't check the range of vid which input by user. If we add a invalid vlan id (such as 0) and configure a ip address for the vlan interface, the 'vlanmgrd' will crash.The crash log as follows:

Sep  9 06:37:11.166624 sonic NOTICE swss#vlanmgrd: :- main: --- Starting vlanmgrd ---
Sep  9 06:37:11.258563 sonic NOTICE swss#vlanmgrd: :- main: starting main loop
Sep  9 06:37:11.289983 sonic ERR swss#vlanmgrd: :- exec: /bin/bash -c "/sbin/bridge vlan add vid 0 dev Bridge self && /sbin/ip link add link Bridge up name Vlan0 address 52:54:00:12:34:56 type vlan id 0": Success
Sep  9 06:37:11.289983 sonic ERR swss#vlanmgrd: :- main: Runtime error: /bin/bash -c "/sbin/bridge vlan add vid 0 dev Bridge self && /sbin/ip link add link Bridge up name Vlan0 address 52:54:00:12:34:56 type vlan id 0" : 

**- How I did it**
Add the vlan id range check.

**- How to verify it**

admin@sonic:~$ sudo config vlan 0 
Usage: config vlan [OPTIONS] COMMAND [ARGS]...

Error: No such command "0".
admin@sonic:~$ sudo config vlan add 0
Usage: config vlan add [OPTIONS] <vid>

Error: Invalid VLAN ID 0 (1-4094)
admin@sonic:~$ sudo config vlan add 4095
Usage: config vlan add [OPTIONS] <vid>

Error: Invalid VLAN ID 4095 (1-4094)


