### PR TITLE
[neighbor_advertiser] Verify that DIPs returned from ferret are not in device VLAN

### DIFF
--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -328,7 +328,6 @@ def post_neighbor_advertiser_slice(ferret_service_vip):
     url = 'http://{}:85{}{}'.format(ferret_service_vip, FERRET_NEIGHBOR_ADVERTISER_API_PREFIX, get_switch_name())
     response = None
 
-    ferret_server_ipv4_addr = None
     for i in range(DEFAULT_FERRET_QUERY_RETRIES):
         try:
             response = requests.post(url, json = request_slice, timeout = DEFAULT_REQUEST_TIMEOUT)
@@ -336,6 +335,7 @@ def post_neighbor_advertiser_slice(ferret_service_vip):
             log_error('The request failed, vip: {}, error: {}'.format(ferret_service_vip, e))
             return None
 
+        # Handle response errors
         if not response:
             log_error('Failed to set up neighbor advertiser slice, vip: {}, no response obtained'.format(ferret_service_vip))
             return None
@@ -344,19 +344,20 @@ def post_neighbor_advertiser_slice(ferret_service_vip):
             return None
 
         neighbor_advertiser_configuration = json.loads(response.content)
-        ferret_dip = neighbor_advertiser_configuration['ipv4Addr']
+        ferret_server_ipv4_addr = neighbor_advertiser_configuration['ipv4Addr']
 
-        if not is_dip_in_device_vlan(ferret_dip):
-            save_as_json(neighbor_advertiser_configuration, NEIGHBOR_ADVERTISER_RESPONSE_CONFIG_PATH)
-            ferret_server_ipv4_addr = ferret_dip
-            break
+        # Retry the request if the provided DIP is in the device VLAN
+        if is_dip_in_device_vlan(ferret_server_ipv4_addr):
+            log_info('Failed to set up neighbor advertiser slice, vip: {}, dip {} is in device VLAN, retrying...'.format(ferret_service_vip, ferret_server_ipv4_addr))
+            continue
 
-    if not ferret_server_ipv4_addr:
-        log_error('Failed to set up neighbor advertiser slice, vip: {}, returned dips were in device VLAN'.format(ferret_service_vip))
-        return None
+        # If all the proceeding checks pass, return the provided DIP
+        save_as_json(neighbor_advertiser_configuration, NEIGHBOR_ADVERTISER_RESPONSE_CONFIG_PATH)
+        log_info('Successfully set up neighbor advertiser slice, vip: {}, dip: {}'.format(ferret_service_vip, ferret_server_ipv4_addr))
+        return ferret_server_ipv4_addr
 
-    log_info('Successfully set up neighbor advertiser slice, vip: {}, dip: {}'.format(ferret_service_vip, ferret_server_ipv4_addr))
-    return ferret_server_ipv4_addr
+    log_error('Failed to set up neighbor advertiser slice, vip: {}, returned dips were in device VLAN'.format(ferret_service_vip))
+    return None
 
 
 def save_as_json(obj, file_path):

--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -97,13 +97,31 @@ def connect_config_db():
 vlan_interface_query = None
 
 
-def is_dip_in_device_vlan(ferret_server_ip_addr):
+def is_dip_in_device_vlan(ferret_dip):
     global vlan_interface_query
 
-    if not vlan_interface_query
+    # Lazy load the vlan interfaces the first time we run this check.
+    if not vlan_interface_query:
         vlan_interface_query = config_db.get_table('VLAN_INTERFACE')
 
-    return any(IPAddress(ferret_server_ip_addr) in IPNetwork(vlan_int[1]) for vlan_int in vlan_interface_query.iterkeys())
+    ferret_dip = IPAddress(ferret_dip)
+
+    for vlan_interface in vlan_interface_query.iterkeys():
+        vlan_subnet = vlan_interface[1]
+        try:
+            vlan_subnet = IPNetwork(vlan_subnet)
+        except:
+            log_info('{} does not have a subnet, skipping...'.format(vlan_interface))
+            continue
+
+        if ferret_dip.version != vlan_subnet.version
+            log_info('{} version (IPv{}) does not match provided DIP version (IPv{}), skipping...'.format(vlan_interface[0], vlan_subnet.version, ferret_dip.version))
+            continue
+
+        if ferret_dip in vlan_subnet:
+            return True
+
+    return False
 
 
 #

