### PR TITLE
[config]: Add hostname command to config CLI

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -525,16 +525,16 @@ def load_minigraph():
 
 
 #
-# 'change-hostname' command
+# 'hostname' command
 #
-@config.command('change-hostname')
-@click.argument('hostname', metavar='<hostname>', required=True)
-def change_hostname(hostname):
+@config.command('hostname')
+@click.argument('new_hostname', metavar='<new_hostname>', required=True)
+def hostname(new_hostname):
     """Change Hostname on a SONiC device without impacting the traffic."""
 
     config_db = ConfigDBConnector()
     config_db.connect()
-    config_db.mod_entry('DEVICE_METADATA' , 'localhost', {"hostname" : hostname})
+    config_db.mod_entry('DEVICE_METADATA' , 'localhost', {"hostname" : new_hostname})
     try:
         command = "service hostname-config restart"
         run_command(command, display_cmd=True)

--- a/config/main.py
+++ b/config/main.py
@@ -530,7 +530,7 @@ def load_minigraph():
 @config.command('hostname')
 @click.argument('new_hostname', metavar='<new_hostname>', required=True)
 def hostname(new_hostname):
-    """Change Hostname on a SONiC device without impacting the traffic."""
+    """Change device hostname without impacting the traffic."""
 
     config_db = ConfigDBConnector()
     config_db.connect()

--- a/config/main.py
+++ b/config/main.py
@@ -525,6 +525,25 @@ def load_minigraph():
 
 
 #
+# 'change-hostname' command
+#
+@config.command('change-hostname')
+@click.argument('hostname', metavar='<hostname>', required=True)
+def change_hostname(hostname):
+    """Change Hostname on a SONiC device without impacting the traffic."""
+
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    config_db.mod_entry('DEVICE_METADATA' , 'localhost', {"hostname" : hostname})
+    try:
+        command = "service hostname-config restart"
+        run_command(command, display_cmd=True)
+    except SystemExit as e:
+        click.echo("Restarting hostname-config  service failed with error {}".format(e))
+        raise
+    click.echo("Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`.")
+
+#
 # 'portchannel' group ('config portchannel ...')
 #
 @config.group()

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -220,8 +220,8 @@ This command lists all the possible configuration commands at the top level.
     aaa                    AAA command line
     acl                    ACL-related configuration tasks
     bgp                    BGP-related configuration tasks
-    change-hostname        Change Hostname on a SONiC device without...
     ecn                    ECN-related configuration tasks
+    hostname               Change Hostname on a SONiC device without...
     interface              Interface-related configuration tasks
     interface_naming_mode  Modify interface naming mode for interacting...
     load                   Import a previous saved config DB dump file.
@@ -1561,25 +1561,6 @@ This command is used to remove particular IPv4 or IPv6 BGP neighbor configuratio
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#BGP-Configuration-And-Show-Commands)
 
-# Update Hostname Configuration Commands
-
-This sub-section of commands is used to change the hostname on a SONiC device without traffic being impacted.
-
-**config hostname <new_hostname>**
-This command is used to change the hostname on a SONiC device without traffic being impacted.
-
-- Usage: config hostname [OPTIONS] <new_hostname>
-
-        Change Hostname on a SONiC device without impacting the traffic.
- Options:
-  -?, -h, --help  Show this message and exit.
-
-- Examples:
-  ```
-  admin@lnos-x1-a-csw06:~$ sudo config hostname CSW06
-  Running command: service hostname-config restart
-  Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`.
-  ```
 
 # ECN Configuration And Show Commands
 
@@ -1655,6 +1636,26 @@ The list of the WRED profile fields that are configurable is listed in the below
   ```
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#ECN-Configuration-And-Show-Commands)
+
+# Update Hostname Configuration Commands
+
+This sub-section of commands is used to change the hostname on a SONiC device without traffic being impacted.
+
+**config hostname <new_hostname>**
+This command is used to change the hostname on a SONiC device without traffic being impacted.
+
+- Usage: config hostname [OPTIONS] <new_hostname>
+
+        Change Hostname on a SONiC device without impacting the traffic.
+ Options:
+  -?, -h, --help  Show this message and exit.
+
+- Examples:
+  ```
+  admin@lnos-x1-a-csw06:~$ sudo config hostname CSW06
+  Running command: service hostname-config restart
+  Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`.
+  ```
 
 # Interface Configuration And Show-Commands
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -220,6 +220,7 @@ This command lists all the possible configuration commands at the top level.
     aaa                    AAA command line
     acl                    ACL-related configuration tasks
     bgp                    BGP-related configuration tasks
+    change-hostname        Change Hostname on a SONiC device without...
     ecn                    ECN-related configuration tasks
     interface              Interface-related configuration tasks
     interface_naming_mode  Modify interface naming mode for interacting...
@@ -1560,6 +1561,28 @@ This command is used to remove particular IPv4 or IPv6 BGP neighbor configuratio
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#BGP-Configuration-And-Show-Commands)
 
+# Update Hostname Configuration Commands
+
+This sub-section of commands is used to change the hostname on a SONiC device without traffic being impacted.
+
+**config change-hostname <hostname>**
+This command is used to change the hostname on a SONiC device without traffic being impacted.
+- Usage: config change-hostname [OPTIONS] <hostname>
+
+        Change Hostname on a SONiC device without impacting the traffic.
+
+        Options:
+          --help  Show this message and exit.
+- Examples:
+  ```
+  admin@csw06:~$ sudo config change-hostname csw06-sonic
+  Running command: service hostname-config restart
+  Please note loaded setting will be lost after system reboot. To preserve setting, run config save.
+
+
+  admin@csw06:~$ sudo config save -y
+  Running command: /usr/local/bin/sonic-cfggen -d --print-data > /etc/sonic/config_db.json
+  ```
 
 # ECN Configuration And Show Commands
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -1565,23 +1565,20 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 
 This sub-section of commands is used to change the hostname on a SONiC device without traffic being impacted.
 
-**config change-hostname <hostname>**
+**config hostname <new_hostname>**
 This command is used to change the hostname on a SONiC device without traffic being impacted.
-- Usage: config change-hostname [OPTIONS] <hostname>
+
+- Usage: config hostname [OPTIONS] <new_hostname>
 
         Change Hostname on a SONiC device without impacting the traffic.
+ Options:
+  -?, -h, --help  Show this message and exit.
 
-        Options:
-          --help  Show this message and exit.
 - Examples:
   ```
