### PR TITLE
issues672 portstat support clear or stat one port

### DIFF
--- a/scripts/portstat
+++ b/scripts/portstat
@@ -71,7 +71,7 @@ class Portstat(object):
         self.db.connect(self.db.COUNTERS_DB)
         self.db.connect(self.db.APPL_DB)
 
-    def get_cnstat(self):
+    def get_cnstat(self, clearport):
         """
             Get the counters info from database.
         """
@@ -96,6 +96,9 @@ class Portstat(object):
         cnstat_dict = OrderedDict()
         cnstat_dict['time'] = datetime.datetime.now()
         if counter_port_name_map is None:
+            return cnstat_dict
+        if None != clearport and clearport in natsorted(counter_port_name_map):
+	    cnstat_dict[clearport] = get_counters(counter_port_name_map[clearport])
             return cnstat_dict
         for port in natsorted(counter_port_name_map):
             cnstat_dict[port] = get_counters(counter_port_name_map[port]) 
@@ -132,7 +135,7 @@ class Portstat(object):
         else:
             return STATUS_NA
 
-    def cnstat_diff_print(self, cnstat_new_dict, cnstat_old_dict, use_json=False, print_all=False):
+    def cnstat_diff_print(self, cnstat_new_dict, cnstat_old_dict, use_json=False, print_all=False, stat_intf=None):
         """
             Print the difference between two cnstat results.
         """
@@ -152,6 +155,8 @@ class Portstat(object):
             else:
                 old_cntr = NStats._make([0] * BUCKET_NUM)
             port_speed = self.get_port_speed(key)
