### PR TITLE
[Mellanox] Don't start & stop pmon when config reload

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1387,7 +1387,7 @@ def add_syslog_server(ctx, syslog_ip_address):
     if syslog_ip_address in syslog_servers:
         click.echo("Syslog server {} is already configured".format(syslog_ip_address))
         return
-    else: 
+    else:
         db.set_entry('SYSLOG_SERVER', syslog_ip_address, {'NULL': 'NULL'})
         click.echo("Syslog server {} added to configuration".format(syslog_ip_address))
         try:
@@ -1408,7 +1408,7 @@ def del_syslog_server(ctx, syslog_ip_address):
     if syslog_ip_address in syslog_servers:
         db.set_entry('SYSLOG_SERVER', '{}'.format(syslog_ip_address), None)
         click.echo("Syslog server {} removed from configuration".format(syslog_ip_address))
-    else: 
+    else:
         ctx.fail("Syslog server {} is not configured.".format(syslog_ip_address))
     try:
         click.echo("Restarting rsyslog-config service...")

--- a/config/main.py
+++ b/config/main.py
@@ -298,21 +298,15 @@ def _abort_if_false(ctx, param, value):
 
 def _stop_services():
     # on Mellanox platform pmon is stopped by syncd
-    if asic_type == 'mellanox':
-        services_to_stop = [
-            'swss',
-            'lldp',
-            'bgp',
-            'hostcfgd',
-        ]
-    else:
-        services_to_stop = [
-            'swss',
-            'lldp',
-            'pmon',
-            'bgp',
-            'hostcfgd',
-        ]
+    services_to_stop = [
+        'swss',
+        'lldp',
+        'pmon',
+        'bgp',
+        'hostcfgd',
+    ]
+    if asic_type == 'mellanox' and 'pmon' in services_to_stop:
+        services_to_stop.remove('pmon')
 
     for service in services_to_stop:
         try:
@@ -357,29 +351,19 @@ def _reset_failed_services():
 
 def _restart_services():
     # on Mellanox platform pmon is started by syncd
-    if asic_type == 'mellanox':
-        services_to_restart = [
-            'hostname-config',
-            'interfaces-config',
-            'ntp-config',
-            'rsyslog-config',
-            'swss',
-            'bgp',
-            'lldp',
-            'hostcfgd',
-        ]
-    else:
-        services_to_restart = [
-            'hostname-config',
-            'interfaces-config',
-            'ntp-config',
-            'rsyslog-config',
-            'swss',
-            'bgp',
-            'pmon',
-            'lldp',
-            'hostcfgd',
-        ]
+    services_to_restart = [
+        'hostname-config',
+        'interfaces-config',
+        'ntp-config',
+        'rsyslog-config',
+        'swss',
+        'bgp',
+        'pmon',
+        'lldp',
+        'hostcfgd',
+    ]
+    if asic_type == 'mellanox' and 'pmon' in services_to_restart:
+        services_to_restart.remove('pmon')
 
     for service in services_to_restart:
         try:

--- a/config/main.py
+++ b/config/main.py
@@ -47,6 +47,16 @@ def log_error(msg):
     syslog.closelog()
 
 #
+# Load asic_type for further use
+#
+
+try:
+    version_info = sonic_device_util.get_sonic_version_info()
+    asic_type = version_info['asic_type']
+except KeyError, TypeError:
+    raise click.Abort()
+
+#
 # Helper functions
 #
 
@@ -288,7 +298,7 @@ def _abort_if_false(ctx, param, value):
 
 def _stop_services():
     # on Mellanox platform pmon is stopped by syncd
