### PR TITLE
Address the 'show ipv6 interface' crash and include the missed bgp columns

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1073,7 +1073,7 @@ def ipv6():
 @ipv6.command()
 def interfaces():
     """Show interfaces IPv6 address"""
-    header = ['Interface', 'IPv6 address/mask', 'Admin/Oper']
+    header = ['Interface', 'IPv6 address/mask', 'Admin/Oper', 'BGP Neighbor', 'Neighbor IP']
     data = []
     bgp_peer = get_bgp_peer()
 

--- a/show/main.py
+++ b/show/main.py
@@ -1104,7 +1104,7 @@ def interfaces():
                     oper = "down"
                 if get_interface_mode() == "alias":
                     iface = iface_alias_converter.name_to_alias(iface)
-                data.append([iface, ifaddresses[0][1], admin + "/" + oper], neighbor_name, neighbor_ip)
+                data.append([iface, ifaddresses[0][1], admin + "/" + oper, neighbor_name, neighbor_ip])
             for ifaddr in ifaddresses[1:]:
                 data.append(["", ifaddr[1], ""])
 


### PR DESCRIPTION
Fixes #685 
Also included the bgp columns that were missed in the output

**- How to verify it**
Updated the /usr/lib/python2.7/dist-packages/show/main.py with the changes. 
After the fix,
root@sonic:~# show ipv6 interface
Interface        IPv6 address/mask                   Admin/Oper    BGP Neighbor    Neighbor IP
---------------  ----------------------------------  ------------  --------------  -------------
Bridge           fe80::c7d:22ff:fe77:4702%Bridge/64  up/down       N/A             N/A
PortChannel0001  fc00::71/126                        down/down     ARISTA01T1      fc00::72
PortChannel0002  fc00::75/126                        down/down     ARISTA02T1      fc00::76
PortChannel0003  fc00::79/126                        down/down     ARISTA03T1      fc00::7a
PortChannel0004  fc00::7d/126                        down/down     ARISTA04T1      fc00::7e
eth0             fc00:2::32/64                       up/up         N/A             N/A
                 fe80::eef4:bbff:fefe:8687%eth0/64
lo               fc00:1::32/128                      up/up         N/A             N/A
                 ::1/128