+            if stat_intf and stat_intf != key:
+                continue
             if print_all:
                 table.append((key, self.get_port_state(key),
                               ns_diff(cntr.rx_ok, old_cntr.rx_ok),
@@ -206,6 +211,8 @@ Examples:
   portstat -r
   portstat -a
   portstat -p 20
+  portstat -c -P Ethernet12
+  portstat -i Ethernet12
 """)
 
     parser.add_argument('-c', '--clear', action='store_true', help='Copy & clear stats')
@@ -216,6 +223,8 @@ Examples:
     parser.add_argument('-a', '--all', action='store_true', help='Display all the stats counters')
     parser.add_argument('-t', '--tag', type=str, help='Save stats with name TAG', default=None)
     parser.add_argument('-p', '--period', type=int, help='Display stats over a specified period (in seconds).', default=0)
+    parser.add_argument('-i', '--interface', type=str, help='Display port the stats counters.', default=None)
+    parser.add_argument('-P', '--port-clear', type=str, help='Clear stat of port.', default=None)
     args = parser.parse_args()
 
     save_fresh_stats = args.clear
@@ -227,6 +236,8 @@ Examples:
     uid = str(os.getuid())
     wait_time_in_seconds = args.period
     print_all = args.all
+    stat_intf = args.interface
+    clear_port = args.port_clear
 
     if tag_name is not None:
         cnstat_file = uid + "-" + tag_name
@@ -260,7 +271,7 @@ Examples:
             sys.exit(0)
 
     portstat = Portstat()
-    cnstat_dict = portstat.get_cnstat()
+    cnstat_dict = portstat.get_cnstat(clear_port)
 
     # Now decide what information to display
     if raw_stats:
@@ -278,7 +289,14 @@ Examples:
 
     if save_fresh_stats:
         try:
-            pickle.dump(cnstat_dict, open(cnstat_fqn_file, 'w'))
+            if clear_port == None or os.path.isfile(cnstat_fqn_file) == False:
+                pickle.dump(cnstat_dict, open(cnstat_fqn_file, 'w'))
+            else:
+                cnstat_dict_o = OrderedDict()
+                with open(cnstat_fqn_file, 'r') as f:
+                    cnstat_dict_o = pickle.loads(f.read())
+                    cnstat_dict_o[clear_port] = cnstat_dict[clear_port]
+                    pickle.dump(cnstat_dict_o, open(cnstat_fqn_file, 'w'))
         except IOError as e:
             sys.exit(e.errno)
         else:
@@ -291,7 +309,7 @@ Examples:
             try:
                 cnstat_cached_dict = pickle.load(open(cnstat_fqn_file, 'r'))
                 print "Last cached time was " + str(cnstat_cached_dict.get('time'))
-                portstat.cnstat_diff_print(cnstat_dict, cnstat_cached_dict, use_json, print_all)
+                portstat.cnstat_diff_print(cnstat_dict, cnstat_cached_dict, use_json, print_all, stat_intf)
             except IOError as e:
                 print e.errno, e
         else:
@@ -299,13 +317,13 @@ Examples:
                 print "\nFile '%s' does not exist" % cnstat_fqn_file
                 print "Did you run 'portstat -c -t %s' to record the counters via tag %s?\n" % (tag_name, tag_name)
             else:
-                portstat.cnstat_diff_print(cnstat_dict, {}, use_json, print_all)
+                portstat.cnstat_diff_print(cnstat_dict, {}, use_json, print_all, stat_intf)
     else:
         #wait for the specified time and then gather the new stats and output the difference.
         time.sleep(wait_time_in_seconds)
         print "The rates are calculated within %s seconds period" % wait_time_in_seconds
-        cnstat_new_dict = portstat.get_cnstat()
-        portstat.cnstat_diff_print(cnstat_new_dict, cnstat_dict, use_json, print_all)
+        cnstat_new_dict = portstat.get_cnstat(None)
+        portstat.cnstat_diff_print(cnstat_new_dict, cnstat_dict, use_json, print_all, stat_intf)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**
```
root@sonic:/usr/lib/python2.7/dist-packages/utilities_common# portstat
      IFACE    STATE              RX_OK    RX_BPS    RX_UTIL             RX_ERR    RX_DRP             RX_OVR              TX_OK    TX_BPS    TX_UTIL             TX_ERR    TX_DRP             TX_OVR
-----------  -------  -----------------  --------  ---------  -----------------  --------  -----------------  -----------------  --------  ---------  -----------------  --------  -----------------
  Ethernet0        D  2,114,316,102,605  0.00 B/s      0.00%  1,348,839,001,261         0    240,203,941,461  2,285,404,265,546  0.00 B/s      0.00%    350,270,733,614         0    365,833,058,905
  Ethernet4        D  2,691,813,640,701  0.00 B/s      0.00%  2,044,188,179,972         0    918,880,245,693  2,181,295,289,532  0.00 B/s      0.00%    897,771,714,278         0    349,470,841,325
  Ethernet8        D  2,374,007,146,306  0.00 B/s      0.00%  2,390,883,192,821         0    300,393,297,279  1,627,669,035,123  0.00 B/s      0.00%    569,485,240,059         0     94,351,277,622
 Ethernet12        D  2,837,410,479,240  0.00 B/s      0.00%  1,288,679,352,877         0    417,034,819,423  2,355,856,598,490  0.00 B/s      0.00%    734,301,611,491         0    948,060,651,671
 Ethernet16        D  2,740,197,878,414  0.00 B/s      0.00%  2,621,988,106,679         0    777,300,884,914  3,703,464,652,903  0.00 B/s      0.00%    887,225,841,025         0    897,597,575,532
 Ethernet20        D  2,814,755,876,466  0.00 B/s      0.00%  2,090,398,383,057         0    201,661,521,758  2,217,451,593,841  0.00 B/s      0.00%    465,189,422,827         0    272,088,163,282
 Ethernet24        D  3,146,667,783,942  0.00 B/s      0.00%  1,934,887,886,049         0    957,300,534,075  2,717,412,392,361  0.00 B/s      0.00%    982,589,839,642         0    913,482,411,127
 Ethernet28        D  2,151,108,084,063  0.00 B/s      0.00%  2,117,863,285,888         0    101,705,702,270  3,001,875,678,191  0.00 B/s      0.00%    513,665,458,611         0    375,204,956,799
 Ethernet32        D  3,264,128,115,095  0.00 B/s      0.00%  2,624,579,657,640         0    938,695,826,347  2,237,579,139,102  0.00 B/s      0.00%    182,276,693,611         0    754,756,455,119
 Ethernet36        D  1,388,605,008,954  0.00 B/s      0.00%  1,032,370,865,099         0     67,305,471,435  2,815,768,604,754  0.00 B/s      0.00%    538,419,259,559         0    549,265,778,187
 Ethernet40        D  3,097,977,734,127  0.00 B/s      0.00%  1,468,197,728,764         0    823,433,939,818  3,508,559,915,050  0.00 B/s      0.00%    587,482,884,382         0  1,081,724,304,026
 Ethernet44        D  2,767,655,338,603  0.00 B/s      0.00%  1,498,689,796,523         0    528,258,661,030  2,802,804,323,061  0.00 B/s      0.00%    268,044,074,967         0    985,407,927,222
 Ethernet48        D  2,713,759,303,527  0.00 B/s      0.00%  1,575,788,134,426         0    789,860,308,069  3,607,712,273,047  0.00 B/s      0.00%    377,545,005,044         0  1,081,657,845,849
 Ethernet52        D  3,491,256,687,576  0.00 B/s      0.00%  2,455,430,724,492         0    649,704,836,349  2,034,750,688,109  0.00 B/s      0.00%    952,884,393,613         0    315,633,409,910
 Ethernet56        D  3,815,244,977,812  0.00 B/s      0.00%  2,206,045,440,664         0    833,159,166,405  3,160,122,412,616  0.00 B/s      0.00%    684,300,115,581         0    770,213,928,771
 Ethernet60        D  1,997,494,429,391  0.00 B/s      0.00%  1,864,667,304,178         0    291,911,265,790  1,861,622,066,234  0.00 B/s      0.00%  1,069,437,999,055         0    362,924,039,503
 Ethernet64        D  2,864,520,686,110  0.00 B/s      0.00%  1,987,087,532,827         0  1,016,464,124,343  2,350,321,984,601  0.00 B/s      0.00%    197,799,685,855         0    663,081,974,515
 Ethernet68        D  2,457,331,450,939  0.00 B/s      0.00%  1,086,411,965,452         0    276,075,216,177  2,365,961,700,054  0.00 B/s      0.00%    463,184,691,071         0    329,351,291,855
 Ethernet72        D  2,451,628,732,112  0.00 B/s      0.00%  2,895,197,231,278         0    891,062,939,606  2,179,839,493,977  0.00 B/s      0.00%    848,079,426,031         0  1,090,256,878,359
 Ethernet76        D  2,347,897,820,366  0.00 B/s      0.00%  2,041,630,789,394         0    514,724,719,408  2,358,488,156,406  0.00 B/s      0.00%    406,880,906,697         0    334,059,065,174
 Ethernet80        D  2,926,735,092,806  0.00 B/s      0.00%  1,122,260,750,722         0    826,166,565,945  1,693,901,621,155  0.00 B/s      0.00%    495,798,081,400         0    505,079,855,596
 Ethernet84        D  2,933,868,293,010  0.00 B/s      0.00%  1,290,644,152,020         0    445,964,963,165  2,384,252,965,964  0.00 B/s      0.00%    506,265,993,045         0    540,953,533,559
 Ethernet88        D  2,182,583,297,346  0.00 B/s      0.00%  1,273,888,687,805         0    936,159,697,358  1,747,388,128,703  0.00 B/s      0.00%  1,073,160,848,709         0    352,879,195,439
 Ethernet92        D  3,123,337,390,488  0.00 B/s      0.00%  1,279,978,561,846         0  1,090,904,621,041  2,167,755,463,604  0.00 B/s      0.00%    646,247,863,199         0    907,594,852,899
 Ethernet96        D  2,498,098,397,014  0.00 B/s      0.00%  1,024,608,760,869         0    506,107,608,933  1,427,913,220,971  0.00 B/s      0.00%    925,529,644,511         0    387,977,174,644
Ethernet100        D  2,151,588,404,300  0.00 B/s      0.00%  2,043,650,224,188         0    211,058,890,181  1,037,030,137,751  0.00 B/s      0.00%    407,582,623,069         0    350,397,748,572
Ethernet104        D  2,766,180,645,268  0.00 B/s      0.00%  1,247,823,628,279         0    936,134,528,782  1,032,169,932,563  0.00 B/s      0.00%    942,725,897,517         0     25,095,755,645
Ethernet108        D  2,709,040,331,509  0.00 B/s      0.00%  2,320,551,242,013         0    227,169,530,331  1,417,086,686,815  0.00 B/s      0.00%    373,890,037,460         0    332,120,030,583
Ethernet112        D  3,403,033,141,593  0.00 B/s      0.00%  1,649,128,632,588         0    920,922,100,015  2,466,182,849,097  0.00 B/s      0.00%    956,743,750,741         0    884,191,520,114
Ethernet116        D  2,528,901,607,694  0.00 B/s      0.00%  2,370,743,157,408         0  1,031,319,408,954  2,128,075,768,126  0.00 B/s      0.00%  1,092,823,285,644         0    470,131,113,822
Ethernet120        D  2,948,185,590,179  0.00 B/s      0.00%  2,049,815,555,275         0  1,053,405,440,221  1,970,717,268,003  0.00 B/s      0.00%    403,030,144,375         0    225,996,667,696
Ethernet124        D  3,291,319,936,510  0.00 B/s      0.00%  1,816,917,691,792         0    466,777,779,120  3,318,967,557,029  0.00 B/s      0.00%    178,949,930,691         0    187,875,449,549
```
**- New command output (if the output of a command-line utility has changed)**
```
root@sonic:/usr/lib/python2.7/dist-packages/utilities_common# portstat -P Ethernet24 -c
Cleared counters
root@sonic:/usr/lib/python2.7/dist-packages/utilities_common# portstat -i Ethernet24
Last cached time was 2019-09-26 02:41:51.528075
     IFACE    STATE    RX_OK    RX_BPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR    TX_OK    TX_BPS    TX_UTIL    TX_ERR    TX_DRP    TX_OVR
----------  -------  -------  --------  ---------  --------  --------  --------  -------  --------  ---------  --------  --------  --------
Ethernet24        D        0  0.00 B/s      0.00%         0         0         0        0  0.00 B/s      0.00%         0         0         0

root@sonic:/usr/lib/python2.7/dist-packages/utilities_common# portstat
Last cached time was 2019-09-26 02:41:51.528075
      IFACE    STATE              RX_OK    RX_BPS    RX_UTIL             RX_ERR    RX_DRP             RX_OVR              TX_OK    TX_BPS    TX_UTIL             TX_ERR    TX_DRP             TX_OVR
-----------  -------  -----------------  --------  ---------  -----------------  --------  -----------------  -----------------  --------  ---------  -----------------  --------  -----------------
  Ethernet0        D  2,114,316,102,605  0.00 B/s      0.00%  1,348,839,001,261         0    240,203,941,461  2,285,404,265,546  0.00 B/s      0.00%    350,270,733,614         0    365,833,058,905
  Ethernet4        D  2,691,813,640,701  0.00 B/s      0.00%  2,044,188,179,972         0    918,880,245,693  2,181,295,289,532  0.00 B/s      0.00%    897,771,714,278         0    349,470,841,325
  Ethernet8        D  2,374,007,146,306  0.00 B/s      0.00%  2,390,883,192,821         0    300,393,297,279  1,627,669,035,123  0.00 B/s      0.00%    569,485,240,059         0     94,351,277,622
 Ethernet12        D  2,837,410,479,240  0.00 B/s      0.00%  1,288,679,352,877         0    417,034,819,423  2,355,856,598,490  0.00 B/s      0.00%    734,301,611,491         0    948,060,651,671
 Ethernet16        D  2,740,197,878,414  0.00 B/s      0.00%  2,621,988,106,679         0    777,300,884,914  3,703,464,652,903  0.00 B/s      0.00%    887,225,841,025         0    897,597,575,532
 Ethernet20        D  2,814,755,876,466  0.00 B/s      0.00%  2,090,398,383,057         0    201,661,521,758  2,217,451,593,841  0.00 B/s      0.00%    465,189,422,827         0    272,088,163,282
 Ethernet24        D                  0  0.00 B/s      0.00%                  0         0                  0                  0  0.00 B/s      0.00%                  0         0                  0
 Ethernet28        D  2,151,108,084,063  0.00 B/s      0.00%  2,117,863,285,888         0    101,705,702,270  3,001,875,678,191  0.00 B/s      0.00%    513,665,458,611         0    375,204,956,799
 Ethernet32        D  3,264,128,115,095  0.00 B/s      0.00%  2,624,579,657,640         0    938,695,826,347  2,237,579,139,102  0.00 B/s      0.00%    182,276,693,611         0    754,756,455,119
 Ethernet36        D  1,388,605,008,954  0.00 B/s      0.00%  1,032,370,865,099         0     67,305,471,435  2,815,768,604,754  0.00 B/s      0.00%    538,419,259,559         0    549,265,778,187
 Ethernet40        D  3,097,977,734,127  0.00 B/s      0.00%  1,468,197,728,764         0    823,433,939,818  3,508,559,915,050  0.00 B/s      0.00%    587,482,884,382         0  1,081,724,304,026
 Ethernet44        D  2,767,655,338,603  0.00 B/s      0.00%  1,498,689,796,523         0    528,258,661,030  2,802,804,323,061  0.00 B/s      0.00%    268,044,074,967         0    985,407,927,222
 Ethernet48        D  2,713,759,303,527  0.00 B/s      0.00%  1,575,788,134,426         0    789,860,308,069  3,607,712,273,047  0.00 B/s      0.00%    377,545,005,044         0  1,081,657,845,849
 Ethernet52        D  3,491,256,687,576  0.00 B/s      0.00%  2,455,430,724,492         0    649,704,836,349  2,034,750,688,109  0.00 B/s      0.00%    952,884,393,613         0    315,633,409,910
 Ethernet56        D  3,815,244,977,812  0.00 B/s      0.00%  2,206,045,440,664         0    833,159,166,405  3,160,122,412,616  0.00 B/s      0.00%    684,300,115,581         0    770,213,928,771
 Ethernet60        D  1,997,494,429,391  0.00 B/s      0.00%  1,864,667,304,178         0    291,911,265,790  1,861,622,066,234  0.00 B/s      0.00%  1,069,437,999,055         0    362,924,039,503
 Ethernet64        D  2,864,520,686,110  0.00 B/s      0.00%  1,987,087,532,827         0  1,016,464,124,343  2,350,321,984,601  0.00 B/s      0.00%    197,799,685,855         0    663,081,974,515
 Ethernet68        D  2,457,331,450,939  0.00 B/s      0.00%  1,086,411,965,452         0    276,075,216,177  2,365,961,700,054  0.00 B/s      0.00%    463,184,691,071         0    329,351,291,855
 Ethernet72        D  2,451,628,732,112  0.00 B/s      0.00%  2,895,197,231,278         0    891,062,939,606  2,179,839,493,977  0.00 B/s      0.00%    848,079,426,031         0  1,090,256,878,359
 Ethernet76        D  2,347,897,820,366  0.00 B/s      0.00%  2,041,630,789,394         0    514,724,719,408  2,358,488,156,406  0.00 B/s      0.00%    406,880,906,697         0    334,059,065,174
 Ethernet80        D  2,926,735,092,806  0.00 B/s      0.00%  1,122,260,750,722         0    826,166,565,945  1,693,901,621,155  0.00 B/s      0.00%    495,798,081,400         0    505,079,855,596
 Ethernet84        D  2,933,868,293,010  0.00 B/s      0.00%  1,290,644,152,020         0    445,964,963,165  2,384,252,965,964  0.00 B/s      0.00%    506,265,993,045         0    540,953,533,559
 Ethernet88        D  2,182,583,297,346  0.00 B/s      0.00%  1,273,888,687,805         0    936,159,697,358  1,747,388,128,703  0.00 B/s      0.00%  1,073,160,848,709         0    352,879,195,439
 Ethernet92        D  3,123,337,390,488  0.00 B/s      0.00%  1,279,978,561,846         0  1,090,904,621,041  2,167,755,463,604  0.00 B/s      0.00%    646,247,863,199         0    907,594,852,899
 Ethernet96        D  2,498,098,397,014  0.00 B/s      0.00%  1,024,608,760,869         0    506,107,608,933  1,427,913,220,971  0.00 B/s      0.00%    925,529,644,511         0    387,977,174,644
Ethernet100        D  2,151,588,404,300  0.00 B/s      0.00%  2,043,650,224,188         0    211,058,890,181  1,037,030,137,751  0.00 B/s      0.00%    407,582,623,069         0    350,397,748,572
Ethernet104        D  2,766,180,645,268  0.00 B/s      0.00%  1,247,823,628,279         0    936,134,528,782  1,032,169,932,563  0.00 B/s      0.00%    942,725,897,517         0     25,095,755,645
Ethernet108        D  2,709,040,331,509  0.00 B/s      0.00%  2,320,551,242,013         0    227,169,530,331  1,417,086,686,815  0.00 B/s      0.00%    373,890,037,460         0    332,120,030,583
Ethernet112        D  3,403,033,141,593  0.00 B/s      0.00%  1,649,128,632,588         0    920,922,100,015  2,466,182,849,097  0.00 B/s      0.00%    956,743,750,741         0    884,191,520,114
Ethernet116        D  2,528,901,607,694  0.00 B/s      0.00%  2,370,743,157,408         0  1,031,319,408,954  2,128,075,768,126  0.00 B/s      0.00%  1,092,823,285,644         0    470,131,113,822
Ethernet120        D  2,948,185,590,179  0.00 B/s      0.00%  2,049,815,555,275         0  1,053,405,440,221  1,970,717,268,003  0.00 B/s      0.00%    403,030,144,375         0    225,996,667,696
Ethernet124        D  3,291,319,936,510  0.00 B/s      0.00%  1,816,917,691,792         0    466,777,779,120  3,318,967,557,029  0.00 B/s      0.00%    178,949,930,691         0    187,875,449,549

```
-->

