### PR TITLE
[config] Fix naming conflict between 'config syslog' function and 'syslog' module

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1358,16 +1358,16 @@ def naming_mode_alias():
 #
 # 'syslog' group ('config syslog ...')
 #
-@config.group()
+@config.group('syslog')
 @click.pass_context
-def syslog(ctx):
+def syslog_group(ctx):
     """Syslog server configuration tasks"""
     config_db = ConfigDBConnector()
     config_db.connect()
     ctx.obj = {'db': config_db}
     pass
 
-@syslog.command('add')
+@syslog_group.command('add')
 @click.argument('syslog_ip_address', metavar='<syslog_ip_address>', required=True)
 @click.pass_context
 def add_syslog_server(ctx, syslog_ip_address):
@@ -1379,7 +1379,7 @@ def add_syslog_server(ctx, syslog_ip_address):
     if syslog_ip_address in syslog_servers:
         click.echo("Syslog server {} is already configured".format(syslog_ip_address))
         return
-    else: 
+    else:
         db.set_entry('SYSLOG_SERVER', syslog_ip_address, {'NULL': 'NULL'})
         click.echo("Syslog server {} added to configuration".format(syslog_ip_address))
         try:
@@ -1388,7 +1388,7 @@ def add_syslog_server(ctx, syslog_ip_address):
         except SystemExit as e:
             ctx.fail("Restart service rsyslog-config failed with error {}".format(e))
 
-@syslog.command('del')
+@syslog_group.command('del')
 @click.argument('syslog_ip_address', metavar='<syslog_ip_address>', required=True)
 @click.pass_context
 def del_syslog_server(ctx, syslog_ip_address):
@@ -1400,7 +1400,7 @@ def del_syslog_server(ctx, syslog_ip_address):
     if syslog_ip_address in syslog_servers:
         db.set_entry('SYSLOG_SERVER', '{}'.format(syslog_ip_address), None)
         click.echo("Syslog server {} removed from configuration".format(syslog_ip_address))
-    else: 
+    else:
         ctx.fail("Syslog server {} is not configured.".format(syslog_ip_address))
     try:
         click.echo("Restarting rsyslog-config service...")


### PR DESCRIPTION
**- What I did**
Updated method name in the config/main.py file to remove the conflict between the "import syslog" command and the click "syslog" command. 

**- How I did it**
Changed the click "syslog" group to be "syslog_group" to remove the conflict

**- How to verify it**
These commands will now work again without the conflict: 
config load_minigraph -y
config reload -y

**- Previous command output (if the output of a command-line utility has changed)**
N/A

**- New command output (if the output of a command-line utility has changed)**
N/A

This fixes #635 
-->

