### PR TITLE
Support sub port interface admin status change

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -79,7 +79,7 @@ def interface_alias_to_name(interface_alias):
     sub_intf_sep_idx = -1
     if interface_alias is not None:
         sub_intf_sep_idx = interface_alias.find(VLAN_SUB_INTERFACE_SEPARATOR)
-        if (sub_intf_sep_idx != -1):
+        if sub_intf_sep_idx != -1:
             vlan_id = interface_alias[sub_intf_sep_idx + 1:]
             # interface_alias holds the parent port name so the subsequent logic still applies
             interface_alias = interface_alias[:sub_intf_sep_idx]

--- a/config/main.py
+++ b/config/main.py
@@ -75,7 +75,7 @@ def interface_alias_to_name(interface_alias):
     config_db.connect()
     port_dict = config_db.get_table('PORT')
 
-    vlan_id = -1
+    vlan_id = ""
     sub_intf_sep_idx = -1
     if interface_alias is not None:
         sub_intf_sep_idx = interface_alias.find(VLAN_SUB_INTERFACE_SEPARATOR)

--- a/config/main.py
+++ b/config/main.py
@@ -1045,7 +1045,10 @@ def startup(ctx, interface_name):
         else:
             config_db.mod_entry("PORT", interface_name, {"admin_status": "up"})
     elif interface_name.startswith("PortChannel"):
-        config_db.mod_entry("PORTCHANNEL", interface_name, {"admin_status": "up"})
+        if VLAN_SUB_INTERFACE_SEPARATOR in interface_name:
+            config_db.mod_entry("VLAN_SUB_INTERFACE", interface_name, {"admin_status": "up"})
+        else:
+            config_db.mod_entry("PORTCHANNEL", interface_name, {"admin_status": "up"})
 #
 # 'shutdown' subcommand
 #
@@ -1070,7 +1073,10 @@ def shutdown(ctx, interface_name):
         else:
             config_db.mod_entry("PORT", interface_name, {"admin_status": "down"})
     elif interface_name.startswith("PortChannel"):
-        config_db.mod_entry("PORTCHANNEL", interface_name, {"admin_status": "down"})
+        if VLAN_SUB_INTERFACE_SEPARATOR in interface_name:
+            config_db.mod_entry("VLAN_SUB_INTERFACE", interface_name, {"admin_status": "down"})
+        else:
+            config_db.mod_entry("PORTCHANNEL", interface_name, {"admin_status": "down"})
 
 #
 # 'speed' subcommand

--- a/config/main.py
+++ b/config/main.py
@@ -19,6 +19,7 @@ import mlnx
 
 SONIC_CFGGEN_PATH = '/usr/local/bin/sonic-cfggen'
 SYSLOG_IDENTIFIER = "config"
+VLAN_SUB_INTERFACE_SEPARATOR = '.'
 
 # ========================== Syslog wrappers ==========================
 
@@ -73,16 +74,26 @@ def interface_alias_to_name(interface_alias):
     config_db.connect()
     port_dict = config_db.get_table('PORT')
 
+    vlan_id = -1
+    sub_intf_sep_idx = -1
+    if interface_alias is not None:
+        sub_intf_sep_idx = interface_alias.find(VLAN_SUB_INTERFACE_SEPARATOR)
+        if (sub_intf_sep_idx != -1):
+            vlan_id = interface_alias[sub_intf_sep_idx + 1:]
+            # interface_alias holds the parent port name so the subsequent logic still applies
+            interface_alias = interface_alias[:sub_intf_sep_idx]
+
     if interface_alias is not None:
         if not port_dict:
             click.echo("port_dict is None!")
             raise click.Abort()
         for port_name in port_dict.keys():
             if interface_alias == port_dict[port_name]['alias']:
-                return port_name
+                return port_name if sub_intf_sep_idx == -1 else port_name + VLAN_SUB_INTERFACE_SEPARATOR + vlan_id
 
