### PR TITLE
[fast reboot] kill teamd docker directly

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -424,10 +424,6 @@ if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
     # restarting the container automatically.
     # Note: teamd must be killed before syncd, because it will send the last packet through CPU port
     debug "Stopping teamd ..."
-    docker exec -i teamd pkill -USR2 teamd || [ $? == 1 ]
-    while docker exec -i teamd pgrep teamd > /dev/null; do
-      sleep 0.05
-    done
     docker kill teamd > /dev/null
     systemctl stop teamd
     debug "Stopped teamd ..."


### PR DESCRIPTION
**- What I did**

Letting teamd quit and send out last handshake cause some unexpected
interaction with orchagent. It appears that orchagent noticed these lag
were removed and start to tear down the LAG on the ASIC side as well.
This would cause the control plane to go down immediately.

Until we have a better solution, revert back to original behavior.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

