### PR TITLE
Techsupport fail redis db

### DIFF
--- a/scripts/fast-reboot-dump.py
+++ b/scripts/fast-reboot-dump.py
@@ -174,7 +174,11 @@ def generate_fdb_entries(filename):
 
 def get_if(iff, cmd):
     s = socket.socket()
-    ifreq = ioctl(s, cmd, struct.pack("16s16x",iff))
+    try:
+        ifreq = ioctl(s, cmd, struct.pack("16s16x",iff))
+    except IOError:
+        # cannot retrieve data from interface, set to ""
+        ifreq = ""
     s.close()
     return ifreq
 

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -357,8 +357,6 @@ main() {
     save_cmd "docker ps -a" "docker.ps"
     save_cmd "docker top pmon" "docker.pmon"
 
-    save_cmd "docker exec -it syncd saidump" "saidump"
-
     local platform="$(/usr/local/bin/sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)"
     if [[ $platform == *"mlnx"* ]]; then
         local sai_dump_filename="/tmp/sai_sdk_dump_$(date +"%m_%d_%Y_%I_%M_%p")"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
fix timeout errors that causes orchagent to crash during show techsupport when switch has a lot of configuration. 

the crash in orchagent is attributed to redis-db in techsupport script that is locking up redis-db for a long time trying to retrieve data.

**- How I did it**
removed call to saidump to fix timeout errors to redis-db during techsupport. There is a redis-dump call that is already retrieving same data prior to call to redis-db

**- How to verify it**
add a lot configuration (i.e. max ip addresses) then issue techsupport

**- Previous command output (if the output of a command-line utility has changed)**
admin@sonic:~$ show techsupp
main
mkdir: created directory '/var/dump/sonic_dump_sonic_20190721_130617'
'/var/dump/sonic_dump_sonic_20190721_130617/generate_dump' -> '/usr/bin/generate_dump'
sonic_dump_sonic_20190721_130617/
sonic_dump_sonic_20190721_130617/generate_dump
mkdir: created directory '/var/dump/sonic_dump_sonic_20190721_130617/proc'
'/proc/buddyinfo' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/buddyinfo'
'/proc/cmdline' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/cmdline'
'/proc/consoles' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/consoles'
'/proc/cpuinfo' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/cpuinfo'
'/proc/devices' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/devices'
'/proc/diskstats' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/diskstats'
'/proc/dma' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/dma'
'/proc/interrupts' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/interrupts'
'/proc/iomem' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/iomem'
'/proc/ioports' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/ioports'
'/proc/kallsyms' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/kallsyms'
'/proc/loadavg' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/loadavg'
'/proc/locks' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/locks'
'/proc/meminfo' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/meminfo'
'/proc/misc' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/misc'
'/proc/modules' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/modules'
'/proc/self/mounts' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/mounts'
'/proc/self/net' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/net'
:
:
:
sonic_dump_sonic_20190721_130617/dump/stp.log
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/stp.log'
sonic_dump_sonic_20190721_130617/dump/ps.aux
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/ps.aux'
sonic_dump_sonic_20190721_130617/dump/free
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/free'
sonic_dump_sonic_20190721_130617/dump/vmstat
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/vmstat'
sonic_dump_sonic_20190721_130617/dump/vmstat.m
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/vmstat.m'
sonic_dump_sonic_20190721_130617/dump/vmstat.s
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/vmstat.s'
sonic_dump_sonic_20190721_130617/dump/mount
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/mount'
sonic_dump_sonic_20190721_130617/dump/df
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/df'
sonic_dump_sonic_20190721_130617/dump/dmesg
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/dmesg'
sonic_dump_sonic_20190721_130617/dump/APP_DB.json
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/APP_DB.json'
sonic_dump_sonic_20190721_130617/dump/ASIC_DB.json
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/ASIC_DB.json'
sonic_dump_sonic_20190721_130617/dump/COUNTERS_DB.json
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/COUNTERS_DB.json'
sonic_dump_sonic_20190721_130617/dump/CONFIG_DB.json
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/CONFIG_DB.json'
sonic_dump_sonic_20190721_130617/dump/docker.ps
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/docker.ps'
sonic_dump_sonic_20190721_130617/dump/docker.pmon
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/docker.pmon'
Jul 21 13:08:57.807649 sonic INFO swss#supervisor-proc-exit-listener: Process orchagent exited unxepectedly. Terminating supervisor...

**- New command output (if the output of a command-line utility has changed)**
admin@sonic:~$ show techsupp
main
mkdir: created directory '/var/dump/sonic_dump_sonic_20190721_130617'
'/var/dump/sonic_dump_sonic_20190721_130617/generate_dump' -> '/usr/bin/generate_dump'
sonic_dump_sonic_20190721_130617/
sonic_dump_sonic_20190721_130617/generate_dump
mkdir: created directory '/var/dump/sonic_dump_sonic_20190721_130617/proc'
'/proc/buddyinfo' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/buddyinfo'
'/proc/cmdline' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/cmdline'
'/proc/consoles' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/consoles'
'/proc/cpuinfo' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/cpuinfo'
'/proc/devices' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/devices'
'/proc/diskstats' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/diskstats'
'/proc/dma' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/dma'
'/proc/interrupts' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/interrupts'
'/proc/iomem' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/iomem'
'/proc/ioports' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/ioports'
'/proc/kallsyms' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/kallsyms'
'/proc/loadavg' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/loadavg'
'/proc/locks' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/locks'
'/proc/meminfo' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/meminfo'
'/proc/misc' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/misc'
'/proc/modules' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/modules'
'/proc/self/mounts' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/mounts'
'/proc/self/net' -> '/var/dump/sonic_dump_sonic_20190721_130617/proc/net'
:
:
:
sonic_dump_sonic_20190721_130617/dump/stp.log
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/stp.log'
sonic_dump_sonic_20190721_130617/dump/ps.aux
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/ps.aux'
sonic_dump_sonic_20190721_130617/dump/free
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/free'
sonic_dump_sonic_20190721_130617/dump/vmstat
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/vmstat'
sonic_dump_sonic_20190721_130617/dump/vmstat.m
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/vmstat.m'
sonic_dump_sonic_20190721_130617/dump/vmstat.s
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/vmstat.s'
sonic_dump_sonic_20190721_130617/dump/mount
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/mount'
sonic_dump_sonic_20190721_130617/dump/df
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/df'
sonic_dump_sonic_20190721_130617/dump/dmesg
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/dmesg'
sonic_dump_sonic_20190721_130617/dump/APP_DB.json
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/APP_DB.json'
sonic_dump_sonic_20190721_130617/dump/ASIC_DB.json
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/ASIC_DB.json'
sonic_dump_sonic_20190721_130617/dump/COUNTERS_DB.json
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/COUNTERS_DB.json'
sonic_dump_sonic_20190721_130617/dump/CONFIG_DB.json
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/CONFIG_DB.json'
sonic_dump_sonic_20190721_130617/dump/docker.ps
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/docker.ps'
sonic_dump_sonic_20190721_130617/dump/docker.pmon
removed '/var/dump/sonic_dump_sonic_20190721_130617/dump/docker.pmon'

-->

