### PR TITLE
Add an on/off knob for BGP EOIU pulling on warm restart

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -744,6 +744,13 @@ def warm_restart_teamsyncd_timer(ctx, seconds):
         ctx.fail("teamsyncd warm restart timer must be in range 1-3600")
     db.mod_entry('WARM_RESTART', 'teamd', {'teamsyncd_timer': seconds})
 
+@warm_restart.command('bgp_eoiu')
+@click.argument('enable', metavar='<enable>', default='true', required=False, type=click.Choice(["true", "false"]))
+@click.pass_context
+def warm_restart_bgp_eoiu(ctx, enable):
+    db = ctx.obj['db']
+    db.mod_entry('WARM_RESTART', 'bgp', {'bgp_eoiu': enable})
+
 #
 # 'vlan' group ('config vlan ...')
 #

--- a/show/main.py
+++ b/show/main.py
@@ -2033,16 +2033,28 @@ def config(redis_unix_socket_path):
             if k not in data:
                 r.append("NULL")
                 r.append("NULL")
+                r.append("NULL")
             elif 'neighsyncd_timer' in  data[k]:
                 r.append("neighsyncd_timer")
                 r.append(data[k]['neighsyncd_timer'])
-            elif 'bgp_timer' in data[k]:
-                r.append("bgp_timer")
-                r.append(data[k]['bgp_timer'])
+                r.append("NULL")
+            elif 'bgp_timer' in data[k] or 'bgp_eoiu' in data[k]:
+                if 'bgp_timer' in data[k]:
+                    r.append("bgp_timer")
+                    r.append(data[k]['bgp_timer'])
+                else:
+                    r.append("NULL")
+                    r.append("NULL")
+                if 'bgp_eoiu' in data[k]:
+                    r.append(data[k]['bgp_eoiu'])
+                else:
+                    r.append("NULL")
             elif 'teamsyncd_timer' in data[k]:
                 r.append("teamsyncd_timer")
                 r.append(data[k]['teamsyncd_timer'])
+                r.append("NULL")
             else:
+                r.append("NULL")
                 r.append("NULL")
                 r.append("NULL")
 
@@ -2050,7 +2062,7 @@ def config(redis_unix_socket_path):
 
         return table
 
-    header = ['name', 'enable', 'timer_name', 'timer_duration']
+    header = ['name', 'enable', 'timer_name', 'timer_duration', 'eoiu_enable']
     click.echo(tabulate(tablelize(keys, data, enable_table_keys, prefix), header))
     state_db.close(state_db.STATE_DB)
 


### PR DESCRIPTION
Add a knob to turn on/off the BGP EOIU pulling when BGP warm restart.  By default, it's off. 
This is to address review comments for https://github.com/Azure/sonic-buildimage/pull/2823

Other related PR

https://github.com/Azure/sonic-buildimage/pull/3489

https://github.com/Azure/sonic-buildimage/pull/2823
https://github.com/Azure/sonic-swss-common/pull/273
https://github.com/Azure/sonic-swss/pull/856

<pre>
root@<!-- -->ASW-7001:~# config warm_restart bgp_eoiu true
root@<!-- -->ASW-7001:~# show warm_restart config 
name    enable    timer_name    timer_duration    eoiu_enable
------  --------  ------------  ----------------  -------------
bgp     false     NULL          NULL              true

root@ASW-7001:~# config warm_restart bgp_eoiu false
root@ASW-7001:~# show warm_restart config 
name    enable    timer_name    timer_duration    eoiu_enable
------  --------  ------------  ----------------  -------------
bgp     false     NULL           NULL             false


root@ASW-7001:~# config warm_restart bgp_timer 120
root@ASW-7001:~# show warm_restart config 
name    enable    timer_name      timer_duration  eoiu_enable
------  --------  ------------  ----------------  -------------
bgp     false     bgp_timer     120               false


root@ASW-7001:~# config warm_restart bgp_eoiu true
root@ASW-7001:~# show warm_restart config 
name    enable    timer_name      timer_duration  eoiu_enable
------  --------  ------------  ----------------  -------------
bgp      false    bgp_timer     120               true

</pre>
