### PR TITLE
[config] Add commands to add BGP neighbor configuration

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1122,7 +1122,7 @@ def add():
 @add.command('neighbor')
 @click.argument('neighbor_ip', metavar='<neighbor_ip>', required=True)
 @click.option('-a','--asn', metavar='<neighbor_asn>',type=int, required=True, help="Neighbor ASN number")
-@click.option('-l','--localip', metavar='<local_ip>', required=False, help="Local ip communicate with neighbor")
+@click.option('-l','--localip', metavar='[local_ip]', required=False, help="Local ip communicate with neighbor")
 @click.option('-n','--name', metavar='[neighbor_name]', required=False, help="Neighbor description name")
 def add_neighbor(neighbor_ip,asn,localip,name):
     """Add BGP session by neighbor IP address"""


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
I have added commands to add BGP neighbor configuration
**- How I did it**
Added some new methods to the config/main.py file to support adding BGP neighbor configuration.
**- How to verify it**
```
admin@48Y-oxl:~$ sudo config bgp add neighbor --help
Usage: config bgp add neighbor [OPTIONS] <neighbor_ip>

  Add BGP session by neighbor IP address

Options:
  -a, --asn <neighbor_asn>    Neighbor ASN number  [required]
  -l, --localip <local_ip>    Local ip communicate with neighbor
  -n, --name [neighbor_name]  Neighbor description name
  --help                      Show this message and exit.
admin@48Y-oxl:~$ show bgp su

IPv4 Unicast Summary:
BGP router identifier 10.1.0.21, local AS number 65100 vrf-id 0
BGP table version 8
RIB entries 7, using 1120 bytes of memory
Peers 2, using 41 KiB of memory

Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
10.0.1.1        4      65226    2164    2162        0    0    0 01:46:36            1
10.0.1.5        4      65200    2184    2182        0    0    0 00:05:52            3

Total number of neighbors 2

L2VPN EVPN Summary:
BGP router identifier 10.1.0.21, local AS number 65100 vrf-id 0
BGP table version 0
RIB entries 7, using 1120 bytes of memory
Peers 2, using 41 KiB of memory

Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
10.0.1.1        4      65226    2164    2162        0    0    0 01:46:36            5
10.0.1.5        4      65200    2184    2182        0    0    0 00:05:52            5

Total number of neighbors 2
admin@48Y-oxl:~$ 
admin@48Y-oxl:~$ sudo config bgp add neighbor 10.106.12.241 -a 65544 -l 10.106.12.240 -n test
admin@48Y-oxl:~$ redis-cli -n 4 hgetall "BGP_NEIGHBOR|10.106.12.241"
1) "admin_status"
2) "up"
3) "local_addr"
4) "10.106.12.240"
5) "asn"
6) "65544"
7) "name"
8) "TEST"
admin@48Y-oxl:~$ 
admin@48Y-oxl:~$ sudo config bgp add neighbor 2001::5 -a 65544 -l 2001::4 -n test
admin@48Y-oxl:~$ redis-cli -n 4 hgetall "BGP_NEIGHBOR|2001::5"
1) "admin_status"
2) "up"
3) "local_addr"
4) "2001::4"
5) "asn"
6) "65544"
7) "name"
8) "TEST"
admin@48Y-oxl:~$ 
admin@48Y-oxl:~$ show bgp summary

IPv4 Unicast Summary:
BGP router identifier 10.1.0.21, local AS number 65100 vrf-id 0
BGP table version 8
RIB entries 7, using 1120 bytes of memory
Peers 3, using 62 KiB of memory

Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
10.0.1.1        4      65226    2175    2173        0    0    0 01:47:12            1
10.0.1.5        4      65200    2196    2194        0    0    0 00:06:28            3
10.106.12.241   4      65544       0       0        0    0    0    never       Active

Total number of neighbors 3

IPv6 Unicast Summary:
BGP router identifier 10.1.0.21, local AS number 65100 vrf-id 0
BGP table version 1
RIB entries 1, using 160 bytes of memory
Peers 1, using 21 KiB of memory

Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
2001::5         4      65544       0       0        0    0    0    never       Active

Total number of neighbors 1

L2VPN EVPN Summary:
BGP router identifier 10.1.0.21, local AS number 65100 vrf-id 0
BGP table version 0
RIB entries 7, using 1120 bytes of memory
Peers 3, using 62 KiB of memory

Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
10.0.1.1        4      65226    2175    2173        0    0    0 01:47:12            5
10.0.1.5        4      65200    2196    2194        0    0    0 00:06:28            5
10.106.12.241   4      65544       0       0        0    0    0    never       Active

Total number of neighbors 3
admin@48Y-oxl:~$ 
admin@48Y-oxl:~$ show run bgp | grep -i test
 neighbor 10.106.12.241 description TEST
 neighbor 2001::5 description TEST
admin@48Y-oxl:~$
```

**- Previous command output (if the output of a command-line utility has changed)**
The output on the command doesn't change. It just adds the neighbor details when you run the "show bgp summary" command
**- New command output (if the output of a command-line utility has changed)**
The output on the command doesn't change. It just adds the neighbor details when you run the "show bgp summary" command
-->

