### PR TITLE
Fixes show commands failure when database is not ready

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -53,8 +53,14 @@ class InterfaceAliasConverter(object):
     def __init__(self):
         self.alias_max_length = 0
 
-        config_db = ConfigDBConnector()
-        config_db.connect()
+        try:
+            config_db = ConfigDBConnector()
+            config_db.connect()
+        except Exception as e:
+            click.echo ("System is not ready - Core services are not up")
+            click.echo("Database service is not ready!\n")
+            sys.exit(0)
+
         self.port_dict = config_db.get_table('PORT')
 
         if not self.port_dict:


### PR DESCRIPTION
Change-Id: I3857bd80ab9667f5f2bd93496d0205eb97962246

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Fixes show commands failure when database is not ready
**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