-  admin@csw06:~$ sudo config change-hostname csw06-sonic
+  admin@lnos-x1-a-csw06:~$ sudo config hostname CSW06
   Running command: service hostname-config restart
-  Please note loaded setting will be lost after system reboot. To preserve setting, run config save.
-
-
-  admin@csw06:~$ sudo config save -y
-  Running command: /usr/local/bin/sonic-cfggen -d --print-data > /etc/sonic/config_db.json
+  Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`.
   ```
 
 # ECN Configuration And Show Commands

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -221,7 +221,7 @@ This command lists all the possible configuration commands at the top level.
     acl                    ACL-related configuration tasks
     bgp                    BGP-related configuration tasks
     ecn                    ECN-related configuration tasks
-    hostname               Change Hostname on a SONiC device without...
+    hostname               Change device hostname without impacting traffic
     interface              Interface-related configuration tasks
     interface_naming_mode  Modify interface naming mode for interacting...
     load                   Import a previous saved config DB dump file.
@@ -1637,16 +1637,16 @@ The list of the WRED profile fields that are configurable is listed in the below
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#ECN-Configuration-And-Show-Commands)
 
-# Update Hostname Configuration Commands
+# Update Device Hostname Configuration Commands
 
-This sub-section of commands is used to change the hostname on a SONiC device without traffic being impacted.
+This sub-section of commands is used to change device hostname without traffic being impacted.
 
 **config hostname <new_hostname>**
-This command is used to change the hostname on a SONiC device without traffic being impacted.
+This command is used to change device hostname without traffic being impacted.
 
 - Usage: config hostname [OPTIONS] <new_hostname>
 
-        Change Hostname on a SONiC device without impacting the traffic.
+        Change device hostname without impacting the traffic.
  Options:
   -?, -h, --help  Show this message and exit.
 


### PR DESCRIPTION
Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
added new command **change-hostname** to config CLI so that the user can change the hostname on a SONiC device without traffic being impacted.

**- How I did it**
update **"hostname"** key to the **"DEVICE_METADATA|localhost"** field in config DB using sonic-cfggen and restart the **hostname-config** service.

**- How to verify it**

> 
changed the hostname from **csw06** to **csw06-sonic**

```
admin@csw06:~$ sudo config change-hostname csw06-sonic
Running command: service hostname-config restart
Please note loaded setting will be lost after system reboot. To preserve setting, run config save.


admin@csw06:~$ sudo config save -y
Running command: /usr/local/bin/sonic-cfggen -d --print-data > /etc/sonic/config_db.json


admin@csw06:~$ exit
logout
Connection to 172.x.x.x closed.


➜  ~ ssh admin@172.x.x.x
admin@172.x.x.x's password:
Linux csw06-sonic 4.9.0-9-amd64 #1 SMP Debian 4.9.168-1+deb9u3 (2015-12-19) x86_64
Unauthorized access and/or use are prohibited.
All access and/or use are subject to monitoring.


Help:    http://azure.github.io/SONiC/


Last login: Tue Sep 24 18:11:57 2019 from 172.x.x.x
admin@csw06-sonic:~$    -> **hostname got updated successfully**
```


