### PR TITLE
[config] Add snmp-community command to set SNMP community string

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -8,6 +8,7 @@ import subprocess
 import netaddr
 import re
 import syslog
+import yaml
 
 import sonic_device_util
 import ipaddress
@@ -22,6 +23,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help', '-?'])
 
 SONIC_CFGGEN_PATH = '/usr/local/bin/sonic-cfggen'
 SYSLOG_IDENTIFIER = "config"
+SNMP_COMMUNITY_FILE = '/etc/sonic/snmp.yml'
 
 # ========================== Syslog wrappers ==========================
 
@@ -674,6 +676,51 @@ def reload():
             click.secho('QoS definition template not found at {}'.format(qos_template_file), fg='yellow')
     else:
         click.secho('Buffer definition template not found at {}'.format(buffer_template_file), fg='yellow')
+
+#
+# 'snmp-community' command
+#
+@config.command('snmp-community')
+@click.argument('community-name', metavar='<community_name>', required=True)
+def snmp_community(community_name):
+    """Set SNMP community string"""
+
+    """Serialization of a Python dict from a SNMP YAML File """
+    with open(SNMP_COMMUNITY_FILE, 'r') as stream:
+        try:
+            snmp_community_dict = yaml.safe_load(stream)
+        except yaml.YAMLError as error:
+            click.echo("SNMP config file not loaded correctly with error {}".format(error))
+            raise
+
+    if 'snmp_rocommunity' in snmp_community_dict.keys():
+        community_exist_name = snmp_community_dict['snmp_rocommunity']
+        del snmp_community_dict['snmp_rocommunity']
+        snmp_community_dict['snmp_rocommunities'] = [community_exist_name]
+        snmp_community_dict['snmp_rocommunities'].append(community_name)
+
+    elif 'snmp_rocommunities' in snmp_community_dict.keys():
+        snmp_community_dict['snmp_rocommunities'].append(community_name)
+
+    else:
+        snmp_community_dict['snmp_rocommunity'] = community_name
+
+    """Serialization of a Python dict into a SNMP YAML File"""
+    with open(SNMP_COMMUNITY_FILE, 'w') as yaml_file:
+        try:
+            yaml.safe_dump(snmp_community_dict, yaml_file, default_flow_style=False)
+        except yaml.YAMLError as error:
+            click.echo("SNMP config data not dumped properly with error {}",format(error))
+            raise
+
+    """Restart SNMP Service"""
+    try:
+        click.echo("Restarting SNMP service...")
+        command = 'service snmp restart'
+        run_command(command, display_cmd=False)
+    except SystemExit as error:
+        click.echo("Restart service SNMP failed with error {}".format(error))
+        raise
 
 #
 # 'warm_restart' group ('config warm_restart ...')

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -67,6 +67,8 @@ Table of Contents
    * [Startup &amp; Running Configuration](#startup--running-configuration)
       * [Startup Configuration command](#startup-configuration-command)
       * [Running Configuration command](#running-configuration-command)
+   * [SNMP Community Configuration](#snmp-community-configuration)
+      * [snmp-community config command](#snmp-community-config-commands)
    * [System State](#system-state)
       * [Processes show commands](#processes-show-commands)
       * [Services &amp; memory show commands](#services--memory-show-commands)
@@ -232,6 +234,7 @@ This command lists all the possible configuration commands at the top level.
     qos
     reload                 Clear current configuration and import a...
     save                   Export current config DB to a file on disk.
+    snmp-community         Set SNMP community string
     tacacs                 TACACS+ server configuration
     vlan                   VLAN-related configuration tasks
     warm_restart           warm_restart-related configuration tasks
@@ -3129,7 +3132,23 @@ This command displays the running configuration of the snmp module.
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Startup--Running-Configuration)
 
+# SNMP Community  Configuration
 
+## snmp-community config command
+
+  This command is used to set SNMP community string or add more string to snmp_rocommunities.
+
+  - Usage:
+	config snmp-community <community_name>
+
+  - Example:
+
+	```
+	admin@sonic:~$ sudo config snmp-community new_public
+	Restarting SNMP service...
+	```
+
+Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#snmp-community-configuration)
 
 # System State
 


### PR DESCRIPTION
Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>


**- What I did**
added a new command called **snmp-community** to set SNMP community string or add to snmp_rocommunities.

**- How I did it**

followed the below doc.
[Set SNMP community string](https://github.com/Azure/SONiC/wiki/How-to-Check-SNMP-Configuration)

**- How to verify it**

before this feature is implemented, there was no **snmp-community** command under config CLI.

There's only one SNMP community string named **public**

```
admin@lnos-x1-a-fab01:~$ sudo cat /etc/sonic/snmp.yml
snmp_location: public
snmp_rocommunity : public




admin@lnos-x1-a-fab01:~$ sudo docker exec -it snmp snmpwalk -v2c -c public 127.0.0.1 iso.3.6.1.2.1.1.1.0

iso.3.6.1.2.1.1.1.0 = STRING: "SONiC Software Version: SONiC.lnos_v2.0.0 - HwSku: Seastone-DX010-10-50 - Distribution: Debian 9.11 - Kernel: 4.9.0-9-amd64"
```

There is no SNMP community string named **new_public**. so, snmpwalk got failed.


```
admin@lnos-x1-a-fab01:~$ sudo docker exec -it snmp snmpwalk -v2c -c new_public 127.0.0.1 iso.3.6.1.2.1.1.1.0

Timeout: No Response from 127.0.0.1
admin@lnos-x1-a-fab01:~$

```

After this feature is implemented

```
admin@lnos-x1-a-fab01:~$ sudo config snmp-community new_public
Restarting SNMP service...
```
so a new SNMP community string named new_public has been added.
```
admin@lnos-x1-a-fab01:~$ cat /etc/sonic/snmp.yml
snmp_location: public
snmp_rocommunities:
- public
- new_public
```
Both the community strings are working fine with snmpwalk.
```
admin@lnos-x1-a-fab01:~$ sudo docker exec -it snmp snmpwalk -v2c -c public 127.0.0.1 iso.3.6.1.2.1.1.1.0
iso.3.6.1.2.1.1.1.0 = STRING: "SONiC Software Version: SONiC.lnos_v2.0.0 - HwSku: Seastone-DX010-10-50 - Distribution: Debian 9.11 - Kernel: 4.9.0-9-amd64"

admin@lnos-x1-a-fab01:~$ sudo docker exec -it snmp snmpwalk -v2c -c new_public 127.0.0.1 iso.3.6.1.2.1.1.1.0
iso.3.6.1.2.1.1.1.0 = STRING: "SONiC Software Version: SONiC.lnos_v2.0.0 - HwSku: Seastone-DX010-10-50 - Distribution: Debian 9.11 - Kernel: 4.9.0-9-amd64"
```
