### PR TITLE
[pfc] rectify asym pfc cli command by adding interface_name as parameter

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1333,14 +1333,21 @@ def pfc(ctx):
 #
 
 @pfc.command()
+@click.argument('interface_name', metavar='<interface_name>', required=True)
 @click.argument('status', type=click.Choice(['on', 'off']))
 @click.pass_context
-def asymmetric(ctx, status):
+def asymmetric(ctx, interface_name, status):
     """Set asymmetric PFC configuration."""
     config_db = ctx.obj["config_db"]
-    interface = ctx.obj["interface_name"]
 
-    run_command("pfc config asymmetric {0} {1}".format(status, interface))
+    if get_interface_naming_mode() == "alias":
+        interface_name = interface_alias_to_name(interface_name)
+        if interface_name is None:
+            ctx.fail("'interface_name' is None!")
+    if interface_name_is_valid(interface_name) is False:
+        ctx.fail("Interface name is invalid!!")
+
+    run_command("pfc config asymmetric {0} {1}".format(status, interface_name))
 
 #
 # 'platform' group ('config platform ...')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Fixed the config interface pfc asymmetric CLI failure.

**- How I did it**
By adding the interface as a parameter to the CLI command( asymmetric command in config/main.py).

**- How to verify it**
By executing "sudo config interface pfc asymmetric <interface_name> on" command. 

**- Previous command output (if the output of a command-line utility has changed)**
admin@sonic:~$ sudo config interface pfc asymmetric Ethernet9 on
Usage: config interface pfc asymmetric [OPTIONS] STATUS

Error: Invalid value for "status": invalid choice: Ethernet9. (choose from on, off)

**- New command output (if the output of a command-line utility has changed)**
admin@sonic:~$ sudo config interface pfc asymmetric Ethernet9 on

admin@sonic:~$ 

-->