--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -107,12 +107,11 @@ def is_dip_in_device_vlan(ferret_dip):
     ferret_dip = IPAddress(ferret_dip)
 
     for vlan_interface in vlan_interface_query.iterkeys():
-        vlan_subnet = vlan_interface[1]
-        try:
-            vlan_subnet = IPNetwork(vlan_subnet)
-        except:
+        if not is_ip_prefix_in_key(vlan_subnet):
             log_info('{} does not have a subnet, skipping...'.format(vlan_interface))
             continue
+
+        vlan_subnet = IPNetwork(vlan_interface[1])
 
         if ferret_dip.version != vlan_subnet.version
             log_info('{} version (IPv{}) does not match provided DIP version (IPv{}), skipping...'.format(vlan_interface[0], vlan_subnet.version, ferret_dip.version))

--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -107,13 +107,13 @@ def is_dip_in_device_vlan(ferret_dip):
     ferret_dip = IPAddress(ferret_dip)
 
     for vlan_interface in vlan_interface_query.iterkeys():
-        if not is_ip_prefix_in_key(vlan_subnet):
+        if not is_ip_prefix_in_key(vlan_interface):
             log_info('{} does not have a subnet, skipping...'.format(vlan_interface))
             continue
 
         vlan_subnet = IPNetwork(vlan_interface[1])
 
-        if ferret_dip.version != vlan_subnet.version
+        if ferret_dip.version != vlan_subnet.version:
             log_info('{} version (IPv{}) does not match provided DIP version (IPv{}), skipping...'.format(vlan_interface[0], vlan_subnet.version, ferret_dip.version))
             continue
 

--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -328,7 +328,7 @@ def post_neighbor_advertiser_slice(ferret_service_vip):
     url = 'http://{}:85{}{}'.format(ferret_service_vip, FERRET_NEIGHBOR_ADVERTISER_API_PREFIX, get_switch_name())
     response = None
 
-    for i in range(DEFAULT_FERRET_QUERY_RETRIES):
+    for retry in range(DEFAULT_FERRET_QUERY_RETRIES):
         try:
             response = requests.post(url, json = request_slice, timeout = DEFAULT_REQUEST_TIMEOUT)
         except Exception as e:
@@ -348,7 +348,7 @@ def post_neighbor_advertiser_slice(ferret_service_vip):
 
         # Retry the request if the provided DIP is in the device VLAN
         if is_dip_in_device_vlan(ferret_server_ipv4_addr):
-            log_info('Failed to set up neighbor advertiser slice, vip: {}, dip {} is in device VLAN, retrying...'.format(ferret_service_vip, ferret_server_ipv4_addr))
+            log_info('Failed to set up neighbor advertiser slice, vip: {}, dip {} is in device VLAN (attempt {}/{})'.format(ferret_service_vip, ferret_server_ipv4_addr, retry + 1, DEFAULT_FERRET_QUERY_RETRIES))
             continue
 
         # If all the proceeding checks pass, return the provided DIP

--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -331,7 +331,6 @@ def post_neighbor_advertiser_slice(ferret_service_vip):
     url = 'http://{}:85{}{}'.format(ferret_service_vip, FERRET_NEIGHBOR_ADVERTISER_API_PREFIX, get_switch_name())
     response = None
 
-    ferret_server_ipv4_addr = None
     for i in range(DEFAULT_FERRET_QUERY_RETRIES):
         try:
             response = requests.post(url, json = request_slice, timeout = DEFAULT_REQUEST_TIMEOUT)

--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -18,6 +18,7 @@ import subprocess
 import sonic_device_util
 from swsssdk import ConfigDBConnector
 from swsssdk import SonicV2Connector
