### PR TITLE
[fdb]cli: fdb entries are cleared according to vlan or port or vlan&&port

### DIFF
--- a/scripts/fdbclear
+++ b/scripts/fdbclear
@@ -42,10 +42,15 @@ def main():
 
     try:
         fdb = FdbClear()
-        if args.vlan is not None:
-            print("command not supported yet.")
+        if args.vlan is not None and args.port is not None:
+            fdb.send_notification("PORTVLAN", args.port+'|'+args.vlan)
+            print("Port {} + Vlan{} FDB entries are cleared.".format(args.port, args.vlan))
+        elif args.vlan is not None:
+            fdb.send_notification("VLAN", args.vlan)
+            print("Vlan{} FDB entries are cleared.".format(args.vlan))
         elif args.port is not None:
-            print("command not supported yet.")
+            fdb.send_notification("PORT", args.port)
+            print("Port {} FDB entries are cleared.".format(args.port))
         else:
             fdb.send_notification("ALL", "ALL")
             print("FDB entries are cleared.")


### PR DESCRIPTION
Fdb entries can be deleted with user specifying vlan or port or vlan&&port.
fdborch is in charge of deleting fdb entries in another issues#1064,and it had pull request.
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

