### PR TITLE
[generate_dump] Make regex more specific for disabling/enabling logrotate

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -256,7 +256,7 @@ find_files() {
 #  None
 ###############################################################################
 disable_logrotate() {
-    sed -i '/logrotate/s/^/#/g' /etc/cron.d/logrotate
+    sed -i '/\/usr\/sbin\/logrotate/s/^/#/g' /etc/cron.d/logrotate
 }
 
 ###############################################################################
@@ -269,7 +269,7 @@ disable_logrotate() {
 #  None
 ###############################################################################
 enable_logrotate() {
-    sed -i '/logrotate/s/^#*//g' /etc/cron.d/logrotate
+    sed -i '/\/usr\/sbin\/logrotate/s/^#*//g' /etc/cron.d/logrotate
 }
 
 ###############################################################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Fixes the bad minute error while reading /etc/cron.d/logrotate:

The following are the two routines used in the scripts/generate_dump script. 

     disable_logrotate() {
           sed -i '/logrotate/s/^/#/g' /etc/cron.d/logrotate
      }
     enable_logrotate() {
           sed -i '/logrotate/s/^#*//g' /etc/cron.d/logrotate
     }

When we run 'show techsupport', it basically disables the log rotate and collect all the logs, and enable them back again.  

Content of cron.d/logrotate file before the 'show techsupport ' execution:

           root@sonic:/home/admin# cat /etc/cron.d/logrotate
             # Attempt to rotate system logs once every 10 minutes.
            # First kill any logrotate process(es) if they are still running, as they're most likely hung
            */10 * * * * root /usr/bin/pkill -9 logrotate > /dev/null 2>&1; /usr/sbin/logrotate /etc/logrotate.conf > /dev/null 2>&1

Content of cron.d/logrotate file after the 'show techsupport ' execution:

         root@sonic:/home/admin# cat /etc/cron.d/logrotate
         # Attempt to rotate system logs once every 10 minutes.
    ---> First kill any logrotate process(es) if they are still running, as they're most likely hung
         */10 * * * * root /usr/bin/pkill -9 logrotate > /dev/null 2>&1; /usr/sbin/logrotate /etc/logrotate.conf > /dev/null 2>&1

As part of the enable log rotation function in the generate_dump script, it uncomments the few extra lines the cron.d/logrotate file which causes the crond to fail with a bad minute error. 

**- How I did it**

    * Fixed the enable/disable routine in the generate_dump script as follows:

      disable_logrotate() {
              sed -i '/\/usr\/sbin\/logrotate/s/^/#/g' /etc/cron.d/logrotate
        }

       enable_logrotate() {
            sed -i '/\/usr\/sbin\/logrotate/s/^#*//g' /etc/cron.d/logrotate
        }

**- How to verify it**

     * Run the 'show techsupport' command
     * Verified the /etc/cron.d/logrorate file that comment lines are not changed.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

