### PR TITLE
[pfcwd] Apply pfcwd config only on physical ports

### DIFF
--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -42,7 +42,13 @@ def get_all_queues(db):
     return natsorted(queue_names.keys())
 
 def get_all_ports(db):
-    port_names = db.get_all(db.COUNTERS_DB, 'COUNTERS_PORT_NAME_MAP')
+    all_port_names = db.get_all(db.COUNTERS_DB, 'COUNTERS_PORT_NAME_MAP')
+
+    # Get list of physical ports
+    port_names = {}
+    for i in all_port_names:
+        if i.startswith('Ethernet'):
+            port_names[i]= all_port_names[i]
     return natsorted(port_names.keys())
 
 def get_server_facing_ports(db):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Restrict the pfcwd config only to physical ports.
 
**- How I did it**
Excluding non-physical in get_all_ports() by matching the port name with "Ethernet".

**- How to verify it**
 Create a Port Channel
 Configure pfc and start pfcwd on a port (sudo pfcwd start --action drop ports all detection-time 200 --restoration-time 2000)
 Stop the pfcwd using (sudo pfcwd stop) -> Leads to crash in syncd as it tries to remove non-existing UC/MC queues for the port channel.
 With the fix, no crash was observed. 


**- Previous command output (if the output of a command-line utility has changed)**
NA
**- New command output (if the output of a command-line utility has changed)**
NA
-->

