### PR TITLE
Added 'config core' and 'show cores' CLI commands

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -336,6 +336,7 @@ def _reset_failed_services():
         'bgp',
         'dhcp_relay',
         'hostcfgd',
+        'coredump-config',
         'hostname-config',
         'interfaces-config',
         'lldp',
@@ -359,6 +360,7 @@ def _reset_failed_services():
 
 def _restart_services():
     services_to_restart = [
+        'coredump-config',
         'hostname-config',
         'interfaces-config',
         'ntp-config',
@@ -1503,3 +1505,35 @@ def del_ntp_server(ctx, ntp_ip_address):
 
 if __name__ == '__main__':
     config()
+
+#
+# 'core' group ('config core ...')
+#
+@config.group()
+def core():
+    """ Configure coredump """
+    if os.geteuid() != 0:
+        exit("Root privileges are required for this operation")
+    pass
+
+@core.command()
+@click.argument('disable', required=False)
+def disable(disable):
+    """Administratively Disable coredump generation"""
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    table = "COREDUMP"
+    key = "config"
+    config_db.set_entry(table, key, {"enabled": "false"})
+    run_command("systemctl restart coredump-config")
+
+@core.command()
+@click.argument('enable', required=False)
+def enable(enable):
+    """Administratively Enable coredump generation"""
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    table = "COREDUMP"
+    key = "config"
+    config_db.set_entry(table, key, {"enabled": "true"})
+    run_command("systemctl restart coredump-config")

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -417,7 +417,7 @@ main() {
             continue
         fi
         # don't gzip already-gzipped log files :)
-        if [ -z "${file##*.gz}" ]; then
+        if [ -z "${file##*.gz}" ] || [ -z "${file##*.lz4}" ]; then
             save_file $file log false
         else
             save_file $file log true

--- a/show/main.py
+++ b/show/main.py
@@ -1602,6 +1602,64 @@ def system_memory(verbose):
     cmd = "free -m"
     run_command(cmd, display_cmd=verbose)
 
+#
+# 'coredumpctl' group ("show cores")
+#
+
+@cli.group(cls=AliasedGroup, default_if_no_args=False)
+def cores():
+    """Show core dump events encountered"""
+    pass
+
+# 'config' subcommand ("show cores config")
+@cores.command()
+@click.option('--verbose', is_flag=True, help="Enable verbose output")
+def config(verbose):
+    """ Show coredump configuration """
+    # Default admin mode
+    admin_mode = True
+    # Obtain config from Config DB
+    config_db = ConfigDBConnector()
+    if config_db is not None:
+        config_db.connect()
+        table_data = config_db.get_table('COREDUMP')
+        if table_data is not None:
+            config_data = table_data.get('config')
+            if config_data is not None:
+                admin_mode = config_data.get('enabled')
+                if admin_mode is not None and admin_mode.lower() == 'false':
+                    admin_mode = False
+
+    # Core dump administrative mode
+    if admin_mode:
+        print('Coredump : %s' % 'Enabled')
+    else:
+        print('Coredump : %s' % 'Disabled')
+
+# 'list' subcommand ("show cores list")
+@cores.command()
+@click.argument('pattern', required=False)
+@click.option('--verbose', is_flag=True, help="Enable verbose output")
+def list(verbose, pattern):
+    """ List available coredumps """
+
+    cmd = "coredumpctl list"
+    if pattern is not None:
+        cmd = cmd + " " + pattern
+    run_command(cmd, display_cmd=verbose)
+
+# 'info' subcommand ("show cores info")
+@cores.command()
+@click.argument('pattern', required=False)
+@click.option('--verbose', is_flag=True, help="Enable verbose output")
+def info(verbose, pattern):
+    """ Show information about one or more coredumps """
+
+    cmd = "coredumpctl info"
+    if pattern is not None:
+        cmd = cmd + " " + pattern
+    run_command(cmd, display_cmd=verbose)
+
 @cli.group(cls=AliasedGroup, default_if_no_args=False)
 def vlan():
     """Show VLAN information"""


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Added wrapper CLI commands to see core files information. Also added CLI command to enable/disable
corefile generation.

**- How I did it**
Added new commands 
config core
show cores

**- How to verify it**

show cores list
config core enable
config core disable

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

root@sonic:/home/admin# show cores
Usage: show cores [OPTIONS] COMMAND [ARGS]...

  Show core dump events encountered

Options:
  -?, -h, --help  Show this message and exit.

Commands:
  config  Show coredump configuration
  info    Show information about one or more coredumps
  list    List available coredumps
root@sonic:/home/admin# show cores list
TIME                            PID   UID   GID SIG COREFILE EXE
Sat 2016-12-31 22:46:22 UTC    4933     0     0   6 present  /usr/bin/vlanmgrd
root@sonic:/home/admin# show cores info
           PID: 4933 (vlanmgrd)
           UID: 0 (root)
           GID: 0 (root)
        Signal: 6 (ABRT)
     Timestamp: Sat 2016-12-31 22:46:22 UTC (6min ago)
  Command Line: /usr/bin/vlanmgrd
    Executable: /usr/bin/vlanmgrd
 Control Group: /docker/38e40a3313bd46ff4e282f897cdc25502a2b15febe9839715f92b035b6f2cffe
         Slice: -.slice
       Boot ID: 3f776b83fa704d089bd81e0b108c2a09
    Machine ID: a0c0523aae8c4c21a8d9fa12e18d85b0
      Hostname: sonic
       Storage: /var/lib/systemd/coredump/core.vlanmgrd.0.3f776b83fa704d089bd81e0b108c2a09.4933.1483224382000000000000.lz4
       Message: Process 4933 (vlanmgrd) of user 0 dumped core.

                Stack trace of thread 90:
                #0  0x00007f69d80cb303 epoll_wait (libc.so.6)
                #1  0x00007f69d9076ef8 n/a (/usr/lib/x86_64-linux-gnu/libswsscommon.so.0.0.0)
root@sonic:/home/admin#

-->