-    # Interface alias not in port_dict, just return interface_alias
-    return interface_alias
+    # Interface alias not in port_dict, just return interface_alias, e.g.,
+    # portchannel is passed in as argument, which does not have an alias
+    return interface_alias if sub_intf_sep_idx == -1 else interface_alias + VLAN_SUB_INTERFACE_SEPARATOR + vlan_id
 
 
 def interface_name_is_valid(interface_name):
@@ -92,6 +103,7 @@ def interface_name_is_valid(interface_name):
     config_db.connect()
     port_dict = config_db.get_table('PORT')
     port_channel_dict = config_db.get_table('PORTCHANNEL')
+    sub_port_intf_dict = config_db.get_table('VLAN_SUB_INTERFACE')
 
     if get_interface_naming_mode() == "alias":
         interface_name = interface_alias_to_name(interface_name)
@@ -106,6 +118,10 @@ def interface_name_is_valid(interface_name):
         if port_channel_dict:
             for port_channel_name in port_channel_dict.keys():
                 if interface_name == port_channel_name:
+                    return True
+        if sub_port_intf_dict:
+            for sub_port_intf_name in sub_port_intf_dict.keys():
+                if interface_name == sub_port_intf_name:
                     return True
     return False
 
@@ -873,7 +889,10 @@ def startup(ctx, interface_name):
         ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
 
     if interface_name.startswith("Ethernet"):
-        config_db.mod_entry("PORT", interface_name, {"admin_status": "up"})
+        if VLAN_SUB_INTERFACE_SEPARATOR in interface_name:
+            config_db.mod_entry("VLAN_SUB_INTERFACE", interface_name, {"admin_status": "up"})
+        else:
+            config_db.mod_entry("PORT", interface_name, {"admin_status": "up"})
     elif interface_name.startswith("PortChannel"):
         config_db.mod_entry("PORTCHANNEL", interface_name, {"admin_status": "up"})
 #
@@ -895,7 +914,10 @@ def shutdown(ctx, interface_name):
         ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
 
     if interface_name.startswith("Ethernet"):
-        config_db.mod_entry("PORT", interface_name, {"admin_status": "down"})
+        if VLAN_SUB_INTERFACE_SEPARATOR in interface_name:
+            config_db.mod_entry("VLAN_SUB_INTERFACE", interface_name, {"admin_status": "down"})
+        else:
+            config_db.mod_entry("PORT", interface_name, {"admin_status": "down"})
     elif interface_name.startswith("PortChannel"):
         config_db.mod_entry("PORTCHANNEL", interface_name, {"admin_status": "down"})
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Implement HLD https://github.com/Azure/SONiC/pull/420

**- How I did it**

**- How to verify it**
On mlnx dut

alias mode:
```
$ show  interfaces naming_mode
alias
```
```
$ sudo config interface shutdown etp17.10

$ redis-cli -n 4 hgetall "VLAN_SUB_INTERFACE|Ethernet64.10"
1) "admin_status"
2) "down"

$ redis-cli -n 0 hgetall "INTF_TABLE:Ethernet64.10"
1) "admin_status"
2) "down"
```
```
$ sudo config interface startup etp17.10

$ redis-cli -n 4 hgetall "VLAN_SUB_INTERFACE|Ethernet64.10"
1) "admin_status"
2) "up"

$ redis-cli -n 0 hgetall "INTF_TABLE:Ethernet64.10"        
1) "admin_status"
2) "up"
```

default mode:
```
$ show interfaces naming_mode 
default
```
```
$ sudo config interface shutdown Ethernet64.10

$ redis-cli -n 4 hgetall "VLAN_SUB_INTERFACE|Ethernet64.10"
1) "admin_status"
2) "down"

$ redis-cli -n 0 hgetall "INTF_TABLE:Ethernet64.10"
1) "admin_status"
2) "down"
```
```
$ sudo config interface startup Ethernet64.10

$ redis-cli -n 4 hgetall "VLAN_SUB_INTERFACE|Ethernet64.10"
1) "admin_status"
2) "up"

$ redis-cli -n 0 hgetall "INTF_TABLE:Ethernet64.10"
1) "admin_status"
2) "up"
```
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