+from netaddr import IPAddress, IPNetwork
 
 
 #
@@ -26,6 +27,7 @@ from swsssdk import SonicV2Connector
 
 DEFAULT_DURATION = 300
 DEFAULT_REQUEST_TIMEOUT = 2
+DEFAULT_FERRET_QUERY_RETRIES = 3
 SYSLOG_IDENTIFIER = 'neighbor_advertiser'
 
 
@@ -82,15 +84,36 @@ def log_error(msg):
 config_db = None
 
 
-#
-# Get switch info and intf addr
-#
-
 def connect_config_db():
     global config_db
     config_db = ConfigDBConnector()
     config_db.connect()
 
+
+#
+# Check if a DIP returned from ferret is in any of this switch's VLANs
+#
+
+is_dip_in_device_vlan = None
+
+
+def get_device_vlan_checker():
+    global is_dip_in_device_vlan
+
+    vlan_interfaces = config_db.get_table('VLAN_INTERFACE')
+
+    def check_device(ferret_server_ip_addr):
+        for vlan_int, _ in vlan_interfaces.iteritems():
+            if IPAddress(ferret_server_ip_addr) in IPNetwork(vlan_int[1]):
+                return True
+        return False
+    
+    is_dip_in_device_vlan = check_device
+
+
+#
+# Get switch info and intf addr
+#
 
 def get_switch_name():
     metadata = config_db.get_table('DEVICE_METADATA')
@@ -308,24 +331,31 @@ def post_neighbor_advertiser_slice(ferret_service_vip):
     url = 'http://{}:85{}{}'.format(ferret_service_vip, FERRET_NEIGHBOR_ADVERTISER_API_PREFIX, get_switch_name())
     response = None
 
-    try:
-        response = requests.post(url, json = request_slice, timeout = DEFAULT_REQUEST_TIMEOUT)
-    except Exception as e:
-        log_error('The request failed, vip: {}, error: {}'.format(ferret_service_vip, e))
-
     ferret_server_ipv4_addr = None
+    for i in range(DEFAULT_FERRET_QUERY_RETRIES):
+        try:
+            response = requests.post(url, json = request_slice, timeout = DEFAULT_REQUEST_TIMEOUT)
+        except Exception as e:
+            log_error('The request failed, vip: {}, error: {}'.format(ferret_service_vip, e))
+            return None
 
-    if response and response.ok:
+        if not response:
+            log_error('Failed to set up neighbor advertiser slice, vip: {}, no response obtained'.format(ferret_service_vip))
+            return None
+        if response and not response.ok:
+            log_error('Failed to set up neighbor advertiser slice, vip: {}, error_code: {}, error_content: {}'.format(ferret_service_vip, response.status_code, response.content))
+            return None
+
         neighbor_advertiser_configuration = json.loads(response.content)
         save_as_json(neighbor_advertiser_configuration, NEIGHBOR_ADVERTISER_RESPONSE_CONFIG_PATH)
         ferret_server_ipv4_addr = neighbor_advertiser_configuration['ipv4Addr']
-        log_info('Successfully set up neighbor advertiser slice, vip: {}, dip: {}'.format(ferret_service_vip, ferret_server_ipv4_addr))
-    elif response:
-        log_error('Failed to set up neighbor advertiser slice, vip: {}, error_code: {}, error_content: {}'.format(ferret_service_vip, response.status_code, response.content))
-    else:
-        log_error('Failed to set up neighbor advertiser slice, vip: {}, no response obtained'.format(ferret_service_vip))
 
-    return ferret_server_ipv4_addr
+        if not is_dip_in_device_vlan(ferret_server_ipv4_addr):
+            log_info('Successfully set up neighbor advertiser slice, vip: {}, dip: {}'.format(ferret_service_vip, ferret_server_ipv4_addr))
+            return ferret_server_ipv4_addr
+
+    log_error('Failed to set up neighbor advertiser slice, vip: {}, returned dips were in device VLAN'.format(ferret_service_vip))
+    return None
 
 
 def save_as_json(obj, file_path):
