### PR TITLE
Negative counter

### DIFF
--- a/scripts/fast-reboot-dump.py
+++ b/scripts/fast-reboot-dump.py
@@ -174,7 +174,11 @@ def generate_fdb_entries(filename):
 
 def get_if(iff, cmd):
     s = socket.socket()
-    ifreq = ioctl(s, cmd, struct.pack("16s16x",iff))
+    try:
+        ifreq = ioctl(s, cmd, struct.pack("16s16x",iff))
+    except IOError:
+        # cannot retrieve data from interface, set to ""
+        ifreq = ""
     s.close()
     return ifreq
 

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -357,8 +357,6 @@ main() {
     save_cmd "docker ps -a" "docker.ps"
     save_cmd "docker top pmon" "docker.pmon"
 
-    save_cmd "docker exec -it syncd saidump" "saidump"
-
     local platform="$(/usr/local/bin/sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)"
     if [[ $platform == *"mlnx"* ]]; then
         local sai_dump_filename="/tmp/sai_sdk_dump_$(date +"%m_%d_%Y_%I_%M_%p")"

--- a/utilities_common/netstat.py
+++ b/utilities_common/netstat.py
@@ -13,7 +13,7 @@ def ns_diff(newstr, oldstr):
         return STATUS_NA
     else:
         new, old = int(newstr), int(oldstr)
-        return '{:,}'.format(new - old)
+        return '{:,}'.format(max(0, new - old))
 
 def ns_brate(newstr, oldstr, delta):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
fix negative counter output when in "show interface counters -a" after show interface counter -c

**- How I did it**
ensure diff will always return 0 if negative

**- How to verify it**
run "show interface counter -c" to clear counter, then immediately run "show interace counters -a"

**- Previous command output (if the output of a command-line utility has changed)**
admin@sonic:~$ show interface counters | grep PortChannel
PortChannel1 U 87 1958.67 B/s 27.20/s 0.00% 0 -23 0 -22 0.00 B/s 0.00/s 0.00% 0 0 0 
PortChannel2 U -13,412 33.63 B/s 0.49/s 0.00% 0 -95 0 -2,739 0.00 B/s 0.00/s 0.00% 0 -25 0 

**- New command output (if the output of a command-line utility has changed)**
admin@sonic:~$ show interface counters | grep PortChannel
PortChannel1 U 238 2084.57 B/s 0.00% 0 0 0 0 0.00 B/s 0.00% 0 0 0
PortChannel2 U 5 41.36 B/s 0.00% 0 0 0 0 0.00 B/s 0.00% 0 0 0

-->