-    if version_info and version_info.get('asic_type') == 'mellanox':
+    if asic_type == 'mellanox':
         services_to_stop = [
             'swss',
             'lldp',
@@ -347,7 +357,7 @@ def _reset_failed_services():
 
 def _restart_services():
     # on Mellanox platform pmon is started by syncd
-    if version_info and version_info.get('asic_type') == 'mellanox':
+    if asic_type == 'mellanox':
         services_to_restart = [
             'hostname-config',
             'interfaces-config',
@@ -1332,8 +1342,7 @@ def asymmetric(ctx, status):
 def platform():
     """Platform-related configuration tasks"""
 
-version_info = sonic_device_util.get_sonic_version_info()
-if (version_info and version_info.get('asic_type') == 'mellanox'):
+if asic_type == 'mellanox':
     platform.add_command(mlnx.mlnx)
 
 #

--- a/config/main.py
+++ b/config/main.py
@@ -287,17 +287,22 @@ def _abort_if_false(ctx, param, value):
         ctx.abort()
 
 def _stop_services():
-    services_to_stop = [
-        'swss',
-        'lldp',
-        'pmon',
-        'bgp',
-        'hostcfgd',
-    ]
-
     # on Mellanox platform pmon is stopped by syncd
     if (version_info and version_info.get('asic_type') == 'mellanox'):
-        services_to_stop.remove('pmon')
+        services_to_stop = [
+            'swss',
+            'lldp',
+            'bgp',
+            'hostcfgd',
+        ]
+    else:
+        services_to_stop = [
+            'swss',
+            'lldp',
+            'pmon',
+            'bgp',
+            'hostcfgd',
+        ]
 
     for service in services_to_stop:
         try:
@@ -341,21 +346,30 @@ def _reset_failed_services():
                 raise
 
 def _restart_services():
-    services_to_restart = [
-        'hostname-config',
-        'interfaces-config',
-        'ntp-config',
-        'rsyslog-config',
-        'swss',
-        'bgp',
-        'pmon',
-        'lldp',
-        'hostcfgd',
-    ]
-
     # on Mellanox platform pmon is started by syncd
     if (version_info and version_info.get('asic_type') == 'mellanox'):
-        services_to_restart.remove('pmon')
+        services_to_restart = [
+            'hostname-config',
+            'interfaces-config',
+            'ntp-config',
+            'rsyslog-config',
+            'swss',
+            'bgp',
+            'lldp',
+            'hostcfgd',
+        ]
+    else:
+        services_to_restart = [
+            'hostname-config',
+            'interfaces-config',
+            'ntp-config',
+            'rsyslog-config',
+            'swss',
+            'bgp',
+            'pmon',
+            'lldp',
+            'hostcfgd',
+        ]
 
     for service in services_to_restart:
         try:

--- a/config/main.py
+++ b/config/main.py
@@ -295,6 +295,10 @@ def _stop_services():
         'hostcfgd',
     ]
 
+    # on Mellanox platform pmon is stopped by syncd
+    if (version_info and version_info.get('asic_type') == 'mellanox'):
+        services_to_stop.remove('pmon')
+
     for service in services_to_stop:
         try:
             click.echo("Stopping service {} ...".format(service))
@@ -348,6 +352,10 @@ def _restart_services():
         'lldp',
         'hostcfgd',
     ]
+
+    # on Mellanox platform pmon is started by syncd
+    if (version_info and version_info.get('asic_type') == 'mellanox'):
+        services_to_restart.remove('pmon')
 
     for service in services_to_restart:
         try:
@@ -1379,7 +1387,7 @@ def add_syslog_server(ctx, syslog_ip_address):
     if syslog_ip_address in syslog_servers:
         click.echo("Syslog server {} is already configured".format(syslog_ip_address))
         return
-    else:
+    else: 
         db.set_entry('SYSLOG_SERVER', syslog_ip_address, {'NULL': 'NULL'})
         click.echo("Syslog server {} added to configuration".format(syslog_ip_address))
         try:
@@ -1400,7 +1408,7 @@ def del_syslog_server(ctx, syslog_ip_address):
     if syslog_ip_address in syslog_servers:
         db.set_entry('SYSLOG_SERVER', '{}'.format(syslog_ip_address), None)
         click.echo("Syslog server {} removed from configuration".format(syslog_ip_address))
-    else:
+    else: 
         ctx.fail("Syslog server {} is not configured.".format(syslog_ip_address))
     try:
         click.echo("Restarting rsyslog-config service...")

--- a/config/main.py
+++ b/config/main.py
@@ -288,7 +288,7 @@ def _abort_if_false(ctx, param, value):
 
 def _stop_services():
     # on Mellanox platform pmon is stopped by syncd
-    if (version_info and version_info.get('asic_type') == 'mellanox'):
+    if version_info and version_info.get('asic_type') == 'mellanox':
         services_to_stop = [
             'swss',
             'lldp',
@@ -347,7 +347,7 @@ def _reset_failed_services():
 
 def _restart_services():
     # on Mellanox platform pmon is started by syncd
-    if (version_info and version_info.get('asic_type') == 'mellanox'):
+    if version_info and version_info.get('asic_type') == 'mellanox':
         services_to_restart = [
             'hostname-config',
             'interfaces-config',


### PR DESCRIPTION
**- What I did**
Don't start/stop pmon during config reload since pmon is triggered by syncd.
This PR depends on [[Mellanox] Stop pmon ahead of syncd #3505](https://github.com/Azure/sonic-buildimage/pull/3505)

**- How I did it**
For Mellanox platform, remove pmon from the services_to_stop and service_to_start list.

**- How to verify it**
execute "config reload" and "systemctl restart swss.service" and check whether all dockers start.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->
