### PR TITLE
QoS queue counters reporting negative values after config reload.

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -380,6 +380,8 @@ def reload(filename, yes, load_sysinfo):
     config_db.connect()
     client = config_db.redis_clients[config_db.CONFIG_DB]
     client.flushdb()
+    # Clear cached queue statistics
+    run_command("queuestat -D", display_cmd=True)
     if load_sysinfo:
         command = "{} -H -k {} --write-to-db".format(SONIC_CFGGEN_PATH, cfg_hwsku)
         run_command(command, display_cmd=True)

--- a/scripts/queuestat
+++ b/scripts/queuestat
@@ -14,6 +14,7 @@ import json
 import os.path
 import swsssdk
 import sys
+import shutil
 
 from collections import namedtuple, OrderedDict
 from natsort import natsorted
@@ -263,15 +264,18 @@ Examples:
   queuestat -p Ethernet0
   queuestat -c
   queuestat -d
+  queuestat -D
 """)
 
     parser.add_argument('-p', '--port', type=str, help='Show the queue conters for just one port', default=None)
     parser.add_argument('-c', '--clear', action='store_true', help='Clear previous stats and save new ones')
     parser.add_argument('-d', '--delete', action='store_true', help='Delete saved stats')
+    parser.add_argument('-D', '--delete_all', action='store_true', help='Delete saved stats for all user sessions')
     args = parser.parse_args()
 
     save_fresh_stats = args.clear
-    delete_all_stats = args.delete
+    delete_all_stats = args.delete_all
+    delete_stats = args.delete
 
     port_to_show_stats = args.port
 
@@ -281,12 +285,30 @@ Examples:
     cnstat_dir = "/tmp/queuestat-" + uid
     cnstat_fqn_file = cnstat_dir + "/" + cnstat_file
 
-    if delete_all_stats:
-        for file in os.listdir(cnstat_dir):
-            os.remove(cnstat_dir + "/" + file)
+    if delete_stats:
+        if os.path.exists(cnstat_dir):
+           for file in os.listdir(cnstat_dir):
+               cnstat_cache_file = cnstat_dir + "/" + file
+               if os.path.exists(cnstat_cache_file):
+                  os.remove(cnstat_cache_file)
 
         try:
-            os.rmdir(cnstat_dir)
+            if os.path.exists(cnstat_dir):
+               os.rmdir(cnstat_dir)
+            else:
+               print cnstat_dir + "does not exist"
+            sys.exit(0)
+        except IOError as e:
+            print e.errno, e
+            sys.exit(e)
+
+    if delete_all_stats:
+        tmp_dir = os.listdir("/tmp")
+        try:
+            for dir in tmp_dir:
+                if dir.startswith('queuestat'):
+                    cnstat_dir = "/tmp/" + dir
+                    shutil.rmtree(cnstat_dir)
             sys.exit(0)
         except IOError as e:
             print e.errno, e


### PR DESCRIPTION
The counter cache file is not removed while config reload but COUNTER_DB gets cleaned up.·
This was resulting in counters in COUNTER_DB lesser than that in cache file resulting into -ve counter display.

Signed-off-by: Prasanth Kunjum Veettil <prasanth.kunjumveettil@broadcom.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Fix for QoS counters reporting negative values after config reload
**- How I did it**
The counter cache file is not removed while config reload but COUNTER_DB gets cleaned up.·
This was resulting in counters in COUNTER_DB lesser than that in cache file resulting into -ve counter display.
**- How to verify it**
Start traffic 
show queue counter
config reload
wait for the system to come up.
show queue counter 
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->