@@ -462,6 +492,7 @@ def main():
         sys.exit(1)
 
     connect_config_db()
+    get_device_vlan_checker()
 
     if operation_mode == 'set':
         set_success = False

--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -94,18 +94,16 @@ def connect_config_db():
 # Check if a DIP returned from ferret is in any of this switch's VLANs
 #
 
-is_dip_in_device_vlan = None
+vlan_interface_query = None
 
 
-def get_device_vlan_checker():
-    global is_dip_in_device_vlan
+def is_dip_in_device_vlan(ferret_server_ip_addr):
+    global vlan_interface_query
 
-    vlan_interfaces = config_db.get_table('VLAN_INTERFACE')
+    if not vlan_interface_query
+        vlan_interface_query = config_db.get_table('VLAN_INTERFACE')
 
-    def check_device(ferret_server_ip_addr):
-        return any(IPAddress(ferret_server_ip_addr) in IPNetwork(vlan_int[1]) for vlan_int in vlan_interfaces.iterkeys())
-    
-    is_dip_in_device_vlan = check_device
+    return any(IPAddress(ferret_server_ip_addr) in IPNetwork(vlan_int[1]) for vlan_int in vlan_interface_query.iterkeys())
 
 
 #
@@ -494,7 +492,6 @@ def main():
         sys.exit(1)
 
     connect_config_db()
-    get_device_vlan_checker()
 
     if operation_mode == 'set':
         set_success = False

--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -103,10 +103,7 @@ def get_device_vlan_checker():
     vlan_interfaces = config_db.get_table('VLAN_INTERFACE')
 
     def check_device(ferret_server_ip_addr):
-        for vlan_int, _ in vlan_interfaces.iteritems():
-            if IPAddress(ferret_server_ip_addr) in IPNetwork(vlan_int[1]):
-                return True
-        return False
+        return any(IPAddress(ferret_server_ip_addr) in IPNetwork(vlan_int[1]) for vlan_int in vlan_interfaces.iterkeys())
     
     is_dip_in_device_vlan = check_device
 
@@ -339,26 +336,26 @@ def post_neighbor_advertiser_slice(ferret_service_vip):
             log_error('The request failed, vip: {}, error: {}'.format(ferret_service_vip, e))
             return None
 
-        if response and response.ok
-            neighbor_advertiser_configuration = json.loads(response.content)
-            save_as_json(neighbor_advertiser_configuration, NEIGHBOR_ADVERTISER_RESPONSE_CONFIG_PATH)
-            ferret_dip = neighbor_advertiser_configuration['ipv4Addr']
-
-            if not is_dip_in_device_vlan(ferret_dip):
-                ferret_server_ipv4_addr = ferret_dip
-                break
-        elif response:
-            log_error('Failed to set up neighbor advertiser slice, vip: {}, error_code: {}, error_content: {}'.format(ferret_service_vip, response.status_code, response.content))
-            return None
-        else:
+        if not response:
             log_error('Failed to set up neighbor advertiser slice, vip: {}, no response obtained'.format(ferret_service_vip))
             return None
+        if response and not response.ok:
+            log_error('Failed to set up neighbor advertiser slice, vip: {}, error_code: {}, error_content: {}'.format(ferret_service_vip, response.status_code, response.content))
+            return None
 
-    if ferret_server_ipv4_addr:
-        log_info('Successfully set up neighbor advertiser slice, vip: {}, dip: {}'.format(ferret_service_vip, ferret_server_ipv4_addr))
-    else:
+        neighbor_advertiser_configuration = json.loads(response.content)
+        ferret_dip = neighbor_advertiser_configuration['ipv4Addr']
+
+        if not is_dip_in_device_vlan(ferret_dip):
+            save_as_json(neighbor_advertiser_configuration, NEIGHBOR_ADVERTISER_RESPONSE_CONFIG_PATH)
+            ferret_server_ipv4_addr = ferret_dip
+            break
+
+    if not ferret_server_ipv4_addr:
         log_error('Failed to set up neighbor advertiser slice, vip: {}, returned dips were in device VLAN'.format(ferret_service_vip))
