### PR TITLE
Need to store hostname in configDB

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -245,6 +245,11 @@ def _change_hostname(hostname):
         run_command('hostname -F /etc/hostname', display_cmd=True)
         run_command('sed -i "/\s{}$/d" /etc/hosts'.format(current_hostname), display_cmd=True)
         run_command('echo "127.0.0.1 {}" >> /etc/hosts'.format(hostname), display_cmd=True)
+        config_db = ConfigDBConnector()
+        config_db.connect()
+        curr_host_name = config_db.get_entry('DEVICE_METADATA', "localhost").get('hostname')
+        if (curr_host_name != hostname):
+            config_db.mod_entry('DEVICE_METADATA', "localhost", {'hostname': hostname})
 
 def _clear_qos():
     QOS_TABLE_NAMES = [


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
After configure hostname,hostname changed but it is not reflecting in configDB(running config) so config save/reboot still shows old hostname.
So store hostname in ConfigDB.

**- How I did it**
As part of change_hostname API, store the new hostname in ConfigDB.

**- How to verify it**
\# config hostname \<new-name\>
\# show host
\# show run all | grep hostname
\<reboot\>
\# show run all | grep hostname (to verify that the new-name is present as hostname)

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

