### PR TITLE
[warm-reboot]: Do not clean up mirror session state database

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -180,10 +180,11 @@ function backup_database()
     debug "Backing up database ..."
     # Dump redis content to a file 'dump.rdb' in warmboot directory
     mkdir -p $WARM_DIR
-    # Delete keys in stateDB except FDB_TABLE|* and WARM_RESTA*
+    # Delete keys in stateDB except FDB_TABLE|*, MIRROR_SESSION_TABLE|*, WARM_RESTART_ENABLE_TABLE|*
     redis-cli -n 6 eval "
         for _, k in ipairs(redis.call('keys', '*')) do
             if not string.match(k, 'FDB_TABLE|') and not string.match(k, 'WARM_RESTART_TABLE|') \
+                                          and not string.match(k, 'MIRROR_SESSION_TABLE|') \
                                           and not string.match(k, 'WARM_RESTART_ENABLE_TABLE|') then
                 redis.call('del', k)
             end


### PR DESCRIPTION
In order to maintain the same monitor port across the warm reboot,
exclude the mirror session state database.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>