### PR TITLE
pfcwd: show storm status to be 'N/A' when pfcwd is stopped

### DIFF
--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -84,7 +84,7 @@ def stats(empty, queues):
             line = stats.get(stat[1], '0') + '/' + stats.get(stat[2], '0')
             stats_list.append(line)
         if stats_list != ['0/0'] * len(STATS_DESCRIPTION) or empty:
-            table.append([queue, stats['PFC_WD_STATUS']] + stats_list)
+            table.append([queue, stats.get('PFC_WD_STATUS', 'N/A')] + stats_list)
 
     click.echo(tabulate(table, STATS_HEADER, stralign='right', numalign='right', tablefmt='simple'))
 


### PR DESCRIPTION
```
$ sudo pfcwd start_default
$ pfcwd show stats        
       QUEUE       STATUS    STORM DETECTED/RESTORED    TX OK/DROP    RX OK/DROP    TX LAST OK/DROP    RX LAST OK/DROP
------------  -----------  -------------------------  ------------  ------------  -----------------  -----------------
Ethernet36:4  operational                        1/1       100/100         0/100            100/100              0/100
Ethernet96:3  operational                        1/1           0/0           0/0                0/0                0/0
Ethernet96:4  operational                        5/5       200/400       100/300              100/0              100/0
```

```
$ sudo pfcwd stop     
$ pfcwd show stats
       QUEUE    STATUS    STORM DETECTED/RESTORED    TX OK/DROP    RX OK/DROP    TX LAST OK/DROP    RX LAST OK/DROP
------------  --------  -------------------------  ------------  ------------  -----------------  -----------------
Ethernet36:4       N/A                        1/1       100/100         0/100            100/100              0/100
Ethernet96:3       N/A                        1/1           0/0           0/0                0/0                0/0
Ethernet96:4       N/A                        5/5       200/400       100/300              100/0              100/0
```
Signed-off-by: Wenda Ni <wenni@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

