### PR TITLE
[config] Add '-h' and '-?' as help options to unify with show/sonic-clear cmds

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -18,6 +18,8 @@ from minigraph import parse_device_desc_xml
 import aaa
 import mlnx
 
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help', '-?'])
+
 SONIC_CFGGEN_PATH = '/usr/local/bin/sonic-cfggen'
 SYSLOG_IDENTIFIER = "config"
 
@@ -386,8 +388,9 @@ def is_ipaddress(val):
         return False
     return True
 
+
 # This is our main entrypoint - the main 'config' command
-@click.group()
+@click.group(context_settings=CONTEXT_SETTINGS)
 def config():
     """SONiC command line - 'config' command"""
     if os.geteuid() != 0:


### PR DESCRIPTION
The `show` and `sonic-clear` commands accepted `--help` as well as `-h` and `-?` as options to display help, but config only supported `--help`. This standardizes the help options among all three commands.

Resolves #646 