### PR TITLE
Add Support for Platform Plugin in FastBoot, Warmboot

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -3,6 +3,9 @@
 REBOOT_USER=$(logname)
 REBOOT_TIME=$(date)
 REBOOT_CAUSE_FILE="/var/cache/sonic/reboot-cause.txt"
+DEVPATH="/usr/share/sonic/device"
+PLATFORM=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
+PLATFORM_PLUGIN="fastboot_plugin"
 
 # Check root privileges
 if [[ "$EUID" -ne 0 ]]
@@ -113,6 +116,11 @@ echo "User issued 'fast-reboot' command [User: ${REBOOT_USER}, Time: ${REBOOT_TI
 sync
 sleep 1
 sync
+
+if [ -x ${DEVPATH}/${PLATFORM}/${PLATFORM_PLUGIN} ]; then
+    VERBOSE=yes debug "Running ${PLATFORM} specific plugin..."
+    ${DEVPATH}/${PLATFORM}/${PLATFORM_PLUGIN}
+fi
 
 # Reboot: explicity call Linux native reboot under sbin
 echo "Rebooting to $NEXT_SONIC_IMAGE..."


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Added support for calling a platform specific plugin in fastboot, warmboot
**- How I did it**
modified: scripts/fast-reboot
**- How to verify it**
Write a platform plugin script and execute fast-reboot command
Plugin script will be executed and then reboot will be invoked
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

