### PR TITLE
gracefully exit out of error condition when retrieving device ip address

### DIFF
--- a/scripts/fast-reboot-dump.py
+++ b/scripts/fast-reboot-dump.py
@@ -174,7 +174,11 @@ def generate_fdb_entries(filename):
 
 def get_if(iff, cmd):
     s = socket.socket()
-    ifreq = ioctl(s, cmd, struct.pack("16s16x",iff))
+    try:
+        ifreq = ioctl(s, cmd, struct.pack("16s16x",iff))
+    except IOError:
+        # cannot retrieve data from interface, set to ""
+        ifreq = ""
     s.close()
     return ifreq
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
fixes an issue where fast reboot fails when an interface ip has been removed

**- How I did it**
added code to catch exception when fast reboot script retrieves an interface ip that has been removed 

**- How to verify it**
remove an interface ip address using ifconfig and issue fast reboot

**- Previous command output (if the output of a command-line utility has changed)**
admin@sonic:~$ sudo fast-reboot -y
Failed to run fast-reboot-dump.py. Exit code: 2

**- New command output (if the output of a command-line utility has changed)**
admin@sonic:~$ sudo fast-reboot -y

-->

