### PR TITLE
[portstat,intfstat] fix table_as_json

### DIFF
--- a/scripts/intfstat
+++ b/scripts/intfstat
@@ -162,7 +162,7 @@ class Intfstat(object):
                         ns_prate(cntr.tx_p_ok, old_cntr.tx_p_ok, time_gap),
                         ns_diff(cntr.tx_p_err, old_cntr.tx_p_err)))
         if use_json:
-            print self.table_as_json(table, header)
+            print table_as_json(table, header)
         else:
             print tabulate(table, header, tablefmt='simple', stralign='right')
 

--- a/scripts/portstat
+++ b/scripts/portstat
@@ -184,7 +184,7 @@ class Portstat(object):
                               ns_diff(cntr.tx_ovr, old_cntr.tx_ovr)))
 
         if use_json:
-            print self.table_as_json(table, print_all)
+            print table_as_json(table, header)
         else:
             if print_all:
                 print tabulate(table, header_all, tablefmt='simple', stralign='right')


### PR DESCRIPTION
Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->
The json format may come in handy. Sadly found it's broken at the moment.
**- What I did**
Fixed it.
**- How I did it**

**- How to verify it**
```
$ portstat -j
$ intfstat -j
```
**- Previous command output (if the output of a command-line utility has changed)**
```
admin@dev-r-vrt-233-010:~$ portstat -j
Traceback (most recent call last):
  File "/usr/bin/portstat", line 311, in <module>
    main()
  File "/usr/bin/portstat", line 302, in main
    portstat.cnstat_diff_print(cnstat_dict, {}, use_json, print_all)
  File "/usr/bin/portstat", line 187, in cnstat_diff_print
    print self.table_as_json(table, print_all)
AttributeError: 'Portstat' object has no attribute 'table_as_json'
```
**- New command output (if the output of a command-line utility has changed)**
```
admin@dev-r-vrt-233-010:~$ portstat -j
{
    "Ethernet0": {
        "RX_BPS": "0.00 B/s", 
        "RX_DRP": "0", 
        "RX_ERR": "0", 
        "RX_OK": "0", 
        "RX_OVR": "N/A", 
        "RX_UTIL": "0.00%", 
        "STATE": "X", 
        "TX_BPS": "0.00 B/s", 
        "TX_DRP": "0", 
        "TX_ERR": "0", 
        "TX_OK": "0", 
        "TX_OVR": "N/A", 
        "TX_UTIL": "0.00%"
    }, 
```
-->

