### PR TITLE
[show] Properly replace port name with alias in command output

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -333,20 +333,41 @@ def run_command_in_alias_mode(command):
                 elif output[0].isdigit():
                     output = "    " + output
                 print_output_in_alias_mode(output, index)
+
             elif command.startswith("nbrshow"):
                 """show arp"""
                 index = 2
                 if "Vlan" in output:
                     output = output.replace('Vlan', '  Vlan')
                 print_output_in_alias_mode(output, index)
+
+            elif command.startswith("sudo teamshow"):
+                """
+                sudo teamshow
+                Search for port names either at the start of a line or preceded immediately by
+                whitespace and followed immediately by either the end of a line or whitespace
+                OR followed immediately by '(D)', '(S)', '(D*)' or '(S*)'
+                """
+                converted_output = raw_output
+                for port_name in iface_alias_converter.port_dict.keys():
+                    converted_output = re.sub(r"(^|\s){}(\([DS]\*{{0,1}}\)(?:$|\s))".format(port_name),
+                            r"\1{}\2".format(iface_alias_converter.name_to_alias(port_name)),
+                            converted_output)
+                click.echo(converted_output.rstrip('\n'))
+
             else:
-                if index:
-                    converted_output = raw_output
-                    for port_name in iface_alias_converter.port_dict.keys():
-                        converted_output = re.sub(r"(^|\s){}($|\s)".format(port_name),
-                                r"\1{}\2".format(iface_alias_converter.name_to_alias(port_name)),
-                                converted_output)
-                    click.echo(converted_output.rstrip('\n'))
+                """
+                Default command conversion
+                Search for port names either at the start of a line or preceded immediately by
+                whitespace and followed immediately by either the end of a line or whitespace
+                or a comma followed by whitespace
+                """
+                converted_output = raw_output
+                for port_name in iface_alias_converter.port_dict.keys():
+                    converted_output = re.sub(r"(^|\s){}($|,{{0,1}}\s)".format(port_name),
+                            r"\1{}\2".format(iface_alias_converter.name_to_alias(port_name)),
+                            converted_output)
+                click.echo(converted_output.rstrip('\n'))
 
     rc = process.poll()
     if rc != 0:

--- a/show/main.py
+++ b/show/main.py
@@ -339,20 +339,14 @@ def run_command_in_alias_mode(command):
                 if "Vlan" in output:
                     output = output.replace('Vlan', '  Vlan')
                 print_output_in_alias_mode(output, index)
-
             else:
                 if index:
+                    converted_output = raw_output
                     for port_name in iface_alias_converter.port_dict.keys():
-                        regex = re.compile(r"\b{}\b".format(port_name))
-                        result = re.findall(regex, raw_output)
-                        if result:
-                            interface_name = ''.join(result)
-                            if not raw_output.startswith("    PortID:"):
-                                raw_output = raw_output.replace(
-                                    interface_name,
-                                    iface_alias_converter.name_to_alias(
-                                            interface_name))
-                    click.echo(raw_output.rstrip('\n'))
+                        converted_output = re.sub(r"(^|\s){}($|\s)".format(port_name),
+                                r"\1{}\2".format(iface_alias_converter.name_to_alias(port_name)),
+                                converted_output)
+                    click.echo(converted_output.rstrip('\n'))
 
     rc = process.poll()
     if rc != 0:


### PR DESCRIPTION
**- What I did**

Properly replace port name with alias in command output. If the device is configured such that any port names happen to be substrings of port aliases (e.g., name  = "Ethernet1", alias = "Ethernet1/1"), alias naming mode would output incorrect aliases (e.g., "Ethernet1/1/1") because it would consider the substring of the alias as a port name.

Previous solution checked for word boundaries (`\b`) on either side of the port name. This did not work properly if there existed a port alias which contained a port name followed by a forwardslash, as the regex considers the forwardslash as a word boundary. Thus, it would get detected as a port name when, in fact, it was actually just a part of an alias name.

This fix will only replace a port name if it is at the start of a line or is preceded by whitespace (`(^|\s)`) **and** it is at the end of a line or is followed by whitespace or a comma followed by whitespace (`($|,{{0,1}}\s)`).

Also added a separate clause to convert the output of `sudo teamshow`, where port names can be followed by '(D)', '(S)', '(D*)' or '(S*)'.

Fixes: https://github.com/Azure/sonic-utilities/issues/658


**- How to verify it**
1. Configure the device such that some or all port names are substrings of some/all port aliases
2. Set interface naming mode to "alias" mode
3. Run all show commands and verify the aliases displayed are correct