+        return None
 
+    log_info('Successfully set up neighbor advertiser slice, vip: {}, dip: {}'.format(ferret_service_vip, ferret_server_ipv4_addr))
     return ferret_server_ipv4_addr
 
 

--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -331,6 +331,7 @@ def post_neighbor_advertiser_slice(ferret_service_vip):
     url = 'http://{}:85{}{}'.format(ferret_service_vip, FERRET_NEIGHBOR_ADVERTISER_API_PREFIX, get_switch_name())
     response = None
 
+    ferret_server_ipv4_addr = None
     for i in range(DEFAULT_FERRET_QUERY_RETRIES):
         try:
             response = requests.post(url, json = request_slice, timeout = DEFAULT_REQUEST_TIMEOUT)
@@ -338,23 +339,27 @@ def post_neighbor_advertiser_slice(ferret_service_vip):
             log_error('The request failed, vip: {}, error: {}'.format(ferret_service_vip, e))
             return None
 
-        if not response:
-            log_error('Failed to set up neighbor advertiser slice, vip: {}, no response obtained'.format(ferret_service_vip))
-            return None
-        if response and not response.ok:
+        if response and response.ok
+            neighbor_advertiser_configuration = json.loads(response.content)
+            save_as_json(neighbor_advertiser_configuration, NEIGHBOR_ADVERTISER_RESPONSE_CONFIG_PATH)
+            ferret_dip = neighbor_advertiser_configuration['ipv4Addr']
+
+            if not is_dip_in_device_vlan(ferret_dip):
+                ferret_server_ipv4_addr = ferret_dip
+                break
+        elif response:
             log_error('Failed to set up neighbor advertiser slice, vip: {}, error_code: {}, error_content: {}'.format(ferret_service_vip, response.status_code, response.content))
             return None
+        else:
+            log_error('Failed to set up neighbor advertiser slice, vip: {}, no response obtained'.format(ferret_service_vip))
+            return None
 
-        neighbor_advertiser_configuration = json.loads(response.content)
-        save_as_json(neighbor_advertiser_configuration, NEIGHBOR_ADVERTISER_RESPONSE_CONFIG_PATH)
-        ferret_server_ipv4_addr = neighbor_advertiser_configuration['ipv4Addr']
+    if ferret_server_ipv4_addr:
+        log_info('Successfully set up neighbor advertiser slice, vip: {}, dip: {}'.format(ferret_service_vip, ferret_server_ipv4_addr))
+    else:
+        log_error('Failed to set up neighbor advertiser slice, vip: {}, returned dips were in device VLAN'.format(ferret_service_vip))
 
-        if not is_dip_in_device_vlan(ferret_server_ipv4_addr):
-            log_info('Successfully set up neighbor advertiser slice, vip: {}, dip: {}'.format(ferret_service_vip, ferret_server_ipv4_addr))
-            return ferret_server_ipv4_addr
-
-    log_error('Failed to set up neighbor advertiser slice, vip: {}, returned dips were in device VLAN'.format(ferret_service_vip))
-    return None
+    return ferret_server_ipv4_addr
 
 
 def save_as_json(obj, file_path):


### PR DESCRIPTION
**- What I did**
I added a check to neighbor_advertiser to make sure that the DIPs returned from ferret are not in any of the device's VLANs.

**- How I did it**
- I added a helper method to query CONFIG_DB for VLAN interfaces and check that a given IP does not fall in that range.
- I used the helper method to check that DIPs returned from ferret did not fall in any of the device's VLANs.
- I added a retry to attempt to get other DIPs from ferret before moving on to the next ferret VIP.

**- How to verify it**
1. Run the script against a response object that contains an IPv4 address that falls inside one of the DUTs VLANs. The script should retry 3 times and then fail.
2. Run the script against a response object that contains an IPv4 address that does not fall inside of the DUTs VLANs. The script should succeed.

Signed-off-by: Danny Allen (daall@microsoft.com)

