### PR TITLE
[Command Reference] Unify style and formatting; Fix organization; Other fixes

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -1677,34 +1677,35 @@ This sub-section contains the show commands that are supported in ECN.
 
 This command displays all the WRED profiles that are configured in the device.
 
-  - Usage:
-    show ecn
+- Usage:
+  ```
+  show ecn
+  ```
 
 - Example:
   ```
-	show ecn
-	Profile: **AZURE_LOSSLESS**
-	-----------------------  -------
-	red_max_threshold        2097152
-	red_drop_probability     5
-	yellow_max_threshold     2097152
-	ecn                      ecn_all
-	green_min_threshold      1048576
-	red_min_threshold        1048576
-	wred_yellow_enable       true
-	yellow_min_threshold     1048576
-	green_max_threshold      2097152
-	green_drop_probability   5
-	wred_green_enable        true
-	yellow_drop_probability  5
-	wred_red_enable          true
-	-----------------------  -------
+  show ecn
+  Profile: **AZURE_LOSSLESS**
+  -----------------------  -------
+  red_max_threshold        2097152
+  red_drop_probability     5
+  yellow_max_threshold     2097152
+  ecn                      ecn_all
+  green_min_threshold      1048576
+  red_min_threshold        1048576
+  wred_yellow_enable       true
+  yellow_min_threshold     1048576
+  green_max_threshold      2097152
+  green_drop_probability   5
+  wred_green_enable        true
+  yellow_drop_probability  5
+  wred_red_enable          true
+  -----------------------  -------
 
-	Profile: **wredprofileabcd**
-	-----------------  ---
-	red_max_threshold  100
-	-----------------  ---
-
+  Profile: **wredprofileabcd**
+  -----------------  ---
+  red_max_threshold  100
+  -----------------  ---
   ```
 
 ## ECN config commands
@@ -1716,27 +1717,23 @@ This sub-section contains the configuration commands that can configure the WRED
 This command configures the possible fields in a particular WRED profile that is specified using "-profile <profilename>" argument.
 The list of the WRED profile fields that are configurable is listed in the below "Usage".
 
-  - Usage:
-    config ecn [OPTIONS]
-
+- Usage:
   ```
-    ECN Config OPTIONS:
-	  -profile <profile_name>       Profile name  [required] - Even though the profile_name is specified as optional parameter, it is a mandatory parameter.
-	  -rmax <red threshold max>     Set red max threshold
-	  -rmin <red threshold min>     Set red min threshold
-	  -ymax <yellow threshold max>  Set yellow max threshold
-	  -ymin <yellow threshold min>  Set yellow min threshold
-	  -gmax <green threshold max>   Set green max threshold
-	  -gmin <green threshold min>   Set green min threshold
-	  -v, --verbose                 Enable verbose output
-	  --help                        Show this message and exit.
+  config ecn -profile <profile_name> [-rmax <red_threshold_max>] [-rmin <red_threshold_min>] [-ymax <yellow_threshold_max>] [-ymin <yellow_threshold_min>] [-gmax <green_threshold_max>] [-gmin <green_threshold_min>] [-v|--verbose]
   ```
 
+  - Parameters:
+    - profile_name          Profile name
+    - red_threshold_max     Set red max threshold
+    - red_threshold_min     Set red min threshold
+    - yellow_threshold_max  Set yellow max threshold
+    - yellow_threshold_min  Set yellow min threshold
+    - green_threshold_max   Set green max threshold
+    - green_threshold_min   Set green min threshold
 
-- Example:
+- Example (Configures the "red max threshold" for the WRED profile name "wredprofileabcd". It will create the WRED profile if it does not exist.):
   ```
-     root@T1-2:~# config ecn -profile wredprofileabcd -rmax 100
-        This command configures the "red max threshold" for the WRED profile name "wredprofileabcd". It will create the WRED profile if it does not exist.
+  root@T1-2:~# config ecn -profile wredprofileabcd -rmax 100
   ```
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#ECN-Configuration-And-Show-Commands)

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -2866,7 +2866,7 @@ This command displays a list of NTP peers known to the server as well as a summa
   *204.2.134.164   46.233.231.73    2 u  916 1024  377    3.079    0.394   0.128
   ```
 
-## NTP Config Commands
+### NTP Config Commands
 
 This sub-section of commands is used to add or remove the configured NTP servers.
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -4306,6 +4306,7 @@ SONiC software can be installed in two methods, viz, "using sonic_installer tool
 ### SONiC Installer
 This is a command line tool available as part of the SONiC software; If the device is already running the SONiC software, this tool can be used to install an alternate image in the partition.
 This tool has facility to install an alternate image, list the available images and to set the next reboot image.
+This command requires elevated (root) privileges to run.
 
 **sonic_installer list**
 
@@ -4325,6 +4326,8 @@ This command displays information about currently installed images. It displays 
   SONiC-OS-HEAD.XXXX
   SONiC-OS-HEAD.YYYY
   ```
+
+TIP: This output can be obtained without evelated privileges by running the `show boot` command. See [here](#show-system-status) for details.
 
 **sonic_installer install**
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -4403,7 +4403,7 @@ This command is used to remove the unused SONiC image from the disk. Note that i
 
 - Usage:
   ```
-  sonic_installer remove <image_name>
+  sonic_installer remove [-y|--yes] <image_name>
   ```
 
 - Example:
@@ -4417,6 +4417,22 @@ This command is used to remove the unused SONiC image from the disk. Note that i
   Command: grub-set-default --boot-directory=/host 0
 
   Image removed
+  ```
+
+**sonic_installer cleanup**
+
+This command removes all unused images from the device, leaving only the currently active image and the image which will be booted into next (if different) installed. If there are no images which can be removed, the command will output `No image(s) to remove`
+
+- Usage:
+  ```
+  sonic_installer cleanup [-y|--yes]
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo sonic_installer cleanup
+  Remove images which are not current and next, continue? [y/N]: y
+  No image(s) to remove
   ```
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#software-installation-and-management)

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -1217,29 +1217,29 @@ This command displays the ARP entries in the device with following options.
   Total number of entries 10
   ```
 
-- Optionally, you can specify the interface in order to display the ARPs learnt on that particular interface
+Optionally, you can specify the interface in order to display the ARPs learnt on that particular interface
 
-  - Example:
-    ```
-      admin@sonic:~$ show arp -if Ethernet40
-      Address          MacAddress          Iface        Vlan
-      -------------    -----------------   ----------   ------
-      192.168.1.181    e4:c7:22:c1:07:7c   Ethernet40   -
-      Total number of entries 1
+- Example:
+  ```
+    admin@sonic:~$ show arp -if Ethernet40
+    Address          MacAddress          Iface        Vlan
+    -------------    -----------------   ----------   ------
+    192.168.1.181    e4:c7:22:c1:07:7c   Ethernet40   -
+    Total number of entries 1
 
-    ```
+  ```
 
-- Optionally, you can specify an IP address in order to display only that particular entry
+Optionally, you can specify an IP address in order to display only that particular entry
 
-  - Example:
-    ```
-      admin@sonic:~$ show arp 192.168.1.181
-      Address          MacAddress          Iface        Vlan
-      -------------    -----------------   ----------   ------
-      192.168.1.181    e4:c7:22:c1:07:7c   Ethernet40   -
-      Total number of entries 1
+- Example:
+  ```
+    admin@sonic:~$ show arp 192.168.1.181
+    Address          MacAddress          Iface        Vlan
+    -------------    -----------------   ----------   ------
+    192.168.1.181    e4:c7:22:c1:07:7c   Ethernet40   -
+    Total number of entries 1
 
-    ```
+  ```
 
 ## NDP show commands
 
@@ -1430,7 +1430,7 @@ In order to get details for an IPv6 neigbor, use "show bgp ipv6 neighbor <ipv6_a
    Read thread: on  Write thread: on
   ```
 
-- Optionally, you can specify an IP address in order to display only that particular neighbor. In this mode, you can optionally specify whether you want to display all routes advertised to the specified neighbor, all routes received from the specified neighbor or all routes (received and accepted) from the specified neighbor.
+Optionally, you can specify an IP address in order to display only that particular neighbor. In this mode, you can optionally specify whether you want to display all routes advertised to the specified neighbor, all routes received from the specified neighbor or all routes (received and accepted) from the specified neighbor.
 
 
 - Example:
@@ -1790,13 +1790,10 @@ This show command displays packet counters for all interfaces since the last tim
 Optional argument "-c" can be used to clear the counters for all interfaces.
 Optional argument "-p" specify a period (in seconds) with which to gather counters over.
 
-  - Usage:
-    show interfaces counters [OPTIONS]
-      OPTIONS:
-      -a, --printall
-      -c, --clear
-      -p, --period TEXT
-
+- Usage:
+  ```
+  show interfaces counters [-a|--printall] [-p|--period <period>]
+  ```
 
 - Example:
   ```
@@ -1812,7 +1809,7 @@ Optional argument "-p" specify a period (in seconds) with which to gather counte
    Ethernet24        U   33,543,533,441   36.59 MB/s      0.71%         0     1,613         0   43,066,076,370   49.92 MB/s      0.97%         0         0         0
   ```
 
-  - Optionally, you can specify a period (in seconds) with which to gather counters over. Note that this function will take `<period>` seconds to execute.
+Optionally, you can specify a period (in seconds) with which to gather counters over. Note that this function will take `<period>` seconds to execute.
 
 - Example:
   ```
@@ -1833,11 +1830,13 @@ Optional argument "-p" specify a period (in seconds) with which to gather counte
 
 This command displays the key fields of the interfaces such as Operational Status, Administrative Status, Alias and Description.
 
-  - Usage:
-    show interfaces description [INTERFACENAME]
+- Usage:
+  ```
+  show interfaces description [<interface_name>]
+  ```
 
 - Example:
-   ```
+  ```
   admin@sonic:~$ show interfaces description
   Interface    Oper    Admin            Alias           Description
   -----------  ------  -------  ---------------  --------------------
@@ -1846,9 +1845,10 @@ This command displays the key fields of the interfaces such as Operational Statu
   Ethernet8    down     down   hundredGigE1/3        hundredGigE1/3
   Ethernet12   down     down   hundredGigE1/4        hundredGigE1/4
   ```
-  ```
-  show the description for one particular interface.
 
+- Example (to only display the description for interface Ethernet4):
+
+  ```
   admin@sonic:~$ show interfaces description Ethernet4
   Interface    Oper    Admin           Alias           Description
   -----------  ------  -------  --------------  --------------------
@@ -1866,18 +1866,20 @@ Refer sub-section [Interface-Naming-Mode](#Interface-Naming-Mode)
 
 This command is used to display the list of expected neighbors for all interfaces (or for a particular interface) that is configured.
 
-  - Usage:
-    show interfaces neighbor expected [INTERFACENAME]
+- Usage:
+  ```
+  show interfaces neighbor expected [<interface_name>]
+  ```
 
 - Example:
   ```
   root@sonic-z9264f-9251:~# show interfaces neighbor expected
-	LocalPort    Neighbor    NeighborPort    NeighborLoopback    NeighborMgmt    NeighborType
-	-----------  ----------  --------------  ------------------  --------------  --------------
-	Ethernet112  ARISTA01T1  Ethernet1       None                10.16.205.100   ToRRouter
-	Ethernet116  ARISTA02T1  Ethernet1       None                10.16.205.101   SpineRouter
-	Ethernet120  ARISTA03T1  Ethernet1       None                10.16.205.102   LeafRouter
-	Ethernet124  ARISTA04T1  Ethernet1       None                10.16.205.103   LeafRouter
+  LocalPort    Neighbor    NeighborPort    NeighborLoopback    NeighborMgmt    NeighborType
+  -----------  ----------  --------------  ------------------  --------------  --------------
+  Ethernet112  ARISTA01T1  Ethernet1       None                10.16.205.100   ToRRouter
+  Ethernet116  ARISTA02T1  Ethernet1       None                10.16.205.101   SpineRouter
+  Ethernet120  ARISTA03T1  Ethernet1       None                10.16.205.102   LeafRouter
+  Ethernet124  ARISTA04T1  Ethernet1       None                10.16.205.103   LeafRouter
 
   ```
 
@@ -1885,8 +1887,10 @@ This command is used to display the list of expected neighbors for all interface
 
 This command displays information regarding port-channel interfaces
 
-  - Usage:
-    show interfaces portchannel
+- Usage:
+  ```
+  show interfaces portchannel
+  ```
 
 - Example:
   ```
@@ -1906,7 +1910,7 @@ This command displays information regarding port-channel interfaces
 This command displays some more fields such as Lanes, Speed, MTU, Type, Asymmetric PFC status and also the operational and administrative status of the interfaces
 
 - Usage:
-  show interfaces status [INTERFACENAME]
+  show interfaces status[<interface_name>]
 
 - Example:
   ```
@@ -1922,6 +1926,7 @@ This command displays some more fields such as Lanes, Speed, MTU, Type, Asymmetr
 
   ```
 
+- Example (to only display the status for interface Ethernet0):
   ```
   show interface status for one particular interface
 
@@ -1944,7 +1949,7 @@ This sub-section explains the following list of configuration on the interfaces.
 4) speed - to set the interface speed
 5) startup - to bring up the administratively shutdown interface
 
-From 201904 release onwards, the “config interface” command syntax is changed and the format is as follows
+From 201904 release onwards, the “config interface” command syntax is changed and the format is as follows:
 
 - config interface  interface_subcommand <interface_name>
 i.e Interface name comes after the subcommand
@@ -1956,6 +1961,7 @@ NOTE: In older versions of SONiC until 201811 release, the command syntax was
       "config interface <interface_name> interface_subcommand"
 
 **config interface ip add <interface-name> <ip_addr> (for 201904+ version)**
+
 **config interface <interface-name> ip add <ip_addr> (for 201811- version)**
 
 This command is used for adding the IP address for an interface.

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -88,7 +88,7 @@
 * [Watermark](#watermark)
   * [Watermark Show commands](#watermark-show-commands)
   * [Watermark Config commands](#watermark-config-commands)
-* [Software Installation Commands](#software-installation-commands)
+* [Software Installation and Management](#software-installation-and-management)
   * [SONiC Installer](#sonic-installer)
 * [Troubleshooting Commands](#troubleshooting-commands)
 * [Routing Stack](#routing-stack)
@@ -171,7 +171,7 @@ Refer the following section for configuring the IP address for management interf
 
 By default, login takes the user to the default prompt from which all the show commands can be executed.
 
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Basic-Configuration-And-Show)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#basic-tasks)
 
 ### Configuring Management Interface
 
@@ -196,7 +196,7 @@ Users can SSH login to this management interface IP address from their managemen
  eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 10.11.11.13  netmask 255.255.255.0  broadcast 10.11.12.255
  ```
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Basic-Configuration-And-Show)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#basic-tasks)
 
 ## Getting Help
 
@@ -252,7 +252,7 @@ This command lists all the possible configuration commands at the top level.
     warm_restart           warm_restart-related configuration tasks
     watermark              Configure watermark
   ```
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Basic-Configuration-And-Show)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#getting-help)
 
 ### Help For Show Commands
 
@@ -334,7 +334,7 @@ The same syntax applies to all subgroups of `show` which themselves contain subc
     transceiver  Show SFP Transceiver information
   ```
 
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Basic-Configuration-And-Show)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#getting-help)
 
 ## Basic Show Commands
 
@@ -388,7 +388,7 @@ This command displays relevant information as the SONiC and Linux kernel version
   docker-fpm-quagga          HEAD.32-21ea29a     546036fe6838        282MB
   docker-fpm-quagga          latest              546036fe6838        282MB
   ```
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Basic-Configuration-And-Show)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#basic-show-commands)
 
 
 ### Show System Status
@@ -570,7 +570,7 @@ This command displays a list of users currently logged in to the device
   admin@sonic:~$ show users
   admin    ttyS1        2019-03-25 20:31
   ```
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Basic-Configuration-And-Show)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#basic-show-commands)
 
 ### Show Hardware Platform
 
@@ -747,7 +747,7 @@ This command displays information for all the interfaces for the transceiver req
   -----------  ----------
   Ethernet100  Present
   ```
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Basic-Configuration-And-Show)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#basic-show-commands)
 
 ## AAA & TACACS+
 This section captures the various show commands & configuration commands that are applicable for the AAA (Authentication, Authorization, and Accounting) module.
@@ -855,6 +855,7 @@ If the authentication fails, AAA will check the "failthrough" configuration and 
   root@sonic:~#
   ```
 
+Go Back To [Beginning of the document](#) or [Beginning of this section](#aaa--tacacs)
 
 ### TACACS+
 
@@ -1026,7 +1027,7 @@ When user has not configured server specific timeout, this global value shall be
   root@T1-2:~#
   ```
 
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#AAA-Configuration-And-Show)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#aaa--tacacs)
 
 
 
@@ -1207,7 +1208,7 @@ When the optional argument "max_priority"  is specified, each rule’s priority 
   File "acl_incremental_snmp_1_3_ssh_4.json" has got SNMP Rule1, SNMP Rule3 and SSH Rule4.
   This file is created by copying the file "acl_full_snmp_1_2_ssh_4.json" to "acl_incremental_snmp_1_3_ssh_4.json" and then removing SNMP Rule2 and adding SNMP Rule3.
 
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#ACL-Configuration-And-Show)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#acl)
 
 
 ## ARP &amp; NDP
@@ -1315,7 +1316,7 @@ This command displays either all the IPv6 neighbor mac addresses, or for a parti
   Total number of entries 3
   ```
 
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Watermark-Configuration-And-Show)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#arp--ndp)
 
 
 ## BGP
@@ -1691,8 +1692,7 @@ This command is used to remove particular IPv4 or IPv6 BGP neighbor configuratio
   admin@sonic:~$ sudo config bgp remove neighbor SONIC02SPINE
   ```
 
-
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#BGP-Configuration-And-Show-Commands)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#bgp)
 
 ## DHCP Relay
 
@@ -1735,7 +1735,7 @@ This command is used to delete a configured DHCP Relay Destination IP address fr
   Running command: systemctl restart dhcp_relay
   ```
 
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#BGP-Configuration-And-Show-Commands)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#dhcp-relay)
 
 
 ## ECN
@@ -1808,7 +1808,7 @@ The list of the WRED profile fields that are configurable is listed in the below
   root@T1-2:~# config ecn -profile wredprofileabcd -rmax 100
   ```
 
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#ECN-Configuration-And-Show-Commands)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#ecn)
 
 ## Update Device Hostname Configuration Commands
 
@@ -2227,7 +2227,7 @@ Dynamic breakout feature is yet to be supported in SONiC and hence uses cannot c
   admin@sonic:~$ sudo config interface Ethernet63 speed 40000
   ```
 
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#interface-configuration-and-show-commands)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#interfaces)
 
 
 ## Interface Naming Mode
@@ -2306,7 +2306,7 @@ The user must log out and log back in for changes to take effect. Note that the 
     Ethernet0   101,102      40G   9100   fortyGigE1/1/1    down     down
   ```
 
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Interface-Naming-Mode)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#interface-naming-mode)
 
 
 ## IP / IPv6
@@ -2531,7 +2531,7 @@ Refer the routing stack [Quagga Command Reference](https://www.quagga.net/docs/q
   any         : none
   ```
 
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#IP)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#ip--ipv6)
 
 
 ## LLDP
@@ -2630,7 +2630,7 @@ Optionally, you can specify an interface name in order to display only that part
       PortDescr:    T0-2:hundredGigE1/29
   -------------------------------------------------------------------------------
   ```
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#LLDP)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#lldp)
 
 
 ## Loading, Reloading And Saving Configuration
@@ -2788,7 +2788,7 @@ Saved file can be transferred to remote machines for debugging. If users wants t
   root@T1-2:~# config save -y /etc/sonic/config2.json
   ```
 
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#loading-reloading-and-saving-configuration)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#loading-reloading-and-saving-configuration)
 
 
 ## Mirroring
@@ -2841,7 +2841,7 @@ While adding a new session, users need to configure the following fields that ar
   root@T1-2:~#
   ```
 
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Mirroring-Configuration-And-Show)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#mirroring)
 
 
 ## NTP
@@ -2902,7 +2902,7 @@ This command is used to delete a configured NTP server IP address.
   Restarting ntp-config service...
   ```
 
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#NTP)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#NTP)
 
 
 ## Platform Specific Commands
@@ -2976,6 +2976,9 @@ In order to avoid that confirmation the -y / --yes option should be used.
   NOTE: In order to avoid that confirmation the -y / --yes option should be used.
   ```
 
+Go Back To [Beginning of the document](#) or [Beginning of this section](#platform-specific-commands)
+
+
 ## PortChannels
 
 ### PortChannel Show commands
@@ -3044,7 +3047,7 @@ This command adds or deletes a member port to/from the already created portchann
   admin@sonic:~$ sudo config portchannel member add PortChannel0011 Ethernet4
   ```
 
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#PortChannel-Configuration-And-Show)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#portchannels)
 
 ## QoS
 
@@ -3349,7 +3352,7 @@ Some of the example QOS configurations that users can modify are given below.
   When there are no changes in the platform specific configutation files, they internally use the file "/usr/share/sonic/templates/buffers_config.j2" and "/usr/share/sonic/templates/qos_config.j2" to generate the configuration.
   ```
 
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#QoS-Configuration-And-Show)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#qos)
 
 
 ## Startup & Running Configuration
@@ -3532,7 +3535,7 @@ This command displays the running configuration of the snmp module.
   admin@sonic:~$ show runningconfiguration ports Ethernet0
   ```
 
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Startup--Running-Configuration)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#Startup--Running-Configuration)
 
 
 ## Syslog
@@ -3573,7 +3576,7 @@ This command is used to delete the syslog server configured.
   Restarting rsyslog-config service...
   ```
 
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Startup--Running-Configuration)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#Startup--Running-Configuration)
 
 ## System State
 
@@ -3860,7 +3863,7 @@ NOTE: This command is not working. It crashes as follows. A bug ticket is opened
   admin@T1-2:~$ show line
   ```
 
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#System-State)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#System-State)
 
 
 ## VLAN &amp; FDB
@@ -4058,7 +4061,7 @@ Clear the FDB table
   FDB entries are cleared.
   ```
 
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#vlan--FDB)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#vlan--FDB)
 
 
 
@@ -4109,7 +4112,7 @@ This command displays the warm_restart state.
   syncd                     0
   ```
 
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#VLAN-Configuration-And-Show)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#warm-restart)
 
 ### Warm Restart Config commands
 
@@ -4248,7 +4251,7 @@ Supported range: 1-9999. 0 is invalid
   admin@sonic:~$ sudo config warm_restart teamsyncd_timer 3000
   ```
 
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Warm-Restart)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#warm-restart)
 
 
 ## Watermark
@@ -4289,11 +4292,11 @@ There is no regulation on the valid range of values; it leverages linux timer.
   admin@sonic:~$ sudo config watermark telemetry interval 999
   ```
 
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Watermark-Configuration-And-Show)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#watermark)
 
 
 
-## Software Installation Commands
+## Software Installation and Management
 
 SONiC software can be installed in two methods, viz, "using sonic_installer tool", "ONIE Installer".
 
@@ -4414,7 +4417,7 @@ This command is used to remove the unused SONiC image from the disk. Note that i
   Image removed
   ```
 
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Software-Installation-Commands)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#software-installation-and-management)
 
 
 
@@ -4443,7 +4446,7 @@ If the SONiC system was running for quite some time `show techsupport` will prod
   admin@sonic:~$ show techsupport --since='hour ago' # Will collect syslog and core files for the last one hour
   ```
 
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Troubleshooting-commands)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#troubleshooting-commands)
 
 ## Routing Stack
 
@@ -4672,4 +4675,4 @@ This command displays the routing policy that takes precedence over the other ro
       Exit routemap
   ```
 
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Quagga-BGP-Show-Commands)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#quagga-bgp-show-commands)

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -115,7 +115,7 @@ All the configuration commands need root privileges to execute them. Note that s
 Root privileges can be obtained either by using "sudo" keyword in front of all config commands, or by going to root prompt using "sudo -i".
 Note that all commands are case sensitive.
 
-  - Example:
+- Example:
   ```
   admin@sonic:~$ sudo config aaa authentication login tacacs+
 
@@ -149,7 +149,7 @@ The default credential (if not modified at image build time) for login is `admin
 In case of SSH login, users can login to the management interface (eth0) IP address after configuring the same using serial console.
 Refer the following section for configuring the IP address for management interface.
 
-  - Example:
+- Example:
   ```
   At Console:
   Debian GNU/Linux 9 sonic ttyS1
@@ -183,7 +183,7 @@ SONiC does not provide a CLI to configure the static IP for the management inter
 Once the IP address is configured, the same can be verified using "/sbin/ifconfig eth0" linux command.
 Users can SSH login to this management interface IP address from their management network.
 
-  - Example:
+- Example:
    ```
    admin@sonic:~$ /sbin/ifconfig eth0
    eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
@@ -195,8 +195,8 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 
 Subsections:
   1. [Help for Config Commands](#Config-Help)
-  2. [Help For Show Commands](#Show-Help)
-  3. [show version](#Show-Versions)
+  2. [Help for Show Commands](#Show-Help)
+  3. [Show Versions](#Show-Versions)
   4. [Show System Status](#Show-System-Status)
   5. [Show Hardware Platform](#Show-Hardware-Platform)
 
@@ -3942,8 +3942,8 @@ Supported range: 1-3600.
   config warm_restart [-s|--redis-unix-socket-path <socket_path>] bgp_timer <seconds>
   ```
 
-- Parameters:
-  - seconds: Range from 1 to 3600
+  - Parameters:
+    - seconds: Range from 1 to 3600
 
 - Example:
   ```
@@ -3961,8 +3961,8 @@ If this configuration is enabled for that service, it will perform warm reboot f
   config warm_restart [-s|--redis-unix-socket-path <socket_path>] enable [<module_name>]
   ```
 
-- Parameters:
-  - module_name: Can be either system or swss or bgp or teamd. If "module_name" argument is not specified, it will enable "system" module.
+  - Parameters:
+    - module_name: Can be either system or swss or bgp or teamd. If "module_name" argument is not specified, it will enable "system" module.
 
 - Example (Set warm_restart as "enable" for the "system" service):
   ```
@@ -3994,8 +3994,8 @@ Valid value is 1-9999. 0 is invalid.
   config warm_restart [-s|--redis-unix-socket-path <socket_path>] neighsyncd_timer <seconds>
   ```
 
-- Parameters:
-  - seconds: Range from 1 to 9999
+  - Parameters:
+    - seconds: Range from 1 to 9999
 
 - Example:
   ```
@@ -4017,8 +4017,8 @@ Valid value is 1-9999. 0 is invalid.
   config warm_restart [-s|--redis-unix-socket-path <socket_path>] bgp_timer <seconds>
   ```
 
-- Parameters:
-  - seconds: Range from 1 to 9999
+  - Parameters:
+    - seconds: Range from 1 to 9999
 
 - Example:
   ```
@@ -4039,8 +4039,8 @@ Supported range: 1-9999. 0 is invalid
   config warm_restart teamsyncd_timer <seconds>
   ```
 
-- Parameters:
-  - seconds: Range from 1 to 9999
+  - Parameters:
+    - seconds: Range from 1 to 9999
 
 - Example:
   ```

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -1,7 +1,6 @@
-# SONiC COMMAND LINE INTERFACE GUIDE
+# SONiC Command Line Interface Guide
 
-Table of Contents
-=================
+## Table of Contents
 
    * [Document History](#document-history)
    * [Introduction](#introduction)
@@ -89,16 +88,16 @@ Table of Contents
    * [Quagga BGP Show Commands](#Quagga-BGP-Show-Commands)
 
 
-# Document History
+## Document History
 
 | Version | Modification Date | Details |
 | --- | --- | --- |
-| v4 | Oct-17-2019 | Unify usage statements and other formatting; Replace tabs with spaces; Fix a few errors; Minor reorganization |
+| v4 | Oct-17-2019 | Unify usage statements and other formatting; Replace tabs with spaces; Modify heading sizes; Fix a few errors; Minor reorganization |
 | v3 | Jun-26-2019 | Update based on 201904 (build#19) release, "config interface" command changes related to interfacename order, FRR/Quagga show command changes, platform specific changes, ACL show changes and few formatting changes |
 | v2 | Apr-22-2019 | CLI Guide for SONiC 201811 version (build#32) with complete "config" command set |
 | v1 | Mar-23-2019 | Initial version of CLI Guide with minimal command set |
 
-# Introduction
+## Introduction
 SONiC is an open source network operating system based on Linux that runs on switches from multiple vendors and ASICs. SONiC offers a full-suite of network functionality, like BGP and RDMA, that has been production-hardened in the data centers of some of the largest cloud-service providers. It offers teams the flexibility to create the network solutions they need while leveraging the collective strength of a large ecosystem and community.
 
 SONiC software shall be loaded in these [supported devices](https://github.com/Azure/SONiC/wiki/Supported-Devices-and-Platforms) and this CLI guide shall be used to configure the devices as well as to display the configuration, state and status.
@@ -136,13 +135,13 @@ The direct scripts/utilities/commands (examples given below) that are not wrappe
   2. crm – this command is not explained in this document.
   3. sonic-clear, sfputil, etc., This document does not explain these scripts also.
 
-# Basic Configuration
+## Basic Configuration
 
 This section covers the basic configurations related to the following:
   1. [SSH login](#SSH-Login)
   2. [Configuring the Management Interface](#Configuring-Management-Interface)
 
-## SSH Login
+### SSH Login
 
 All SONiC devices support both the serial console based login and the SSH based login by default.
 The default credential (if not modified at image build time) for login is `admin/YourPaSsWoRd`.
@@ -166,7 +165,7 @@ By default, login takes the user to the default prompt from which all the show c
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Basic-Configuration-And-Show)
 
-## Configuring Management Interface
+### Configuring Management Interface
 
 The management interface (eth0) in SONiC is configured (by default) to use DHCP client to get the IP address from the DHCP server. Connect the management interface to the same network in which your DHCP server is connected and get the IP address from DHCP server.
 The IP address received from DHCP server can be verified using the "/sbin/ifconfig eth0" linux command.
@@ -191,7 +190,7 @@ Users can SSH login to this management interface IP address from their managemen
    ```
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Basic-Configuration-And-Show)
 
-# Getting Help
+## Getting Help
 
 Subsections:
   1. [Help for Config Commands](#Config-Help)
@@ -200,7 +199,7 @@ Subsections:
   4. [Show System Status](#Show-System-Status)
   5. [Show Hardware Platform](#Show-Hardware-Platform)
 
-## Help for Config Commands
+### Help for Config Commands
 
 All commands has got in-built help that helps the user to understand the command as well as the possible sub-commands and options.
 "--help" can be used at any level of the command; i.e. it can be used at the command level, or sub-command level or at argument level. The in-built help will display the next possibilities corresponding to that particular command/sub-command.
@@ -248,7 +247,7 @@ This command lists all the possible configuration commands at the top level.
   ```
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Basic-Configuration-And-Show)
 
-## Help For Show Commands
+### Help For Show Commands
 
 **show help**
 This command displays the full list of show commands available in the software; the output of each of those show commands can be used to analyze, debug or troubleshoot the network node.
@@ -330,14 +329,14 @@ The same syntax applies to all subgroups of `show` which themselves contain subc
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Basic-Configuration-And-Show)
 
-# Basic 'show' Commands
+## Basic 'show' Commands
 
 Subsections:
   1. [Show Versions](#Show-Versions)
   2. [Show System Status](#Show-System-Status)
   3. [Show Hardware Platform](#Show-Hardware-Platform)
 
-## Show Versions
+### Show Versions
 
 **show version**
 This command displays software component versions of the currently running SONiC image. This includes the SONiC image version as well as Docker image versions.
@@ -385,7 +384,7 @@ This command displays relevant information as the SONiC and Linux kernel version
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Basic-Configuration-And-Show)
 
 
-## Show System Status
+### Show System Status
 This sub-section explains some set of sub-commands that are used to display the status of various parameters pertaining to the physical state of the network node.
 
 **show clock**
@@ -562,7 +561,7 @@ This command displays a list of users currently logged in to the device
   ```
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Basic-Configuration-And-Show)
 
-## Show Hardware Platform
+### Show Hardware Platform
 
 The information displayed in this set of commands partially overlaps with the one generated by “show envinronment” instruction. In this case though, the information is presented in a more succinct fashion. In the future these two CLI stanzas may end up getting combined.
 
@@ -670,7 +669,7 @@ This command displays the status of the device's power supply units
   PSU 2  OK
   ```
 
-### Transceivers
+#### Transceivers
 Displays diagnostic monitoring information of the transceivers
 
 **show interfaces transceiver**
@@ -734,14 +733,14 @@ This command displays information for all the interfaces for the transceiver req
   ```
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Basic-Configuration-And-Show)
 
-# AAA & TACACS+ Configuration And Show
+## AAA & TACACS+ Configuration And Show
 This section captures the various show commands & configuration commands that are applicable for the AAA (Authentication, Authorization, and Accounting) module.
 Admins can configure the type of authentication (local or remote tacacs based) required for the users and also the authentication failthrough and fallback options.
 Following show command displays the current running configuration related to the AAA.
 
-## AAA Configuration And Show
+### AAA Configuration And Show
 
-### AAA show commands
+#### AAA show commands
 
 This command is used to view the Authentication, Authorization & Accounting settings that are configured in the network node.
 
@@ -761,7 +760,7 @@ This command displays the AAA settings currently present in the network node
    AAA authentication fallback True (default)
    ```
 
-### AAA config commands
+#### AAA config commands
 
 This sub-section explains all the possible CLI based configuration options for the AAA module. The list of commands/sub-commands possible for aaa is given below.
 
@@ -840,9 +839,9 @@ If the authentication fails, AAA will check the "failthrough" configuration and 
   ```
 
 
-## TACACS+ Configuration And Show
+### TACACS+ Configuration And Show
 
-### TACACS+ show commands
+#### TACACS+ show commands
 
 **show tacacs**
 
@@ -872,7 +871,7 @@ This command displays the global configuration fields and the list of all tacacs
                          tcp_port 49
   ```
 
-### TACACS+ Config commands
+#### TACACS+ Config commands
 
 This sub-section explains the command "config tacacs" and its sub-commands that are used to configure the following tacacs+ parameters.
 Some of the parameters like authtype, passkey and timeout can be either configured at per server level or at global level (global value will be applied if there no server level configuration)
@@ -1014,11 +1013,11 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 
 
 
-# ACL Configuration And Show
+## ACL Configuration And Show
 
 This section explains the various show commands and configuration commands available for users.
 
-## ACL show commands
+### ACL show commands
 
 **show acl table**
 
@@ -1095,7 +1094,7 @@ Users can choose to have a default permit rule or default deny rule. In case of 
   ```
 
 
-## ACL config commands
+### ACL config commands
 This sub-section explains the list of configuration options available for ACL module.
 Note that there is no direct command to add or delete or modify the ACL table and ACL rule.
 Existing ACL tables and ACL rules can be updated by specifying the ACL rules in json file formats and configure those files using this CLI command.
@@ -1194,9 +1193,9 @@ When the optional argument "max_priority"  is specified, each rule’s priority 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#ACL-Configuration-And-Show)
 
 
-# ARP &amp; NDP
+## ARP &amp; NDP
 
-## ARP show commands
+### ARP show commands
 
 **show arp**
 
@@ -1259,7 +1258,7 @@ Optionally, you can specify an IP address in order to display only that particul
 
   ```
 
-## NDP show commands
+### NDP show commands
 
 **show ndp**
 This command displays either all the IPv6 neighbor mac addresses, or for a particular IPv6 neighbor, or for all IPv6 neighbors reachable via a specific interface.
@@ -1303,14 +1302,14 @@ This command displays either all the IPv6 neighbor mac addresses, or for a parti
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Watermark-Configuration-And-Show)
 
 
-# BGP Configuration And Show Commands
+## BGP Configuration And Show Commands
 
 This section explains all the BGP show commands and BGP configuation commands in both "Quagga" and "FRR" routing software that are supported in SONiC.
 In 201811 and older verisons "Quagga" was enabled by default. In current version "FRR" is enabled by default.
 Most of the FRR show commands start with "show bgp". Similar commands in Quagga starts with "show ip bgp". All sub-options supported in all these show commands are common for FRR and Quagga.
 Detailed show commands examples for Quagga are provided at the end of this document.This section captures only the commands supported by FRR.
 
-## BGP show commands
+### BGP show commands
 
 
 **show bgp summary (Versions >= 201904 using default FRR routing stack)**
@@ -1589,7 +1588,7 @@ This command displays the routing policy that takes precedence over the other ro
   ```
 
 
-## BGP config commands
+### BGP config commands
 
 This sub-section explains the list of configuration options available for BGP module for both IPv4 and IPv6 BGP neighbors.
 
@@ -1683,11 +1682,11 @@ This command is used to remove particular IPv4 or IPv6 BGP neighbor configuratio
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#BGP-Configuration-And-Show-Commands)
 
 
-# ECN Configuration And Show Commands
+## ECN Configuration And Show Commands
 
 This section explains all the Explicit Congestion Notification (ECN) show commands and ECN configuation options that are supported in SONiC.
 
-## ECN show commands
+### ECN show commands
 This sub-section contains the show commands that are supported in ECN.
 
 **show ecn**
@@ -1725,7 +1724,7 @@ This command displays all the WRED profiles that are configured in the device.
   -----------------  ---
   ```
 
-## ECN config commands
+### ECN config commands
 
 This sub-section contains the configuration commands that can configure the WRED profiles.
 
@@ -1760,24 +1759,24 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 This sub-section of commands is used to change device hostname without traffic being impacted.
 
 **config hostname <new_hostname>**
+
 This command is used to change device hostname without traffic being impacted.
 
-- Usage: config hostname [OPTIONS] <new_hostname>
+- Usage:
+  ```
+  config hostname <new_hostname>
+  ```
 
-        Change device hostname without impacting the traffic.
- Options:
-  -?, -h, --help  Show this message and exit.
-
-- Examples:
+- Example:
   ```
   admin@lnos-x1-a-csw06:~$ sudo config hostname CSW06
   Running command: service hostname-config restart
   Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`.
   ```
 
-# Interface Configuration And Show-Commands
+## Interface Configuration And Show-Commands
 
-## Interface Show Commands
+### Interface Show Commands
 
 This sub-section lists all the possible show commands for the interfaces available in the device. Following example gives the list of possible shows on interfaces.
 Subsequent pages explain each of these commands in detail.
@@ -1964,7 +1963,7 @@ This command displays some more fields such as Lanes, Speed, MTU, Type, Asymmetr
 
 This command is already explained [here](#Transceivers)
 
-## Interface Config Commands
+### Interface Config Commands
 This sub-section explains the following list of configuration on the interfaces.
 1) ip - To add or remove IP address for the interface
 2) pfc - to set the PFC configuration for the interface
@@ -2119,9 +2118,9 @@ Dynamic breakout feature is yet to be supported in SONiC and hence uses cannot c
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#interface-configuration-and-show-commands)
 
 
-# Interface Naming Mode
+## Interface Naming Mode
 
-## Interface naming mode show commands
+### Interface naming mode show commands
 This command displays the current interface naming mode. Interface naming mode originally set to 'default'. Interfaces are referenced by default SONiC interface names.
 Users can change the naming_mode using "config interface_naming_mode" command.
 
@@ -2149,7 +2148,7 @@ This command displays the current interface naming mode
   - "alias" naming mode will display all hardware vendor interface aliases in 'show' commands and accept hardware vendor interface aliases as parameters in 'config commands
 
 
-## Interface naming mode config commands
+### Interface naming mode config commands
 
 **config interface naming mode**
 This command is used to change the interface naming mode.
@@ -2197,9 +2196,9 @@ NOTE: Some platforms do not support alias mapping. In such cases, this command i
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Interface-Naming-Mode)
 
 
-# IP
+## IP
 
-## IP show commands
+### IP show commands
 
 This sub-section explains the various IP protocol specific show commands that are used to display the following.
 1) routes
@@ -2308,7 +2307,7 @@ Refer the routing stack [Quagga Command Reference](https://www.quagga.net/docs/q
   any         : none
   ```
 
-## IPv6 show commands
+### IPv6 show commands
 
 This sub-section explains the various IPv6 protocol specific show commands that are used to display the following.
 1) routes
@@ -2423,9 +2422,9 @@ Refer the routing stack [Quagga Command Reference](https://www.quagga.net/docs/q
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#IP)
 
 
-# LLDP
+## LLDP
 
-## LLDP show commands
+### LLDP show commands
 
 **show lldp table**
 
@@ -2522,11 +2521,11 @@ Optionally, you can specify an interface name in order to display only that part
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#LLDP)
 
 
-# Loading, Reloading And Saving Configuration
+## Loading, Reloading And Saving Configuration
 
 This section explains the commands that are used to load the configuration from either the ConfigDB or from the minigraph.
 
-## Load config command
+### Load config command
 
 This command is used to load the configuration from configDB.
 This command loads the configuration from the input file (if user specifies this optional filename, it will use that input file. Or else, it will use the /etc/sonic/config_db.json as the input file) into CONFIG_DB.
@@ -2552,7 +2551,7 @@ If the argument is not specified, it prompts the user to confirm whether user re
   root@T1-2:~#
   ```
 
-## Load_mgmt_config command
+### Load_mgmt_config command
 
 This command is used to reconfigure hostname and mgmt interface based on device description file.
 This command either uses the optional file specified as arguement or looks for the file "/etc/sonic/device_desc.xml".
@@ -2575,7 +2574,7 @@ If the argument is not specified, it prompts the user to confirm whether user re
   ```
 
 
-## Load_minigraph config command
+### Load_minigraph config command
 
 This command is used to load the configuration from /etc/sonic/minigraph.xml.
 When users do not want to use configuration from config_db.json, they can copy the minigraph.xml configuration file to the device and load it using this command.
@@ -2600,7 +2599,7 @@ If the argument is not specified, it prompts the user to confirm whether user re
   root@T1-2:~#
   ```
 
-## Reload config command
+### Reload config command
 
 This command is used to clear current configuration and import new configurationn from the input file or from /etc/sonic/config_db.json.
 This command shall stop all services before clearing the configuration and it then restarts those services.
@@ -2647,7 +2646,7 @@ If the argument is not specified, it prompts the user to confirm whether user re
   root@T1-2:~#
   ```
 
-## Save config command
+### Save config command
 
 This command is to save the config DB configuration into the user-specified filename or into the default /etc/sonic/config_db.json. This saves the configuration into the disk which is available even after reboots.
 Saved file can be transferred to remote machines for debugging. If users wants to load the configuration from this new file at any point of time, they can use "config load" command and provide this newly generated file as input. If users wants this newly generated file to be used during reboot, they need to copy this file to /etc/sonic/config_db.json.
@@ -2670,9 +2669,9 @@ Saved file can be transferred to remote machines for debugging. If users wants t
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#loading-reloading-and-saving-configuration)
 
 
-# Mirroring Configuration And Show
+## Mirroring Configuration And Show
 
-## Mirroring Show command
+### Mirroring Show command
 
 **show mirror_session**
 
@@ -2692,7 +2691,7 @@ This command displays all the mirror sessions that are configured.
 
   ```
 
-## Mirroring Config command
+### Mirroring Config command
 
 This command is used to add or remove mirroring sessions. Mirror session is identified by "session_name".
 While adding a new session, users need to configure the following fields that are used while forwarding the mirrored packets.
@@ -2722,9 +2721,9 @@ While adding a new session, users need to configure the following fields that ar
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Mirroring-Configuration-And-Show)
 
 
-# NTP
+## NTP
 
-## NTP show command
+### NTP show command
 
 **show ntp**
 
@@ -2747,7 +2746,7 @@ This command displays a list of NTP peers known to the server as well as a summa
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#NTP)
 
 
-# Platform Specific Commands
+## Platform Specific Commands
 
 There are few commands that are platform specific. Mellanox has used this feature and implemented Mellanox specific commands as follows.
 
@@ -2817,9 +2816,9 @@ In order to avoid that confirmation the -y / --yes option should be used.
   NOTE: In order to avoid that confirmation the -y / --yes option should be used.
   ```
 
-# PortChannel Configuration And Show
+## PortChannel Configuration And Show
 
-## PortChannel Show commands
+### PortChannel Show commands
 
 **show interfaces portchannel**
 
@@ -2844,7 +2843,7 @@ This command displays all the port channels that are configured in the device an
   ```
 
 
-## PortChannel Config commands
+### PortChannel Config commands
 
 This sub-section explains how to configure the portchannel and its member ports.
 
@@ -2887,11 +2886,11 @@ This command adds or deletes a member port to/from the already created portchann
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#PortChannel-Configuration-And-Show)
 
-# QoS Configuration & Show
+## QoS Configuration & Show
 
-## QoS Show commands
+### QoS Show commands
 
-### PFC
+#### PFC
 
 **show pfc counters**
 This command displays the details of Rx & Tx priority-flow-control (pfc) for all ports. This command can be used to clear the counters using -c option.
@@ -2927,7 +2926,7 @@ This command displays the details of Rx & Tx priority-flow-control (pfc) for all
   root@sonic:~# sonic-clear pfccounters
   ```
 
-### Queue And Priority-Group
+#### Queue And Priority-Group
 
 This sub-section explains the following queue parameters that can be displayed using "show queue" command.
 1) queue counters
@@ -3110,7 +3109,7 @@ This command displays the user persistet-watermark for the queues (Egress shared
   ```
 
 
-## QoS config commands
+### QoS config commands
 
 **config qos clear**
 
@@ -3191,9 +3190,9 @@ Some of the example QOS configurations that users can modify are given below.
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#QoS-Configuration-And-Show)
 
 
-# Startup & Running Configuration
+## Startup & Running Configuration
 
-## Startup Configuration command
+### Startup Configuration command
 
 **show startupconfiguration bgp**
 
@@ -3235,7 +3234,7 @@ This command is used to display the startup configuration for the BGP module.
   <Only the partial output is shown here. In actual command, more configuration information will be displayed>
   ```
 
-## Running Configuration command
+### Running Configuration command
 This sub-section explains the show commands for displaying the running configuration for the following modules.
 1) bgp
 2) interfaces
@@ -3375,9 +3374,9 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 
 
 
-# System State
+## System State
 
-## Processes show commands
+### Processes show commands
 
 This command is used to determine the CPU utilization. It also lists the active processes along with their corresponding process ID and other relevant parameters.
 
@@ -3479,7 +3478,7 @@ This command displays the current summary information about all the processes
   ```
 
 
-## Services & memory show commands
+### Services & memory show commands
 
 These commands are used to know the services that are running and the memory that is utilized currently.
 
@@ -3662,11 +3661,11 @@ NOTE: This command is not working. It crashes as follows. A bug ticket is opened
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#System-State)
 
 
-# VLAN &amp; FDB
+## VLAN &amp; FDB
 
-## VLAN
+### VLAN
 
-### VLAN show commands
+#### VLAN show commands
 
 **show vlan brief**
 
@@ -3709,7 +3708,7 @@ This command displays all the vlan configuration.
   ```
 
 
-### VLAN Config commands
+#### VLAN Config commands
 
 This sub-section explains how to configure the vlan and its member ports.
 
@@ -3748,9 +3747,9 @@ This command is to add or delete a member port into the already created vlan.
   This command will add Ethernet4 as member of the vlan 100.
   ```
 
-## FDB
+### FDB
 
-### FDB show commands
+#### FDB show commands
 
 **show mac**
 
@@ -3861,9 +3860,9 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 
 
 
-# Warm Restart
+## Warm Restart
 
-## Warm Restart show command
+### Warm Restart show command
 
 **show warm_restart config**
 
@@ -3910,7 +3909,7 @@ This command displays the warm_restart state.
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#VLAN-Configuration-And-Show)
 
-## Warm Restart Config command
+### Warm Restart Config command
 
 This sub-section explains the various configuration related to warm restart feature. Following parameters can be configured using this command.
 1) bgp_timer
@@ -4050,9 +4049,9 @@ Supported range: 1-9999. 0 is invalid
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Warm-Restart)
 
 
-# Watermark Configuration And Show
+## Watermark Configuration And Show
 
-## Watermark Show command
+### Watermark Show command
 
 **show watermark telemetry interval**
 
@@ -4070,7 +4069,7 @@ This command displays the configured interval for the telemetry.
   Telemetry interval 120 second(s)
   ```
 
-## Watermark Config command
+### Watermark Config command
 
 **config watermark telemetry interval**
 
@@ -4092,12 +4091,12 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 
 
 
-# Software Installation Commands
+## Software Installation Commands
 
 SONiC software can be installed in two methods, viz, "using sonic_installer tool", "ONIE Installer".
 
 
-## SONiC Installer
+### SONiC Installer
 This is a command line tool available as part of the SONiC software; If the device is already running the SONiC software, this tool can be used to install an alternate image in the partition.
 This tool has facility to install an alternate image, list the available images and to set the next reboot image.
 
@@ -4217,7 +4216,7 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 
 
 
-# Troubleshooting Commands
+## Troubleshooting Commands
 
 For troubleshooting and debugging purposes, this command gathers pertinent information about the state of the device; information is as diverse as syslog entries, database state, routing-stack state, etc., It then compresses it into an archive file. This archive file can be sent to the SONiC development team for examination.
 Resulting archive file is saved as `/var/dump/<DEVICE_HOST_NAME>_YYYYMMDD_HHMMSS.tar.gz`
@@ -4244,7 +4243,7 @@ If the SONiC system was running for quite some time `show techsupport` will prod
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Troubleshooting-commands)
 
-# Routing Stack Configuration And Show
+## Routing Stack Configuration And Show
 
 SONiC software is agnostic of the routing software that is being used in the device. For example, users can use either Quagga or FRR routing stack as per their requirement.
 A separate shell (vtysh) is provided to configure such routing stacks.
@@ -4274,7 +4273,7 @@ Refer the routing stack [Quagga Command Reference](https://www.quagga.net/docs/q
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE)
 
 
-# Quagga BGP Show Commands
+## Quagga BGP Show Commands
 
 **show ip bgp summary**
 
@@ -4471,7 +4470,7 @@ This command displays the routing policy that takes precedence over the other ro
       Exit routemap
   ```
 
-# Syslog Server Configuration Commands
+## Syslog Server Configuration Commands
 
 This sub-section of commands is used to add or remove the configured syslog servers.
 
@@ -4507,7 +4506,7 @@ This command is used to delete the syslog server configured.
   Restarting rsyslog-config service...
   ```
 
-# DHCP Relay Destination IP address Configuration Commands
+## DHCP Relay Destination IP address Configuration Commands
 
 This sub-section of commands is used to add or remove the DHCP Relay Destination IP address(es) for a VLAN interface.
 
@@ -4546,7 +4545,7 @@ This command is used to delete a configured DHCP Relay Destination IP address fr
   Running command: systemctl restart dhcp_relay
   ```
 
-# NTP Server Configuration Commands
+## NTP Server Configuration Commands
 
 This sub-section of commands is used to add or remove the configured NTP servers.
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -71,6 +71,8 @@
 * [Startup &amp; Running Configuration](#startup--running-configuration)
   * [Startup Configuration](#startup-configuration)
   * [Running Configuration](#running-configuration)
+* [Syslog](#syslog)
+  * [Syslog config commands](#syslog-config-commands)
 * [System State](#system-state)
   * [Processes](#processes)
   * [Services &amp; Memory](#services--memory)
@@ -97,7 +99,7 @@
 
 | Version | Modification Date | Details |
 | --- | --- | --- |
-| v4 | Oct-17-2019 | Unify usage statements and other formatting; Replace tabs with spaces; Modify heading sizes; Fix spelling, grammar and other errors; Minor reorganization |
+| v4 | Oct-17-2019 | Unify usage statements and other formatting; Replace tabs with spaces; Modify heading sizes; Fix spelling, grammar and other errors; Fix organization of new commands |
 | v3 | Jun-26-2019 | Update based on 201904 (build#19) release, "config interface" command changes related to interfacename order, FRR/Quagga show command changes, platform specific changes, ACL show changes and few formatting changes |
 | v2 | Apr-22-2019 | CLI Guide for SONiC 201811 version (build#32) with complete "config" command set |
 | v1 | Mar-23-2019 | Initial version of CLI Guide with minimal command set |
@@ -3533,6 +3535,45 @@ This command displays the running configuration of the snmp module.
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Startup--Running-Configuration)
 
 
+## Syslog
+
+### Syslog Config Commands
+
+This sub-section of commands is used to add or remove the configured syslog servers.
+
+**config syslog add**
+
+This command is used to add a SYSLOG server to the syslog server list.  Note that more that one syslog server can be added in the device.
+
+- Usage:
+  ```
+  config syslog add <ip_address>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config syslog add 1.1.1.1
+  Syslog server 1.1.1.1 added to configuration
+  Restarting rsyslog-config service...
+  ```
+
+**config syslog delete**
+
+This command is used to delete the syslog server configured.
+
+- Usage:
+  ```
+  config syslog del <ip_address>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config syslog del 1.1.1.1
+  Syslog server 1.1.1.1 removed from configuration
+  Restarting rsyslog-config service...
+  ```
+
+Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Startup--Running-Configuration)
 
 ## System State
 
@@ -4629,42 +4670,6 @@ This command displays the routing policy that takes precedence over the other ro
     Call clause:
     Action:
       Exit routemap
-  ```
-
-## Syslog Server Configuration Commands
-
-This sub-section of commands is used to add or remove the configured syslog servers.
-
-**config syslog add**
-
-This command is used to add a SYSLOG server to the syslog server list.  Note that more that one syslog server can be added in the device.
-
-- Usage:
-  ```
-  config syslog add <ip_address>
-  ```
-
-- Example:
-  ```
-  admin@sonic:~$ sudo config syslog add 1.1.1.1
-  Syslog server 1.1.1.1 added to configuration
-  Restarting rsyslog-config service...
-  ```
-
-**config syslog delete**
-
-This command is used to delete the syslog server configured.
-
-- Usage:
-  ```
-  config syslog del <ip_address>
-  ```
-
-- Example:
-  ```
-  admin@sonic:~$ sudo config syslog del 1.1.1.1
-  Syslog server 1.1.1.1 removed from configuration
-  Restarting rsyslog-config service...
   ```
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Quagga-BGP-Show-Commands)

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -93,7 +93,7 @@ Table of Contents
 
 | Version | Modification Date | Details |
 | --- | --- | --- |
-| v4 | Oct-17-2019 | Unify usage statements and other formatting; Replace tabs with spaces; Fix a few errors |
+| v4 | Oct-17-2019 | Unify usage statements and other formatting; Replace tabs with spaces; Fix a few errors; Minor reorganization |
 | v3 | Jun-26-2019 | Update based on 201904 (build#19) release, "config interface" command changes related to interfacename order, FRR/Quagga show command changes, platform specific changes, ACL show changes and few formatting changes |
 | v2 | Apr-22-2019 | CLI Guide for SONiC 201811 version (build#32) with complete "config" command set |
 | v1 | Mar-23-2019 | Initial version of CLI Guide with minimal command set |
@@ -106,9 +106,9 @@ SONiC software shall be loaded in these [supported devices](https://github.com/A
 Follow the [Quick Start Guide](https://github.com/Azure/SONiC/wiki/Quick-Start) to boot the device in ONIE mode, install the SONiC software using the steps specified in the document and login to the device using the default username and password.
 
 After logging into the device, SONiC software can be configured in following three methods.
- 1) Command Line Interface (CLI)
- 2) [config_db.json](https://github.com/Azure/SONiC/wiki/Configuration)
- 3) [minigraph.xml](https://github.com/Azure/SONiC/wiki/Configuration-with-Minigraph-(~Sep-2017))
+  1. Command Line Interface (CLI)
+  2. [config_db.json](https://github.com/Azure/SONiC/wiki/Configuration)
+  3. [minigraph.xml](https://github.com/Azure/SONiC/wiki/Configuration-with-Minigraph-(~Sep-2017))
 
 This document explains the first method and gives the complete list of commands that are supported in SONiC 201904 version (build#19).
 All the configuration commands need root privileges to execute them. Note that show commands can be executed by all users without the root privileges.
@@ -132,20 +132,15 @@ Please follow config_db.json based configuration for the complete list of config
 It is assumed that all configuration commands start with the keyword “config” as prefix.
 Any other scripts/utilities/commands  that need user configuration control are wrapped as sub-commands under the “config” command.
 The direct scripts/utilities/commands (examples given below) that are not wrapped under the "config" command are not in the scope of this document.
-  1) acl_loader – This script is already wrapped inside “config acl” command; i.e. any ACL configuration that user is allowed to do is already part of “config acl” command; users are not expected to use the acl_loader script directly and hence this document need not explain the “acl_loader” script.
-  2) crm – this command is not explained in this document.
-  3) sonic-clear, sfputil, etc., This document does not explain these scripts also.
+  1. acl_loader – This script is already wrapped inside “config acl” command; i.e. any ACL configuration that user is allowed to do is already part of “config acl” command; users are not expected to use the acl_loader script directly and hence this document need not explain the “acl_loader” script.
+  2. crm – this command is not explained in this document.
+  3. sonic-clear, sfputil, etc., This document does not explain these scripts also.
 
-# Basic Configuration And Show
+# Basic Configuration
 
-This section covers the basic configurations related to the following
- 1) [SSH login](#SSH-Login),
- 2) [configuring the management interface](#Configuring-Management-Interface),
- 3) [Help for Config Commands](#Config-Help),
- 4) [Help For Show Commands](#Show-Help),
- 5) [show version](#Show-Versions),
- 6) [Show System Status](#Show-System-Status) and
- 7) [Show Hardware Platform](#Show-Hardware-Platform).
+This section covers the basic configurations related to the following:
+  1. [SSH login](#SSH-Login)
+  2. [Configuring the Management Interface](#Configuring-Management-Interface)
 
 ## SSH Login
 
@@ -177,13 +172,13 @@ The management interface (eth0) in SONiC is configured (by default) to use DHCP 
 The IP address received from DHCP server can be verified using the "/sbin/ifconfig eth0" linux command.
 
 SONiC does not provide a CLI to configure the static IP for the management interface. There are few alternate ways by which a static IP address can be configured for the management interface.
-   1) use "ifconfig eth0" linux command (example: ifconfig eth0 10.11.12.13/24). This configuration won't be preserved across reboot.
+   1. Use "ifconfig eth0" linux command (example: ifconfig eth0 10.11.12.13/24). NOTE: This configuration **will not** be preserved across reboots.
    Example:
    ```
    admin@sonic:~$ /sbin/ifconfig eth0 10.11.12.13/24
    ```
-   2) use config_db.json and configure the MGMT_INTERFACE key with the appropriate values. Refer [here](https://github.com/Azure/SONiC/wiki/Configuration#Management-Interface)
-   3) use minigraph.xml and configure "ManagementIPInterfaces" tag inside "DpgDesc" tag as given at the [page](https://github.com/Azure/SONiC/wiki/Configuration-with-Minigraph-(~Sep-2017))
+   2. Use config_db.json and configure the MGMT_INTERFACE key with the appropriate values. Refer [here](https://github.com/Azure/SONiC/wiki/Configuration#Management-Interface)
+   3. Use minigraph.xml and configure "ManagementIPInterfaces" tag inside "DpgDesc" tag as given at the [page](https://github.com/Azure/SONiC/wiki/Configuration-with-Minigraph-(~Sep-2017))
 
 Once the IP address is configured, the same can be verified using "/sbin/ifconfig eth0" linux command.
 Users can SSH login to this management interface IP address from their management network.
@@ -196,7 +191,16 @@ Users can SSH login to this management interface IP address from their managemen
    ```
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Basic-Configuration-And-Show)
 
-## Config Help
+# Getting Help
+
+Subsections:
+  1. [Help for Config Commands](#Config-Help)
+  2. [Help For Show Commands](#Show-Help)
+  3. [show version](#Show-Versions)
+  4. [Show System Status](#Show-System-Status)
+  5. [Show Hardware Platform](#Show-Hardware-Platform)
+
+## Help for Config Commands
 
 All commands has got in-built help that helps the user to understand the command as well as the possible sub-commands and options.
 "--help" can be used at any level of the command; i.e. it can be used at the command level, or sub-command level or at argument level. The in-built help will display the next possibilities corresponding to that particular command/sub-command.
@@ -244,7 +248,7 @@ This command lists all the possible configuration commands at the top level.
   ```
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Basic-Configuration-And-Show)
 
-## Show Help
+## Help For Show Commands
 
 **show help**
 This command displays the full list of show commands available in the software; the output of each of those show commands can be used to analyze, debug or troubleshoot the network node.
@@ -326,6 +330,12 @@ The same syntax applies to all subgroups of `show` which themselves contain subc
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Basic-Configuration-And-Show)
 
+# Basic 'show' Commands
+
+Subsections:
+  1. [Show Versions](#Show-Versions)
+  2. [Show System Status](#Show-System-Status)
+  3. [Show Hardware Platform](#Show-Hardware-Platform)
 
 ## Show Versions
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -1754,11 +1754,11 @@ The list of the WRED profile fields that are configurable is listed in the below
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#ECN-Configuration-And-Show-Commands)
 
-# Update Device Hostname Configuration Commands
+## Update Device Hostname Configuration Commands
 
 This sub-section of commands is used to change device hostname without traffic being impacted.
 
-**config hostname <new_hostname>**
+**config hostname**
 
 This command is used to change device hostname without traffic being impacted.
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -31,6 +31,8 @@
 * [BGP](#bgp)
   * [BGP show commands](#bgp-show-commands)
   * [BGP config commands](#bgp-config-commands)
+* [DHCP Relay](#dhcp-relay)
+  * [DHCP Relay config commands](#dhcp-relay-config-commands)
 * [ECN](#ecn)
   * [ECN show commands](#ecn-show-commands)
   * [ECN config commands](#ecn-config-commands)
@@ -1687,6 +1689,49 @@ This command is used to remove particular IPv4 or IPv6 BGP neighbor configuratio
   admin@sonic:~$ sudo config bgp remove neighbor SONIC02SPINE
   ```
 
+
+Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#BGP-Configuration-And-Show-Commands)
+
+## DHCP Relay
+
+### DHCP Relay config commands
+
+This sub-section of commands is used to add or remove the DHCP Relay Destination IP address(es) for a VLAN interface.
+
+**config vlan dhcp_relay add**
+
+This command is used to add a DHCP Relay Destination IP address to the a VLAN.  Note that more that one DHCP Relay Destination IP address can be added on a VLAN interface.
+
+- Usage:
+  ```
+  config vlan dhcp_relay add <vlan_id> <dhcp_relay_destination_ip>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config vlan dhcp_relay add 1000 7.7.7.7
+  Added DHCP relay destination address 7.7.7.7 to Vlan1000
+  Restarting DHCP relay service...
+  Running command: systemctl restart dhcp_relay
+  admin@str-s6000-acs-11:~$
+  ```
+
+**config vlan dhcp_relay delete**
+
+This command is used to delete a configured DHCP Relay Destination IP address from a VLAN interface.
+
+- Usage:
+  ```
+  config vlan dhcp_relay del <vlan-id> <dhcp_relay_destination_ip>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config vlan dhcp_relay del 1000 7.7.7.7
+  Removed DHCP relay destination address 7.7.7.7 from Vlan1000
+  Restarting DHCP relay service...
+  Running command: systemctl restart dhcp_relay
+  ```
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#BGP-Configuration-And-Show-Commands)
 
@@ -4620,45 +4665,6 @@ This command is used to delete the syslog server configured.
   admin@sonic:~$ sudo config syslog del 1.1.1.1
   Syslog server 1.1.1.1 removed from configuration
   Restarting rsyslog-config service...
-  ```
-
-## DHCP Relay Destination IP Address Configuration Commands
-
-This sub-section of commands is used to add or remove the DHCP Relay Destination IP address(es) for a VLAN interface.
-
-**config vlan dhcp_relay add**
-
-This command is used to add a DHCP Relay Destination IP address to the a VLAN.  Note that more that one DHCP Relay Destination IP address can be added on a VLAN interface.
-
-- Usage:
-  ```
-  config vlan dhcp_relay add <vlan_id> <dhcp_relay_destination_ip>
-  ```
-
-- Example:
-  ```
-  admin@sonic:~$ sudo config vlan dhcp_relay add 1000 7.7.7.7
-  Added DHCP relay destination address 7.7.7.7 to Vlan1000
-  Restarting DHCP relay service...
-  Running command: systemctl restart dhcp_relay
-  admin@str-s6000-acs-11:~$
-  ```
-
-**config vlan dhcp_relay delete**
-
-This command is used to delete a configured DHCP Relay Destination IP address from a VLAN interface.
-
-- Usage:
-  ```
-  config vlan dhcp_relay del <vlan-id> <dhcp_relay_destination_ip>
-  ```
-
-- Example:
-  ```
-  admin@sonic:~$ sudo config vlan dhcp_relay del 1000 7.7.7.7
-  Removed DHCP relay destination address 7.7.7.7 from Vlan1000
-  Restarting DHCP relay service...
-  Running command: systemctl restart dhcp_relay
   ```
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Quagga-BGP-Show-Commands)

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -9,7 +9,7 @@ Table of Contents
       * [SSH Login](#ssh-login)
       * [Configuring Management Interface](#configuring-management-interface)
       * [Config Help](#config-help)
-	  * [Show Help](#show-help)
+         * [Show Help](#show-help)
       * [Show Versions](#show-versions)
       * [Show System Status](#show-system-status)
       * [Show Hardware Platform](#show-hardware-platform)
@@ -41,7 +41,7 @@ Table of Contents
       * [Interface naming mode config commands](#interface-naming-mode-config-commands)
    * [IP](#ip)
       * [IP show commands](#ip-show-commands)
-	  * [IPv6 show commands](#ipv6-show-commands)
+         * [IPv6 show commands](#ipv6-show-commands)
    * [LLDP](#lldp)
       * [LLDP show commands](#lldp-show-commands)
    * [Loading, Reloading And Saving Configuration](#loading-reloading-and-saving-configuration)
@@ -131,9 +131,9 @@ Please follow config_db.json based configuration for the complete list of config
 It is assumed that all configuration commands start with the keyword “config” as prefix.
 Any other scripts/utilities/commands  that need user configuration control are wrapped as sub-commands under the “config” command.
 The direct scripts/utilities/commands (examples given below) that are not wrapped under the "config" command are not in the scope of this document.
-  1)	Acl_loader – This script is already wrapped inside “config acl” command; i.e. any ACL configuration that user is allowed to do is already part of “config acl” command; users are not expected to use the acl_loader script directly and hence this document need not explain the “acl_loader” script.
-  2)	Crm – this command is not explained in this document.
-  3)	Sonic-clear, sfputil, etc., This document does not explain these scripts also.
+  1) acl_loader – This script is already wrapped inside “config acl” command; i.e. any ACL configuration that user is allowed to do is already part of “config acl” command; users are not expected to use the acl_loader script directly and hence this document need not explain the “acl_loader” script.
+  2) crm – this command is not explained in this document.
+  3) sonic-clear, sfputil, etc., This document does not explain these scripts also.
 
 # Basic Configuration And Show
 
@@ -1831,6 +1831,10 @@ Optionally, you can specify a period (in seconds) with which to gather counters 
   Ethernet24        U      173   16.09 KB/s      0.00%         0         0         0      169   11.39 KB/s      0.00%         0         0         0
   ```
 
+- NOTE: Interface counters can be cleared by the user with the following command:
+  ```
+  root@sonic:~# sonic-clear counters
+  ```
 
 **show interfaces description**
 
@@ -2073,22 +2077,32 @@ NOTE: In versions until 201811, syntax is "config interface <interface_name> sta
 
 
 
-**config interface speed <interface_name> (for 201904+ version)**
-**config interface <interface_name> speed (for 201811- version)**
+**config interface speed <interface_name> (Versions >= 201904)**
+
+**config interface <interface_name> speed (Versions <= 201811)**
 
 This command is used to configure the speed for the Physical interface. Use the value 40000 for setting it to 40G and 100000 for 100G. Users need to know the device to configure it properly.
 Dynamic breakout feature is yet to be supported in SONiC and hence uses cannot configure any values other than 40G and 100G.
 
 - Usage:
-    config interface speed <interface_name> <speed_value>  (for 201904+ version)
-    config interface <interface_name> speed <speed_value>  (for 201811- version)
+  *Versions >= 201904*
+  ```
+  config interface speed <interface_name> <speed_value>
+  ```
+  *Versions <= 201811*
+  ```
+  config interface <interface_name> speed <speed_value>
+  ```
 
-- Example:
+- Example (Versions >= 201904):
   ```
   admin@sonic:~$ sudo config interface speed Ethernet63 40000
   ```
 
-NOTE: In versions until 201811, syntax is "config interface <interface_name> speed <4000>"
+- Example (Versions <= 201811):
+  ```
+  admin@sonic:~$ sudo config interface Ethernet63 speed 40000
+  ```
 
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#interface-configuration-and-show-commands)
@@ -2103,19 +2117,25 @@ Users can change the naming_mode using "config interface_naming_mode" command.
 **show interfce naming mode**
 This command displays the current interface naming mode
 
-  - Usage:
-    show interfaces naming_mode
+- Usage:
+  ```
+  show interfaces naming_mode
+  ```
 
-- Example:
+- Examples:
   ```
   admin@sonic:~$ show interfaces naming_mode
-  **default**
-  - "default" is the name of the default naming_mode since users have not modified it in this example.
-
-  Following example shows the modified interface_naming_mode
-  admin@sonic:~$ show interfaces naming_mode
-  **alias**
+  default
   ```
+
+  - "default" naming mode will display all SONiC interface names in 'show' commands and accept SONiC interface names as parameters in 'config commands
+
+  ```
+  admin@sonic:~$ show interfaces naming_mode
+  alias
+  ```
+
+  - "alias" naming mode will display all hardware vendor interface aliases in 'show' commands and accept hardware vendor interface aliases as parameters in 'config commands
 
 
 ## Interface naming mode config commands
@@ -2129,36 +2149,38 @@ The user must log out and log back in for changes to take effect. Note that the 
 
 NOTE: Some platforms do not support alias mapping. In such cases, this command is not applicable. Such platforms always use the same SONiC interface names.
 
-  - Usage:
-    config interface_naming_mode (default | alias)
+- Usage:
+  ```
+  config interface_naming_mode (default | alias)
+  ```
 
-  - Interface naming mode originally set to 'default'. Interfaces are referenced by default SONiC interface names:
+  - Interface naming mode is originally set to 'default'. Interfaces are referenced by default SONiC interface names:
 
 - Example:
   ```
-    admin@sonic:~$ show interfaces naming_mode
-    default
+  admin@sonic:~$ show interfaces naming_mode
+  default
 
-    admin@sonic:~$ show interface status Ethernet0
-      Interface     Lanes    Speed    MTU            Alias    Oper    Admin
-    -----------  --------  -------  -----   --------------  ------  -------
-      Ethernet0   101,102      40G   9100   fortyGigE1/1/1      up       up
+  admin@sonic:~$ show interface status Ethernet0
+    Interface     Lanes    Speed    MTU            Alias    Oper    Admin
+  -----------  --------  -------  -----   --------------  ------  -------
+    Ethernet0   101,102      40G   9100   fortyGigE1/1/1      up       up
 
-    admin@sonic:~$ sudo config interface_naming_mode alias
-    Please logout and log back in for changes take effect.
+  admin@sonic:~$ sudo config interface_naming_mode alias
+  Please logout and log back in for changes take effect.
   ```
 
-    - After user logs out and back in again, interfaces now referenced by hardware vendor aliases:
+  - After user logs out and logs back in again, interfaces will then referenced by hardware vendor aliases:
 
   ```
-    admin@sonic:~$ show interfaces naming_mode
-    alias
+  admin@sonic:~$ show interfaces naming_mode
+  alias
 
-    admin@sonic:~$ sudo config interface fortyGigE1/1/1 shutdown
-    admin@sonic:~$ show interface status fortyGigE1/1/1
-      Interface     Lanes    Speed    MTU            Alias    Oper    Admin
-    -----------  --------  -------  -----   --------------  ------  -------
-      Ethernet0   101,102      40G   9100   fortyGigE1/1/1    down     down
+  admin@sonic:~$ sudo config interface fortyGigE1/1/1 shutdown
+  admin@sonic:~$ show interface status fortyGigE1/1/1
+    Interface     Lanes    Speed    MTU            Alias    Oper    Admin
+  -----------  --------  -------  -----   --------------  ------  -------
+    Ethernet0   101,102      40G   9100   fortyGigE1/1/1    down     down
   ```
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Interface-Naming-Mode)
@@ -2179,9 +2201,10 @@ This sub-section explains the various IP protocol specific show commands that ar
 
 This command displays either all the route entries from the routing table or a specific route.
 
-  - Usage:
-    show ip route [\<ip_address\>]
-
+- Usage:
+  ```
+  show ip route [<ip_address>]
+  ```
 
 - Example:
   ```
@@ -2189,26 +2212,26 @@ This command displays either all the route entries from the routing table or a s
   Codes: K - kernel route, C - connected, S - static, R - RIP,
          O - OSPF, I - IS-IS, B - BGP, P - PIM, A - Babel,
          > - selected route, * - FIB route
-	S>* 0.0.0.0/0 [200/0] via 10.11.162.254, eth0
-	C>* 1.1.0.0/16 is directly connected, Vlan100
-	C>* 10.1.0.1/32 is directly connected, lo
-	C>* 10.1.0.32/32 is directly connected, lo
-	C>* 10.1.1.0/31 is directly connected, Ethernet112
-	C>* 10.1.1.2/31 is directly connected, Ethernet116
-	C>* 10.11.162.0/24 is directly connected, eth0
-	C>* 10.12.0.102/32 is directly connected, lo
-	C>* 127.0.0.0/8 is directly connected, lo
-	C>* 240.127.1.0/24 is directly connected, docker0
-
+  S>* 0.0.0.0/0 [200/0] via 10.11.162.254, eth0
+  C>* 1.1.0.0/16 is directly connected, Vlan100
+  C>* 10.1.0.1/32 is directly connected, lo
+  C>* 10.1.0.32/32 is directly connected, lo
+  C>* 10.1.1.0/31 is directly connected, Ethernet112
+  C>* 10.1.1.2/31 is directly connected, Ethernet116
+  C>* 10.11.162.0/24 is directly connected, eth0
+  C>* 10.12.0.102/32 is directly connected, lo
+  C>* 127.0.0.0/8 is directly connected, lo
+  C>* 240.127.1.0/24 is directly connected, docker0
   ```
- - Optionally, you can specify an IP address in order to display only routes to that particular IP address
+
+  - Optionally, you can specify an IP address in order to display only routes to that particular IP address
 
 - Example:
   ```
-	admin@sonic:~$ show ip route 10.1.1.0
-	Routing entry for 10.1.1.0/31
-	  Known via "connected", distance 0, metric 0, best
-	  * directly connected, Ethernet112
+  admin@sonic:~$ show ip route 10.1.1.0
+  Routing entry for 10.1.1.0/31
+    Known via "connected", distance 0, metric 0, best
+    * directly connected, Ethernet112
   ```
 
 **show ip interfaces**
@@ -2222,22 +2245,24 @@ The type of interfaces include the following.
 5) docker interface and
 6) management interface
 
-  - Usage:
-    show ip interfaces
+- Usage:
+  ```
+  show ip interfaces
+  ```
 
 - Example:
   ```
-	admin@sonic:~$ show ip interfaces
-	Interface      IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
-	-------------  -------------------  ------------  --------------  -------------
-	PortChannel01  10.0.0.56/31         up/down       DEVICE1         10.0.0.57
-	PortChannel02  10.0.0.58/31         up/down       DEVICE2         10.0.0.59
-	PortChannel03  10.0.0.60/31         up/down       DEVICE3         10.0.0.61
-	PortChannel04  10.0.0.62/31         up/down       DEVICE4         10.0.0.63
-	Vlan1000       192.168.0.1/27       up/up         N/A             N/A
-	docker0        240.127.1.1/24       up/down       N/A             N/A
-	eth0           10.3.147.252/23      up/up         N/A             N/A
-	lo             127.0.0.1/8          up/up         N/A             N/A
+  admin@sonic:~$ show ip interfaces
+  Interface      IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
+  -------------  -------------------  ------------  --------------  -------------
+  PortChannel01  10.0.0.56/31         up/down       DEVICE1         10.0.0.57
+  PortChannel02  10.0.0.58/31         up/down       DEVICE2         10.0.0.59
+  PortChannel03  10.0.0.60/31         up/down       DEVICE3         10.0.0.61
+  PortChannel04  10.0.0.62/31         up/down       DEVICE4         10.0.0.63
+  Vlan1000       192.168.0.1/27       up/up         N/A             N/A
+  docker0        240.127.1.1/24       up/down       N/A             N/A
+  eth0           10.3.147.252/23      up/up         N/A             N/A
+  lo             127.0.0.1/8          up/up         N/A             N/A
   ```
 
 **show ip protocol**
@@ -2245,30 +2270,31 @@ The type of interfaces include the following.
 This command displays the route-map that is configured for the routing protocol.
 Refer the routing stack [Quagga Command Reference](https://www.quagga.net/docs/quagga.pdf) or [FRR Command Reference](https://buildmedia.readthedocs.org/media/pdf/frrouting/latest/frrouting.pdf) to know more about this command.
 
-  - Usage:
-    show ip protocol
-
+- Usage:
+  ```
+  show ip protocol
+  ```
 
 - Example:
   ```
-	show ip protocol
-	Protocol    : route-map
-	------------------------
-	system      : none
-	kernel      : none
-	connected   : none
-	static      : none
-	rip         : none
-	ripng       : none
-	ospf        : none
-	ospf6       : none
-	isis        : none
-	bgp         : RM_SET_SRC
-	pim         : none
-	hsls        : none
-	olsr        : none
-	babel       : none
-	any         : none
+  show ip protocol
+  Protocol    : route-map
+  ------------------------
+  system      : none
+  kernel      : none
+  connected   : none
+  static      : none
+  rip         : none
+  ripng       : none
+  ospf        : none
+  ospf6       : none
+  isis        : none
+  bgp         : RM_SET_SRC
+  pim         : none
+  hsls        : none
+  olsr        : none
+  babel       : none
+  any         : none
   ```
 
 ## IPv6 show commands
@@ -2283,29 +2309,30 @@ This sub-section explains the various IPv6 protocol specific show commands that 
 
 This command displays either all the IPv6 route entries from the routing table or a specific IPv6 route.
 
-  - Usage:
-    show ipv6 route [\<ipv6_address\>]
-
+- Usage:
+  ```
+  show ipv6 route [<ipv6_address>]
+  ```
 
 - Example:
   ```
   admin@sonic:~$ show ipv6 route
-	Codes: K - kernel route, C - connected, S - static, R - RIPng,
-		   O - OSPFv6, I - IS-IS, B - BGP, A - Babel,
-		   > - selected route, * - FIB route
+  Codes: K - kernel route, C - connected, S - static, R - RIPng,
+         O - OSPFv6, I - IS-IS, B - BGP, A - Babel,
+         > - selected route, * - FIB route
 
-	C>* ::1/128 is directly connected, lo
-	C>* 2018:2001::/126 is directly connected, Ethernet112
-	C>* 2018:2002::/126 is directly connected, Ethernet116
-	C>* fc00:1::32/128 is directly connected, lo
-	C>* fc00:1::102/128 is directly connected, lo
-	C>* fc00:2::102/128 is directly connected, eth0
-	C * fe80::/64 is directly connected, Vlan100
-	C * fe80::/64 is directly connected, Ethernet112
-	C * fe80::/64 is directly connected, Ethernet116
-	C * fe80::/64 is directly connected, Bridge
-	C * fe80::/64 is directly connected, PortChannel0011
-	C>* fe80::/64 is directly connected, eth0
+  C>* ::1/128 is directly connected, lo
+  C>* 2018:2001::/126 is directly connected, Ethernet112
+  C>* 2018:2002::/126 is directly connected, Ethernet116
+  C>* fc00:1::32/128 is directly connected, lo
+  C>* fc00:1::102/128 is directly connected, lo
+  C>* fc00:2::102/128 is directly connected, eth0
+  C * fe80::/64 is directly connected, Vlan100
+  C * fe80::/64 is directly connected, Ethernet112
+  C * fe80::/64 is directly connected, Ethernet116
+  C * fe80::/64 is directly connected, Bridge
+  C * fe80::/64 is directly connected, PortChannel0011
+  C>* fe80::/64 is directly connected, eth0
 
   ```
  - Optionally, you can specify an IPv6 address in order to display only routes to that particular IPv6 address
@@ -2313,10 +2340,10 @@ This command displays either all the IPv6 route entries from the routing table o
 
 - Example:
   ```
-	admin@sonic:~$ show ipv6 route  fc00:1::32
-	Routing entry for fc00:1::32/128
-	  Known via "connected", distance 0, metric 0, best
-	  * directly connected, lo
+  admin@sonic:~$ show ipv6 route  fc00:1::32
+  Routing entry for fc00:1::32/128
+    Known via "connected", distance 0, metric 0, best
+    * directly connected, lo
   ```
 
 **show ipv6 interfaces**
@@ -2329,23 +2356,24 @@ The type of interfaces include the following.
 4) Loopback interfaces
 5) management interface
 
-  - Usage:
-    show ipv6 interfaces
-
+- Usage:
+  ```
+  show ipv6 interfaces
+  ```
 
 - Example:
   ```
-	admin@sonic:~$ show ipv6 interfaces
-	Interface      IPv6 address/mask                         Admin/Oper    BGP Neighbor    Neighbor IP
-	-------------  ----------------------------------------  ------------  --------------  -------------
-	Bridge         fe80::7c45:1dff:fe08:cdd%Bridge/64        up/up         N/A             N/A
-	PortChannel01  fc00::71/126                              up/down       DEVICE1         fc00::72
-	PortChannel02  fc00::75/126                              up/down       DEVICE2         fc00::76
-	PortChannel03  fc00::79/126                              up/down       DEVICE3         fc00::7a
-	PortChannel04  fc00::7d/126                              up/down       DEVICE4         fc00::7e
-	Vlan100        fe80::eef4:bbff:fefe:880a%Vlan100/64      up/up         N/A             N/A
-	eth0           fe80::eef4:bbff:fefe:880a%eth0/64         up/up         N/A             N/A
-	lo             fc00:1::32/128                            up/up         N/A             N/A
+  admin@sonic:~$ show ipv6 interfaces
+  Interface      IPv6 address/mask                         Admin/Oper    BGP Neighbor    Neighbor IP
+  -------------  ----------------------------------------  ------------  --------------  -------------
+  Bridge         fe80::7c45:1dff:fe08:cdd%Bridge/64        up/up         N/A             N/A
+  PortChannel01  fc00::71/126                              up/down       DEVICE1         fc00::72
+  PortChannel02  fc00::75/126                              up/down       DEVICE2         fc00::76
+  PortChannel03  fc00::79/126                              up/down       DEVICE3         fc00::7a
+  PortChannel04  fc00::7d/126                              up/down       DEVICE4         fc00::7e
+  Vlan100        fe80::eef4:bbff:fefe:880a%Vlan100/64      up/up         N/A             N/A
+  eth0           fe80::eef4:bbff:fefe:880a%eth0/64         up/up         N/A             N/A
+  lo             fc00:1::32/128                            up/up         N/A             N/A
   ```
 
 **show ipv6 protocol**
@@ -2354,30 +2382,31 @@ This command displays the route-map that is configured for the IPv6 routing prot
 Refer the routing stack [Quagga Command Reference](https://www.quagga.net/docs/quagga.pdf) or [FRR Command Reference](https://buildmedia.readthedocs.org/media/pdf/frrouting/latest/frrouting.pdf) to know more about this command.
 
 
-  - Usage:
-    show ipv6 protocol
-
+- Usage:
+  ```
+  show ipv6 protocol
+  ```
 
 - Example:
   ```
-	show ipv6 protocol
-	Protocol    : route-map
-	------------------------
-	system      : none
-	kernel      : none
-	connected   : none
-	static      : none
-	rip         : none
-	ripng       : none
-	ospf        : none
-	ospf6       : none
-	isis        : none
-	bgp         : RM_SET_SRC6
-	pim         : none
-	hsls        : none
-	olsr        : none
-	babel       : none
-	any         : none
+  admin@sonic:~$ show ipv6 protocol
+  Protocol    : route-map
+  ------------------------
+  system      : none
+  kernel      : none
+  connected   : none
+  static      : none
+  rip         : none
+  ripng       : none
+  ospf        : none
+  ospf6       : none
+  isis        : none
+  bgp         : RM_SET_SRC6
+  pim         : none
+  hsls        : none
+  olsr        : none
+  babel       : none
+  any         : none
   ```
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#IP)
@@ -2391,93 +2420,93 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 
 This command displays the brief summary of all LLDP neighbors.
 
-  - Usage:
-    show lldp table
-
+- Usage:
+  ```
+  show lldp table
+  ```
 
 - Example:
   ```
-	admin@sonic:~$ show lldp table
-	Capability codes: (R) Router, (B) Bridge, (O) Other
-	LocalPort    RemoteDevice       RemotePortID         Capability    RemotePortDescr
-	-----------  -----------------  -------------------  ------------  --------------------
-	Ethernet112  T1-1               hundredGigE1/2       BR            T0-2:hundredGigE1/29
-	Ethernet116  T1-2               hundredGigE1/2       BR            T0-2:hundredGigE1/30
-	eth0         swtor-b2lab2-1610  GigabitEthernet 0/2  OBR
-	--------------------------------------------------
-	Total entries displayed:  3
+  admin@sonic:~$ show lldp table
+  Capability codes: (R) Router, (B) Bridge, (O) Other
+  LocalPort    RemoteDevice       RemotePortID         Capability    RemotePortDescr
+  -----------  -----------------  -------------------  ------------  --------------------
+  Ethernet112  T1-1               hundredGigE1/2       BR            T0-2:hundredGigE1/29
+  Ethernet116  T1-2               hundredGigE1/2       BR            T0-2:hundredGigE1/30
+  eth0         swtor-b2lab2-1610  GigabitEthernet 0/2  OBR
+  --------------------------------------------------
+  Total entries displayed:  3
   ```
 
 **show lldp neighbors**
 
 This command displays more details about all LLDP neighbors or only the neighbors connected to a specific interface.
 
-  - Usage:
-    show lldp neighbors [INTERFACENAME]
-
+- Usage:
+  ```
+  show lldp neighbors <interface_name>
+  ```
 
 - Example1: To display all neighbors in all interfaces
   ```
-	admin@sonic:~$ show lldp neighbors
-	-------------------------------------------------------------------------------
-	LLDP neighbors:
-	-------------------------------------------------------------------------------
-	Interface:    eth0, via: LLDP, RID: 1, Time: 0 day, 12:21:21
-	  Chassis:
-		ChassisID:    mac 00:01:e8:81:e3:45
-		SysName:      swtor-b2lab2-1610
-		SysDescr:     Dell Force10 Networks Real Time Operating System Software. Dell Force10 Operating System Version: 1.0. Dell Force10 Application Software Version: 8.3.3.10d. Copyright (c) 1999-2012 by Dell Inc. All Rights Reserved.Build Time: Tue Sep 22 11:21:54 PDT 2015
-		TTL:          20
-		Capability:   Repeater, on
-		Capability:   Bridge, on
-		Capability:   Router, on
-	  Port:
-		PortID:       ifname GigabitEthernet 0/2
-	  VLAN:         162, pvid: yes
-	-------------------------------------------------------------------------------
-	Interface:    Ethernet116, via: LLDP, RID: 3, Time: 0 day, 12:20:49
-	  Chassis:
-		ChassisID:    mac 4c:76:25:e7:f0:c0
-		SysName:      T1-2
-		SysDescr:     Debian GNU/Linux 8 (jessie) Linux 4.9.0-8-amd64 #1 SMP Debian 4.9.110-3+deb9u6 (2015-12-19) x86_64
-		TTL:          120
-		MgmtIP:       10.11.162.40
-		Capability:   Bridge, on
-		Capability:   Router, on
-		Capability:   Wlan, off
-		Capability:   Station, off
-	  Port:
-		PortID:       local hundredGigE1/2
-		PortDescr:    T0-2:hundredGigE1/30
-	-------------------------------------------------------------------------------
+  admin@sonic:~$ show lldp neighbors
+  -------------------------------------------------------------------------------
+  LLDP neighbors:
+  -------------------------------------------------------------------------------
+  Interface:    eth0, via: LLDP, RID: 1, Time: 0 day, 12:21:21
+    Chassis:
+      ChassisID:    mac 00:01:e8:81:e3:45
+      SysName:      swtor-b2lab2-1610
+      SysDescr:     Dell Force10 Networks Real Time Operating System Software. Dell Force10 Operating System Version: 1.0. Dell Force10 Application Software Version: 8.3.3.10d. Copyright (c) 1999-2012 by Dell Inc. All Rights Reserved.Build Time: Tue Sep 22 11:21:54 PDT 2015
+      TTL:          20
+      Capability:   Repeater, on
+      Capability:   Bridge, on
+      Capability:   Router, on
+    Port:
+      PortID:       ifname GigabitEthernet 0/2
+    VLAN:         162, pvid: yes
+  -------------------------------------------------------------------------------
+  Interface:    Ethernet116, via: LLDP, RID: 3, Time: 0 day, 12:20:49
+    Chassis:
+      ChassisID:    mac 4c:76:25:e7:f0:c0
+      SysName:      T1-2
+      SysDescr:     Debian GNU/Linux 8 (jessie) Linux 4.9.0-8-amd64 #1 SMP Debian 4.9.110-3+deb9u6 (2015-12-19) x86_64
+      TTL:          120
+      MgmtIP:       10.11.162.40
+      Capability:   Bridge, on
+      Capability:   Router, on
+      Capability:   Wlan, off
+      Capability:   Station, off
+    Port:
+      PortID:       local hundredGigE1/2
+      PortDescr:    T0-2:hundredGigE1/30
+  -------------------------------------------------------------------------------
   ```
 
-
-  - Optionally, you can specify an interface name in order to display only that particular interface
+Optionally, you can specify an interface name in order to display only that particular interface
 
 - Example2:
   ```
   admin@sonic:~$ show lldp neighbors Ethernet112
-	show lldp neighbors Ethernet112
-	-------------------------------------------------------------------------------
-	LLDP neighbors:
-	-------------------------------------------------------------------------------
-	Interface:    Ethernet112, via: LLDP, RID: 2, Time: 0 day, 19:24:17
-	  Chassis:
-		ChassisID:    mac 4c:76:25:e5:e6:c0
-		SysName:      T1-1
-		SysDescr:     Debian GNU/Linux 8 (jessie) Linux 4.9.0-8-amd64 #1 SMP Debian 4.9.110-3+deb9u6 (2015-12-19) x86_64
-		TTL:          120
-		MgmtIP:       10.11.162.41
-		Capability:   Bridge, on
-		Capability:   Router, on
-		Capability:   Wlan, off
-		Capability:   Station, off
-	  Port:
-		PortID:       local hundredGigE1/2
-		PortDescr:    T0-2:hundredGigE1/29
-	-------------------------------------------------------------------------------
-
+  show lldp neighbors Ethernet112
+  -------------------------------------------------------------------------------
+  LLDP neighbors:
+  -------------------------------------------------------------------------------
+  Interface:    Ethernet112, via: LLDP, RID: 2, Time: 0 day, 19:24:17
+    Chassis:
+      ChassisID:    mac 4c:76:25:e5:e6:c0
+      SysName:      T1-1
+      SysDescr:     Debian GNU/Linux 8 (jessie) Linux 4.9.0-8-amd64 #1 SMP Debian 4.9.110-3+deb9u6 (2015-12-19) x86_64
+      TTL:          120
+      MgmtIP:       10.11.162.41
+      Capability:   Bridge, on
+      Capability:   Router, on
+      Capability:   Wlan, off
+      Capability:   Station, off
+    Port:
+      PortID:       local hundredGigE1/2
+      PortDescr:    T0-2:hundredGigE1/29
+  -------------------------------------------------------------------------------
   ```
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#LLDP)
 
@@ -2499,17 +2528,18 @@ If the config present in the input file matches (when key matches) with the runn
 When user specifies the optional argument "-y" or "--yes", this command forces the loading without prompting the user for confirmation.
 If the argument is not specified, it prompts the user to confirm whether user really wants to load this configuration file.
 
-  - Usage:
-    config load [OPTIONS] [FILENAME]
-    OPTIONS : -y, --yes
+- Usage:
+  ```
+  config load [-y|--yes] [<filename>]
+  ```
 
 - Example:
-   ```
-   root@T1-2:~# config load
-	Load config from the file /etc/sonic/config_db.json? [y/N]: y
-	Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/config_db.json --write-to-db
-	root@T1-2:~#
-   ```
+  ```
+  root@T1-2:~# config load
+  Load config from the file /etc/sonic/config_db.json? [y/N]: y
+  Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/config_db.json --write-to-db
+  root@T1-2:~#
+  ```
 
 ## Load_mgmt_config command
 
@@ -2520,17 +2550,18 @@ If the file does not exist or if the file does not have valid fields for "hostna
 When user specifies the optional argument "-y" or "--yes", this command forces the loading without prompting the user for confirmation.
 If the argument is not specified, it prompts the user to confirm whether user really wants to load this configuration file.
 
-  - Usage:
-    config load_mgmt_config [OPTIONS] [FILENAME]
-    OPTIONS : -y, --yes
+- Usage:
+  ```
+  config load_mgmt_config [-y|--yes] [<filename>]
+  ```
 
 - Example:
-   ```
-   root@T1-2:~# config load_mgmt_config
-	Reload config from minigraph? [y/N]: y
-	Running command: /usr/local/bin/sonic-cfggen -M /etc/sonic/device_desc.xml --write-to-db
-	root@T1-2:~#
-   ```
+  ```
+  root@T1-2:~# config load_mgmt_config
+  Reload config from minigraph? [y/N]: y
+  Running command: /usr/local/bin/sonic-cfggen -M /etc/sonic/device_desc.xml --write-to-db
+  root@T1-2:~#
+  ```
 
 
 ## Load_minigraph config command
@@ -2545,17 +2576,18 @@ NOTE: Management interface IP address and default route (or specific route) may 
 When user specifies the optional argument "-y" or "--yes", this command forces the loading without prompting the user for confirmation.
 If the argument is not specified, it prompts the user to confirm whether user really wants to load this configuration file.
 
-  - Usage:
-    config load_minigraph [OPTIONS]
-    OPTIONS : -y, --yes
+- Usage:
+  ```
+  config load_minigraph [-y|--yes]
+  ```
 
 - Example:
-   ```
-   root@T1-2:~# config load_minigraph
-	Reload config from minigraph? [y/N]: y
-	Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/config_db.json --write-to-db
-	root@T1-2:~#
-   ```
+  ```
+  root@T1-2:~# config load_minigraph
+  Reload config from minigraph? [y/N]: y
+  Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/config_db.json --write-to-db
+  root@T1-2:~#
+  ```
 
 ## Reload config command
 
@@ -2578,44 +2610,51 @@ NOTE: Management interface IP address and default route (or specific route) may 
 When user specifies the optional argument "-y" or "--yes", this command forces the loading without prompting the user for confirmation.
 If the argument is not specified, it prompts the user to confirm whether user really wants to load this configuration file.
 
-  - Usage:
-    config reload [-y|--yes] [-l | --load-sysinfo] [FILENAME]
+- Usage:
+  ```
+  config reload [-y|--yes] [-l|--load-sysinfo] [<filename>]
+  ```
 
 - Example:
-   ```
-   root@T1-2:~# config reload
-	Clear current config and reload config from the file /etc/sonic/config_db.json? [y/N]: y
-	Running command: systemctl stop dhcp_relay
-	Running command: systemctl stop swss
-	Running command: systemctl stop snmp
-	Warning: Stopping snmp.service, but it can still be activated by:
-	  snmp.timer
-	Running command: systemctl stop lldp
-	Running command: systemctl stop pmon
-	Running command: systemctl stop bgp
-	Running command: systemctl stop teamd
-	Running command: /usr/local/bin/sonic-cfggen -H -k Force10-Z9100-C32 --write-to-db
-	Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/config_db.json --write-to-db
-	Running command: systemctl restart hostname-config
-	Running command: systemctl restart interfaces-config
-	Timeout, server 10.11.162.42 not responding.
-	root@T1-2:~#
-   ```
+  ```
+  root@T1-2:~# config reload
+  Clear current config and reload config from the file /etc/sonic/config_db.json? [y/N]: y
+  Running command: systemctl stop dhcp_relay
+  Running command: systemctl stop swss
+  Running command: systemctl stop snmp
+  Warning: Stopping snmp.service, but it can still be activated by:
+    snmp.timer
+  Running command: systemctl stop lldp
+  Running command: systemctl stop pmon
+  Running command: systemctl stop bgp
+  Running command: systemctl stop teamd
+  Running command: /usr/local/bin/sonic-cfggen -H -k Force10-Z9100-C32 --write-to-db
+  Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/config_db.json --write-to-db
+  Running command: systemctl restart hostname-config
+  Running command: systemctl restart interfaces-config
+  Timeout, server 10.11.162.42 not responding.
+  root@T1-2:~#
+  ```
 
-## Save config  command
+## Save config command
 
 This command is to save the config DB configuration into the user-specified filename or into the default /etc/sonic/config_db.json. This saves the configuration into the disk which is available even after reboots.
 Saved file can be transferred to remote machines for debugging. If users wants to load the configuration from this new file at any point of time, they can use "config load" command and provide this newly generated file as input. If users wants this newly generated file to be used during reboot, they need to copy this file to /etc/sonic/config_db.json.
 
-  - Usage:
-    config save [OPTIONS] [FILENAME]
-	OPTIONS : -y, --yes
+- Usage:
+  ```
+  config save [-y|--yes] [<filename>]
+  ```
 
-- Example:
-   ```
-   root@T1-2:~# config save -y /etc/sonic/config2.json - this saves to the filename specified.
-   root@T1-2:~# config save -y - this saves to /etc/sonic/config_db.json.
-   ```
+- Example (Save configuration to /etc/sonic/config_db.json):
+  ```
+  root@T1-2:~# config save -y
+  ```
+
+- Example (Save configuration to a specified file):
+  ```
+  root@T1-2:~# config save -y /etc/sonic/config2.json
+  ```
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#loading-reloading-and-saving-configuration)
 
@@ -2629,8 +2668,9 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 This command displays all the mirror sessions that are configured.
 
 - Usage:
+  ```
   show mirror_session
-
+  ```
 
 - Example:
   ```
@@ -2653,19 +2693,19 @@ While adding a new session, users need to configure the following fields that ar
 5) optional - GRE Type in case if user wants to send the packet via GRE tunnel. GRE type could be anything; it could also be left as empty; by default, it is 0x8949 for Mellanox; and 0x88be for the rest of the chips.
 6) optional - Queue in which packets shall be sent out of the device. Valid values 0 to 7 for most of the devices. Users need to know their device and the number of queues supported in that device.
 
-  - Usage:
-    config mirror_session add <session_name> <src_ip> <dst_ip>
-                                 <dscp> <ttl> [gre_type] [queue]
+- Usage:
+  ```
+  config mirror_session add <session_name> <src_ip> <dst_ip> <dscp> <ttl> [gre_type] [queue]
+  ```
 
 - Example:
   ```
-	root@T1-2:~# config mirror_session add mrr_abcd 1.2.3.4 20.21.22.23 8 100 0x6558 0
-	root@T1-2:~# show mirror_session
-	Name       Status    SRC IP       DST IP       GRE     DSCP    TTL    Queue
-	---------  --------  -----------  -----------  ------  ------  -----  -------
-	mrr_abcd   inactive  1.2.3.4      20.21.22.23  0x6558  8       100    0
-	root@T1-2:~#
-
+  root@T1-2:~# config mirror_session add mrr_abcd 1.2.3.4 20.21.22.23 8 100 0x6558 0
+  root@T1-2:~# show mirror_session
+  Name       Status    SRC IP       DST IP       GRE     DSCP    TTL    Queue
+  ---------  --------  -----------  -----------  ------  ------  -----  -------
+  mrr_abcd   inactive  1.2.3.4      20.21.22.23  0x6558  8       100    0
+  root@T1-2:~#
   ```
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Mirroring-Configuration-And-Show)
@@ -2679,17 +2719,18 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 
 This command displays a list of NTP peers known to the server as well as a summary of their state.
 
-  - Usage:
-    show ntp
-
+- Usage:
+  ```
+  show ntp
+  ```
 
 - Example:
   ```
   admin@sonic:~$ show ntp
-		 remote           refid      st t when poll reach   delay   offset  jitter
-	==============================================================================
-	 23.92.29.245    .XFAC.          16 u    - 1024    0    0.000    0.000   0.000
-	*204.2.134.164   46.233.231.73    2 u  916 1024  377    3.079    0.394   0.128
+       remote           refid      st t when poll reach   delay   offset  jitter
+  ==============================================================================
+   23.92.29.245    .XFAC.          16 u    - 1024    0    0.000    0.000   0.000
+  *204.2.134.164   46.233.231.73    2 u  916 1024  377    3.079    0.394   0.128
   ```
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#NTP)
@@ -2703,9 +2744,10 @@ There are few commands that are platform specific. Mellanox has used this featur
 
 This command shows the SDK sniffer status
 
-  - Usage:
-    show platform mlnx sniffer
-
+- Usage:
+  ```
+  show platform mlnx sniffer
+  ```
 
 - Example:
   ```
@@ -2718,11 +2760,12 @@ This command shows the SDK sniffer status
 Another show command available on ‘show platform mlnx’ which is the issu status.
 This means if ISSU is enabled on this SKU or not. A warm boot command can be executed only when ISSU is enabled on the SKU.
 
-  - Usage:
-    show platform mlnx issu
+- Usage:
+  ```
+  show platform mlnx issu
+  ```
 
-
-  - Example:
+- Example:
   ```
   admin@arc-switch1004:~$ show platform mlnx issu
   ISSU is enabled
@@ -2730,12 +2773,12 @@ This means if ISSU is enabled on this SKU or not. A warm boot command can be exe
 
 In the case ISSU is disabled and warm-boot is called, the user will get a notification message explaining that the command cannot be invoked.
 
-Example:
-```
-admin@arc-switch1038:~$ sudo warm-reboot
-ISSU is not enabled on this HWSKU
-Warm reboot is not supported
-```
+- Example:
+  ```
+  admin@arc-switch1038:~$ sudo warm-reboot
+  ISSU is not enabled on this HWSKU
+  Warm reboot is not supported
+  ```
 
 **config platform mlnx**
 This command is valid only on mellanox devices. The sub-commands for "config platform" gets populated only on mellanox platforms.
@@ -2751,13 +2794,12 @@ Once SDK sniffer is enabled/disabled, the user is requested to approve that swss
 For example: To change SDK sniffer status, swss service will be restarted, continue? [y/N]:
 In order to avoid that confirmation the -y / --yes option should be used.
 
-  - Usage:
-    config platform mlnx sniffer sdk [OPTIONS] OPTION
-    Options:
-    -y, --yes
-    --help     Show this message and exit.
+- Usage:
+  ```
+  config platform mlnx sniffer sdk [-y|--yes]
+  ```
 
-  - Example:
+- Example:
   ```
   admin@arc-switch1038:~$ config platform mlnx sniffer sdk
   To change SDK sniffer status, swss service will be restarted, continue? [y/N]: y
@@ -2772,8 +2814,10 @@ In order to avoid that confirmation the -y / --yes option should be used.
 
 This command displays all the port channels that are configured in the device and its current status.
 
-  - Usage:
-    show interfaces portchannel
+- Usage:
+  ```
+  show interfaces portchannel
+  ```
 
 - Example:
   ```
@@ -2806,26 +2850,28 @@ Command takes two optional arguements given below.
 1) min-links  - minimum number of links required to bring up the portchannel
 2) fallback - true/false. LACP fallback feature can be enabled / disabled.  When it is set to true, only one member port will be selected as active per portchannel during fallback mode. Refer https://github.com/Azure/SONiC/blob/master/doc/lag/LACP%20Fallback%20Feature%20for%20SONiC_v0.5.md for more details about fallback feature.
 
-  - Usage:
-    config portchannel add/del <portchannel_name> [min-links INTEGER] [fallback true/false]
+- Usage:
+  ```
+  config portchannel (add | del) <portchannel_name> [min-links <num_min_links>] [fallback (true | false)]
+  ```
 
-- Example:
+- Example (Create the portchannel with name "PortChannel0011"):
   ```
   admin@sonic:~$ sudo config portchannel add PortChannel0011
-  This command will create the portchannel with name "PortChannel0011".
   ```
 
 **config portchannel member add/del <portchannel_name> <member_portname>**
 
-This command is to add or delete a member port into the already created portchannel.
+This command adds or deletes a member port to/from the already created portchannel.
 
-  - Usage:
-    config portchannel member add/del <portchannel_name> <member_portname>
+- Usage:
+  ```
+  config portchannel member (add | del) <portchannel_name> <member_portname>
+  ```
 
-- Example:
+- Example (Add interface Ethernet4 as member of the portchannel "PortChannel0011"):
   ```
   admin@sonic:~$ sudo config portchannel member add PortChannel0011 Ethernet4
-  This command will add Ethernet4 as member of the portchannel "PortChannel0011".
   ```
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#PortChannel-Configuration-And-Show)
@@ -2839,8 +2885,10 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 **show pfc counters**
 This command displays the details of Rx & Tx priority-flow-control (pfc) for all ports. This command can be used to clear the counters using -c option.
 
-  - Usage:
-    show pfc counters [-c or --clear]
+- Usage:
+  ```
+  show pfc counters
+  ```
 
 - Example:
    ```
@@ -2858,7 +2906,15 @@ This command displays the details of Rx & Tx priority-flow-control (pfc) for all
     Ethernet4       0       0       0       0       0       0       0       0
     Ethernet8       0       0       0       0       0       0       0       0
    Ethernet12       0       0       0       0       0       0       0       0
+
+   ...
    ```
+
+
+- NOTE: PFC counters can be cleared by the user with the following command:
+  ```
+  root@sonic:~# sonic-clear pfccounters
+  ```
 
 ### Queue And Priority-Group
 
@@ -2874,73 +2930,83 @@ This sub-section explains the following queue parameters that can be displayed u
 This command displays packet and byte counters for all queues of all ports or one specific-port given as arguement.
 This command can be used to clear the counters for all queues of all ports. Note that port specific clear is not supported.
 
-  - Usage:
-    show queue counters [-c or --clear] [<interface-name>]
+- Usage:
+  ```
+  show queue counters [<interface_name>]
+  ```
 
 - Example:
   ```
-    This example gives the sample output from two ports Ethernet0 and Ethernet4.
+  admin@sonic:~$ show queue counters
+       Port    TxQ    Counter/pkts    Counter/bytes    Drop/pkts    Drop/bytes
+  ---------  -----  --------------  ---------------  -----------  ------------
+  Ethernet0    UC0               0                0            0             0
+  Ethernet0    UC1               0                0            0             0
+  Ethernet0    UC2               0                0            0             0
+  Ethernet0    UC3               0                0            0             0
+  Ethernet0    UC4               0                0            0             0
+  Ethernet0    UC5               0                0            0             0
+  Ethernet0    UC6               0                0            0             0
+  Ethernet0    UC7               0                0            0             0
+  Ethernet0    UC8               0                0            0             0
+  Ethernet0    UC9               0                0            0             0
+  Ethernet0    MC0               0                0            0             0
+  Ethernet0    MC1               0                0            0             0
+  Ethernet0    MC2               0                0            0             0
+  Ethernet0    MC3               0                0            0             0
+  Ethernet0    MC4               0                0            0             0
+  Ethernet0    MC5               0                0            0             0
+  Ethernet0    MC6               0                0            0             0
+  Ethernet0    MC7               0                0            0             0
+  Ethernet0    MC8               0                0            0             0
+  Ethernet0    MC9               0                0            0             0
 
-    admin@sonic:~$ show queue counters
-         Port    TxQ    Counter/pkts    Counter/bytes    Drop/pkts    Drop/bytes
-    ---------  -----  --------------  ---------------  -----------  ------------
-    Ethernet0    UC0               0                0            0             0
-    Ethernet0    UC1               0                0            0             0
-    Ethernet0    UC2               0                0            0             0
-    Ethernet0    UC3               0                0            0             0
-    Ethernet0    UC4               0                0            0             0
-    Ethernet0    UC5               0                0            0             0
-    Ethernet0    UC6               0                0            0             0
-    Ethernet0    UC7               0                0            0             0
-    Ethernet0    UC8               0                0            0             0
-    Ethernet0    UC9               0                0            0             0
-    Ethernet0    MC0               0                0            0             0
-    Ethernet0    MC1               0                0            0             0
-    Ethernet0    MC2               0                0            0             0
-    Ethernet0    MC3               0                0            0             0
-    Ethernet0    MC4               0                0            0             0
-    Ethernet0    MC5               0                0            0             0
-    Ethernet0    MC6               0                0            0             0
-    Ethernet0    MC7               0                0            0             0
-    Ethernet0    MC8               0                0            0             0
-    Ethernet0    MC9               0                0            0             0
+       Port    TxQ    Counter/pkts    Counter/bytes    Drop/pkts    Drop/bytes
+  ---------  -----  --------------  ---------------  -----------  ------------
+  Ethernet4    UC0               0                0            0             0
+  Ethernet4    UC1               0                0            0             0
+  Ethernet4    UC2               0                0            0             0
+  Ethernet4    UC3               0                0            0             0
+  Ethernet4    UC4               0                0            0             0
+  Ethernet4    UC5               0                0            0             0
+  Ethernet4    UC6               0                0            0             0
+  Ethernet4    UC7               0                0            0             0
+  Ethernet4    UC8               0                0            0             0
+  Ethernet4    UC9               0                0            0             0
+  Ethernet4    MC0               0                0            0             0
+  Ethernet4    MC1               0                0            0             0
+  Ethernet4    MC2               0                0            0             0
+  Ethernet4    MC3               0                0            0             0
+  Ethernet4    MC4               0                0            0             0
+  Ethernet4    MC5               0                0            0             0
+  Ethernet4    MC6               0                0            0             0
+  Ethernet4    MC7               0                0            0             0
+  Ethernet4    MC8               0                0            0             0
+  Ethernet4    MC9               0                0            0             0
 
-         Port    TxQ    Counter/pkts    Counter/bytes    Drop/pkts    Drop/bytes
-    ---------  -----  --------------  ---------------  -----------  ------------
-    Ethernet4    UC0               0                0            0             0
-    Ethernet4    UC1               0                0            0             0
-    Ethernet4    UC2               0                0            0             0
-    Ethernet4    UC3               0                0            0             0
-    Ethernet4    UC4               0                0            0             0
-    Ethernet4    UC5               0                0            0             0
-    Ethernet4    UC6               0                0            0             0
-    Ethernet4    UC7               0                0            0             0
-    Ethernet4    UC8               0                0            0             0
-    Ethernet4    UC9               0                0            0             0
-    Ethernet4    MC0               0                0            0             0
-    Ethernet4    MC1               0                0            0             0
-    Ethernet4    MC2               0                0            0             0
-    Ethernet4    MC3               0                0            0             0
-    Ethernet4    MC4               0                0            0             0
-    Ethernet4    MC5               0                0            0             0
-    Ethernet4    MC6               0                0            0             0
-    Ethernet4    MC7               0                0            0             0
-    Ethernet4    MC8               0                0            0             0
-    Ethernet4    MC9               0                0            0             0
+  ...
   ```
-  - Optionally, you can specify an interface name in order to display only that particular interface
+
+Optionally, you can specify an interface name in order to display only that particular interface
 
 - Example:
   ```
   admin@sonic:~$ show queue counters Ethernet72
   ```
 
+- NOTE: Queue counters can be cleared by the user with the following command:
+  ```
+  root@sonic:~# sonic-clear queuecounters
+  ```
+
 **show queue watermark**
 
 This command displays the user watermark for the queues (Egress shared pool occupancy per queue) for either the unicast queues or multicast queues for all ports
 
-  - Usage:
-    show queue watermark <multicast|unicast>
+- Usage:
+  ```
+  show queue watermark (multicast | unicast)
+  ```
 
 - Example:
   ```
@@ -2960,8 +3026,10 @@ This command displays the user watermark for the queues (Egress shared pool occu
 **show priority-group watermark|persistent-watermark**
 This command displays the user watermark or persistent-watermark for the Ingress "headroom" or "shared pool occupancy" per priority-group for  all ports
 
-  - Usage:
-    show priority-group <watermark|persistent-watermark> <headroom|shared>
+- Usage:
+  ```
+  show priority-group (watermark | persistent-watermark) (headroom | shared)
+  ```
 
 - Example:
   ```
@@ -2973,10 +3041,21 @@ This command displays the user watermark or persistent-watermark for the Ingress
     Ethernet4      0      0      0      0      0      0      0      0
     Ethernet8      0      0      0      0      0      0      0      0
     Ethernet12     0      0      0      0      0      0      0      0
+  ```
 
-  admin@sonic:~$ show priority-group watermark headroom	(Ingress headroom per PG)
-  admin@sonic:~$ show priority-group persistent-watermark shared (Ingress shared pool occupancy per PG)
-  admin@sonic:~$ show priority-group persistent-watermark headroom (Ingress headroom per PG)
+- Example (Ingress headroom per PG):
+  ```
+  admin@sonic:~$ show priority-group watermark headroom
+  ```
+
+- Example (Ingress shared pool occupancy per PG):
+  ```
+  admin@sonic:~$ show priority-group persistent-watermark shared
+  ```
+
+- Example (Ingress headroom per PG):
+  ```
+  admin@sonic:~$ show priority-group persistent-watermark headroom
   ```
 
 In addition to user watermark("show queue|priority-group watermark ..."), a persistent watermark is available.
@@ -2984,8 +3063,11 @@ It hold values independently of user watermark. This way user can use "user wate
 
 **show queue persistent-watermark**
 This command displays the user persistet-watermark for the queues (Egress shared pool occupancy per queue) for either the unicast queues or multicast queues for all ports
-  - Usage:
-    show queue persistent-watermark <unicast|multicast>
+
+- Usage:
+  ```
+  show queue persistent-watermark (unicast | multicast)
+  ```
 
 - Example:
   ```
@@ -2997,12 +3079,15 @@ This command displays the user persistet-watermark for the queues (Egress shared
     Ethernet4    N/A    N/A    N/A    N/A    N/A    N/A    N/A    N/A
     Ethernet8    N/A    N/A    N/A    N/A    N/A    N/A    N/A    N/A
     Ethernet12   N/A    N/A    N/A    N/A    N/A    N/A    N/A    N/A
-
-  admin@sonic:~$ show queue persistent-watermark multicast (Egress shared pool occupancy per multicast queue)
-
   ```
 
-  Both "user watermark" and "persistent watermark" can be cleared by user:
+- Example (Egress shared pool occupancy per multicast queue):
+  ```
+  admin@sonic:~$ show queue persistent-watermark multicast
+  ```
+
+- NOTE: Both "user watermark" and "persistent watermark" can be cleared by user:
+
   ```
   root@sonic:~# sonic-clear queue persistent-watermark unicast
 
@@ -3035,13 +3120,14 @@ This command is used to clear all the QoS configuration from all the following Q
 13) BUFFER_PG,
 14) BUFFER_QUEUE
 
-   - Usage:
-     config qos clear
+- Usage:
+  ```
+   config qos clear
+  ```
 
 - Example:
   ```
   admin@sonic:~$ sudo config qos clear
-
   ```
 
 **config qos reload**
@@ -3074,19 +3160,21 @@ Some of the example QOS configurations that users can modify are given below.
 9) CABLE_LENGTH
 10) BUFFER_QUEUE
 
-   - Usage:
-     config qos reload
+- Usage:
+  ```
+  config qos reload
+  ```
 
 - Example:
   ```
-	root@T1-2:~# config qos reload
-	Running command: /usr/local/bin/sonic-cfggen -d -t /usr/share/sonic/device/x86_64-dell_z9100_c2538-r0/Force10-Z9100-C32/buffers.json.j2 >/tmp/buffers.json
-	Running command: /usr/local/bin/sonic-cfggen -d -t /usr/share/sonic/device/x86_64-dell_z9100_c2538-r0/Force10-Z9100-C32/qos.json.j2 -y /etc/sonic/sonic_version.yml >/tmp/qos.json
-	Running command: /usr/local/bin/sonic-cfggen -j /tmp/buffers.json --write-to-db
-	Running command: /usr/local/bin/sonic-cfggen -j /tmp/qos.json --write-to-db
-	root@T1-2:~#
-	In this example, it uses the buffers.json.j2 file and qos.json.j2 file from platform specific folders.
-	When there are no changes in the platform specific configutation files, they internally use the file "/usr/share/sonic/templates/buffers_config.j2" and "/usr/share/sonic/templates/qos_config.j2" to generate the configuration.
+  root@T1-2:~# config qos reload
+  Running command: /usr/local/bin/sonic-cfggen -d -t /usr/share/sonic/device/x86_64-dell_z9100_c2538-r0/Force10-Z9100-C32/buffers.json.j2 >/tmp/buffers.json
+  Running command: /usr/local/bin/sonic-cfggen -d -t /usr/share/sonic/device/x86_64-dell_z9100_c2538-r0/Force10-Z9100-C32/qos.json.j2 -y /etc/sonic/sonic_version.yml >/tmp/qos.json
+  Running command: /usr/local/bin/sonic-cfggen -j /tmp/buffers.json --write-to-db
+  Running command: /usr/local/bin/sonic-cfggen -j /tmp/qos.json --write-to-db
+  root@T1-2:~#
+  In this example, it uses the buffers.json.j2 file and qos.json.j2 file from platform specific folders.
+  When there are no changes in the platform specific configutation files, they internally use the file "/usr/share/sonic/templates/buffers_config.j2" and "/usr/share/sonic/templates/qos_config.j2" to generate the configuration.
   ```
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#QoS-Configuration-And-Show)
@@ -3100,39 +3188,40 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 
 This command is used to display the startup configuration for the BGP module.
 
-  - Usage:
-    show startupconfiguration bgp`
-
+- Usage:
+  ```
+  show startupconfiguration bgp`
+  ```
 
 - Example:
   ```
-	admin@sonic:~$ show startupconfiguration bgp
-	Routing-Stack is: quagga
-	!
-	! =========== Managed by sonic-cfggen DO NOT edit manually! ====================
-	! generated by templates/quagga/bgpd.conf.j2 with config DB data
-	! file: bgpd.conf
-	!
-	!
-	hostname T1-2
-	password zebra
-	log syslog informational
-	log facility local4
-	! enable password !
-	!
-	! bgp multiple-instance
-	!
-	route-map FROM_BGP_SPEAKER_V4 permit 10
-	!
-	route-map TO_BGP_SPEAKER_V4 deny 10
-	!
-	router bgp 65000
-	  bgp log-neighbor-changes
-	  bgp bestpath as-path multipath-relax
-	  no bgp default ipv4-unicast
-	  bgp graceful-restart restart-time 180
+  admin@sonic:~$ show startupconfiguration bgp
+  Routing-Stack is: quagga
+  !
+  ! =========== Managed by sonic-cfggen DO NOT edit manually! ====================
+  ! generated by templates/quagga/bgpd.conf.j2 with config DB data
+  ! file: bgpd.conf
+  !
+  !
+  hostname T1-2
+  password zebra
+  log syslog informational
+  log facility local4
+  ! enable password !
+  !
+  ! bgp multiple-instance
+  !
+  route-map FROM_BGP_SPEAKER_V4 permit 10
+  !
+  route-map TO_BGP_SPEAKER_V4 deny 10
+  !
+  router bgp 65000
+    bgp log-neighbor-changes
+    bgp bestpath as-path multipath-relax
+    no bgp default ipv4-unicast
+    bgp graceful-restart restart-time 180
 
-	  <Only the partial output is shown here. In actual command, more configuration information will be displayed>
+  <Only the partial output is shown here. In actual command, more configuration information will be displayed>
   ```
 
 ## Running Configuration command
@@ -3150,9 +3239,10 @@ This sub-section explains the show commands for displaying the running configura
 
 This command displays the entire running configuration.
 
-  - Usage:
-    show runningconfiguration all
-
+- Usage:
+  ```
+  show runningconfiguration all
+  ```
 
 - Example:
   ```
@@ -3163,9 +3253,10 @@ This command displays the entire running configuration.
 
 This command displays the running configuration of the BGP module.
 
-  - Usage:
-    show runningconfiguration bgp
-
+- Usage:
+  ```
+  show runningconfiguration bgp
+  ```
 
 - Example:
   ```
@@ -3176,9 +3267,10 @@ This command displays the running configuration of the BGP module.
 
 This command displays the running configuration for the "interfaces".
 
-  - Usage:
-    show runningconfiguration interfaces
-
+- Usage:
+  ```
+  show runningconfiguration interfaces
+  ```
 
 - Example:
   ```
@@ -3189,9 +3281,10 @@ This command displays the running configuration for the "interfaces".
 
 This command displays the running configuration of the ntp module.
 
-  - Usage:
-    show runningconfiguration ntp
-
+- Usage:
+  ```
+  show runningconfiguration ntp
+  ```
 
 - Example:
   ```
@@ -3204,15 +3297,16 @@ This command displays the running configuration of the ntp module.
 
 **show runningconfiguration syslog**
 
-This command displays the running configuration of the syslog module. 
+This command displays the running configuration of the syslog module.
 
-  - Usage:
-    show runningconfiguration syslog
-
+- Usage:
+  ```
+  show runningconfiguration syslog
+  ```
 
 - Example:
   ```
-  admin@str-s6000-acs-11:~$ show runningconfiguration syslog 
+  admin@str-s6000-acs-11:~$ show runningconfiguration syslog
   Syslog Servers
   ----------------
   4.4.4.4
@@ -3224,9 +3318,10 @@ This command displays the running configuration of the syslog module.
 
 This command displays the running configuration of the snmp module.
 
-  - Usage:
-    show runningconfiguration snmp
-
+- Usage:
+  ```
+  show runningconfiguration snmp
+  ```
 
 - Example:
   ```
@@ -3237,30 +3332,32 @@ This command displays the running configuration of the snmp module.
 
  This command displays the running configuration of the acls
 
-   - Usage:
-    show runningconfiguration acl
+- Usage:
+  ```
+  show runningconfiguration acl
+  ```
 
-
- - Example:
+- Example:
   ```
   admin@sonic:~$ show runningconfiguration acl
   ```
 
- **show runningconfiguration ports <portname>**
+ **show runningconfiguration ports**
 
  This command displays the running configuration of the ports
 
-   - Usage:
-    show runningconfiguration ports <portname>
+- Usage:
+  ```
+  show runningconfiguration ports [<portname>]
+  ```
 
-
- - Example:
+- Examples:
   ```
   admin@sonic:~$ show runningconfiguration ports
   ```
 
-   ```
-  admin@sonic:~$ show runningconfiguration ports <portname>
+  ```
+  admin@sonic:~$ show runningconfiguration ports Ethernet0
   ```
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Startup--Running-Configuration)
@@ -3284,11 +3381,12 @@ This sub-section explains the various "processes" specific data that includes th
 
 This command displays the current CPU usage by process. This command uses linux's "top -bn 1 -o %CPU" command to display the output.
 
-  - Usage:
-    show processes cpu
+- Usage:
+  ```
+  show processes cpu
+  ```
 
-	NOTE that pipe option can be used using " | head -n" to display only the "n" number of lines.
-
+*NOTE that pipe option can be used using " | head -n" to display only the "n" number of lines*
 
 - Example:
   ```
@@ -3307,43 +3405,45 @@ This command displays the current CPU usage by process. This command uses linux'
       2 root      20   0       0      0      0 S   0.0  0.0   0:00.00 kthreadd
       3 root      20   0       0      0      0 S   0.0  0.0   0:00.56 ksoftirqd/0
       5 root       0 -20       0      0      0 S   0.0  0.0   0:00.00 kworker/0:0H
+  ...
   ```
 
 **show processes memory**
 
 This command displays the current memory usage by processes. This command uses linux's "top -bn 1 -o %MEM" command to display the output.
 
-  - Usage:
-    show processes memory
+- Usage:
+  ```
+  show processes memory
+  ```
 
-	NOTE that pipe option can be used using " | head -n" to display only the "n" number of lines.
-
+*NOTE that pipe option can be used using " | head -n" to display only the "n" number of lines*
 
 - Example:
   ```
-	admin@SONiC:~$  show processes memory
-	top - 23:41:24 up 7 days, 39 min,  2 users,  load average: 1.21, 1.19, 1.18
-	Tasks: 191 total,   2 running, 189 sleeping,   0 stopped,   0 zombie
-	%Cpu(s):  2.8 us, 20.7 sy,  0.0 ni, 76.3 id,  0.0 wa,  0.0 hi,  0.2 si,  0.0 st
-	KiB Mem :  8162264 total,  5720412 free,   945516 used,  1496336 buff/cache
-	KiB Swap:        0 total,        0 free,        0 used.  6855632 avail Mem
+  admin@SONiC:~$  show processes memory
+  top - 23:41:24 up 7 days, 39 min,  2 users,  load average: 1.21, 1.19, 1.18
+  Tasks: 191 total,   2 running, 189 sleeping,   0 stopped,   0 zombie
+  %Cpu(s):  2.8 us, 20.7 sy,  0.0 ni, 76.3 id,  0.0 wa,  0.0 hi,  0.2 si,  0.0 st
+  KiB Mem :  8162264 total,  5720412 free,   945516 used,  1496336 buff/cache
+  KiB Swap:        0 total,        0 free,        0 used.  6855632 avail Mem
 
-	  PID USER      PR  NI    VIRT    RES    SHR S  %CPU %MEM     TIME+ COMMAND
-	18051 root      20   0  851540 274784   8344 S   0.0  3.4   0:02.77 syncd
-	17760 root      20   0 1293428 259212  58732 S   5.9  3.2  96:46.22 syncd
-	  508 root      20   0  725364  76244  38220 S   0.0  0.9   4:54.49 dockerd
-	30853 root      20   0   96348  56824   7880 S   0.0  0.7   0:00.98 show
-	17266 root      20   0  509876  49772  30640 S   0.0  0.6   0:06.36 docker
-	24891 admin     20   0  515864  49560  30644 S   0.0  0.6   0:05.54 docker
-	17643 admin     20   0  575668  49428  30628 S   0.0  0.6   0:06.29 docker
-	23885 admin     20   0  369552  49344  30840 S   0.0  0.6   0:05.57 docker
-	18055 root      20   0  509076  49260  30296 S   0.0  0.6   0:06.36 docker
-	17268 root      20   0  371120  49052  30372 S   0.0  0.6   0:06.45 docker
-	 1227 root      20   0  443284  48640  30100 S   0.0  0.6   0:41.91 docker
-	23785 admin     20   0  443796  48552  30128 S   0.0  0.6   0:05.58 docker
-	17820 admin     20   0  435088  48144  29480 S   0.0  0.6   0:06.33 docker
-	  506 root      20   0 1151040  43140  23964 S   0.0  0.5   8:51.08 containerd
-	18437 root      20   0   84852  26388   7380 S   0.0  0.3  65:59.76 python3.6
+    PID USER      PR  NI    VIRT    RES    SHR S  %CPU %MEM     TIME+ COMMAND
+  18051 root      20   0  851540 274784   8344 S   0.0  3.4   0:02.77 syncd
+  17760 root      20   0 1293428 259212  58732 S   5.9  3.2  96:46.22 syncd
+    508 root      20   0  725364  76244  38220 S   0.0  0.9   4:54.49 dockerd
+  30853 root      20   0   96348  56824   7880 S   0.0  0.7   0:00.98 show
+  17266 root      20   0  509876  49772  30640 S   0.0  0.6   0:06.36 docker
+  24891 admin     20   0  515864  49560  30644 S   0.0  0.6   0:05.54 docker
+  17643 admin     20   0  575668  49428  30628 S   0.0  0.6   0:06.29 docker
+  23885 admin     20   0  369552  49344  30840 S   0.0  0.6   0:05.57 docker
+  18055 root      20   0  509076  49260  30296 S   0.0  0.6   0:06.36 docker
+  17268 root      20   0  371120  49052  30372 S   0.0  0.6   0:06.45 docker
+   1227 root      20   0  443284  48640  30100 S   0.0  0.6   0:41.91 docker
+  23785 admin     20   0  443796  48552  30128 S   0.0  0.6   0:05.58 docker
+  17820 admin     20   0  435088  48144  29480 S   0.0  0.6   0:06.33 docker
+    506 root      20   0 1151040  43140  23964 S   0.0  0.5   8:51.08 containerd
+  18437 root      20   0   84852  26388   7380 S   0.0  0.3  65:59.76 python3.6
   ```
 
 
@@ -3351,18 +3451,20 @@ This command displays the current memory usage by processes. This command uses l
 
 This command displays the current summary information about all the processes
 
-  - Usage:
-    show processes summary
-
+- Usage:
+  ```
+  show processes summary
+  ```
 
 - Example:
   ```
-	admin@SONiC:~$  show processes summary
-	  PID  PPID CMD                         %MEM %CPU
-		1     0 /sbin/init                   0.0  0.0
-		2     0 [kthreadd]                   0.0  0.0
-		3     2 [ksoftirqd/0]                0.0  0.0
-		5     2 [kworker/0:0H]               0.0  0.0
+  admin@SONiC:~$ show processes summary
+  PID  PPID CMD                         %MEM %CPU
+  1       0 /sbin/init                   0.0  0.0
+  2       0 [kthreadd]                   0.0  0.0
+  3       2 [ksoftirqd/0]                0.0  0.0
+  5       2 [kworker/0:0H]               0.0  0.0
+  ...
   ```
 
 
@@ -3375,153 +3477,158 @@ These commands are used to know the services that are running and the memory tha
 
 This command displays the state of all the SONiC processes running inside a docker container. This helps to identify the status of SONiC’s critical processes.
 
-  - Usage:
-    sonic_installer remove <image_name>
-
+- Usage:
+  ```
+  show services
+  ```
 
 - Example:
   ```
-	admin@lnos-x1-a-asw02:~$ show services
-	dhcp_relay      docker
-	---------------------------
-	UID        PID  PPID  C STIME TTY          TIME CMD
-	root         1     0  0 05:26 ?        00:00:12 /usr/bin/python /usr/bin/supervi
-	root        24     1  0 05:26 ?        00:00:00 /usr/sbin/rsyslogd -n
+  admin@lnos-x1-a-asw02:~$ show services
+  dhcp_relay      docker
+  ---------------------------
+  UID        PID  PPID  C STIME TTY          TIME CMD
+  root         1     0  0 05:26 ?        00:00:12 /usr/bin/python /usr/bin/supervi
+  root        24     1  0 05:26 ?        00:00:00 /usr/sbin/rsyslogd -n
 
-	snmp    docker
-	---------------------------
-	UID        PID  PPID  C STIME TTY          TIME CMD
-	root         1     0  0 05:26 ?        00:00:16 /usr/bin/python /usr/bin/supervi
-	root        24     1  0 05:26 ?        00:00:02 /usr/sbin/rsyslogd -n
-	Debian-+    29     1  0 05:26 ?        00:00:04 /usr/sbin/snmpd -f -LS4d -u Debi
-	root        31     1  1 05:26 ?        00:15:10 python3.6 -m sonic_ax_impl
+  snmp    docker
+  ---------------------------
+  UID        PID  PPID  C STIME TTY          TIME CMD
+  root         1     0  0 05:26 ?        00:00:16 /usr/bin/python /usr/bin/supervi
+  root        24     1  0 05:26 ?        00:00:02 /usr/sbin/rsyslogd -n
+  Debian-+    29     1  0 05:26 ?        00:00:04 /usr/sbin/snmpd -f -LS4d -u Debi
+  root        31     1  1 05:26 ?        00:15:10 python3.6 -m sonic_ax_impl
 
-	syncd   docker
-	---------------------------
-	UID        PID  PPID  C STIME TTY          TIME CMD
-	root         1     0  0 05:26 ?        00:00:13 /usr/bin/python /usr/bin/supervi
-	root        12     1  0 05:26 ?        00:00:00 /usr/sbin/rsyslogd -n
-	root        17     1  0 05:26 ?        00:00:00 /usr/bin/dsserve /usr/bin/syncd
-	root        27    17 22 05:26 ?        04:09:30 /usr/bin/syncd --diag -p /usr/sh
-	root        51    27  0 05:26 ?        00:00:01 /usr/bin/syncd --diag -p /usr/sh
+  syncd   docker
+  ---------------------------
+  UID        PID  PPID  C STIME TTY          TIME CMD
+  root         1     0  0 05:26 ?        00:00:13 /usr/bin/python /usr/bin/supervi
+  root        12     1  0 05:26 ?        00:00:00 /usr/sbin/rsyslogd -n
+  root        17     1  0 05:26 ?        00:00:00 /usr/bin/dsserve /usr/bin/syncd
+  root        27    17 22 05:26 ?        04:09:30 /usr/bin/syncd --diag -p /usr/sh
+  root        51    27  0 05:26 ?        00:00:01 /usr/bin/syncd --diag -p /usr/sh
 
-	swss    docker
-	---------------------------
-	UID        PID  PPID  C STIME TTY          TIME CMD
-	root         1     0  0 05:26 ?        00:00:29 /usr/bin/python /usr/bin/supervi
-	root        25     1  0 05:26 ?        00:00:00 /usr/sbin/rsyslogd -n
-	root        30     1  0 05:26 ?        00:00:13 /usr/bin/orchagent -d /var/log/s
-	root        42     1  1 05:26 ?        00:12:40 /usr/bin/portsyncd -p /usr/share
-	root        45     1  0 05:26 ?        00:00:00 /usr/bin/intfsyncd
-	root        48     1  0 05:26 ?        00:00:03 /usr/bin/neighsyncd
-	root        59     1  0 05:26 ?        00:00:01 /usr/bin/vlanmgrd
-	root        92     1  0 05:26 ?        00:00:01 /usr/bin/intfmgrd
-	root      3606     1  0 23:36 ?        00:00:00 bash -c /usr/bin/arp_update; sle
-	root      3621  3606  0 23:36 ?        00:00:00 sleep 300
+  swss    docker
+  ---------------------------
+  UID        PID  PPID  C STIME TTY          TIME CMD
+  root         1     0  0 05:26 ?        00:00:29 /usr/bin/python /usr/bin/supervi
+  root        25     1  0 05:26 ?        00:00:00 /usr/sbin/rsyslogd -n
+  root        30     1  0 05:26 ?        00:00:13 /usr/bin/orchagent -d /var/log/s
+  root        42     1  1 05:26 ?        00:12:40 /usr/bin/portsyncd -p /usr/share
+  root        45     1  0 05:26 ?        00:00:00 /usr/bin/intfsyncd
+  root        48     1  0 05:26 ?        00:00:03 /usr/bin/neighsyncd
+  root        59     1  0 05:26 ?        00:00:01 /usr/bin/vlanmgrd
+  root        92     1  0 05:26 ?        00:00:01 /usr/bin/intfmgrd
+  root      3606     1  0 23:36 ?        00:00:00 bash -c /usr/bin/arp_update; sle
+  root      3621  3606  0 23:36 ?        00:00:00 sleep 300
+
+  ...
   ```
 
 **show system-memory**
 
 This command displays the system-wide memory utilization information – just a wrapper over linux native “free” command
 
-  - Usage:
-    show system-memory
-
+- Usage:
+  ```
+  show system-memory
+  ```
 
 - Example:
   ```
-	admin@lnos-x1-a-asw02:~$ show system-memory
-	Command: free -m -h
-				 total       used       free     shared    buffers     cached
-	Mem:          3.9G       2.0G       1.8G        33M       324M       791M
-	-/+ buffers/cache:       951M       2.9G
-	Swap:           0B         0B         0B
+  admin@lnos-x1-a-asw02:~$ show system-memory
+  Command: free -m -h
+               total       used       free     shared    buffers     cached
+  Mem:          3.9G       2.0G       1.8G        33M       324M       791M
+  -/+ buffers/cache:       951M       2.9G
+  Swap:           0B         0B         0B
   ```
 
 **show mmu**
 
 This command displays virtual address to the physical address translation status of the Memory Management Unit (MMU).
 
-  - Usage:
-    show mmu
-
+- Usage:
+  ```
+  show mmu
+  ```
 
 - Example:
   ```
-	admin@T1-2:~$ show mmu
-	Pool: ingress_lossless_pool
-	----  --------
-	xoff  4194112
-	type  ingress
-	mode  dynamic
-	size  10875072
-	----  --------
+  admin@T1-2:~$ show mmu
+  Pool: ingress_lossless_pool
+  ----  --------
+  xoff  4194112
+  type  ingress
+  mode  dynamic
+  size  10875072
+  ----  --------
 
-	Pool: egress_lossless_pool
-	----  --------
-	type  egress
-	mode  static
-	size  15982720
-	----  --------
+  Pool: egress_lossless_pool
+  ----  --------
+  type  egress
+  mode  static
+  size  15982720
+  ----  --------
 
-	Pool: egress_lossy_pool
-	----  -------
-	type  egress
-	mode  dynamic
-	size  9243812
-	----  -------
+  Pool: egress_lossy_pool
+  ----  -------
+  type  egress
+  mode  dynamic
+  size  9243812
+  ----  -------
 
-	Profile: egress_lossy_profile
-	----------  -------------------------------
-	dynamic_th  3
-	pool        [BUFFER_POOL|egress_lossy_pool]
-	size        1518
-	----------  -------------------------------
+  Profile: egress_lossy_profile
+  ----------  -------------------------------
+  dynamic_th  3
+  pool        [BUFFER_POOL|egress_lossy_pool]
+  size        1518
+  ----------  -------------------------------
 
-	Profile: pg_lossless_100000_300m_profile
-	----------  -----------------------------------
-	xon_offset  2288
-	dynamic_th  -3
-	xon         2288
-	xoff        268736
-	pool        [BUFFER_POOL|ingress_lossless_pool]
-	size        1248
-	----------  -----------------------------------
+  Profile: pg_lossless_100000_300m_profile
+  ----------  -----------------------------------
+  xon_offset  2288
+  dynamic_th  -3
+  xon         2288
+  xoff        268736
+  pool        [BUFFER_POOL|ingress_lossless_pool]
+  size        1248
+  ----------  -----------------------------------
 
-	Profile: egress_lossless_profile
-	---------  ----------------------------------
-	static_th  3995680
-	pool       [BUFFER_POOL|egress_lossless_pool]
-	size       1518
-	---------  ----------------------------------
+  Profile: egress_lossless_profile
+  ---------  ----------------------------------
+  static_th  3995680
+  pool       [BUFFER_POOL|egress_lossless_pool]
+  size       1518
+  ---------  ----------------------------------
 
-	Profile: pg_lossless_100000_40m_profile
-	----------  -----------------------------------
-	xon_offset  2288
-	dynamic_th  -3
-	xon         2288
-	xoff        177632
-	pool        [BUFFER_POOL|ingress_lossless_pool]
-	size        1248
-	----------  -----------------------------------
+  Profile: pg_lossless_100000_40m_profile
+  ----------  -----------------------------------
+  xon_offset  2288
+  dynamic_th  -3
+  xon         2288
+  xoff        177632
+  pool        [BUFFER_POOL|ingress_lossless_pool]
+  size        1248
+  ----------  -----------------------------------
 
-	Profile: ingress_lossy_profile
-	----------  -----------------------------------
-	dynamic_th  3
-	pool        [BUFFER_POOL|ingress_lossless_pool]
-	size        0
-	----------  -----------------------------------
+  Profile: ingress_lossy_profile
+  ----------  -----------------------------------
+  dynamic_th  3
+  pool        [BUFFER_POOL|ingress_lossless_pool]
+  size        0
+  ----------  -----------------------------------
 
-	Profile: pg_lossless_40000_40m_profile
-	----------  -----------------------------------
-	xon_offset  2288
-	dynamic_th  -3
-	xon         2288
-	xoff        71552
-	pool        [BUFFER_POOL|ingress_lossless_pool]
-	size        1248
-	----------  -----------------------------------
-   ```
+  Profile: pg_lossless_40000_40m_profile
+  ----------  -----------------------------------
+  xon_offset  2288
+  dynamic_th  -3
+  xon         2288
+  xoff        71552
+  pool        [BUFFER_POOL|ingress_lossless_pool]
+  size        1248
+  ----------  -----------------------------------
+  ```
 
 **show line**
 
@@ -3530,11 +3637,12 @@ This command is used only when SONiC is used as console switch.
 This command is not applicable when SONiC used as regular switch.
 NOTE: This command is not working. It crashes as follows. A bug ticket is opened for this issue.
 
-  - Usage:
-    show line
+- Usage:
+  ```
+  show line
+  ```
 
 - Example:
-
   ```
   admin@T1-2:~$ show line
 
@@ -3553,40 +3661,40 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 
 This command displays brief information about all the vlans configured in the device. It displays the vlan ID, IP address (if configured for the vlan), list of vlan member ports, whether the port is tagged or in untagged mode and the DHCP Helper Address.
 
-  - Usage:
-    show vlan brief
-
+- Usage:
+  ```
+  show vlan brief
+  ```
 
 - Example:
   ```
   admin@sonic:~$ show vlan brief
 
-	+-----------+--------------+-----------+----------------+-----------------------+
-	|   VLAN ID | IP Address   | Ports     | Port Tagging   | DHCP Helper Address   |
-	+===========+==============+===========+================+=======================+
-	|       100 | 1.1.2.2/16   | Ethernet0 | tagged         | 192.0.0.1             |
-	|           |              | Ethernet4 | tagged         | 192.0.0.2             |
-	|           |              |           |                | 192.0.0.3             |
-	+-----------+--------------+-----------+----------------+-----------------------+
-
+  +-----------+--------------+-----------+----------------+-----------------------+
+  |   VLAN ID | IP Address   | Ports     | Port Tagging   | DHCP Helper Address   |
+  +===========+==============+===========+================+=======================+
+  |       100 | 1.1.2.2/16   | Ethernet0 | tagged         | 192.0.0.1             |
+  |           |              | Ethernet4 | tagged         | 192.0.0.2             |
+  |           |              |           |                | 192.0.0.3             |
+  +-----------+--------------+-----------+----------------+-----------------------+
   ```
 
 **show vlan config**
 
 This command displays all the vlan configuration.
 
-  - Usage:
-    show vlan config
-
+- Usage:
+  ```
+  show vlan config
+  ```
 
 - Example:
   ```
   admin@sonic:~$ show vlan config
-	Name       VID  Member     Mode
-	-------  -----  ---------  ------
-	Vlan100    100  Ethernet0  tagged
-	Vlan100    100  Ethernet4  tagged
-
+  Name       VID  Member     Mode
+  -------  -----  ---------  ------
+  Vlan100    100  Ethernet0  tagged
+  Vlan100    100  Ethernet4  tagged
   ```
 
 
@@ -3598,23 +3706,26 @@ This sub-section explains how to configure the vlan and its member ports.
 
 This command is used to add or delete the vlan.
 
-  - Usage:
-    config vlan add/del <vlan__id>
+- Usage:
+  ```
+  config vlan (add | del) <vlan_id>
+  ```
 
-
-- Example:
+- Example (Create the VLAN "Vlan100" if it does not already exist):
   ```
   admin@sonic:~$ sudo config vlan add 100
-  This command will create the vlan 100 if not exists.
   ```
 
 **config vlan member add/del**
 
 This command is to add or delete a member port into the already created vlan.
 
-  - Usage:
-    config vlan member add/del [-u or --untagged] <vlan_id> <member_portname>
-    -u will set the port in untagged mode.
+- Usage:
+  ```
+  config vlan member add/del [-u|--untagged] <vlan_id> <member_portname>
+  ```
+
+*NOTE: Adding the -u or --untagged flag will set the member in "untagged" mode*
 
 
 - Example:
@@ -3638,9 +3749,10 @@ This command displays the MAC (FDB) entries either in full or partial as given b
 3) show mac -p <port>  - displays the MACs learnt on the particular port.
 
 
-  - Usage:
-    show mac [-v vlan_id] [-p port_name]
-
+- Usage:
+  ```
+  show mac [-v <vlan_id>] [-p <port_name>]
+  ```
 
 - Example:
   ```
@@ -3668,9 +3780,9 @@ This command displays the MAC (FDB) entries either in full or partial as given b
   Total number of entries 18
   ```
 
-  - Optionally, you can specify a VLAN ID or interface name in order to display only that particular entries
+Optionally, you can specify a VLAN ID or interface name in order to display only that particular entries
 
-- Example:
+- Examples:
   ```
   admin@sonic:~$ show mac -v 1000
   No.    Vlan  MacAddress         Port
@@ -3694,7 +3806,8 @@ This command displays the MAC (FDB) entries either in full or partial as given b
    17    1000  50:96:23:AD:F1:65  Ethernet192
    18    1000  C6:C9:5E:AE:24:42  Ethernet192
   Total number of entries 18
-
+  ```
+  ```
   admin@sonic:~$ show mac -p Ethernet192
   No.    Vlan  MacAddress         Port
   -----  ------  -----------------  -----------
@@ -3719,10 +3832,14 @@ This command displays the MAC (FDB) entries either in full or partial as given b
   Total number of entries 18
   ```
 
-- `sonic-clear fdb [OPTIONS]`
-  - Clear FDB table
+**sonic-clear fdb all**
 
+Clear the FDB table
 
+- Usage:
+  ```
+  sonic-clear fdb all
+  ```
 - Example:
   ```
   admin@sonic:~$ sonic-clear fdb all
@@ -3741,42 +3858,43 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 
 This command displays all the configuration related to warm_restart.
 
-  - Usage:
-    show warm_restart config
-
+- Usage:
+  ```
+  show warm_restart config
+  ```
 
 - Example:
   ```
-	admin@sonic:~$ show warm_restart config
-	name    enable    timer_name        timer_duration
-	------  --------  ----------------  ----------------
-	bgp     true      bgp_timer         100
-	teamd   false     teamsyncd_timer   300
-	swss    false     neighsyncd_timer  200
-	system  true      NULL              NULL
+  admin@sonic:~$ show warm_restart config
+  name    enable    timer_name        timer_duration
+  ------  --------  ----------------  ----------------
+  bgp     true      bgp_timer         100
+  teamd   false     teamsyncd_timer   300
+  swss    false     neighsyncd_timer  200
+  system  true      NULL              NULL
   ```
 
 **show warm_restart state**
 
 This command displays the warm_restart state.
 
-  - Usage:
-    show warm_restart state
-
+- Usage:
+  ```
+  show warm_restart state
+  ```
 
 - Example:
   ```
-	name          restore_count  state
-	----------  ---------------  ----------
-	orchagent                 0
-	vlanmgrd                  0
-	bgp                       1  reconciled
-	portsyncd                 0
-	teammgrd                  1
-	neighsyncd                0
-	teamsyncd                 1
-	syncd                     0
-
+  name          restore_count  state
+  ----------  ---------------  ----------
+  orchagent                 0
+  vlanmgrd                  0
+  bgp                       1  reconciled
+  portsyncd                 0
+  teammgrd                  1
+  neighsyncd                0
+  teamsyncd                 1
+  syncd                     0
   ```
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#VLAN-Configuration-And-Show)
@@ -3808,14 +3926,17 @@ Upon expiration of this timer, fpmsyncd will execute the reconciliation logic to
 This timer should match the BGP-GR restart-timer configured within the elected routing-stack.
 Supported range: 1-3600.
 
-  - Usage:
-    config warm_restart bgp_timer <seconds>
-	seconds range 1 to 3600.
+- Usage:
+  ```
+  config warm_restart [-s|--redis-unix-socket-path <socket_path>] bgp_timer <seconds>
+  ```
 
+- Parameters:
+  - seconds: Range from 1 to 3600
 
 - Example:
   ```
-	admin@sonic:~$ sudo config warm_restart bgp_timer 1000
+  admin@sonic:~$ sudo config warm_restart bgp_timer 1000
   ```
 
 **config warm_restart enable/disable**
@@ -3824,25 +3945,27 @@ This command is used to enable or disable the warm_restart for a particular serv
 Following four services support warm reboot. When user restarts the particular service using "systemctl restart <service_name>", this configured value will be checked for whether it is enabled or disabled.
 If this configuration is enabled for that service, it will perform warm reboot for that service. Otherwise, it will do cold restart of the service.
 
-  - Usage:
-    config warm_restart enable [<module_name>]
-
-       module_name can be either system or swss or bgp or teamd.
-	   If "module_name" argument is not specified, it will enable "system" module.
-
-
-- Example:
+- Usage:
   ```
-	admin@sonic:~$ sudo config warm_restart enable
-	The above command will set warm_restart as "enable" for the "system" service.
+  config warm_restart [-s|--redis-unix-socket-path <socket_path>] enable [<module_name>]
+  ```
 
-	admin@sonic:~$ sudo config warm_restart enable swss
-	The above command will set warm_restart as "enable" for the "swss" service. When user does "systemctl restart swss", it will perform warm reboot instead of cold reboot.
+- Parameters:
+  - module_name: Can be either system or swss or bgp or teamd. If "module_name" argument is not specified, it will enable "system" module.
 
-	admin@sonic:~$ sudo config warm_restart enable teamd
-	The above command will set warm_restart as "enable" for the "teamd" service. When user does "systemctl restart teamd", it will perform warm reboot instead of cold reboot.
+- Example (Set warm_restart as "enable" for the "system" service):
+  ```
+  admin@sonic:~$ sudo config warm_restart enable
+  ```
 
+- Example (Set warm_restart as "enable" for the "swss" service. When user does "systemctl restart swss", it will perform warm reboot instead of cold reboot)
+  ```
+  admin@sonic:~$ sudo config warm_restart enable swss
+  ```
 
+- Example (Set warm_restart as "enable" for the "teamd" service. When user does "systemctl restart teamd", it will perform warm reboot instead of cold reboot)
+  ```
+  admin@sonic:~$ sudo config warm_restart enable teamd
   ```
 
 
@@ -3851,20 +3974,45 @@ If this configuration is enabled for that service, it will perform warm reboot f
 This command is used to set the neighsyncd_timer value for warm_restart of "swss" service.
 neighsyncd_timer is the timer used for "swss" (neighsyncd) service during the warm restart.
 Timer is started after the neighborTable is restored to internal data structures.
-neighborsyncd then starts to read all linux kernel entries and mark the entries in the data structures accordingly.
+neighborsyncd then starts to read all Linux kernel entries and mark the entries in the data structures accordingly.
 Once the timer is expired, reconciliation is done and the delta is pushed to appDB
 Valid value is 1-9999. 0 is invalid.
 
-  - Usage:
-    config warm_restart bgp_timerneighsyncd_timer <seconds>
-	seconds range 1 to 9999.
+- Usage:
+  ```
+  config warm_restart [-s|--redis-unix-socket-path <socket_path>] neighsyncd_timer <seconds>
+  ```
 
+- Parameters:
+  - seconds: Range from 1 to 9999
 
 - Example:
   ```
-	admin@sonic:~$ sudo config warm_restart neighsyncd_timer 2000
+  admin@sonic:~$ sudo config warm_restart neighsyncd_timer 2000
   ```
 
+
+**config warm_restart bgp_timer**
+
+This command is used to set the bgp_timer value for warm_restart of "bgp" service.
+bgp_timer is the timer used for "bgp" service during the warm restart.
+Timer is started after the BGP table is restored to internal data structures.
+BGP services then start to read all Linux kernel entries and mark the entries in the data structures accordingly.
+Once the timer is expired, reconciliation is done and the delta is pushed to appDB
+Valid value is 1-9999. 0 is invalid.
+
+- Usage:
+  ```
+  config warm_restart [-s|--redis-unix-socket-path <socket_path>] bgp_timer <seconds>
+  ```
+
+- Parameters:
+  - seconds: Range from 1 to 9999
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config warm_restart bgp_timer 2000
+  ```
 
 **config warm_restart teamsyncd_timer**
 
@@ -3875,14 +4023,17 @@ The changes will only be applied when the timer expires.
 When the changes are applied, the stale LAG entries will be removed, the new LAG entries will be created.
 Supported range: 1-9999. 0 is invalid
 
-  - Usage:
-    config warm_restart teamsyncd_timer <seconds>
-	seconds range 1 to 9999.
+- Usage:
+  ```
+  config warm_restart teamsyncd_timer <seconds>
+  ```
 
+- Parameters:
+  - seconds: Range from 1 to 9999
 
 - Example:
   ```
-	admin@sonic:~$ sudo config warm_restart teamsyncd_timer 3000
+  admin@sonic:~$ sudo config warm_restart teamsyncd_timer 3000
   ```
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Warm-Restart)
@@ -3896,16 +4047,16 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 
 This command displays the configured interval for the telemetry.
 
-  - Usage:
-    show watermark telemetry interval
-
+- Usage:
+  ```
+  show watermark telemetry interval
+  ```
 
 - Example:
   ```
-	admin@sonic:~$ show watermark telemetry interval
+  admin@sonic:~$ show watermark telemetry interval
 
-      Telemetry interval 120 second(s)
-
+  Telemetry interval 120 second(s)
   ```
 
 ## Watermark Config command
@@ -3916,13 +4067,14 @@ This command is used to configure the interval for telemetry.
 The default interval is 120 seconds.
 There is no regulation on the valid range of values; it leverages linux timer.
 
-  - Usage:
-    config watermark telemetry interval <value>
-
+- Usage:
+  ```
+  config watermark telemetry interval <value>
+  ```
 
 - Example:
   ```
-	admin@sonic:~$ sudo config watermark telemetry interval 999
+  admin@sonic:~$ sudo config watermark telemetry interval 999
   ```
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Watermark-Configuration-And-Show)
@@ -3942,9 +4094,10 @@ This tool has facility to install an alternate image, list the available images 
 
 This command is used to install a new image on the alternate image partition.  This command takes a path to an installable SONiC image or URL and installs the image.
 
-  - Usage:
-    sonic_installer install <path>
-
+- Usage:
+  ```
+  sonic_installer install <image_file_path>
+  ```
 
 - Example:
   ```
@@ -3984,8 +4137,10 @@ This command is used to install a new image on the alternate image partition.  T
 
 This command displays information about currently installed images. It displays a list of installed images, currently running image and image set to be loaded in next reboot.
 
-  - Usage:
-    sonic_installer list
+- Usage:
+  ```
+  sonic_installer list
+  ```
 
 - Example:
    ```
@@ -4001,8 +4156,10 @@ This command displays information about currently installed images. It displays 
 
 This command is be used to change the image which can be loaded by default in all the subsequent reboots.
 
-  - Usage:
-    sonic_installer set_default <image_name>
+- Usage:
+  ```
+  sonic_installer set_default <image_name>
+  ```
 
 - Example:
   ```
@@ -4013,8 +4170,10 @@ This command is be used to change the image which can be loaded by default in al
 
 This command is used to change the image that can be loaded in the *next* reboot only. Note that it will fallback to current image in all other subsequent reboots after the next reboot.
 
-  - Usage:
-    sonic_installer set_next_boot <image_name>
+- Usage:
+  ```
+  sonic_installer set_next_boot <image_name>
+  ```
 
 - Example:
   ```
@@ -4025,8 +4184,10 @@ This command is used to change the image that can be loaded in the *next* reboot
 
 This command is used to remove the unused SONiC image from the disk. Note that it's *not* allowed to remove currently running image.
 
-  - Usage:
-    sonic_installer remove <image_name>
+- Usage:
+  ```
+  sonic_installer remove <image_name>
+  ```
 
 - Example:
   ```
@@ -4050,19 +4211,23 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 For troubleshooting and debugging purposes, this command gathers pertinent information about the state of the device; information is as diverse as syslog entries, database state, routing-stack state, etc., It then compresses it into an archive file. This archive file can be sent to the SONiC development team for examination.
 Resulting archive file is saved as `/var/dump/<DEVICE_HOST_NAME>_YYYYMMDD_HHMMSS.tar.gz`
 
-  - Usage:
-    show techsupport
-
+- Usage:
+  ```
+  show techsupport
+  ```
 
 - Example:
   ```
-  admin@sonic:~$ show techsupport
+  admin@sonic:~$ show techsupport [--since=<time_specifier>]
   ```
+
 If the SONiC system was running for quite some time `show techsupport` will produce a large dump file. To reduce the amount of syslog and core files gathered during system dump use `--since` option:
 
-- Example:
+- Examples:
   ```
   admin@sonic:~$ show techsupport --since=yesterday  # Will collect syslog and core files for the last 24 hours
+  ```
+  ```
   admin@sonic:~$ show techsupport --since='hour ago' # Will collect syslog and core files for the last one hour
   ```
 
@@ -4074,22 +4239,22 @@ SONiC software is agnostic of the routing software that is being used in the dev
 A separate shell (vtysh) is provided to configure such routing stacks.
 Once if users go to "vtysh", they can use the routing stack specific commands as given in the following example.
 
-  - Example: Quagga Routing Stack
+- Example (Quagga Routing Stack):
   ```
-	admin@T1-2:~$ vtysh
+  admin@T1-2:~$ vtysh
 
-	Hello, this is Quagga (version 0.99.24.1).
-	Copyright 1996-2005 Kunihiro Ishiguro, et al.
+  Hello, this is Quagga (version 0.99.24.1).
+  Copyright 1996-2005 Kunihiro Ishiguro, et al.
 
-	T1-2# show route-map (This command displays the route-map that is configured for the routing protocol.)
-	ZEBRA:
-	route-map RM_SET_SRC, permit, sequence 10
-	  Match clauses:
-	  Set clauses:
-		src 10.12.0.102
-	  Call clause:
-	  Action:
-		Exit routemap
+  T1-2# show route-map (This command displays the route-map that is configured for the routing protocol.)
+  ZEBRA:
+  route-map RM_SET_SRC, permit, sequence 10
+    Match clauses:
+    Set clauses:
+      src 10.12.0.102
+    Call clause:
+    Action:
+      Exit routemap
   ```
 
 Refer the routing stack [Quagga Command Reference](https://www.quagga.net/docs/quagga.pdf) or [FRR Command Reference](https://buildmedia.readthedocs.org/media/pdf/frrouting/latest/frrouting.pdf) to know more about about the routing stack configuration.
@@ -4104,8 +4269,10 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE)
 
 This command displays the summary of all IPv4 bgp neighbors that are configured and the corresponding states.
 
-  - Usage:
-    show ip bgp summary
+- Usage:
+  ```
+  show ip bgp summary
+  ```
 
 - Example:
   ```
@@ -4131,9 +4298,10 @@ Command has got additional optional arguments to display only the advertised rou
 
 In order to get details for an IPv6 neigbor, use "show ipv6 bgp neighbor <ipv6_address>" command.
 
-  - Usage:
-    show ip bgp neighbors [<ipv4-address> [advertised-routes | received-routes | routes]]
-
+- Usage:
+  ```
+  show ip bgp neighbors [<ipv4-address> [advertised-routes | received-routes | routes]]
+  ```
 
 - Example:
   ```
@@ -4183,10 +4351,10 @@ In order to get details for an IPv6 neigbor, use "show ipv6 bgp neighbor <ipv6_a
   Read thread: on  Write thread: off
   ```
 
-  - Optionally, you can specify an IP address in order to display only that particular neighbor. In this mode, you can optionally specify whether you want to display all routes advertised to the specified neighbor, all routes received from the specified neighbor or all routes (received and accepted) from the specified neighbor.
+Optionally, you can specify an IP address in order to display only that particular neighbor. In this mode, you can optionally specify whether you want to display all routes advertised to the specified neighbor, all routes received from the specified neighbor or all routes (received and accepted) from the specified neighbor.
 
 
-- Example:
+- Examples:
   ```
   admin@sonic:~$ show ip bgp neighbors 192.168.1.161
 
@@ -4201,9 +4369,10 @@ In order to get details for an IPv6 neigbor, use "show ipv6 bgp neighbor <ipv6_a
 
 This command displays the summary of all IPv4 bgp neighbors that are configured and the corresponding states.
 
-  - Usage:
-     show ipv6 bgp summary
-
+- Usage:
+  ```
+  show ipv6 bgp summary
+  ```
 
 - Example:
   ```
@@ -4225,10 +4394,12 @@ This command displays the summary of all IPv4 bgp neighbors that are configured 
 
 This command displays all the details of one particular IPv6 Border Gateway Protocol (BGP) neighbor. Option is also available to display only the advertised routes, or the received routes, or all routes.
 
-  - Usage:
-    show ipv6 bgp neighbors <ipv6-address> (advertised-routes | received-routes | routes)`
+- Usage:
+  ```
+  show ipv6 bgp neighbors <ipv6-address> (advertised-routes | received-routes | routes)`
+  ```
 
-- Example:
+- Examples:
   ```
   admin@sonic:~$ show ipv6 bgp neighbors fc00::72 advertised-routes
 
@@ -4241,142 +4412,163 @@ This command displays all the details of one particular IPv6 Border Gateway Prot
 
 This command displays the routing policy that takes precedence over the other route processes that are configured.
 
-  - Usage:
-    show route-map
-
-  - Example:
+- Usage:
   ```
-	admin@T1-2:~$ show route-map
-	ZEBRA:
-	route-map RM_SET_SRC, permit, sequence 10
-	  Match clauses:
-	  Set clauses:
-		src 10.12.0.102
-	  Call clause:
-	  Action:
-		Exit routemap
-	ZEBRA:
-	route-map RM_SET_SRC6, permit, sequence 10
-	  Match clauses:
-	  Set clauses:
-		src fc00:1::102
-	  Call clause:
-	  Action:
-		Exit routemap
-	BGP:
-	route-map FROM_BGP_SPEAKER_V4, permit, sequence 10
-	  Match clauses:
-	  Set clauses:
-	  Call clause:
-	  Action:
-	    Exit routemap
-	BGP:
-	route-map TO_BGP_SPEAKER_V4, deny, sequence 10
-	  Match clauses:
-	  Set clauses:
-	  Call clause:
-	  Action:
-	    Exit routemap
-	BGP:
-	route-map ISOLATE, permit, sequence 10
-	  Match clauses:
-	  Set clauses:
-		as-path prepend 65000
-	  Call clause:
-	  Action:
-		Exit routemap
+  show route-map
   ```
 
-# Syslog Server Configuration Commands 
+- Example:
+  ```
+  admin@T1-2:~$ show route-map
+  ZEBRA:
+  route-map RM_SET_SRC, permit, sequence 10
+    Match clauses:
+    Set clauses:
+      src 10.12.0.102
+    Call clause:
+    Action:
+      Exit routemap
+  ZEBRA:
+  route-map RM_SET_SRC6, permit, sequence 10
+    Match clauses:
+    Set clauses:
+      src fc00:1::102
+    Call clause:
+    Action:
+      Exit routemap
+  BGP:
+  route-map FROM_BGP_SPEAKER_V4, permit, sequence 10
+    Match clauses:
+    Set clauses:
+    Call clause:
+    Action:
+      Exit routemap
+  BGP:
+  route-map TO_BGP_SPEAKER_V4, deny, sequence 10
+    Match clauses:
+    Set clauses:
+    Call clause:
+    Action:
+      Exit routemap
+  BGP:
+  route-map ISOLATE, permit, sequence 10
+    Match clauses:
+    Set clauses:
+      as-path prepend 65000
+    Call clause:
+    Action:
+      Exit routemap
+  ```
+
+# Syslog Server Configuration Commands
 
 This sub-section of commands is used to add or remove the configured syslog servers.
 
-**config syslog add** 
+**config syslog add**
 
 This command is used to add a SYSLOG server to the syslog server list.  Note that more that one syslog server can be added in the device.
 
-- Usage: config syslog add <ip-address>
-- Example: 
+- Usage:
   ```
-  admin@str-s6000-acs-11:~$ sudo config syslog add 1.1.1.1
+  config syslog add <ip_address>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config syslog add 1.1.1.1
   Syslog server 1.1.1.1 added to configuration
   Restarting rsyslog-config service...
-  admin@str-s6000-acs-11:~$
   ```
 
 **config syslog delete**
 
-This command is used to delete the syslog server configured. 
+This command is used to delete the syslog server configured.
 
-- Usage: config syslog del <ip-address>
+- Usage:
+  ```
+  config syslog del <ip_address>
+  ```
+
 - Example:
   ```
-  admin@str-s6000-acs-11:~$ sudo config syslog del 1.1.1.1
+  admin@sonic:~$ sudo config syslog del 1.1.1.1
   Syslog server 1.1.1.1 removed from configuration
   Restarting rsyslog-config service...
-  admin@str-s6000-acs-11:~$
   ```
 
-# DHCP Relay Destination IP address Configuration Commands 
+# DHCP Relay Destination IP address Configuration Commands
 
 This sub-section of commands is used to add or remove the DHCP Relay Destination IP address(es) for a VLAN interface.
 
-**config vlan dhcp_relay add** 
+**config vlan dhcp_relay add**
 
 This command is used to add a DHCP Relay Destination IP address to the a VLAN.  Note that more that one DHCP Relay Destination IP address can be added on a VLAN interface.
 
-- Usage: config vlan dhcp_relay add <vlan-id> <dhcp_relay_destination_ip>
-- Example: 
+- Usage:
   ```
-  admin@str-s6000-acs-11:~$ sudo config vlan dhcp_relay add 1000 7.7.7.7
+  config vlan dhcp_relay add <vlan_id> <dhcp_relay_destination_ip>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config vlan dhcp_relay add 1000 7.7.7.7
   Added DHCP relay destination address 7.7.7.7 to Vlan1000
   Restarting DHCP relay service...
   Running command: systemctl restart dhcp_relay
-  admin@str-s6000-acs-11:~$ 
+  admin@str-s6000-acs-11:~$
   ```
 
 **config vlan dhcp_relay delete**
 
-This command is used to delete a configured DHCP Relay Destination IP address from a VLAN interface. 
+This command is used to delete a configured DHCP Relay Destination IP address from a VLAN interface.
 
-- Usage: config vlan dhcp_relay del <vlan-id> <dhcp_relay_destination_ip>
+- Usage:
+  ```
+  config vlan dhcp_relay del <vlan-id> <dhcp_relay_destination_ip>
+  ```
+
 - Example:
   ```
-  admin@str-s6000-acs-11:~$ sudo config vlan dhcp_relay del 1000 7.7.7.7
+  admin@sonic:~$ sudo config vlan dhcp_relay del 1000 7.7.7.7
   Removed DHCP relay destination address 7.7.7.7 from Vlan1000
   Restarting DHCP relay service...
   Running command: systemctl restart dhcp_relay
-  admin@str-s6000-acs-11:~$ 
   ```
-  
-# NTP Server Configuration Commands 
+
+# NTP Server Configuration Commands
 
 This sub-section of commands is used to add or remove the configured NTP servers.
 
-**config ntp add** 
+**config ntp add**
 
 This command is used to add a NTP server IP address to the NTP server list.  Note that more that one NTP server IP address can be added in the device.
 
-- Usage: config ntp add <ip-address>
-- Example: 
+- Usage:
   ```
-  admin@str-s6000-acs-11:~$ sudo config ntp add 9.9.9.9
+  config ntp add <ip_address>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config ntp add 9.9.9.9
   NTP server 9.9.9.9 added to configuration
   Restarting ntp-config service...
-  admin@str-s6000-acs-11:~$
   ```
 
 **config ntp delete**
 
-This command is used to delete a configured NTP server IP address. 
+This command is used to delete a configured NTP server IP address.
 
-- Usage: config ntp del <ip-address>
+- Usage:
+  ```
+  config ntp del <ip_address>
+  ```
+
 - Example:
   ```
-  admin@str-s6000-acs-11:~$ sudo config ntp del 9.9.9.9
+  admin@sonic:~$ sudo config ntp del 9.9.9.9
   NTP server 9.9.9.9 removed from configuration
   Restarting ntp-config service...
-  admin@str-s6000-acs-11:~$
   ```
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Quagga-BGP-Show-Commands)

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -4506,7 +4506,7 @@ This command is used to delete the syslog server configured.
   Restarting rsyslog-config service...
   ```
 
-## DHCP Relay Destination IP address Configuration Commands
+## DHCP Relay Destination IP Address Configuration Commands
 
 This sub-section of commands is used to add or remove the DHCP Relay Destination IP address(es) for a VLAN interface.
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -91,11 +91,12 @@ Table of Contents
 
 # Document History
 
-| # | Date    |  Document Version | Details |
-| --- | --- | --- | --- |
-| 3 |  Jun-26-2019 |v3 | Update based on 201904 (build#19) release, "config interface" command changes related to interfacename order, FRR/Quagga show command changes, platform specific changes, ACL show changes and few formatting changes |
-| 2 |  Apr-22-2019 |v2 | CLI Guide for SONiC 201811 version (build#32) with complete "config" command set |
-| 1 |  Mar-23-2019 |v1 | Initial version of CLI Guide with minimal command set |
+| Version | Modification Date | Details |
+| --- | --- | --- |
+| v4 | Oct-17-2019 | Unify usage statements and other formatting; Replace tabs with spaces; Fix a few errors |
+| v3 | Jun-26-2019 | Update based on 201904 (build#19) release, "config interface" command changes related to interfacename order, FRR/Quagga show command changes, platform specific changes, ACL show changes and few formatting changes |
+| v2 | Apr-22-2019 | CLI Guide for SONiC 201811 version (build#32) with complete "config" command set |
+| v1 | Mar-23-2019 | Initial version of CLI Guide with minimal command set |
 
 # Introduction
 SONiC is an open source network operating system based on Linux that runs on switches from multiple vendors and ASICs. SONiC offers a full-suite of network functionality, like BGP and RDMA, that has been production-hardened in the data centers of some of the largest cloud-service providers. It offers teams the flexibility to create the network solutions they need while leveraging the collective strength of a large ecosystem and community.

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -493,26 +493,29 @@ Individual process can also be viewed using the command `ps -ax | grep <\process
 
 - Usage:
   ```
-  show logging ([<process_name>] [(-l|--lines) <number_of_lines>]) | [-f|--follow]
+  show logging [(<process_name> [-l|--lines <number_of_lines>]) | (-f|--follow)]
   ```
 
 - Example:
   ```
   admin@sonic:~$ show logging
   ```
-  - It can be useful to pipe the output from `show logging` to the command `more` in order to examine one screenful of log messages at a time
+
+It can be useful to pipe the output from `show logging` to the command `more` in order to examine one screenful of log messages at a time
 
 - Example:
   ```
   admin@sonic:~$ show logging | more
   ```
-  - Optionally, you can specify a process name in order to display only log messages mentioning that process
+
+Optionally, you can specify a process name in order to display only log messages mentioning that process
 
 - Example:
   ```
   admin@sonic:~$ show logging sensord
   ```
-  - Optionally, you can specify a number of lines to display using the `-l' or `--lines` option. Only the most recent N lines will be displayed. Also note that this option can be combined with a process name.
+
+Optionally, you can specify a number of lines to display using the `-l' or `--lines` option. Only the most recent N lines will be displayed. Also note that this option can be combined with a process name.
 
 - Examples:
   ```
@@ -522,7 +525,7 @@ Individual process can also be viewed using the command `ps -ax | grep <\process
   admin@sonic:~$ show logging sensord --lines 50
   ```
 
-  - Optionally, you can follow the log live as entries are written to it by specifying the `-f` or `--follow` flag
+Optionally, you can follow the log live as entries are written to it by specifying the `-f` or `--follow` flag
 
 - Example:
   ```
@@ -660,11 +663,11 @@ This command displays the status of the device's power supply units
 Displays diagnostic monitoring information of the transceivers
 
 **show interfaces transceiver**
-This command displays information for all the interfaces for the transceiver requested or a specific interface if the optional "interface-name" is specified.
+This command displays information for all the interfaces for the transceiver requested or a specific interface if the optional "interface_name" is specified.
 
 - Usage:
   ```
-  show interfaces transceiver (eeprom [-d|--dom] | lpmode | presence]) [<interface-name>]
+  show interfaces transceiver (eeprom [-d|--dom] | lpmode | presence) [<interface_name>]
   ```
 
 - Example (Decode and display information stored on the EEPROM of SFP transceiver connected to Ethernet0):
@@ -811,6 +814,7 @@ If the authentication fails, AAA will check the "failthrough" configuration and 
 - Usage:
   ```
   config aaa authentication (tacacs+ | local | default)
+  ```
 
   - Parameters:
     - tacacs+: Enables remote authentication based on tacacs+
@@ -877,16 +881,18 @@ When any server times out, device will try the next server one by one based on t
 When this command is executed, the configured tacacs+ server addresses are updated in /etc/pam.d/common-auth-sonic configuration file which is being used by tacacs service.
 
 - Usage:
+  ```
    config tacacs add <ip_address> [-t|--timeout <seconds>] [-k|--key <secret>] [-a|--type <type>] [-o|--port <port>] [-p|--pri <priority>] [-m|--use-mgmt-vrf]
+  ```
 
-  - Arguments:
+  - Parameters:
     - ip_address: TACACS+ server IP address.
     - timeout: Transmission timeout interval in seconds, range 1 to 60, default 5
     - key: Shared secret
     - type: Authentication type, "chap" or "pap" or "mschap" or "login", default is "pap".
     - port: TCP port range is 1 to 65535, default 49
     - pri: Priority, priority range 1 to 64, default 1.
-    - use-mgmt-vrf: this means that the server is part of Management vrf, default is "no vrf"
+    - use-mgmt-vrf: This means that the server is part of Management vrf, default is "no vrf"
 
 
 - Example:
@@ -949,10 +955,10 @@ Default for authtype is "pap", default for passkey is EMPTY_STRING and default f
   config tacacs default (authtype | passkey | timeout)
   ```
 
-- Example:
+- Example (This will reset the global authtype back to the default value "pap"):
   ```
   root@T1-2:~# config tacacs default authtype
-  This will reset the global authtype back to the default value "pap".
+  root@T1-2:~#
   ```
 
 **config tacacs passkey**
@@ -964,7 +970,6 @@ When user has not configured server specific passkey, this global value shall be
   ```
   config tacacs passkey <pass_key>
   ```
-
 
 - Example:
   ```
@@ -1107,7 +1112,7 @@ When the optional argument "max_priority"  is specified, each rule’s priority 
   config acl update full [--table_name <table_name>] [--session_name <session_name>] [--mirror_stage (ingress | egress)] [--max_priority <priority_value>] <acl_json_file_name>
   ```
 
-  - Options:
+  - Parameters:
     - table_name: Specifiy the name of the ACL table to load. Example: config acl update full "--table_name DT_ACL_T1  /etc/sonic/acl_table_1.json"
     - session_name: Specifiy the name of the ACL session to load. Example: config acl update full "--session_name mirror_ses1 /etc/sonic/acl_table_1.json"
     - priority_value: Specify the maximum priority to use when loading ACL rules. Example: config acl update full "--max-priority 100  /etc/sonic/acl_table_1.json"
@@ -1115,17 +1120,17 @@ When the optional argument "max_priority"  is specified, each rule’s priority 
     *NOTE 1: All these optional parameters should be inside double quotes. If none of the options are provided, double quotes are not required for specifying filename alone.*
     *NOTE 2: Any number of optional parameters can be configured in the same command.*
 
-- Example:
+- Examples:
   ```
   admin@sonic:~$ config acl update full /etc/sonic/acl_full_snmp_1_2_ssh_4.json
-  admin@sonic:~$ config acl update full " --table_name SNMP-ACL /etc/sonic/acl_full_snmp_1_2_ssh_4.json "
-  admin@sonic:~$ config acl update full " --session_name everflow0 /etc/sonic/acl_full_snmp_1_2_ssh_4.json "
+  admin@sonic:~$ config acl update full "--table_name SNMP-ACL /etc/sonic/acl_full_snmp_1_2_ssh_4.json"
+  admin@sonic:~$ config acl update full "--session_name everflow0 /etc/sonic/acl_full_snmp_1_2_ssh_4.json"
+  ```
 
   This command will remove all rules from all the ACL tables and insert all the rules present in this input file.
   Refer the example file [acl_full_snmp_1_2_ssh_4.json](#) that adds two rules for SNMP (Rule1 and Rule2) and one rule for SSH (Rule4)
   Refer an example for input file format [here](https://github.com/Azure/sonic-mgmt/blob/master/ansible/roles/test/files/helpers/config_service_acls.sh)
   Refer another example [here](https://github.com/Azure/sonic-mgmt/blob/master/ansible/roles/test/tasks/acl/acltb_test_rules_part_1.json)
-  ```
 
 **config acl update incremental**
 
@@ -1153,7 +1158,7 @@ When the optional argument "max_priority"  is specified, each rule’s priority 
   config acl update incremental [--session_name <session_name>] [--mirror_stage (ingress | egress)] [--max_priority <priority_value>] <acl_json_file_name>
   ```
 
-  - Options:
+  - Parameters:
     - table_name: Specifiy the name of the ACL table to load. Example: config acl update full "--table_name DT_ACL_T1  /etc/sonic/acl_table_1.json"
     - session_name: Specifiy the name of the ACL session to load. Example: config acl update full "--session_name mirror_ses1 /etc/sonic/acl_table_1.json"
     - priority_value: Specify the maximum priority to use when loading ACL rules. Example: config acl update full "--max-priority 100  /etc/sonic/acl_table_1.json"
@@ -1161,18 +1166,19 @@ When the optional argument "max_priority"  is specified, each rule’s priority 
     *NOTE 1: All these optional parameters should be inside double quotes. If none of the options are provided, double quotes are not required for specifying filename alone.*
     *NOTE 2: Any number of optional parameters can be configured in the same command.*
 
-- Example:
+- Examples:
   ```
   admin@sonic:~$ config acl update incremental /etc/sonic/acl_incremental_snmp_1_3_ssh_4.json
-  admin@sonic:~$ config acl update incremental " --session_name everflow0 /etc/sonic/acl_incremental_snmp_1_3_ssh_4.json "
+  ```
+  ```
+  admin@sonic:~$ config acl update incremental "--session_name everflow0 /etc/sonic/acl_incremental_snmp_1_3_ssh_4.json"
+  ```
 
   Refer the example file [acl_incremental_snmp_1_3_ssh_4.json](#) that adds two rules for SNMP (Rule1 and Rule3) and one rule for SSH (Rule4)
   When this "incremental" command is executed after "full" command, it has removed SNMP Rule2 and added SNMP Rule3 in the example.
   File "acl_full_snmp_1_2_ssh_4.json" has got SNMP Rule1, SNMP Rule2 and SSH Rule4.
   File "acl_incremental_snmp_1_3_ssh_4.json" has got SNMP Rule1, SNMP Rule3 and SSH Rule4.
   This file is created by copying the file "acl_full_snmp_1_2_ssh_4.json" to "acl_incremental_snmp_1_3_ssh_4.json" and then removing SNMP Rule2 and adding SNMP Rule3.
-
-  ```
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#ACL-Configuration-And-Show)
 
@@ -1193,9 +1199,10 @@ This command displays the ARP entries in the device with following options.
   show arp [-if <interface_name>] [<ip_address>]
   ```
 
-    show arp - displays all entries
-    show arp -if <ifname> - displays the ARP specific to the specified interface.
-    show arp <ip-address> - displays the ARP specific to the specicied ip-address.
+- Details:
+  - show arp: Displays all entries
+  - show arp -if <ifname>: Displays the ARP specific to the specified interface.
+  - show arp <ip-address>: Displays the ARP specific to the specicied ip-address.
 
 
 - Example:
@@ -1221,11 +1228,11 @@ Optionally, you can specify the interface in order to display the ARPs learnt on
 
 - Example:
   ```
-    admin@sonic:~$ show arp -if Ethernet40
-    Address          MacAddress          Iface        Vlan
-    -------------    -----------------   ----------   ------
-    192.168.1.181    e4:c7:22:c1:07:7c   Ethernet40   -
-    Total number of entries 1
+  admin@sonic:~$ show arp -if Ethernet40
+  Address          MacAddress          Iface        Vlan
+  -------------    -----------------   ----------   ------
+  192.168.1.181    e4:c7:22:c1:07:7c   Ethernet40   -
+  Total number of entries 1
 
   ```
 
@@ -1233,11 +1240,11 @@ Optionally, you can specify an IP address in order to display only that particul
 
 - Example:
   ```
-    admin@sonic:~$ show arp 192.168.1.181
-    Address          MacAddress          Iface        Vlan
-    -------------    -----------------   ----------   ------
-    192.168.1.181    e4:c7:22:c1:07:7c   Ethernet40   -
-    Total number of entries 1
+  admin@sonic:~$ show arp 192.168.1.181
+  Address          MacAddress          Iface        Vlan
+  -------------    -----------------   ----------   ------
+  192.168.1.181    e4:c7:22:c1:07:7c   Ethernet40   -
+  Total number of entries 1
 
   ```
 
@@ -1314,37 +1321,37 @@ This command displays the summary of all IPv4 & IPv6 bgp neighbors that are conf
 
 - Example:
   ```
-   admin@sonic-z9264f-9251:~# show bgp summary
+  admin@sonic-z9264f-9251:~# show bgp summary
 
-   IPv4 Unicast Summary:
-   BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
-   BGP table version 6465
-   RIB entries 12807, using 2001 KiB of memory
-   Peers 4, using 83 KiB of memory
-   Peer groups 2, using 128 bytes of memory
+  IPv4 Unicast Summary:
+  BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
+  BGP table version 6465
+  RIB entries 12807, using 2001 KiB of memory
+  Peers 4, using 83 KiB of memory
+  Peer groups 2, using 128 bytes of memory
 
-   Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
-   10.0.0.57       4      64600    3995    4001        0    0    0 00:39:32         6400
-   10.0.0.59       4      64600    3995    3998        0    0    0 00:39:32         6400
-   10.0.0.61       4      64600    3995    4001        0    0    0 00:39:32         6400
-   10.0.0.63       4      64600    3995    3998        0    0    0 00:39:32         6400
+  Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
+  10.0.0.57       4      64600    3995    4001        0    0    0 00:39:32         6400
+  10.0.0.59       4      64600    3995    3998        0    0    0 00:39:32         6400
+  10.0.0.61       4      64600    3995    4001        0    0    0 00:39:32         6400
+  10.0.0.63       4      64600    3995    3998        0    0    0 00:39:32         6400
 
-   Total number of neighbors 4
+  Total number of neighbors 4
 
-   IPv6 Unicast Summary:
-   BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
-   BGP table version 12803
-   RIB entries 12805, using 2001 KiB of memory
-   Peers 4, using 83 KiB of memory
-   Peer groups 2, using 128 bytes of memory
+  IPv6 Unicast Summary:
+  BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
+  BGP table version 12803
+  RIB entries 12805, using 2001 KiB of memory
+  Peers 4, using 83 KiB of memory
+  Peer groups 2, using 128 bytes of memory
 
-   Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
-   fc00::72        4      64600    3995    5208        0    0    0 00:39:30         6400
-   fc00::76        4      64600    3994    5208        0    0    0 00:39:30         6400
-   fc00::7a        4      64600    3993    5208        0    0    0 00:39:30         6400
-   fc00::7e        4      64600    3993    5208        0    0    0 00:39:30         6400
+  Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
+  fc00::72        4      64600    3995    5208        0    0    0 00:39:30         6400
+  fc00::76        4      64600    3994    5208        0    0    0 00:39:30         6400
+  fc00::7a        4      64600    3993    5208        0    0    0 00:39:30         6400
+  fc00::7e        4      64600    3993    5208        0    0    0 00:39:30         6400
 
-   Total number of neighbors 4
+  Total number of neighbors 4
   ```
   Click [here](#Quagga-BGP-Show-Commands) to see the example for "show ip bgp summary" for Quagga.
 
@@ -1376,40 +1383,40 @@ In order to get details for an IPv6 neigbor, use "show bgp ipv6 neighbor <ipv6_a
 
 - Example:
   ```
-   admin@sonic:~$ show bgp neighbors
-   BGP neighbor is 10.0.0.57, remote AS 64600, local AS 65100, external link
-   Description: ARISTA01T1
-   BGP version 4, remote router ID 100.1.0.29, local router ID 10.1.0.32
-   BGP state = Established, up for 00:42:15
-   Last read 00:00:00, Last write 00:00:03
-   Hold time is 10, keepalive interval is 3 seconds
-   Configured hold time is 10, keepalive interval is 3 seconds
-   Neighbor capabilities:
-     4 Byte AS: advertised and received
-     AddPath:
-       IPv4 Unicast: RX advertised IPv4 Unicast and received
-     Route refresh: advertised and received(new)
-     Address Family IPv4 Unicast: advertised and received
-     Hostname Capability: advertised (name: sonic-z9264f-9251,domain name: n/a) not received
-     Graceful Restart Capabilty: advertised and received
-       Remote Restart timer is 300 seconds
-       Address families by peer:
-         none
-   Graceful restart information:
-     End-of-RIB send: IPv4 Unicast
-     End-of-RIB received: IPv4 Unicast
-   Message statistics:
-     Inq depth is 0
-     Outq depth is 0
-                          Sent       Rcvd
-     Opens:                  2          1
-     Notifications:          2          0
-     Updates:             3206       3202
-     Keepalives:           845        847
-     Route Refresh:          0          0
-     Capability:             0          0
-     Total:               4055       4050
-   Minimum time between advertisement runs is 0 seconds
+  admin@sonic:~$ show bgp neighbors
+  BGP neighbor is 10.0.0.57, remote AS 64600, local AS 65100, external link
+  Description: ARISTA01T1
+  BGP version 4, remote router ID 100.1.0.29, local router ID 10.1.0.32
+  BGP state = Established, up for 00:42:15
+  Last read 00:00:00, Last write 00:00:03
+  Hold time is 10, keepalive interval is 3 seconds
+  Configured hold time is 10, keepalive interval is 3 seconds
+  Neighbor capabilities:
+    4 Byte AS: advertised and received
+    AddPath:
+      IPv4 Unicast: RX advertised IPv4 Unicast and received
+    Route refresh: advertised and received(new)
+    Address Family IPv4 Unicast: advertised and received
+    Hostname Capability: advertised (name: sonic-z9264f-9251,domain name: n/a) not received
+    Graceful Restart Capabilty: advertised and received
+      Remote Restart timer is 300 seconds
+      Address families by peer:
+        none
+  Graceful restart information:
+    End-of-RIB send: IPv4 Unicast
+    End-of-RIB received: IPv4 Unicast
+  Message statistics:
+    Inq depth is 0
+    Outq depth is 0
+                         Sent       Rcvd
+    Opens:                  2          1
+    Notifications:          2          0
+    Updates:             3206       3202
+    Keepalives:           845        847
+    Route Refresh:          0          0
+    Capability:             0          0
+    Total:               4055       4050
+  Minimum time between advertisement runs is 0 seconds
 
   For address family: IPv4 Unicast
    Update group 1, subgroup 1
@@ -1432,16 +1439,15 @@ In order to get details for an IPv6 neigbor, use "show bgp ipv6 neighbor <ipv6_a
 
 Optionally, you can specify an IP address in order to display only that particular neighbor. In this mode, you can optionally specify whether you want to display all routes advertised to the specified neighbor, all routes received from the specified neighbor or all routes (received and accepted) from the specified neighbor.
 
-
 - Example:
   ```
-    admin@sonic:~$ show bgp neighbors 10.0.0.57
+  admin@sonic:~$ show bgp neighbors 10.0.0.57
 
-    admin@sonic:~$ show bgp neighbors 10.0.0.57 advertised-routes
+  admin@sonic:~$ show bgp neighbors 10.0.0.57 advertised-routes
 
-    admin@sonic:~$ show bgp neighbors 10.0.0.57 received-routes
+  admin@sonic:~$ show bgp neighbors 10.0.0.57 received-routes
 
-    admin@sonic:~$ show bgp neighbors 10.0.0.57 routes
+  admin@sonic:~$ show bgp neighbors 10.0.0.57 routes
 
   ```
 
@@ -1910,7 +1916,9 @@ This command displays information regarding port-channel interfaces
 This command displays some more fields such as Lanes, Speed, MTU, Type, Asymmetric PFC status and also the operational and administrative status of the interfaces
 
 - Usage:
-  show interfaces status[<interface_name>]
+  ```
+  show interfaces status [<interface_name>]
+  ```
 
 - Example:
   ```

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -243,7 +243,6 @@ This command lists all the possible configuration commands at the top level.
     vlan                   VLAN-related configuration tasks
     warm_restart           warm_restart-related configuration tasks
     watermark              Configure watermark
-
   ```
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Basic-Configuration-And-Show)
 
@@ -303,7 +302,6 @@ This command displays the full list of show commands available in the software; 
     vlan                  Show VLAN information
     warm_restart          Show warm restart configuration and state
     watermark             Show details of watermark
-
   ```
 
 The same syntax applies to all subgroups of `show` which themselves contain subcommands, and subcommands which accept options/arguments.
@@ -379,7 +377,6 @@ This command displays relevant information as the SONiC and Linux kernel version
   docker-platform-monitor    latest              40b40a4b2164        287MB
   docker-fpm-quagga          HEAD.32-21ea29a     546036fe6838        282MB
   docker-fpm-quagga          latest              546036fe6838        282MB
-
   ```
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Basic-Configuration-And-Show)
 
@@ -462,7 +459,6 @@ This command displays the platform environmentals, such as voltages, temperature
     PSU 1:
       Input:           AC
   <... few more things ...>
-
   ```
 NOTE: The show output has got lot of information; only the sample output is given in the above example.
 Though the displayed output slightly differs from one platform to another platform, the overall content will be similar to the example mentioned above.
@@ -558,7 +554,6 @@ This command displays a list of users currently logged in to the device
 
   admin@sonic:~$ show users
   admin    ttyS1        2019-03-25 20:31
-
   ```
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Basic-Configuration-And-Show)
 
@@ -893,7 +888,7 @@ When this command is executed, the configured tacacs+ server addresses are updat
 
 - Usage:
   ```
-   config tacacs add <ip_address> [-t|--timeout <seconds>] [-k|--key <secret>] [-a|--type <type>] [-o|--port <port>] [-p|--pri <priority>] [-m|--use-mgmt-vrf]
+  config tacacs add <ip_address> [-t|--timeout <seconds>] [-k|--key <secret>] [-a|--type <type>] [-o|--port <port>] [-p|--pri <priority>] [-m|--use-mgmt-vrf]
   ```
 
   - Parameters:
@@ -1244,7 +1239,6 @@ Optionally, you can specify the interface in order to display the ARPs learnt on
   -------------    -----------------   ----------   ------
   192.168.1.181    e4:c7:22:c1:07:7c   Ethernet40   -
   Total number of entries 1
-
   ```
 
 Optionally, you can specify an IP address in order to display only that particular entry
@@ -1256,7 +1250,6 @@ Optionally, you can specify an IP address in order to display only that particul
   -------------    -----------------   ----------   ------
   192.168.1.181    e4:c7:22:c1:07:7c   Ethernet40   -
   Total number of entries 1
-
   ```
 
 ### NDP show commands
@@ -1459,7 +1452,6 @@ Optionally, you can specify an IP address in order to display only that particul
   admin@sonic:~$ show bgp neighbors 10.0.0.57 received-routes
 
   admin@sonic:~$ show bgp neighbors 10.0.0.57 routes
-
   ```
 
   Click [here](#Quagga-BGP-Show-Commands) to see the example for "show ip bgp neighbors" for Quagga.
@@ -1499,7 +1491,6 @@ This command displays the summary of all IPv6 bgp neighbors that are configured 
   fc00::7e        4      64600    3993    5208        0    0    0 00:39:30         6400
 
   Total number of neighbors 4
-
   ```
   Click [here](#Quagga-BGP-Show-Commands) to see the example for "show ipv6 bgp summary" for Quagga.
 
@@ -1530,7 +1521,6 @@ This command displays all the details of one particular IPv6 Border Gateway Prot
   admin@sonic:~$ show bgp ipv6 neighbors fc00::72 received-routes
 
   admin@sonic:~$ show bgp ipv6 neighbors fc00::72 routes
-
   ```
   Click [here](#Quagga-BGP-Show-Commands) to see the example for "show ip bgp summary" for Quagga.
 
@@ -1874,7 +1864,6 @@ This command displays the key fields of the interfaces such as Operational Statu
   Interface    Oper    Admin           Alias           Description
   -----------  ------  -------  --------------  --------------------
   Ethernet4    down       up  hundredGigE1/2  T0-2:hundredGigE1/30
-
   ```
 
 
@@ -1901,7 +1890,6 @@ This command is used to display the list of expected neighbors for all interface
   Ethernet116  ARISTA02T1  Ethernet1       None                10.16.205.101   SpineRouter
   Ethernet120  ARISTA03T1  Ethernet1       None                10.16.205.102   LeafRouter
   Ethernet124  ARISTA04T1  Ethernet1       None                10.16.205.103   LeafRouter
-
   ```
 
 **show interfaces portchannel**
@@ -1946,7 +1934,6 @@ This command displays some more fields such as Lanes, Speed, MTU, Type, Asymmetr
   Ethernet4      53,54,55,56     100G   9100   hundredGigE1/2    down       up     N/A         off
   Ethernet8      57,58,59,60     100G   9100   hundredGigE1/3    down     down     N/A         off
   <contiues to display all the interfaces>
-
   ```
 
 - Example (to only display the status for interface Ethernet0):
@@ -1957,7 +1944,6 @@ This command displays some more fields such as Lanes, Speed, MTU, Type, Asymmetr
   Interface     Lanes    Speed    MTU            Alias    Oper    Admin
   -----------  --------  -------  -----   --------------  ------  -------
   Ethernet0   101,102      40G   9100   fortyGigE1/1/1      up       up
-
   ```
 
 **show interfaces transceiver**
@@ -2404,7 +2390,6 @@ This command displays either all the IPv6 route entries from the routing table o
   C * fe80::/64 is directly connected, Bridge
   C * fe80::/64 is directly connected, PortChannel0011
   C>* fe80::/64 is directly connected, eth0
-
   ```
  - Optionally, you can specify an IPv6 address in order to display only routes to that particular IPv6 address
 
@@ -2749,7 +2734,6 @@ This command displays all the mirror sessions that are configured.
   Name       Status    SRC IP     DST IP    GRE    DSCP    TTL    Queue
   ---------  --------  ---------  --------  -----  ------  -----  -------
   everflow0  active    10.1.0.32  10.0.0.7
-
   ```
 
 ### Mirroring Config command
@@ -3091,7 +3075,6 @@ This command displays the user watermark for the queues (Egress shared pool occu
     Ethernet12     0      0      0      0      0      0      0      0
 
   admin@sonic:~$ show queue  watermark multicast (Egress shared pool occupancy per multicast queue)
-
   ```
 
 **show priority-group watermark|persistent-watermark**
@@ -3193,7 +3176,7 @@ This command is used to clear all the QoS configuration from all the following Q
 
 - Usage:
   ```
-   config qos clear
+  config qos clear
   ```
 
 - Example:
@@ -3716,7 +3699,6 @@ NOTE: This command is not working. It crashes as follows. A bug ticket is opened
 - Example:
   ```
   admin@T1-2:~$ show line
-
   ```
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#System-State)

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -2016,6 +2016,8 @@ IP address for either physical interface or for portchannel or for VLAN interfac
 VLAN interface names take the form of `vlan<vlan_id>`. E.g., VLAN 100 will be named `vlan100`
 
 - Example:
+
+  *Versions >= 201904*
   ```
   admin@sonic:~$ sudo config interface ip add vlan100 10.11.12.13/24
   ```

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -4477,7 +4477,7 @@ Once if users go to "vtysh", they can use the routing stack specific commands as
 Refer the routing stack [Quagga Command Reference](https://www.quagga.net/docs/quagga.pdf) or [FRR Command Reference](https://buildmedia.readthedocs.org/media/pdf/frrouting/latest/frrouting.pdf) to know more about about the routing stack configuration.
 
 
-Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#routing-stack)
 
 
 ## Quagga BGP Show Commands

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -1992,6 +1992,7 @@ IP address for either physical interface or for portchannel or for VLAN interfac
 
 
 - Usage:
+
   *Versions >= 201904*
   ```
   config interface ip add <interface_name> <ip_addr>
@@ -2002,6 +2003,7 @@ IP address for either physical interface or for portchannel or for VLAN interfac
   ```
 
 - Example:
+
   *Versions >= 201904*
   ```
   admin@sonic:~$ sudo config interface ip add Ethernet63 10.11.12.13/24
@@ -2028,6 +2030,7 @@ VLAN interface names take the form of `vlan<vlan_id>`. E.g., VLAN 100 will be na
 **config interface <interface_name> ip remove <ip_addr> (Versions <= 201811)**
 
 - Usage:
+
   *Versions >= 201904*
   ```
   config interface ip remove <interface_name> <ip_addr>
@@ -2038,6 +2041,7 @@ VLAN interface names take the form of `vlan<vlan_id>`. E.g., VLAN 100 will be na
   ```
 
 - Example:
+
   *Versions >= 201904*
   ```
   admin@sonic:~$ sudo config interface ip remove Ethernet63 10.11.12.13/24
@@ -2050,6 +2054,7 @@ VLAN interface names take the form of `vlan<vlan_id>`. E.g., VLAN 100 will be na
 VLAN interface names take the form of `vlan<vlan_id>`. E.g., VLAN 100 will be named `vlan100`
 
 - Example:
+
   *Versions >= 201904*
   ```
   admin@sonic:~$ sudo config interface ip remove vlan100 10.11.12.13/24
@@ -2066,6 +2071,7 @@ VLAN interface names take the form of `vlan<vlan_id>`. E.g., VLAN 100 will be na
 This command is used for setting the asymmetric PFC for an interface to either "on" or "off". Once if it is configured, use "show interfaces status" to check the same.
 
 - Usage:
+
   *Versions >= 201904*
   ```
   config interface pfc asymmetric <interface_name> on/off (for 201904+ version)
@@ -2076,6 +2082,7 @@ This command is used for setting the asymmetric PFC for an interface to either "
   ```
 
 - Example:
+
   *Versions >= 201904*
   ```
   admin@sonic:~$ sudo config interface pfc asymmetric Ethernet60 on
@@ -2092,6 +2099,7 @@ This command is used for setting the asymmetric PFC for an interface to either "
 This command is used to administratively shut down either the Physical interface or port channel interface. Once if it is configured, use "show interfaces status" to check the same.
 
 - Usage:
+
   *Versions >= 201904*
   ```
   config interface shutdown <interface_name> (for 201904+ version)
@@ -2101,6 +2109,7 @@ This command is used to administratively shut down either the Physical interface
   config interface <interface_name> shutdown (for 201811- version)
 
 - Example:
+
   *Versions >= 201904*
   ```
   admin@sonic:~$ sudo config interface shutdown Ethernet63
@@ -2117,6 +2126,7 @@ This command is used to administratively shut down either the Physical interface
 This command is used for administratively bringing up the Physical interface or port channel interface.Once if it is configured, use "show interfaces status" to check the same.
 
 - Usage:
+
   *Versions >= 201904*
   ```
   config interface startup <interface_name> (for 201904+ version)
@@ -2126,6 +2136,7 @@ This command is used for administratively bringing up the Physical interface or 
   config interface <interface_name> startup (for 201811- version)
 
 - Example:
+
   *Versions >= 201904*
   ```
   admin@sonic:~$ sudo config interface startup Ethernet63
@@ -2143,6 +2154,7 @@ This command is used to configure the speed for the Physical interface. Use the 
 Dynamic breakout feature is yet to be supported in SONiC and hence uses cannot configure any values other than 40G and 100G.
 
 - Usage:
+
   *Versions >= 201904*
   ```
   config interface speed <interface_name> <speed_value>

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -2196,7 +2196,7 @@ NOTE: Some platforms do not support alias mapping. In such cases, this command i
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Interface-Naming-Mode)
 
 
-## IP
+## IP / IPv6
 
 ### IP show commands
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -205,7 +205,9 @@ All commands has got in-built help that helps the user to understand the command
 This command lists all the possible configuration commands at the top level.
 
 - Usage:
+  ```
   config --help
+  ```
 
 - Example:
   ```
@@ -247,7 +249,9 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 This command displays the full list of show commands available in the software; the output of each of those show commands can be used to analyze, debug or troubleshoot the network node.
 
 - Usage:
-  You can enter `show -?`, `show -h` or `show --help`
+  ```
+  show (-?|-h|--help)
+  ```
 
 - Example:
   ```
@@ -329,7 +333,9 @@ This command displays software component versions of the currently running SONiC
 This command displays relevant information as the SONiC and Linux kernel version being utilized, as well as the commit-id used to build the SONiC image. The second section of the output displays the various docker images and their associated id’s.
 
 - Usage:
+  ```
   show version
+  ```
 
 - Example:
   ```
@@ -374,8 +380,10 @@ This sub-section explains some set of sub-commands that are used to display the 
 **show clock**
 This command displays the current date and time configured on the system
 
--  Usage:
-   show clock
+- Usage:
+  ```
+  show clock
+  ```
 
 - Example:
   ```
@@ -386,23 +394,27 @@ This command displays the current date and time configured on the system
 **show boot**
 This command displays the current OS image, the image loaded on next reboot, and the lists the available images on the system
 
--  Usage:
-   show boot
+- Usage:
+  ```
+  show boot
+  ```
 
 - Example:
   ```
   admin@sonic:~$ show boot
   Current: SONiC-OS-20181130.31
   Next: SONiC-OS-20181130.31
-  Available: 
+  Available:
   SONiC-OS-20181130.31
   ```
 
 **show environment**
 This command displays the platform environmentals, such as voltages, temperatures and fan speeds
 
--  Usage:
-   show environment
+- Usage:
+  ```
+  show environment
+  ```
 
 - Example:
   ```
@@ -449,9 +461,11 @@ Though the displayed output slightly differs from one platform to another platfo
 This command displays the cause of the previous reboot
 
 - Usage:
+  ```
   show reboot-cause
+  ```
 
--  Example:
+- Example:
   ```
   admin@sonic:~$ show reboot-cause
   User issued reboot command [User: admin, Time: Mon Mar 25 01:02:03 UTC 2019]
@@ -461,7 +475,9 @@ This command displays the cause of the previous reboot
 This command displays the current system uptime
 
 - Usage:
+  ```
   show uptime
+  ```
 
 - Example:
   ```
@@ -476,7 +492,9 @@ This file is saved in the path `/var/log` and can be viewed by giving the comman
 Individual process can also be viewed using the command `ps -ax | grep <\process name>
 
 - Usage:
-  show logging ([\<process_name\>] [-l lines] | [-f])
+  ```
+  show logging ([<process_name>] [(-l|--lines) <number_of_lines>]) | [-f|--follow]
+  ```
 
 - Example:
   ```
@@ -515,7 +533,9 @@ Individual process can also be viewed using the command `ps -ax | grep <\process
 This command displays a list of users currently logged in to the device
 
 - Usage:
+  ```
   show users
+  ```
 
 - Examples:
   ```
@@ -536,7 +556,9 @@ The information displayed in this set of commands partially overlaps with the on
 This command displays a summary of the device's hardware platform
 
 - Usage:
+  ```
   show platform summary
+  ```
 
 - Example:
   ```
@@ -552,7 +574,9 @@ Note that the output of this command is not the same for all vendor's platforms.
 Couple of example outputs are given below.
 
 - Usage:
+  ```
   show platform syseeprom
+  ```
 
 - Example:
   ```
@@ -572,38 +596,40 @@ Couple of example outputs are given below.
   ```
 
   ```
-	admin@arc-switch1025:~$ show platform syseeprom
-	TlvInfo Header:
-	  Id String:    TlvInfo
-	  Version:      1
-	  Total Length: 527
-	TLV Name             Code Len Value
-	---- --- -----
-	Product Name         0x21  64 MSN2700
-	Part Number          0x22  20 MSN2700-CS2FO
-	Serial Number        0x23  24 MT1822K07815
-	Base MAC Address     0x24   6 50:6B:4B:8F:CE:40
-	Manufacture Date     0x25  19 05/28/2018 23:56:02
-	Device Version       0x26   1 16
-	MAC Addresses        0x2A   2 128
-	Manufacturer         0x2B   8 Mellanox
-	Vendor Extension     0xFD  36
-	Vendor Extension     0xFD 164
-	Vendor Extension     0xFD  36
-	Vendor Extension     0xFD  36
-	Vendor Extension     0xFD  36
-	Platform Name        0x28  18 x86_64-mlnx_x86-r0
-	ONIE Version         0x29  21 2018.08-5.2.0006-9600
-	CRC-32               0xFE   4 0x11C017E1
+  admin@arc-switch1025:~$ show platform syseeprom
+  TlvInfo Header:
+    Id String:    TlvInfo
+    Version:      1
+    Total Length: 527
+  TLV Name             Code Len Value
+  ---- --- -----
+  Product Name         0x21  64 MSN2700
+  Part Number          0x22  20 MSN2700-CS2FO
+  Serial Number        0x23  24 MT1822K07815
+  Base MAC Address     0x24   6 50:6B:4B:8F:CE:40
+  Manufacture Date     0x25  19 05/28/2018 23:56:02
+  Device Version       0x26   1 16
+  MAC Addresses        0x2A   2 128
+  Manufacturer         0x2B   8 Mellanox
+  Vendor Extension     0xFD  36
+  Vendor Extension     0xFD 164
+  Vendor Extension     0xFD  36
+  Vendor Extension     0xFD  36
+  Vendor Extension     0xFD  36
+  Platform Name        0x28  18 x86_64-mlnx_x86-r0
+  ONIE Version         0x29  21 2018.08-5.2.0006-9600
+  CRC-32               0xFE   4 0x11C017E1
 
-	(checksum valid)
+  (checksum valid)
   ```
 
-**show platform ssdhealth**  
+**show platform ssdhealth**
 This command displays health parameters of the device's SSD
 
-- Usage:  
-  show platform ssdhealth [--verbose, --vendor]
+- Usage:
+  ```
+  show platform ssdhealth [--vendor]
+  ```
 
 - Example:
   ```
@@ -617,7 +643,9 @@ This command displays health parameters of the device's SSD
 This command displays the status of the device's power supply units
 
 - Usage:
+  ```
   show platform psustatus
+  ```
 
 - Example:
   ```
@@ -635,10 +663,11 @@ Displays diagnostic monitoring information of the transceivers
 This command displays information for all the interfaces for the transceiver requested or a specific interface if the optional "interface-name" is specified.
 
 - Usage:
-  show interfaces transceiver [eeprom | lpmode | presence]
-  show interfaces transceiver [eeprom [-d | --dom] | lpmode | presence] [<interface-name>]
+  ```
+  show interfaces transceiver (eeprom [-d|--dom] | lpmode | presence]) [<interface-name>]
+  ```
 
-- Example (Decode and display information stored on the SFP EEPROM):
+- Example (Decode and display information stored on the EEPROM of SFP transceiver connected to Ethernet0):
   ```
   admin@sonic:~$ show interfaces transceiver eeprom --dom Ethernet0
   Ethernet0: SFP detected
@@ -673,7 +702,7 @@ This command displays information for all the interfaces for the transceiver req
                   Vcc : 0.0000Volts
   ```
 
-- Example (Display status of low-power mode):
+- Example (Display status of low-power mode of SFP transceiver connected to Ethernet100):
   ```
   admin@sonic:~$ show interfaces transceiver lpmode Ethernet100
   Port         Low-power Mode
@@ -682,7 +711,7 @@ This command displays information for all the interfaces for the transceiver req
   ```
 
 
-- Example (Display SFP transceiver presence):
+- Example (Display presence of SFP transceiver connected to Ethernet100):
   ```
   admin@sonic:~$ show interfaces transceiver presence Ethernet100
   Port         Presence
@@ -706,7 +735,9 @@ This command is used to view the Authentication, Authorization & Accounting sett
 This command displays the AAA settings currently present in the network node
 
 - Usage:
+  ```
   show aaa
+  ```
 
 - Example:
    ```
@@ -720,11 +751,11 @@ This command displays the AAA settings currently present in the network node
 
 This sub-section explains all the possible CLI based configuration options for the AAA module. The list of commands/sub-commands possible for aaa is given below.
 
-	Command: aaa authentication
-             sub-commands:
-               aaa authentication failthrough
-               aaa authentication fallback
-               aaa authentication login
+  Command: aaa authentication
+    sub-commands:
+      - aaa authentication failthrough
+      - aaa authentication fallback
+      - aaa authentication login
 
 **aaa authentication failthrough**
 
@@ -736,12 +767,14 @@ When this is disabled and if the authentication request fails on first server, a
 
 
 - Usage:
-  config aaa authentication failthrough enable|disable|default
+  ```
+  config aaa authentication failthrough (enable | disable | default)
+  ```
 
-		   Allow AAA fail-through [enable | disable | default]
-           enable - this allows the AAA module to process with local authentication if remote authentication fails.
-		   disbale - this disallows the AAA module to proceed further if remote authentication fails.
-		   default - this re-configures the default value, which is "enable".
+  - Options:
+    - enable: This allows the AAA module to process with local authentication if remote authentication fails.
+    - disable: This disallows the AAA module to proceed further if remote authentication fails.
+    - default: This re-configures the default value, which is "enable".
 
 
 - Example:
@@ -756,9 +789,9 @@ The command is not used at the moment.
 When the tacacs+ authentication fails, it falls back to local authentication by default.
 
 - Usage:
-  config aaa authentication fallback enable|disable|default
-
-	   Allow AAA fallback [enable | disable | default]
+  ```
+  config aaa authentication fallback (enable | disable | default)
+  ```
 
 - Example:
   ```
@@ -776,12 +809,13 @@ Once if the admins choose the remote authentication based on tacacs+ server, all
 If the authentication fails, AAA will check the "failthrough" configuration and authenticates the user based on local database if failthrough is enabled.
 
 - Usage:
-  Switch login authentication [ {tacacs+, local} | default ]
+  ```
+  config aaa authentication (tacacs+ | local | default)
 
-	  Switch login authentication [ {tacacs+, local} | default ]
-	  tacacs+ - This enables remote authentication based on tacacs+
-	  local - this disables remote authentication and uses local authentication
-	  default - reset back to default value, which is nothing but the "local" authentication
+  - Options:
+    - tacacs+: Enables remote authentication based on tacacs+
+    - local: Disables remote authentication and uses local authentication
+    - default: Reset back to default value, which is only "local" authentication
 
 
 - Example:
@@ -800,24 +834,27 @@ If the authentication fails, AAA will check the "failthrough" configuration and 
 This command displays the global configuration fields and the list of all tacacs servers and their correponding configurations.
 
 - Usage:
-	show tacacs
+  ```
+  show tacacs
+  ```
 
 - Example:
   ```
-	TACPLUS global auth_type pap (default)
-	TACPLUS global timeout 99
-	TACPLUS global passkey <EMPTY_STRING> (default)
+  admin@sonic:~$ show tacacs
+  TACPLUS global auth_type pap (default)
+  TACPLUS global timeout 99
+  TACPLUS global passkey <EMPTY_STRING> (default)
 
-	TACPLUS_SERVER address 10.11.12.14
-				   priority 9
-				   tcp_port 50
-				   auth_type mschap
-				   timeout 10
-				   passkey testing789
+  TACPLUS_SERVER address 10.11.12.14
+                         priority 9
+                         tcp_port 50
+                         auth_type mschap
+                         timeout 10
+                         passkey testing789
 
-	TACPLUS_SERVER address 10.0.0.9
-				   priority 1
-				   tcp_port 49
+  TACPLUS_SERVER address 10.0.0.9
+                         priority 1
+                         tcp_port 49
   ```
 
 ### TACACS+ Config commands
@@ -840,44 +877,45 @@ When any server times out, device will try the next server one by one based on t
 When this command is executed, the configured tacacs+ server addresses are updated in /etc/pam.d/common-auth-sonic configuration file which is being used by tacacs service.
 
 - Usage:
-   config tacacs add <ip_address> [-t|--timeout SECOND] [-k|--key SECRET] [-a|--type TYPE] [-o|--port PORT] [-p|--pri PRIORITY] [-m|--use-mgmt-vrf]
+   config tacacs add <ip_address> [-t|--timeout <seconds>] [-k|--key <secret>] [-a|--type <type>] [-o|--port <port>] [-p|--pri <priority>] [-m|--use-mgmt-vrf]
 
-	 **Arguments:**
-
-	 ip_address - TACACS+ server IP address.
-	 timeout - Transmission timeout interval in seconds, range 1 to 60, default 5
-	 key - Shared secret
-	 type - Authentication type, "chap" or "pap" or "mschap" or "login", default is "pap".
-	 port - TCP port range is 1 to 65535, default 49
-	 pri - Priority, priority range 1 to 64, default 1.
-	 use-mgmt-vrf - this means that the server is part of Management vrf, default is "no vrf"
+  - Arguments:
+    - ip_address: TACACS+ server IP address.
+    - timeout: Transmission timeout interval in seconds, range 1 to 60, default 5
+    - key: Shared secret
+    - type: Authentication type, "chap" or "pap" or "mschap" or "login", default is "pap".
+    - port: TCP port range is 1 to 65535, default 49
+    - pri: Priority, priority range 1 to 64, default 1.
+    - use-mgmt-vrf: this means that the server is part of Management vrf, default is "no vrf"
 
 
 - Example:
   ```
   root@T1-2:~# config tacacs add 10.11.12.13 -t 10 -k testing789 -a mschap -o 50 -p 9
   root@T1-2:~#
-
-	Example Server Configuration in /etc/pam.d/common-auth-sonic configuration file:
-
-	auth    [success=done new_authtok_reqd=done default=ignore]     pam_tacplus.so server=10.11.12.14:50 secret=testing789 login=mschap timeout=10  try_first_pass
-	auth    [success=done new_authtok_reqd=done default=ignore]     pam_tacplus.so server=10.11.12.24:50 secret=testing789 login=mschap timeout=987654321098765433211
-	0987  try_first_pass
-	auth    [success=done new_authtok_reqd=done default=ignore]     pam_tacplus.so server=10.0.0.9:49 secret= login=mschap timeout=5  try_first_pass
-	auth    [success=done new_authtok_reqd=done default=ignore]     pam_tacplus.so server=10.0.0.8:49 secret= login=mschap timeout=5  try_first_pass
-	auth    [success=done new_authtok_reqd=done default=ignore]     pam_tacplus.so server=10.11.12.13:50 secret=testing789 login=mschap timeout=10  try_first_pass
-	auth    [success=1 default=ignore]      pam_unix.so nullok try_first_pass
-
-	   NOTE: In the above example, the servers are stored (sorted) based on the priority value configured for the server.
-
   ```
+
+  - Example Server Configuration in /etc/pam.d/common-auth-sonic configuration file:
+    ```
+    auth    [success=done new_authtok_reqd=done default=ignore]     pam_tacplus.so server=10.11.12.14:50 secret=testing789 login=mschap timeout=10  try_first_pass
+    auth    [success=done new_authtok_reqd=done default=ignore]     pam_tacplus.so server=10.11.12.24:50 secret=testing789 login=mschap timeout=987654321098765433211
+    0987  try_first_pass
+    auth    [success=done new_authtok_reqd=done default=ignore]     pam_tacplus.so server=10.0.0.9:49 secret= login=mschap timeout=5  try_first_pass
+    auth    [success=done new_authtok_reqd=done default=ignore]     pam_tacplus.so server=10.0.0.8:49 secret= login=mschap timeout=5  try_first_pass
+    auth    [success=done new_authtok_reqd=done default=ignore]     pam_tacplus.so server=10.11.12.13:50 secret=testing789 login=mschap timeout=10  try_first_pass
+    auth    [success=1 default=ignore]      pam_unix.so nullok try_first_pass
+    ```
+
+    *NOTE: In the above example, the servers are stored (sorted) based on the priority value configured for the server.*
 
 **config tacacs delete**
 
 This command is used to delete the tacacs+ servers configured.
 
 - Usage:
-   config tacacs delete <ip_address>
+  ```
+  config tacacs delete <ip_address>
+  ```
 
 - Example:
   ```
@@ -890,8 +928,10 @@ This command is used to delete the tacacs+ servers configured.
 This command is used to modify the global value for the TACACS+ authtype.
 When user has not configured server specific authtype, this global value shall be used for that server.
 
-   - Usage:
-     config tacacs authtype  chap|pap||mschap|login
+- Usage:
+  ```
+  config tacacs authtype (chap | pap | mschap | login)
+  ```
 
 - Example:
   ```
@@ -905,8 +945,9 @@ This command is used to reset the global value for authtype or passkey or timeou
 Default for authtype is "pap", default for passkey is EMPTY_STRING and default for timeout is 5 seconds.
 
 - Usage:
-   config tacacs default authtype|passkey|timeout
-
+  ```
+  config tacacs default (authtype | passkey | timeout)
+  ```
 
 - Example:
   ```
@@ -919,8 +960,10 @@ Default for authtype is "pap", default for passkey is EMPTY_STRING and default f
 This command is used to modify the global value for the TACACS+ passkey.
 When user has not configured server specific passkey, this global value shall be used for that server.
 
-   - Usage:
-     config tacacs passkey <pass_key>
+- Usage:
+  ```
+  config tacacs passkey <pass_key>
+  ```
 
 
 - Example:
@@ -935,11 +978,15 @@ This command is used to modify the global value for the TACACS+ timeout.
 When user has not configured server specific timeout, this global value shall be used for that server.
 
 
-   - Usage:
-    config tacacs [default] timeout [\<timeout_value_in_seconds\>]
-     valid values for timeout is 1 to 60 seconds.
-	 When the optional keyword "default" is specified, timeout_value_in_seconds parameter wont be used; default value of 5 is used.
-	 Configuration using the keyword "default" is introduced in 201904 release.
+- Usage:
+  ```
+  config tacacs [default] timeout [<timeout_value_in_seconds>]
+  ```
+
+  - Options:
+    - Valid values for timeout is 1 to 60 seconds.
+    - When the optional keyword "default" is specified, timeout_value_in_seconds parameter wont be used; default value of 5 is used.
+    - Configuration using the keyword "default" is introduced in 201904 release.
 
 - Example: To configure non-default timeout value
   ```
@@ -963,7 +1010,9 @@ This command displays either all the ACL tables that are configured or only the 
 Output from the command displays the table name, type of the table, the list of interface(s) to which the table is bound and the description about the table.
 
 - Usage:
-  show acl table [TABLE_NAME]
+  ```
+  show acl table [<table_name>]
+  ```
 
 - Example:
   ```
@@ -982,7 +1031,6 @@ Output from the command displays the table name, type of the table, the list of 
                        Ethernet112
                        Ethernet116
   SSH_ONLY  CTRLPLANE  SSH              SSH_ONLY         ingress
-
   ```
 
 **show acl rule**
@@ -1008,8 +1056,9 @@ Users can choose to have a default permit rule or default deny rule. In case of 
 5) Match  - The fields from the packet header that need to be matched against the same present in the incoming traffic.
 
 - Usage:
-  show acl rule [TABLE_NAME] [RULE_ID]
-
+  ```
+  show acl rule [<table_name>] [<rule_id>]
+  ```
 
 - Example:
   ```
@@ -1030,17 +1079,10 @@ Users can choose to have a default permit rule or default deny rule. In case of 
   ```
 
 
-
 ## ACL config commands
 This sub-section explains the list of configuration options available for ACL module.
 Note that there is no direct command to add or delete or modify the ACL table and ACL rule.
 Existing ACL tables and ACL rules can be updated by specifying the ACL rules in json file formats and configure those files using this CLI command.
-
-	Command :acl
-              update
-                 full
-                 incremental
-
 
 **config acl update full**
 
@@ -1061,15 +1103,17 @@ When "--mirror_stage" optional argument is specified, command sets the mirror ac
 When the optional argument "max_priority"  is specified, each rule’s priority is calculated by subtracting its “sequence_id” value from the “max_priority”. If this value is not passed, the default “max_priority” 10000 is used.
 
 - Usage:
-  config acl update full FILE_NAME
-	Some of the possible options are
-	1) --table_name <table_name>, Example: config acl update full " --table_name DT_ACL_T1  /etc/sonic/acl_table_1.json "
-	2) --session_name <session_name>, Example: config acl update full " --session_name mirror_ses1 /etc/sonic/acl_table_1.json "
-	3) --mirror_stage ingress|egress, Example: config acl update full " --mirror_stage egress /etc/sonic/acl_table_1.json "
-	4) --max_priority <priority_value>, Example: config acl update full " --max-priority 100  /etc/sonic/acl_table_1.json "
+  ```
+  config acl update full [--table_name <table_name>] [--session_name <session_name>] [--mirror_stage (ingress | egress)] [--max_priority <priority_value>] <acl_json_file_name>
+  ```
 
-	NOTE: All these optional parameters should be inside the double quotes. If none of the options are provided, double quotes is not required for specifying filename alone.
-	Any number of optional parameters can be configured in the same command.
+  - Options:
+    - table_name: Specifiy the name of the ACL table to load. Example: config acl update full "--table_name DT_ACL_T1  /etc/sonic/acl_table_1.json"
+    - session_name: Specifiy the name of the ACL session to load. Example: config acl update full "--session_name mirror_ses1 /etc/sonic/acl_table_1.json"
+    - priority_value: Specify the maximum priority to use when loading ACL rules. Example: config acl update full "--max-priority 100  /etc/sonic/acl_table_1.json"
+
+    *NOTE 1: All these optional parameters should be inside double quotes. If none of the options are provided, double quotes are not required for specifying filename alone.*
+    *NOTE 2: Any number of optional parameters can be configured in the same command.*
 
 - Example:
   ```
@@ -1083,7 +1127,7 @@ When the optional argument "max_priority"  is specified, each rule’s priority 
   Refer another example [here](https://github.com/Azure/sonic-mgmt/blob/master/ansible/roles/test/tasks/acl/acltb_test_rules_part_1.json)
   ```
 
-**config acl update incremental:**
+**config acl update incremental**
 
 This command is used to perform incremental update of ACL rule table. This command gets existing rules from Config DB and compares with rules specified in input file and performs corresponding modifications.
 
@@ -1104,15 +1148,18 @@ When "--mirror_stage" optional argument is specified, command sets the mirror ac
 
 When the optional argument "max_priority"  is specified, each rule’s priority is calculated by subtracting its “sequence_id” value from the “max_priority”. If this value is not passed, the default “max_priority” 10000 is used.
 
-  - Usage:
-    config acl update incremental FILE_NAME
-	Some of the possible options are
-	1) --session_name <session_name>, Example: config acl update full " --session_name mirror_ses1 /etc/sonic/acl_table_1.json "
-	2) --mirror_stage ingress|egress, Example: config acl update full " --mirror_stage egress /etc/sonic/acl_table_1.json "
-	3) --max-priority <priority_value>, Example: config acl update full " --max-priority 100  /etc/sonic/acl_table_1.json "
+- Usage:
+  ```
+  config acl update incremental [--session_name <session_name>] [--mirror_stage (ingress | egress)] [--max_priority <priority_value>] <acl_json_file_name>
+  ```
 
-	NOTE: All these optional parameters should be inside the double quotes. If none of the options are provided, double quotes is not required for specifying filename alone.
-	Any number of optional parameters can be configured in the same command.
+  - Options:
+    - table_name: Specifiy the name of the ACL table to load. Example: config acl update full "--table_name DT_ACL_T1  /etc/sonic/acl_table_1.json"
+    - session_name: Specifiy the name of the ACL session to load. Example: config acl update full "--session_name mirror_ses1 /etc/sonic/acl_table_1.json"
+    - priority_value: Specify the maximum priority to use when loading ACL rules. Example: config acl update full "--max-priority 100  /etc/sonic/acl_table_1.json"
+
+    *NOTE 1: All these optional parameters should be inside double quotes. If none of the options are provided, double quotes are not required for specifying filename alone.*
+    *NOTE 2: Any number of optional parameters can be configured in the same command.*
 
 - Example:
   ```
@@ -1141,8 +1188,11 @@ This command displays the ARP entries in the device with following options.
 2) Display the ARP entries learnt on a specific interface.
 3) Display the ARP of a specific ip-address.
 
-  - Usage:
-    show arp [-if \<if_name\>] [\<ip_address\>]
+- Usage:
+  ```
+  show arp [-if <interface_name>] [<ip_address>]
+  ```
+
     show arp - displays all entries
     show arp -if <ifname> - displays the ARP specific to the specified interface.
     show arp <ip-address> - displays the ARP specific to the specicied ip-address.
@@ -1167,67 +1217,69 @@ This command displays the ARP entries in the device with following options.
   Total number of entries 10
   ```
 
-  - Optionally, you can specify the interface in order to display the ARPs learnt on that particular interface
+- Optionally, you can specify the interface in order to display the ARPs learnt on that particular interface
 
+  - Example:
+    ```
+      admin@sonic:~$ show arp -if Ethernet40
+      Address          MacAddress          Iface        Vlan
+      -------------    -----------------   ----------   ------
+      192.168.1.181    e4:c7:22:c1:07:7c   Ethernet40   -
+      Total number of entries 1
 
-- Example:
-  ```
-    admin@sonic:~$ show arp -if Ethernet40
-    Address          MacAddress          Iface        Vlan
-    -------------    -----------------   ----------   ------
-    192.168.1.181    e4:c7:22:c1:07:7c   Ethernet40   -
-    Total number of entries 1
+    ```
 
-  ```
+- Optionally, you can specify an IP address in order to display only that particular entry
 
-  - Optionally, you can specify an IP address in order to display only that particular entry
+  - Example:
+    ```
+      admin@sonic:~$ show arp 192.168.1.181
+      Address          MacAddress          Iface        Vlan
+      -------------    -----------------   ----------   ------
+      192.168.1.181    e4:c7:22:c1:07:7c   Ethernet40   -
+      Total number of entries 1
 
-- Example:
-  ```
-    admin@sonic:~$ show arp 192.168.1.181
-    Address          MacAddress          Iface        Vlan
-    -------------    -----------------   ----------   ------
-    192.168.1.181    e4:c7:22:c1:07:7c   Ethernet40   -
-    Total number of entries 1
-
-  ```
+    ```
 
 ## NDP show commands
 
 **show ndp**
 This command displays either all the IPv6 neighbor mac addresses, or for a particular IPv6 neighbor, or for all IPv6 neighbors reachable via a specific interface.
 
-  - Usage:
-    show ndp [-if|--iface \<interface_name\>] [IPv6_ADDRESS]
-
-
-- Example:
+- Usage:
   ```
-    **ALL IPv6 NEIGHBORS:**
-	admin@sonic:~$ show ndp
-	Address                   MacAddress         Iface    Vlan    Status
-	------------------------  -----------------  -------  ------  ---------
-	fe80::20c:29ff:feb8:b11e  00:0c:29:b8:b1:1e  eth0     -       REACHABLE
-	fe80::20c:29ff:feb8:cff0  00:0c:29:b8:cf:f0  eth0     -       REACHABLE
-	fe80::20c:29ff:fef9:324   00:0c:29:f9:03:24  eth0     -       REACHABLE
-	Total number of entries 3
+  show ndp [-if|--iface <interface_name>] <ipv6_address>
+  ```
 
-	**SPECIFIC IPv6 NEIGHBOR**
-	admin@sonic:~$ show ndp fe80::20c:29ff:feb8:b11e
-	Address                   MacAddress         Iface    Vlan    Status
-	------------------------  -----------------  -------  ------  ---------
-	fe80::20c:29ff:feb8:b11e  00:0c:29:b8:b1:1e  eth0     -       REACHABLE
-	Total number of entries 1
+- Example (show all IPv6 neighbors):
+  ```
+  admin@sonic:~$ show ndp
+  Address                   MacAddress         Iface    Vlan    Status
+  ------------------------  -----------------  -------  ------  ---------
+  fe80::20c:29ff:feb8:b11e  00:0c:29:b8:b1:1e  eth0     -       REACHABLE
+  fe80::20c:29ff:feb8:cff0  00:0c:29:b8:cf:f0  eth0     -       REACHABLE
+  fe80::20c:29ff:fef9:324   00:0c:29:f9:03:24  eth0     -       REACHABLE
+  Total number of entries 3
+  ```
 
-	**SPECIFIC INTERFACE**
-	admin@sonic:~$ show ndp -if eth0
-	Address                   MacAddress         Iface    Vlan    Status
-	------------------------  -----------------  -------  ------  ---------
-	fe80::20c:29ff:feb8:b11e  00:0c:29:b8:b1:1e  eth0     -       REACHABLE
-	fe80::20c:29ff:feb8:cff0  00:0c:29:b8:cf:f0  eth0     -       REACHABLE
-	fe80::20c:29ff:fef9:324   00:0c:29:f9:03:24  eth0     -       REACHABLE
-	Total number of entries 3
+- Example (show specific IPv6 neighbor):
+  ```
+  admin@sonic:~$ show ndp fe80::20c:29ff:feb8:b11e
+  Address                   MacAddress         Iface    Vlan    Status
+  ------------------------  -----------------  -------  ------  ---------
+  fe80::20c:29ff:feb8:b11e  00:0c:29:b8:b1:1e  eth0     -       REACHABLE
+  Total number of entries 1
+  ```
 
+- Example (show IPv6 neighbors learned on a specific interface):
+  ```
+  admin@sonic:~$ show ndp -if eth0
+  Address                   MacAddress         Iface    Vlan    Status
+  ------------------------  -----------------  -------  ------  ---------
+  fe80::20c:29ff:feb8:b11e  00:0c:29:b8:b1:1e  eth0     -       REACHABLE
+  fe80::20c:29ff:feb8:cff0  00:0c:29:b8:cf:f0  eth0     -       REACHABLE
+  fe80::20c:29ff:fef9:324   00:0c:29:f9:03:24  eth0     -       REACHABLE
+  Total number of entries 3
   ```
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Watermark-Configuration-And-Show)

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -3576,7 +3576,7 @@ This command is used to delete the syslog server configured.
   Restarting rsyslog-config service...
   ```
 
-Go Back To [Beginning of the document](#) or [Beginning of this section](#Startup--Running-Configuration)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#syslog)
 
 ## System State
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -2,90 +2,92 @@
 
 ## Table of Contents
 
-   * [Document History](#document-history)
-   * [Introduction](#introduction)
-   * [Basic Configuration And Show](#basic-configuration-and-show)
-      * [SSH Login](#ssh-login)
-      * [Configuring Management Interface](#configuring-management-interface)
-      * [Config Help](#config-help)
-         * [Show Help](#show-help)
-      * [Show Versions](#show-versions)
-      * [Show System Status](#show-system-status)
-      * [Show Hardware Platform](#show-hardware-platform)
-         * [Transceivers](#transceivers)
-   * [AAA &amp; TACACS  Configuration And Show](#aaa--tacacs-configuration-and-show)
-      * [AAA Configuration And Show](#aaa-configuration-and-show)
-         * [AAA show commands](#aaa-show-commands)
-         * [AAA config commands](#aaa-config-commands)
-      * [TACACS  Configuration And Show](#tacacs-configuration-and-show)
-         * [TACACS  show commands](#tacacs-show-commands)
-         * [TACACS  Config commands](#tacacs-config-commands)
-   * [ACL Configuration And Show](#acl-configuration-and-show)
-      * [ACL show commands](#acl-show-commands)
-      * [ACL config commands](#acl-config-commands)
-   * [ARP &amp; NDP](#arp--ndp)
-      * [ARP show commands](#arp-show-commands)
-      * [NDP show commands](#ndp-show-commands)
-   * [BGP Configuration And Show Commands](#bgp-configuration-and-show-commands)
-      * [BGP show commands](#bgp-show-commands)
-      * [BGP config commands](#bgp-config-commands)
-   * [ECN Configuration And Show Commands](#ecn-configuration-and-show-commands)
-      * [ECN show commands](#ecn-show-commands)
-      * [ECN config commands](#ecn-config-commands)
-   * [Interface Configuration And Show-Commands](#interface-configuration-and-show-commands)
-      * [Interface Show Commands](#interface-show-commands)
-      * [Interface Config Commands](#interface-config-commands)
-   * [Interface Naming Mode](#interface-naming-mode)
-      * [Interface naming mode show commands](#interface-naming-mode-show-commands)
-      * [Interface naming mode config commands](#interface-naming-mode-config-commands)
-   * [IP](#ip)
-      * [IP show commands](#ip-show-commands)
-         * [IPv6 show commands](#ipv6-show-commands)
-   * [LLDP](#lldp)
-      * [LLDP show commands](#lldp-show-commands)
-   * [Loading, Reloading And Saving Configuration](#loading-reloading-and-saving-configuration)
-      * [Load config command](#load-config-command)
-      * [Load_mgmt_config command](#load_mgmt_config-command)
-      * [Load_minigraph config command](#load_minigraph-config-command)
-      * [Reload config command](#reload-config-command)
-      * [Save config  command](#save-config--command)
-   * [Mirroring Configuration And Show](#mirroring-configuration-and-show)
-      * [Mirroring Show command](#mirroring-show-command)
-      * [Mirroring Config command](#mirroring-config-command)
-   * [NTP](#ntp)
-      * [NTP show command](#network-time-protocol-show-command)
-   * [Platform Specific Commands](#platform-specific-commands)
-   * [PortChannel Configuration And Show](#portchannel-configuration-and-show)
-      * [PortChannel Show commands](#portchannel-show-commands)
-      * [PortChannel Config commands](#portchannel-config-commands)
-   * [QoS Configuration &amp; Show](#qos-configuration--show)
-      * [QoS Show commands](#qos-show-commands)
-         * [PFC](#pfc)
-         * [Queue And Priority-Group](#queue-and-priority-group)
-      * [QoS config commands](#qos-config-commands)
-   * [Startup &amp; Running Configuration](#startup--running-configuration)
-      * [Startup Configuration command](#startup-configuration-command)
-      * [Running Configuration command](#running-configuration-command)
-   * [System State](#system-state)
-      * [Processes show commands](#processes-show-commands)
-      * [Services &amp; memory show commands](#services--memory-show-commands)
-   * [VLAN &amp; FDB](#vlan--fdb)
-      * [VLAN](#vlan)
-         * [VLAN show commands](#vlan-show-commands)
-         * [VLAN Config commands](#vlan-config-commands)
-      * [FDB](#fdb)
-         * [FDB show commands](#fdb-show-commands)
-   * [Warm Restart](#warm-restart)
-      * [Warm Restart show command](#warm-restart-show-command)
-      * [Warm Restart Config command](#warm-restart-config-command)
-   * [Watermark Configuration And Show](#watermark-configuration-and-show)
-      * [Watermark Show command](#watermark-show-command)
-      * [Watermark Config command](#watermark-config-command)
-   * [Software Installation Commands](#software-installation-commands)
-      * [SONiC Installer](#sonic-installer)
-   * [Troubleshooting Commands](#troubleshooting-commands)
-   * [Routing Stack Configuration And Show](#routing-stack-configuration-and-show)
-   * [Quagga BGP Show Commands](#Quagga-BGP-Show-Commands)
+* [Document History](#document-history)
+* [Introduction](#introduction)
+* [Basic Tasks](#basic-tasks)
+  * [SSH Login](#ssh-login)
+  * [Configuring Management Interface](#configuring-management-interface)
+* [Getting Help](#getting-help)
+  * [Help for Config Commands](#help-for-config-commands)
+  * [Help for Show Commands](#help-for-show-commands)
+* [Basic Show Commands](#basic-show-commands)
+  * [Show Versions](#show-versions)
+  * [Show System Status](#show-system-status)
+  * [Show Hardware Platform](#show-hardware-platform)
+    * [Transceivers](#transceivers)
+* [AAA &amp; TACACS+](#aaa--tacacs)
+  * [AAA](#aaa)
+    * [AAA show commands](#aaa-show-commands)
+    * [AAA config commands](#aaa-config-commands)
+  * [TACACS+](#tacacs)
+    * [TACACS+ show commands](#tacacs-show-commands)
+    * [TACACS+ config commands](#tacacs-config-commands)
+* [ACL](#acl)
+  * [ACL show commands](#acl-show-commands)
+  * [ACL config commands](#acl-config-commands)
+* [ARP &amp; NDP](#arp--ndp)
+  * [ARP show commands](#arp-show-commands)
+  * [NDP show commands](#ndp-show-commands)
+* [BGP](#bgp)
+  * [BGP show commands](#bgp-show-commands)
+  * [BGP config commands](#bgp-config-commands)
+* [ECN](#ecn)
+  * [ECN show commands](#ecn-show-commands)
+  * [ECN config commands](#ecn-config-commands)
+* [Interfaces](#interfaces)
+  * [Interface Show Commands](#interface-show-commands)
+  * [Interface Config Commands](#interface-config-commands)
+* [Interface Naming Mode](#interface-naming-mode)
+  * [Interface naming mode show commands](#interface-naming-mode-show-commands)
+  * [Interface naming mode config commands](#interface-naming-mode-config-commands)
+* [IP / IPv6](#ip--ipv6)
+  * [IP show commands](#ip-show-commands)
+  * [IPv6 show commands](#ipv6-show-commands)
+* [LLDP](#lldp)
+  * [LLDP show commands](#lldp-show-commands)
+* [Loading, Reloading And Saving Configuration](#loading-reloading-and-saving-configuration)
+  * [Loading configuration from JSON file](#loading-configuration-from-json-file)
+  * [Loading configuration from minigraph (XML) file](#loading-configuration-from-minigraph-xml-file)
+  * [Reloading Configuration](#reloading-configuration)
+  * [Loading Management Configuration](#loading-management-configuration)
+  * [Saving Configuration to a File for Persistence](saving-configuration-to-a-file-for-persistence)
+* [Mirroring](#mirroring)
+  * [Mirroring Show commands](#mirroring-show-commands)
+  * [Mirroring Config commands](#mirroring-config-commands)
+* [NTP](#ntp)
+  * [NTP show commands](#ntp-show-commands)
+* [Platform Specific Commands](#platform-specific-commands)
+* [PortChannels](#portchannels)
+  * [PortChannel Show commands](#portchannel-show-commands)
+  * [PortChannel Config commands](#portchannel-config-commands)
+* [QoS](#qos)
+  * [QoS Show commands](#qos-show-commands)
+    * [PFC](#pfc)
+    * [Queue And Priority-Group](#queue-and-priority-group)
+  * [QoS config commands](#qos-config-commands)
+* [Startup &amp; Running Configuration](#startup--running-configuration)
+  * [Startup Configuration](#startup-configuration)
+  * [Running Configuration](#running-configuration)
+* [System State](#system-state)
+  * [Processes](#processes)
+  * [Services &amp; Memory](#services--memory)
+* [VLAN &amp; FDB](#vlan--fdb)
+  * [VLAN](#vlan)
+    * [VLAN show commands](#vlan-show-commands)
+    * [VLAN Config commands](#vlan-config-commands)
+  * [FDB](#fdb)
+    * [FDB show commands](#fdb-show-commands)
+* [Warm Restart](#warm-restart)
+  * [Warm Restart show commands](#warm-restart-show-commands)
+  * [Warm Restart Config commands](#warm-restart-config-commands)
+* [Watermark](#watermark)
+  * [Watermark Show commands](#watermark-show-commands)
+  * [Watermark Config commands](#watermark-config-commands)
+* [Software Installation Commands](#software-installation-commands)
+  * [SONiC Installer](#sonic-installer)
+* [Troubleshooting Commands](#troubleshooting-commands)
+* [Routing Stack](#routing-stack)
+* [Quagga BGP Show Commands](#Quagga-BGP-Show-Commands)
 
 
 ## Document History
@@ -136,7 +138,7 @@ The direct scripts/utilities/commands (examples given below) that are not wrappe
   2. crm – this command is not explained in this document.
   3. sonic-clear, sfputil, etc., This document does not explain these scripts also.
 
-## Basic Configuration
+## Basic Tasks
 
 This section covers the basic configurations related to the following:
   1. [SSH login](#SSH-Login)
@@ -329,7 +331,7 @@ The same syntax applies to all subgroups of `show` which themselves contain subc
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Basic-Configuration-And-Show)
 
-## Basic 'show' Commands
+## Basic Show Commands
 
 Subsections:
   1. [Show Versions](#Show-Versions)
@@ -742,12 +744,12 @@ This command displays information for all the interfaces for the transceiver req
   ```
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Basic-Configuration-And-Show)
 
-## AAA & TACACS+ Configuration And Show
+## AAA & TACACS+
 This section captures the various show commands & configuration commands that are applicable for the AAA (Authentication, Authorization, and Accounting) module.
 Admins can configure the type of authentication (local or remote tacacs based) required for the users and also the authentication failthrough and fallback options.
 Following show command displays the current running configuration related to the AAA.
 
-### AAA Configuration And Show
+### AAA
 
 #### AAA show commands
 
@@ -849,7 +851,7 @@ If the authentication fails, AAA will check the "failthrough" configuration and 
   ```
 
 
-### TACACS+ Configuration And Show
+### TACACS+
 
 #### TACACS+ show commands
 
@@ -881,7 +883,7 @@ This command displays the global configuration fields and the list of all tacacs
                          tcp_port 49
   ```
 
-#### TACACS+ Config commands
+#### TACACS+ config commands
 
 This sub-section explains the command "config tacacs" and its sub-commands that are used to configure the following tacacs+ parameters.
 Some of the parameters like authtype, passkey and timeout can be either configured at per server level or at global level (global value will be applied if there no server level configuration)
@@ -1023,7 +1025,7 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 
 
 
-## ACL Configuration And Show
+## ACL
 
 This section explains the various show commands and configuration commands available for users.
 
@@ -1311,7 +1313,7 @@ This command displays either all the IPv6 neighbor mac addresses, or for a parti
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Watermark-Configuration-And-Show)
 
 
-## BGP Configuration And Show Commands
+## BGP
 
 This section explains all the BGP show commands and BGP configuation commands in both "Quagga" and "FRR" routing software that are supported in SONiC.
 In 201811 and older verisons "Quagga" was enabled by default. In current version "FRR" is enabled by default.
@@ -1688,7 +1690,7 @@ This command is used to remove particular IPv4 or IPv6 BGP neighbor configuratio
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#BGP-Configuration-And-Show-Commands)
 
 
-## ECN Configuration And Show Commands
+## ECN
 
 This section explains all the Explicit Congestion Notification (ECN) show commands and ECN configuation options that are supported in SONiC.
 
@@ -1780,7 +1782,7 @@ This command is used to change device hostname without traffic being impacted.
   Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`.
   ```
 
-## Interface Configuration And Show-Commands
+## Interfaces
 
 ### Interface Show Commands
 
@@ -2587,7 +2589,7 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 
 This section explains the commands that are used to load the configuration from either the ConfigDB or from the minigraph.
 
-### Loading config from JSON file
+### Loading configuration from JSON file
 
 **config load**
 
@@ -2614,7 +2616,7 @@ If the argument is not specified, it prompts the user to confirm whether user re
   root@T1-2:~#
   ```
 
-### Loading config from a minigraph (MXL) file
+### Loading configuration from minigraph (XML) file
 
 **config load_minigraph**
 
@@ -2741,9 +2743,9 @@ Saved file can be transferred to remote machines for debugging. If users wants t
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#loading-reloading-and-saving-configuration)
 
 
-## Mirroring Configuration And Show
+## Mirroring
 
-### Mirroring Show command
+### Mirroring Show commands
 
 **show mirror_session**
 
@@ -2762,7 +2764,7 @@ This command displays all the mirror sessions that are configured.
   everflow0  active    10.1.0.32  10.0.0.7
   ```
 
-### Mirroring Config command
+### Mirroring Config commands
 
 **config mirror_session**
 
@@ -2796,7 +2798,7 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 
 ## NTP
 
-### NTP show command
+### NTP show commands
 
 **show ntp**
 
@@ -2890,7 +2892,7 @@ In order to avoid that confirmation the -y / --yes option should be used.
   NOTE: In order to avoid that confirmation the -y / --yes option should be used.
   ```
 
-## PortChannel Configuration And Show
+## PortChannels
 
 ### PortChannel Show commands
 
@@ -2960,7 +2962,7 @@ This command adds or deletes a member port to/from the already created portchann
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#PortChannel-Configuration-And-Show)
 
-## QoS Configuration & Show
+## QoS
 
 ### QoS Show commands
 
@@ -3268,7 +3270,7 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 
 ## Startup & Running Configuration
 
-### Startup Configuration command
+### Startup Configuration
 
 **show startupconfiguration bgp**
 
@@ -3310,7 +3312,7 @@ This command is used to display the startup configuration for the BGP module.
   <Only the partial output is shown here. In actual command, more configuration information will be displayed>
   ```
 
-### Running Configuration command
+### Running Configuration
 This sub-section explains the show commands for displaying the running configuration for the following modules.
 1) bgp
 2) interfaces
@@ -3452,7 +3454,7 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 
 ## System State
 
-### Processes show commands
+### Processes
 
 This command is used to determine the CPU utilization. It also lists the active processes along with their corresponding process ID and other relevant parameters.
 
@@ -3556,7 +3558,7 @@ This command displays the current summary information about all the processes
   ```
 
 
-### Services & memory show commands
+### Services & Memory
 
 These commands are used to know the services that are running and the memory that is utilized currently.
 
@@ -3939,7 +3941,7 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 
 ## Warm Restart
 
-### Warm Restart show command
+### Warm Restart show commands
 
 **show warm_restart config**
 
@@ -3986,7 +3988,7 @@ This command displays the warm_restart state.
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#VLAN-Configuration-And-Show)
 
-### Warm Restart Config command
+### Warm Restart Config commands
 
 This sub-section explains the various configuration related to warm restart feature. Following parameters can be configured using this command.
 1) bgp_timer
@@ -4126,9 +4128,9 @@ Supported range: 1-9999. 0 is invalid
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Warm-Restart)
 
 
-## Watermark Configuration And Show
+## Watermark
 
-### Watermark Show command
+### Watermark Show commands
 
 **show watermark telemetry interval**
 
@@ -4146,7 +4148,7 @@ This command displays the configured interval for the telemetry.
   Telemetry interval 120 second(s)
   ```
 
-### Watermark Config command
+### Watermark Config commands
 
 **config watermark telemetry interval**
 
@@ -4320,7 +4322,7 @@ If the SONiC system was running for quite some time `show techsupport` will prod
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Troubleshooting-commands)
 
-## Routing Stack Configuration And Show
+## Routing Stack
 
 SONiC software is agnostic of the routing software that is being used in the device. For example, users can use either Quagga or FRR routing stack as per their requirement.
 A separate shell (vtysh) is provided to configure such routing stacks.

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -3683,6 +3683,7 @@ This command displays the current summary information about all the processes
   ...
   ```
 
+Go Back To [Beginning of the document](#) or [Beginning of this section](#System-State)
 
 ### Services & Memory
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -496,10 +496,11 @@ This command displays the current system uptime
   ```
 
 **show logging**
+
 This command displays all the currently stored log messages.
 All the latest processes and corresponding transactions are stored in the "syslog" file.
 This file is saved in the path `/var/log` and can be viewed by giving the command ` sudo cat syslog` as this requires root login.
-Individual process can also be viewed using the command `ps -ax | grep <\process name>
+Individual processes can also be viewed using the command `ps -ax | grep <process name>`
 
 - Usage:
   ```
@@ -525,7 +526,7 @@ Optionally, you can specify a process name in order to display only log messages
   admin@sonic:~$ show logging sensord
   ```
 
-Optionally, you can specify a number of lines to display using the `-l' or `--lines` option. Only the most recent N lines will be displayed. Also note that this option can be combined with a process name.
+Optionally, you can specify a number of lines to display using the `-l` or `--lines` option. Only the most recent N lines will be displayed. Also note that this option can be combined with a process name.
 
 - Examples:
   ```
@@ -1646,7 +1647,7 @@ This command is used to start up the particular IPv4 or IPv6 BGP neighbor using 
 
 - Usage:
   ```
-  sudo config bgp startup neighbor (<ip-address> | <hostname>)`
+  sudo config bgp startup neighbor (<ip-address> | <hostname>)
   ```
 
 - Examples:
@@ -3200,7 +3201,7 @@ This command is used to display the startup configuration for the BGP module.
 
 - Usage:
   ```
-  show startupconfiguration bgp`
+  show startupconfiguration bgp
   ```
 
 - Example:
@@ -4406,7 +4407,7 @@ This command displays all the details of one particular IPv6 Border Gateway Prot
 
 - Usage:
   ```
-  show ipv6 bgp neighbors <ipv6-address> (advertised-routes | received-routes | routes)`
+  show ipv6 bgp neighbors <ipv6-address> (advertised-routes | received-routes | routes)
   ```
 
 - Examples:

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -1295,18 +1295,26 @@ Detailed show commands examples for Quagga are provided at the end of this docum
 ## BGP show commands
 
 
-**show bgp summary (for default FRR in 201904+ version) **
-**show ip bgp summary (for Quagga in 201811- version) **
+**show bgp summary (Versions >= 201904 using default FRR routing stack)**
+
+**show ip bgp summary (Versions <= 201811 using Quagga routing stack)**
 
 This command displays the summary of all IPv4 & IPv6 bgp neighbors that are configured and the corresponding states.
 
 - Usage:
-  show bgp summary (for default FRR in 201904+ version)
-  show ip bgp summary (for Quagga in 201811- version)
+
+  *Versions >= 201904 using default FRR routing stack*
+  ```
+  show bgp summary
+  ```
+  *Versions <= 201811 using Quagga routing stack*
+  ```
+  show ip bgp summary
+  ```
 
 - Example:
   ```
-   root@sonic-z9264f-9251:~# show bgp summary
+   admin@sonic-z9264f-9251:~# show bgp summary
 
    IPv4 Unicast Summary:
    BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
@@ -1342,9 +1350,9 @@ This command displays the summary of all IPv4 & IPv6 bgp neighbors that are conf
 
 
 
-**show bgp neighbors (for default FRR in 201904+ version)**
-**show ip bgp neighbors (for Quagga in 201811- version)**
+**show bgp neighbors (Versions >= 201904 using default FRR routing stack)**
 
+**show ip bgp neighbors (Versions <= 201811 using Quagga routing stack)**
 
 This command displays all the details of IPv4 & IPv6 BGP neighbors when no optional argument is specified.
 
@@ -1356,8 +1364,15 @@ In order to get details for an IPv6 neigbor, use "show bgp ipv6 neighbor <ipv6_a
 
 
 - Usage:
-  show bgp neighbors [\<ipv4-address\> [advertised-routes | received-routes | routes]] (for default FRR in 201904+ version)
-  show ip bgp neighbors [\<ipv4-address\> [advertised-routes | received-routes | routes]] (for Quagga in 201811- version)
+
+  *Versions >= 201904 using default FRR routing stack*
+  ```
+  show bgp neighbors [<ipv4-address> [advertised-routes | received-routes | routes]]
+  ```
+  *Versions <= 201811 using Quagga routing stack*
+  ```
+  show ip bgp neighbors [<ipv4-address> [advertised-routes | received-routes | routes]]
+  ```
 
 - Example:
   ```
@@ -1434,14 +1449,22 @@ In order to get details for an IPv6 neigbor, use "show bgp ipv6 neighbor <ipv6_a
 
 
 
-**show bgp ipv6 summary (for default FRR in 201904+ version)**
-**show ipv6 bgp summary (for Quagga in 201811- version)**
+**show bgp ipv6 summary (Versions >= 201904 using default FRR routing stack)**
+
+**show ipv6 bgp summary (Versions <= 201811 using Quagga routing stack)**
 
 This command displays the summary of all IPv6 bgp neighbors that are configured and the corresponding states.
 
 - Usage:
-  show bgp ipv6 summary (for default FRR in 201904+ version)
-  show ipv6 bgp summary (for Quagga in 201811- version)
+
+  *Versions >= 201904 using default FRR routing stack*
+  ```
+  show bgp ipv6 summary
+  ```
+  *Versions <= 201811 using Quagga routing stack*
+  ```
+  show ipv6 bgp summary
+  ```
 
 - Example:
   ```
@@ -1465,24 +1488,31 @@ This command displays the summary of all IPv6 bgp neighbors that are configured 
 
 
 
-**show bgp ipv6 neighbors (for default FRR in 201904+ version)**
-**show ipv6 bgp neighbors (for Quagga in 201811- version)**
+**show bgp ipv6 neighbors (Versions >= 201904 using default FRR routing stack)**
 
+**show ipv6 bgp neighbors (Versions <= 201811 using Quagga routing stack)**
 
 This command displays all the details of one particular IPv6 Border Gateway Protocol (BGP) neighbor. Option is also available to display only the advertised routes, or the received routes, or all routes.
 
 
-  - Usage:
-    show bgp ipv6 neighbors [\<ipv6-address\> [(advertised-routes | received-routes | routes)]] (for default FRR in 201904+ version)
-    show ipv6 bgp neighbors [\<ipv6-address\> [(advertised-routes | received-routes | routes)]] (for Quagga in 201811- version)
+- Usage:
+
+  *Versions >= 201904 using default FRR routing stack*
+  ```
+  show bgp ipv6 neighbors [<ipv6-address> [(advertised-routes | received-routes | routes)]]
+  ```
+  *Versions <= 201811 using Quagga routing stack*
+  ```
+  show ipv6 bgp neighbors [<ipv6-address> [(advertised-routes | received-routes | routes)]]
+  ```
 
 - Example:
   ```
-   admin@sonic:~$ show bgp ipv6 neighbors fc00::72 advertised-routes
+  admin@sonic:~$ show bgp ipv6 neighbors fc00::72 advertised-routes
 
-   admin@sonic:~$ show bgp ipv6 neighbors fc00::72 received-routes
+  admin@sonic:~$ show bgp ipv6 neighbors fc00::72 received-routes
 
-   admin@sonic:~$ show bgp ipv6 neighbors fc00::72 routes
+  admin@sonic:~$ show bgp ipv6 neighbors fc00::72 routes
 
   ```
   Click [here](#Quagga-BGP-Show-Commands) to see the example for "show ip bgp summary" for Quagga.
@@ -1493,50 +1523,52 @@ This command displays all the details of one particular IPv6 Border Gateway Prot
 
 This command displays the routing policy that takes precedence over the other route processes that are configured.
 
-  - Usage:
-    show route-map
-
-  - Example:
+- Usage:
   ```
-	admin@T1-2:~$ show route-map
-	ZEBRA:
-	route-map RM_SET_SRC, permit, sequence 10
-	  Match clauses:
-	  Set clauses:
-		src 10.12.0.102
-	  Call clause:
-	  Action:
-		Exit routemap
-	ZEBRA:
-	route-map RM_SET_SRC6, permit, sequence 10
-	  Match clauses:
-	  Set clauses:
-		src fc00:1::102
-	  Call clause:
-	  Action:
-		Exit routemap
-	BGP:
-	route-map FROM_BGP_SPEAKER_V4, permit, sequence 10
-	  Match clauses:
-	  Set clauses:
-	  Call clause:
-	  Action:
-	    Exit routemap
-	BGP:
-	route-map TO_BGP_SPEAKER_V4, deny, sequence 10
-	  Match clauses:
-	  Set clauses:
-	  Call clause:
-	  Action:
-	    Exit routemap
-	BGP:
-	route-map ISOLATE, permit, sequence 10
-	  Match clauses:
-	  Set clauses:
-		as-path prepend 65000
-	  Call clause:
-	  Action:
-		Exit routemap
+  show route-map
+  ```
+
+- Example:
+  ```
+  admin@T1-2:~$ show route-map
+  ZEBRA:
+  route-map RM_SET_SRC, permit, sequence 10
+    Match clauses:
+    Set clauses:
+      src 10.12.0.102
+    Call clause:
+    Action:
+      Exit routemap
+  ZEBRA:
+  route-map RM_SET_SRC6, permit, sequence 10
+    Match clauses:
+    Set clauses:
+      src fc00:1::102
+    Call clause:
+    Action:
+      Exit routemap
+  BGP:
+  route-map FROM_BGP_SPEAKER_V4, permit, sequence 10
+    Match clauses:
+    Set clauses:
+    Call clause:
+    Action:
+      Exit routemap
+  BGP:
+  route-map TO_BGP_SPEAKER_V4, deny, sequence 10
+    Match clauses:
+    Set clauses:
+    Call clause:
+    Action:
+      Exit routemap
+  BGP:
+  route-map ISOLATE, permit, sequence 10
+    Match clauses:
+    Set clauses:
+      as-path prepend 65000
+    Call clause:
+    Action:
+      Exit routemap
   ```
 
 
@@ -1544,37 +1576,29 @@ This command displays the routing policy that takes precedence over the other ro
 
 This sub-section explains the list of configuration options available for BGP module for both IPv4 and IPv6 BGP neighbors.
 
-The list of possible BGP config commands are given below.
-
-	bgp
-        shutdown
-            all
-            neighbor
-        startup
-            all
-            neighbor
-        remove
-            neighbor
-
-**config bgp shut down all**
+**config bgp shutdown all**
 
 This command is used to shutdown all the BGP IPv4 & IPv6 sessions.
 When the session is shutdown using this command, BGP state in "show ip bgp summary" is displayed as "Idle (Admin)"
 
-  - Usage:
-    sudo config bgp shutdown all
+- Usage:
+  ```
+  sudo config bgp shutdown all
+  ```
 
-- Examples:
+- Example:
   ```
   admin@sonic:~$ sudo config bgp shutdown all
   ```
 
-**config bgp shutdown <neighbor>**
+**config bgp shutdown neighbor**
 
 This command is to shut down a BGP session with a neighbor by that neighbor's IP address or hostname
 
-  - Usage:
-    sudo config bgp shutdown (<ip-address> | <hostname>)
+- Usage:
+  ```
+  sudo config bgp shutdown neighbor (<ip_address> | <hostname>)
+  ```
 
 - Examples:
   ```
@@ -1589,21 +1613,25 @@ This command is to shut down a BGP session with a neighbor by that neighbor's IP
 
 This command is used to start up all the IPv4 & IPv6 BGP neighbors
 
-  - Usage:
-    sudo config bgp startup all`
+- Usage:
+  ```
+  sudo config bgp startup all
+  ```
 
-- Examples:
+- Example:
   ```
   admin@sonic:~$ sudo config bgp startup all
   ```
 
 
-**config bgp startup <neighbor>**
+**config bgp startup neighbor**
 
 This command is used to start up the particular IPv4 or IPv6 BGP neighbor using either the IP address or hostname.
 
-  - Usage:
-    sudo config bgp startup (<ip-address> | <hostname>)`
+- Usage:
+  ```
+  sudo config bgp startup neighbor (<ip-address> | <hostname>)`
+  ```
 
 - Examples:
   ```
@@ -1618,8 +1646,10 @@ This command is used to start up the particular IPv4 or IPv6 BGP neighbor using 
 
 This command is used to remove particular IPv4 or IPv6 BGP neighbor configuration using either the IP address or hostname.
 
-  - Usage:
-    sudo config bgp remove neighbor <neighbor_ip_or_hostname>
+- Usage:
+  ```
+  sudo config bgp remove neighbor <neighbor_ip_or_hostname>
+  ```
 
 - Examples:
   ```
@@ -1630,7 +1660,7 @@ This command is used to remove particular IPv4 or IPv6 BGP neighbor configuratio
   ```
   ```
   admin@sonic:~$ sudo config bgp remove neighbor SONIC02SPINE
-  ``` 
+  ```
 
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#BGP-Configuration-And-Show-Commands)

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -15,7 +15,7 @@
   * [Show System Status](#show-system-status)
   * [Show Hardware Platform](#show-hardware-platform)
     * [Transceivers](#transceivers)
-* [AAA &amp; TACACS+](#aaa--tacacs)
+* [AAA & TACACS+](#aaa--tacacs)
   * [AAA](#aaa)
     * [AAA show commands](#aaa-show-commands)
     * [AAA config commands](#aaa-config-commands)
@@ -25,7 +25,7 @@
 * [ACL](#acl)
   * [ACL show commands](#acl-show-commands)
   * [ACL config commands](#acl-config-commands)
-* [ARP &amp; NDP](#arp--ndp)
+* [ARP & NDP](#arp--ndp)
   * [ARP show commands](#arp-show-commands)
   * [NDP show commands](#ndp-show-commands)
 * [BGP](#bgp)
@@ -68,15 +68,15 @@
     * [PFC](#pfc)
     * [Queue And Priority-Group](#queue-and-priority-group)
   * [QoS config commands](#qos-config-commands)
-* [Startup &amp; Running Configuration](#startup--running-configuration)
+* [Startup & Running Configuration](#startup--running-configuration)
   * [Startup Configuration](#startup-configuration)
   * [Running Configuration](#running-configuration)
 * [Syslog](#syslog)
   * [Syslog config commands](#syslog-config-commands)
 * [System State](#system-state)
   * [Processes](#processes)
-  * [Services &amp; Memory](#services--memory)
-* [VLAN &amp; FDB](#vlan--fdb)
+  * [Services & Memory](#services--memory)
+* [VLAN & FDB](#vlan--fdb)
   * [VLAN](#vlan)
     * [VLAN show commands](#vlan-show-commands)
     * [VLAN Config commands](#vlan-config-commands)
@@ -1211,7 +1211,7 @@ When the optional argument "max_priority"  is specified, each rule’s priority 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#acl)
 
 
-## ARP &amp; NDP
+## ARP & NDP
 
 ### ARP show commands
 
@@ -3867,7 +3867,7 @@ NOTE: This command is not working. It crashes as follows. A bug ticket is opened
 Go Back To [Beginning of the document](#) or [Beginning of this section](#System-State)
 
 
-## VLAN &amp; FDB
+## VLAN & FDB
 
 ### VLAN
 
@@ -3952,6 +3952,8 @@ This command is to add or delete a member port into the already created vlan.
   admin@sonic:~$ sudo config vlan member add 100 Ethernet4
   This command will add Ethernet4 as member of the vlan 100.
   ```
+
+Go Back To [Beginning of the document](#) or [Beginning of this section](#vlan--FDB)
 
 ### FDB
 
@@ -4063,7 +4065,6 @@ Clear the FDB table
   ```
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#vlan--FDB)
-
 
 
 ## Warm Restart

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -1980,113 +1980,160 @@ i.e Interface name comes after the subcommand
 
 The syntax for all such interface_subcommands are given below under each command
 
-NOTE: In older versions of SONiC until 201811 release, the command syntax was
-      "config interface <interface_name> interface_subcommand"
+NOTE: In older versions of SONiC until 201811 release, the command syntax was `config interface <interface_name> interface_subcommand`
 
-**config interface ip add <interface-name> <ip_addr> (for 201904+ version)**
 
-**config interface <interface-name> ip add <ip_addr> (for 201811- version)**
+**config interface ip add <interface_name> <ip_addr> (Versions >= 201904)**
+
+**config interface <interface_name> ip add <ip_addr> (Versions <= 201811)**
 
 This command is used for adding the IP address for an interface.
 IP address for either physical interface or for portchannel or for VLAN interface can be configured using this command.
 
 
 - Usage:
-    config interface ip add <interface-name> <ip_addr> (for 201904+ version)
-    config interface <interface-name> ip add <ip_addr> (for 201811- version)
+  *Versions >= 201904*
+  ```
+  config interface ip add <interface_name> <ip_addr>
+  ```
+  *Versions <= 201811*
+  ```
+  config interface <interface_name> ip add <ip_addr>
+  ```
 
 - Example:
+  *Versions >= 201904*
   ```
   admin@sonic:~$ sudo config interface ip add Ethernet63 10.11.12.13/24
   ```
-NOTE: In SONiC versions until 201811, syntax was "config <interface_name> ip add <ip_addr>"
+  *Versions <= 201811*
+  ```
+  admin@sonic:~$ sudo config interface Ethernet63 ip add 10.11.12.13/24
+  ```
 
-
-**IP Address Configuration for Vlan Interface**
-- Usage:
-    config interface ip add <ip_addr> <vlan_IDName>
+VLAN interface names take the form of `vlan<vlan_id>`. E.g., VLAN 100 will be named `vlan100`
 
 - Example:
   ```
   admin@sonic:~$ sudo config interface ip add vlan100 10.11.12.13/24
   ```
-NOTE: In versions until 201811, syntax was "config interface <vlan_IDName> ip add <ip_addr>"
+  *Versions <= 201811*
+  ```
+  admin@sonic:~$ sudo config interface vlan100 ip add 10.11.12.13/24
+  ```
 
 
+**config interface ip remove <interface_name> <ip_addr> (Versions >= 201904)**
 
-**config interface ip remove <interface_name> <ip_addr> (for 201904+ version)**
-**config interface <interface_name> ip remove <ip_addr> (for 201811- version)**
+**config interface <interface_name> ip remove <ip_addr> (Versions <= 201811)**
 
 - Usage:
-    config interface ip remove <interface_name> <ip_addr> (for 201904+ version)
-    config interface ip remove <interface_name> <ip_addr> (for 201811- version)
+  *Versions >= 201904*
+  ```
+  config interface ip remove <interface_name> <ip_addr>
+  ```
+  *Versions <= 201811*
+  ```
+  config interface ip remove <interface_name> <ip_addr>
+  ```
 
 - Example:
+  *Versions >= 201904*
   ```
   admin@sonic:~$ sudo config interface ip remove Ethernet63 10.11.12.13/24
   ```
-NOTE: In versions until 201811, syntax is "config  interface <interface_name> ip remove <ip_addr>"
+  *Versions <= 201811*
+  ```
+  admin@sonic:~$ sudo config interface Ethernet63 ip remove 10.11.12.13/24
+  ```
 
-
-
-**IP Address Removal for Vlan Interface**
-- Usage:
-    config interface ip remove <vlan_IDName> <ip_addr>
+VLAN interface names take the form of `vlan<vlan_id>`. E.g., VLAN 100 will be named `vlan100`
 
 - Example:
+  *Versions >= 201904*
   ```
   admin@sonic:~$ sudo config interface ip remove vlan100 10.11.12.13/24
   ```
-NOTE: In versions until 201811, syntax is "config interface <vlan_ID> ip remove <ip_addr>"
+  *Versions <= 201811*
+  ```
+  admin@sonic:~$ sudo config interface vlan100 ip remove 10.11.12.13/24
+  ```
 
+**config interface pfc asymmetric <interface_name> (Versions >= 201904)**
 
+**config interface <interface_name> pfc asymmetric (Versions <= 201811)**
 
-**config interface pfc asymmetric <interface_name> (for 201904+ version)**
-**config interface <interface_name> pfc asymmetric (for 201811- version)**
 This command is used for setting the asymmetric PFC for an interface to either "on" or "off". Once if it is configured, use "show interfaces status" to check the same.
 
 - Usage:
-    config interface pfc asymmetric <interface_name> on/off (for 201904+ version)
-    config interface <interface_name> pfc asymmetric on/off (for 201811- version)
+  *Versions >= 201904*
+  ```
+  config interface pfc asymmetric <interface_name> on/off (for 201904+ version)
+  ```
+  *Versions <= 201811*
+  ```
+  config interface <interface_name> pfc asymmetric on/off (for 201811- version)
+  ```
 
 - Example:
+  *Versions >= 201904*
   ```
   admin@sonic:~$ sudo config interface pfc asymmetric Ethernet60 on
   ```
+  *Versions <= 201811*
+  ```
+  admin@sonic:~$ sudo config interface Ethernet60 pfc asymmetric on
+  ```
 
-**config interface shutdown <interface_name> (for 201904+ version)**
-**config interface <interface_name> shutdown (for 201811- version)**
+**config interface shutdown <interface_name> (Versions >= 201904)**
+
+**config interface <interface_name> shutdown (Versions <= 201811)**
 
 This command is used to administratively shut down either the Physical interface or port channel interface. Once if it is configured, use "show interfaces status" to check the same.
 
 - Usage:
-    config interface shutdown <interface_name> (for 201904+ version)
-    config interface <interface_name> shutdown (for 201811- version)
+  *Versions >= 201904*
+  ```
+  config interface shutdown <interface_name> (for 201904+ version)
+  ```
+  *Versions <= 201811*
+  ```
+  config interface <interface_name> shutdown (for 201811- version)
 
 - Example:
+  *Versions >= 201904*
   ```
   admin@sonic:~$ sudo config interface shutdown Ethernet63
   ```
-NOTE: In versions until 201811, syntax is "config interface <interface_name> shutdown"
+  *Versions <= 201811*
+  ```
+  admin@sonic:~$ sudo config interface Ethernet63 shutdown
+  ```
 
+**config interface startup <interface_name> (Versions >= 201904)**
 
-
-**config interface startup <interface_name> (for 201904+ version)**
-**config interface <interface_name> startup (for 201811- version)**
+**config interface <interface_name> startup (Versions <= 201811)**
 
 This command is used for administratively bringing up the Physical interface or port channel interface.Once if it is configured, use "show interfaces status" to check the same.
 
 - Usage:
-    config interface startup <interface_name> (for 201904+ version)
-    config interface <interface_name> startup (for 201811- version)
+  *Versions >= 201904*
+  ```
+  config interface startup <interface_name> (for 201904+ version)
+  ```
+  *Versions <= 201811*
+  ```
+  config interface <interface_name> startup (for 201811- version)
 
 - Example:
+  *Versions >= 201904*
   ```
   admin@sonic:~$ sudo config interface startup Ethernet63
   ```
-NOTE: In versions until 201811, syntax is "config interface <interface_name> startup"
-
-
+  *Versions <= 201811*
+  ```
+  admin@sonic:~$ sudo config interface Ethernet63 startup
+  ```
 
 **config interface speed <interface_name> (Versions >= 201904)**
 
@@ -2114,7 +2161,6 @@ Dynamic breakout feature is yet to be supported in SONiC and hence uses cannot c
   ```
   admin@sonic:~$ sudo config interface Ethernet63 speed 40000
   ```
-
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#interface-configuration-and-show-commands)
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -92,7 +92,7 @@
 
 | Version | Modification Date | Details |
 | --- | --- | --- |
-| v4 | Oct-17-2019 | Unify usage statements and other formatting; Replace tabs with spaces; Modify heading sizes; Fix a few errors; Minor reorganization |
+| v4 | Oct-17-2019 | Unify usage statements and other formatting; Replace tabs with spaces; Modify heading sizes; Fix spelling, grammar and other errors; Minor reorganization |
 | v3 | Jun-26-2019 | Update based on 201904 (build#19) release, "config interface" command changes related to interfacename order, FRR/Quagga show command changes, platform specific changes, ACL show changes and few formatting changes |
 | v2 | Apr-22-2019 | CLI Guide for SONiC 201811 version (build#32) with complete "config" command set |
 | v1 | Mar-23-2019 | Initial version of CLI Guide with minimal command set |
@@ -127,7 +127,8 @@ Note that all commands are case sensitive.
 Note that the command list given in this document is just a subset of all possible configurations in SONiC.
 Please follow config_db.json based configuration for the complete list of configuration options.
 
-**Scope Of The Document**
+**Scope of this Document**
+
 It is assumed that all configuration commands start with the keyword “config” as prefix.
 Any other scripts/utilities/commands  that need user configuration control are wrapped as sub-commands under the “config” command.
 The direct scripts/utilities/commands (examples given below) that are not wrapped under the "config" command are not in the scope of this document.
@@ -168,26 +169,26 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 ### Configuring Management Interface
 
 The management interface (eth0) in SONiC is configured (by default) to use DHCP client to get the IP address from the DHCP server. Connect the management interface to the same network in which your DHCP server is connected and get the IP address from DHCP server.
-The IP address received from DHCP server can be verified using the "/sbin/ifconfig eth0" linux command.
+The IP address received from DHCP server can be verified using the `/sbin/ifconfig eth0` Linux command.
 
 SONiC does not provide a CLI to configure the static IP for the management interface. There are few alternate ways by which a static IP address can be configured for the management interface.
-   1. Use "ifconfig eth0" linux command (example: ifconfig eth0 10.11.12.13/24). NOTE: This configuration **will not** be preserved across reboots.
-   Example:
-   ```
-   admin@sonic:~$ /sbin/ifconfig eth0 10.11.12.13/24
-   ```
-   2. Use config_db.json and configure the MGMT_INTERFACE key with the appropriate values. Refer [here](https://github.com/Azure/SONiC/wiki/Configuration#Management-Interface)
-   3. Use minigraph.xml and configure "ManagementIPInterfaces" tag inside "DpgDesc" tag as given at the [page](https://github.com/Azure/SONiC/wiki/Configuration-with-Minigraph-(~Sep-2017))
+  1. Use the `/sbin/ifconfig eth0 ...` Linux command. NOTE: This configuration **will not** be preserved across reboots.
+  - Example:
+  ```
+  admin@sonic:~$ /sbin/ifconfig eth0 10.11.12.13/24
+  ```
+  2. Use config_db.json and configure the MGMT_INTERFACE key with the appropriate values. Refer [here](https://github.com/Azure/SONiC/wiki/Configuration#Management-Interface)
+  3. Use minigraph.xml and configure "ManagementIPInterfaces" tag inside "DpgDesc" tag as given at the [page](https://github.com/Azure/SONiC/wiki/Configuration-with-Minigraph-(~Sep-2017))
 
 Once the IP address is configured, the same can be verified using "/sbin/ifconfig eth0" linux command.
 Users can SSH login to this management interface IP address from their management network.
 
 - Example:
-   ```
-   admin@sonic:~$ /sbin/ifconfig eth0
-   eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
-         inet 10.11.11.13  netmask 255.255.255.0  broadcast 10.11.12.255
-   ```
+ ```
+ admin@sonic:~$ /sbin/ifconfig eth0
+ eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+       inet 10.11.11.13  netmask 255.255.255.0  broadcast 10.11.12.255
+ ```
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Basic-Configuration-And-Show)
 
 ## Getting Help
@@ -201,8 +202,8 @@ Subsections:
 
 ### Help for Config Commands
 
-All commands has got in-built help that helps the user to understand the command as well as the possible sub-commands and options.
-"--help" can be used at any level of the command; i.e. it can be used at the command level, or sub-command level or at argument level. The in-built help will display the next possibilities corresponding to that particular command/sub-command.
+All commands have in-built help that aids the user in understanding the command as well as the possible sub-commands and options.
+"--help" can be used at any level of the command; i.e. it can be used at the command level, or sub-command level or at argument level. The in-built help will display the available possibilities corresponding to that particular command/sub-command.
 
 **config --help**
 
@@ -249,6 +250,7 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 ### Help For Show Commands
 
 **show help**
+
 This command displays the full list of show commands available in the software; the output of each of those show commands can be used to analyze, debug or troubleshoot the network node.
 
 - Usage:
@@ -337,8 +339,9 @@ Subsections:
 ### Show Versions
 
 **show version**
+
 This command displays software component versions of the currently running SONiC image. This includes the SONiC image version as well as Docker image versions.
-This command displays relevant information as the SONiC and Linux kernel version being utilized, as well as the commit-id used to build the SONiC image. The second section of the output displays the various docker images and their associated id’s.
+This command displays relevant information as the SONiC and Linux kernel version being utilized, as well as the ID of the commit used to build the SONiC image. The second section of the output displays the various docker images and their associated IDs.
 
 - Usage:
   ```
@@ -385,6 +388,7 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 This sub-section explains some set of sub-commands that are used to display the status of various parameters pertaining to the physical state of the network node.
 
 **show clock**
+
 This command displays the current date and time configured on the system
 
 - Usage:
@@ -399,7 +403,8 @@ This command displays the current date and time configured on the system
   ```
 
 **show boot**
-This command displays the current OS image, the image loaded on next reboot, and the lists the available images on the system
+
+This command displays the current OS image, the image to be loaded on next reboot, and lists all the available images installed on the device
 
 - Usage:
   ```
@@ -416,6 +421,7 @@ This command displays the current OS image, the image loaded on next reboot, and
   ```
 
 **show environment**
+
 This command displays the platform environmentals, such as voltages, temperatures and fan speeds
 
 - Usage:
@@ -464,6 +470,7 @@ NOTE: The show output has got lot of information; only the sample output is give
 Though the displayed output slightly differs from one platform to another platform, the overall content will be similar to the example mentioned above.
 
 **show reboot-cause**
+
 This command displays the cause of the previous reboot
 
 - Usage:
@@ -478,6 +485,7 @@ This command displays the cause of the previous reboot
   ```
 
 **show uptime**
+
 This command displays the current system uptime
 
 - Usage:
@@ -496,7 +504,6 @@ This command displays the current system uptime
 This command displays all the currently stored log messages.
 All the latest processes and corresponding transactions are stored in the "syslog" file.
 This file is saved in the path `/var/log` and can be viewed by giving the command ` sudo cat syslog` as this requires root login.
-Individual processes can also be viewed using the command `ps -ax | grep <process name>`
 
 - Usage:
   ```
@@ -540,6 +547,7 @@ Optionally, you can follow the log live as entries are written to it by specifyi
   ```
 
 **show users**
+
 This command displays a list of users currently logged in to the device
 
 - Usage:
@@ -562,6 +570,7 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 The information displayed in this set of commands partially overlaps with the one generated by “show envinronment” instruction. In this case though, the information is presented in a more succinct fashion. In the future these two CLI stanzas may end up getting combined.
 
 **show platform summary**
+
 This command displays a summary of the device's hardware platform
 
 - Usage:
@@ -578,6 +587,7 @@ This command displays a summary of the device's hardware platform
   ```
 
 **show platform syseeprom**
+
 This command displays information stored on the system EEPROM.
 Note that the output of this command is not the same for all vendor's platforms.
 Couple of example outputs are given below.
@@ -633,6 +643,7 @@ Couple of example outputs are given below.
   ```
 
 **show platform ssdhealth**
+
 This command displays health parameters of the device's SSD
 
 - Usage:
@@ -649,6 +660,7 @@ This command displays health parameters of the device's SSD
   ```
 
 **show platform psustatus**
+
 This command displays the status of the device's power supply units
 
 - Usage:
@@ -669,6 +681,7 @@ This command displays the status of the device's power supply units
 Displays diagnostic monitoring information of the transceivers
 
 **show interfaces transceiver**
+
 This command displays information for all the interfaces for the transceiver requested or a specific interface if the optional "interface_name" is specified.
 
 - Usage:
@@ -741,6 +754,7 @@ Following show command displays the current running configuration related to the
 This command is used to view the Authentication, Authorization & Accounting settings that are configured in the network node.
 
 **show aaa**
+
 This command displays the AAA settings currently present in the network node
 
 - Usage:
@@ -1255,6 +1269,7 @@ Optionally, you can specify an IP address in order to display only that particul
 ### NDP show commands
 
 **show ndp**
+
 This command displays either all the IPv6 neighbor mac addresses, or for a particular IPv6 neighbor, or for all IPv6 neighbors reachable via a specific interface.
 
 - Usage:
@@ -1649,7 +1664,7 @@ This command is used to start up the particular IPv4 or IPv6 BGP neighbor using 
   ```
 
 
-**config bgp remove neighbor <neighbor_ip_or_hostname>**
+**config bgp remove neighbor**
 
 This command is used to remove particular IPv4 or IPv6 BGP neighbor configuration using either the IP address or hostname.
 
@@ -2171,7 +2186,8 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 This command displays the current interface naming mode. Interface naming mode originally set to 'default'. Interfaces are referenced by default SONiC interface names.
 Users can change the naming_mode using "config interface_naming_mode" command.
 
-**show interfce naming mode**
+**show interfaces naming_mode**
+
 This command displays the current interface naming mode
 
 - Usage:
@@ -2197,14 +2213,14 @@ This command displays the current interface naming mode
 
 ### Interface naming mode config commands
 
-**config interface naming mode**
+**config interface_naming_ mode**
+
 This command is used to change the interface naming mode.
 Users can select between default mode (SONiC interface names) or alias mode (Hardware vendor names).
 The user must log out and log back in for changes to take effect. Note that the newly-applied interface mode will affect all interface-related show/config commands.
 
 
-
-NOTE: Some platforms do not support alias mapping. In such cases, this command is not applicable. Such platforms always use the same SONiC interface names.
+*NOTE: Some platforms do not support alias mapping. In such cases, this command is not applicable. Such platforms always use the same SONiC interface names.*
 
 - Usage:
   ```
@@ -2571,15 +2587,16 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 
 This section explains the commands that are used to load the configuration from either the ConfigDB or from the minigraph.
 
-### Load config command
+### Loading config from JSON file
 
-This command is used to load the configuration from configDB.
-This command loads the configuration from the input file (if user specifies this optional filename, it will use that input file. Or else, it will use the /etc/sonic/config_db.json as the input file) into CONFIG_DB.
-The configurations present in the input file are applied on top of the already running configuration.
-This command does not flush the config DB before loading the new configuration.
-i.e. If the configuration present in the input file is same as the current running-configuration, nothing happens.
-If the config present in the input file is not present in running-configuration, it will be added.
-If the config present in the input file matches (when key matches) with the running-configuration, it will be modified as per the new values for those keys.
+**config load**
+
+This command is used to load the configuration from a JSON file like the file which SONiC saves its configuration to, `/etc/sonic/config_db.json`
+This command loads the configuration from the input file (if user specifies this optional filename, it will use that input file. Otherwise, it will use the default `/etc/sonic/config_db.json` file as the input file) into CONFIG_DB.
+The configuration present in the input file is applied on top of the already running configuration.
+This command does not flush the config DB before loading the new configuration (i.e., If the configuration present in the input file is same as the current running configuration, nothing happens)
+If the config present in the input file is not present in running configuration, it will be added.
+If the config present in the input file differs (when key matches) from that of the running configuration, it will be modified as per the new values for those keys.
 
 When user specifies the optional argument "-y" or "--yes", this command forces the loading without prompting the user for confirmation.
 If the argument is not specified, it prompts the user to confirm whether user really wants to load this configuration file.
@@ -2597,30 +2614,9 @@ If the argument is not specified, it prompts the user to confirm whether user re
   root@T1-2:~#
   ```
 
-### Load_mgmt_config command
+### Loading config from a minigraph (MXL) file
 
-This command is used to reconfigure hostname and mgmt interface based on device description file.
-This command either uses the optional file specified as arguement or looks for the file "/etc/sonic/device_desc.xml".
-If the file does not exist or if the file does not have valid fields for "hostname" and "ManagementAddress", it fails.
-
-When user specifies the optional argument "-y" or "--yes", this command forces the loading without prompting the user for confirmation.
-If the argument is not specified, it prompts the user to confirm whether user really wants to load this configuration file.
-
-- Usage:
-  ```
-  config load_mgmt_config [-y|--yes] [<filename>]
-  ```
-
-- Example:
-  ```
-  root@T1-2:~# config load_mgmt_config
-  Reload config from minigraph? [y/N]: y
-  Running command: /usr/local/bin/sonic-cfggen -M /etc/sonic/device_desc.xml --write-to-db
-  root@T1-2:~#
-  ```
-
-
-### Load_minigraph config command
+**config load_minigraph**
 
 This command is used to load the configuration from /etc/sonic/minigraph.xml.
 When users do not want to use configuration from config_db.json, they can copy the minigraph.xml configuration file to the device and load it using this command.
@@ -2645,7 +2641,9 @@ If the argument is not specified, it prompts the user to confirm whether user re
   root@T1-2:~#
   ```
 
-### Reload config command
+### Reloading Configuration
+
+**config reload**
 
 This command is used to clear current configuration and import new configurationn from the input file or from /etc/sonic/config_db.json.
 This command shall stop all services before clearing the configuration and it then restarts those services.
@@ -2692,7 +2690,35 @@ If the argument is not specified, it prompts the user to confirm whether user re
   root@T1-2:~#
   ```
 
-### Save config command
+
+### Loading Management Configuration
+
+**config load_mgmt_config**
+
+This command is used to reconfigure hostname and mgmt interface based on device description file.
+This command either uses the optional file specified as arguement or looks for the file "/etc/sonic/device_desc.xml".
+If the file does not exist or if the file does not have valid fields for "hostname" and "ManagementAddress", it fails.
+
+When user specifies the optional argument "-y" or "--yes", this command forces the loading without prompting the user for confirmation.
+If the argument is not specified, it prompts the user to confirm whether user really wants to load this configuration file.
+
+- Usage:
+  ```
+  config load_mgmt_config [-y|--yes] [<filename>]
+  ```
+
+- Example:
+  ```
+  root@T1-2:~# config load_mgmt_config
+  Reload config from minigraph? [y/N]: y
+  Running command: /usr/local/bin/sonic-cfggen -M /etc/sonic/device_desc.xml --write-to-db
+  root@T1-2:~#
+  ```
+
+
+### Saving Configuration to a File for Persistence
+
+**config save**
 
 This command is to save the config DB configuration into the user-specified filename or into the default /etc/sonic/config_db.json. This saves the configuration into the disk which is available even after reboots.
 Saved file can be transferred to remote machines for debugging. If users wants to load the configuration from this new file at any point of time, they can use "config load" command and provide this newly generated file as input. If users wants this newly generated file to be used during reboot, they need to copy this file to /etc/sonic/config_db.json.
@@ -2737,6 +2763,8 @@ This command displays all the mirror sessions that are configured.
   ```
 
 ### Mirroring Config command
+
+**config mirror_session**
 
 This command is used to add or remove mirroring sessions. Mirror session is identified by "session_name".
 While adding a new session, users need to configure the following fields that are used while forwarding the mirrored packets.
@@ -2836,6 +2864,7 @@ In the case ISSU is disabled and warm-boot is called, the user will get a notifi
   ```
 
 **config platform mlnx**
+
 This command is valid only on mellanox devices. The sub-commands for "config platform" gets populated only on mellanox platforms.
 There are no other subcommands on non-Mellanox devices and hence this command appears empty and useless in other platforms.
 The platform mellanox command currently includes a single sub command which is the SDK sniffer.
@@ -2892,7 +2921,7 @@ This command displays all the port channels that are configured in the device an
 
 This sub-section explains how to configure the portchannel and its member ports.
 
-**config portchannel add/del <portchannel_name>**
+**config portchannel**
 
 This command is used to add or delete the portchannel.
 It is recommended to use portchannel names in the format "PortChannelxxxx", where "xxxx" is number of 1 to 4 digits. Ex: "PortChannel0002".
@@ -2915,7 +2944,7 @@ Command takes two optional arguements given below.
   admin@sonic:~$ sudo config portchannel add PortChannel0011
   ```
 
-**config portchannel member add/del <portchannel_name> <member_portname>**
+**config portchannel member**
 
 This command adds or deletes a member port to/from the already created portchannel.
 
@@ -2938,6 +2967,7 @@ Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [
 #### PFC
 
 **show pfc counters**
+
 This command displays the details of Rx & Tx priority-flow-control (pfc) for all ports. This command can be used to clear the counters using -c option.
 
 - Usage:
@@ -3077,7 +3107,8 @@ This command displays the user watermark for the queues (Egress shared pool occu
   admin@sonic:~$ show queue  watermark multicast (Egress shared pool occupancy per multicast queue)
   ```
 
-**show priority-group watermark|persistent-watermark**
+**show priority-group**
+
 This command displays the user watermark or persistent-watermark for the Ingress "headroom" or "shared pool occupancy" per priority-group for  all ports
 
 - Usage:
@@ -3116,6 +3147,7 @@ In addition to user watermark("show queue|priority-group watermark ..."), a pers
 It hold values independently of user watermark. This way user can use "user watermark" for debugging, clear it, etc, but the "persistent watermark" will not be affected.
 
 **show queue persistent-watermark**
+
 This command displays the user persistet-watermark for the queues (Egress shared pool occupancy per queue) for either the unicast queues or multicast queues for all ports
 
 - Usage:
@@ -3440,7 +3472,7 @@ This command displays the current CPU usage by process. This command uses linux'
   show processes cpu
   ```
 
-*NOTE that pipe option can be used using " | head -n" to display only the "n" number of lines*
+*TIP: Users can pipe the output to "head" to display only the "n" number of lines (e.g., `show processes cpu | head -n 10`)*
 
 - Example:
   ```
@@ -3461,6 +3493,8 @@ This command displays the current CPU usage by process. This command uses linux'
       5 root       0 -20       0      0      0 S   0.0  0.0   0:00.00 kworker/0:0H
   ...
   ```
+
+*TIP: Advanced users can view individual processes using variations of the `ps` command (e.g., `ps -ax | grep <process name>`)*
 
 **show processes memory**
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -56,6 +56,7 @@
   * [Mirroring Config commands](#mirroring-config-commands)
 * [NTP](#ntp)
   * [NTP show commands](#ntp-show-commands)
+  * [NTP config commands](#ntp-config-commands)
 * [Platform Specific Commands](#platform-specific-commands)
 * [PortChannels](#portchannels)
   * [PortChannel Show commands](#portchannel-show-commands)
@@ -2818,6 +2819,42 @@ This command displays a list of NTP peers known to the server as well as a summa
   *204.2.134.164   46.233.231.73    2 u  916 1024  377    3.079    0.394   0.128
   ```
 
+## NTP Config Commands
+
+This sub-section of commands is used to add or remove the configured NTP servers.
+
+**config ntp add**
+
+This command is used to add a NTP server IP address to the NTP server list.  Note that more that one NTP server IP address can be added in the device.
+
+- Usage:
+  ```
+  config ntp add <ip_address>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config ntp add 9.9.9.9
+  NTP server 9.9.9.9 added to configuration
+  Restarting ntp-config service...
+  ```
+
+**config ntp delete**
+
+This command is used to delete a configured NTP server IP address.
+
+- Usage:
+  ```
+  config ntp del <ip_address>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config ntp del 9.9.9.9
+  NTP server 9.9.9.9 removed from configuration
+  Restarting ntp-config service...
+  ```
+
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#NTP)
 
 
@@ -4622,42 +4659,6 @@ This command is used to delete a configured DHCP Relay Destination IP address fr
   Removed DHCP relay destination address 7.7.7.7 from Vlan1000
   Restarting DHCP relay service...
   Running command: systemctl restart dhcp_relay
-  ```
-
-## NTP Server Configuration Commands
-
-This sub-section of commands is used to add or remove the configured NTP servers.
-
-**config ntp add**
-
-This command is used to add a NTP server IP address to the NTP server list.  Note that more that one NTP server IP address can be added in the device.
-
-- Usage:
-  ```
-  config ntp add <ip_address>
-  ```
-
-- Example:
-  ```
-  admin@sonic:~$ sudo config ntp add 9.9.9.9
-  NTP server 9.9.9.9 added to configuration
-  Restarting ntp-config service...
-  ```
-
-**config ntp delete**
-
-This command is used to delete a configured NTP server IP address.
-
-- Usage:
-  ```
-  config ntp del <ip_address>
-  ```
-
-- Example:
-  ```
-  admin@sonic:~$ sudo config ntp del 9.9.9.9
-  NTP server 9.9.9.9 removed from configuration
-  Restarting ntp-config service...
   ```
 
 Go Back To [Beginning of the document](#SONiC-COMMAND-LINE-INTERFACE-GUIDE) or [Beginning of this section](#Quagga-BGP-Show-Commands)

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -771,7 +771,7 @@ When this is disabled and if the authentication request fails on first server, a
   config aaa authentication failthrough (enable | disable | default)
   ```
 
-  - Options:
+  - Parameters:
     - enable: This allows the AAA module to process with local authentication if remote authentication fails.
     - disable: This disallows the AAA module to proceed further if remote authentication fails.
     - default: This re-configures the default value, which is "enable".
@@ -812,7 +812,7 @@ If the authentication fails, AAA will check the "failthrough" configuration and 
   ```
   config aaa authentication (tacacs+ | local | default)
 
-  - Options:
+  - Parameters:
     - tacacs+: Enables remote authentication based on tacacs+
     - local: Disables remote authentication and uses local authentication
     - default: Reset back to default value, which is only "local" authentication

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -4307,6 +4307,25 @@ SONiC software can be installed in two methods, viz, "using sonic_installer tool
 This is a command line tool available as part of the SONiC software; If the device is already running the SONiC software, this tool can be used to install an alternate image in the partition.
 This tool has facility to install an alternate image, list the available images and to set the next reboot image.
 
+**sonic_installer list**
+
+This command displays information about currently installed images. It displays a list of installed images, currently running image and image set to be loaded in next reboot.
+
+- Usage:
+  ```
+  sonic_installer list
+  ```
+
+- Example:
+   ```
+  admin@sonic:~$ sudo sonic_installer list
+  Current: SONiC-OS-HEAD.XXXX
+  Next: SONiC-OS-HEAD.XXXX
+  Available:
+  SONiC-OS-HEAD.XXXX
+  SONiC-OS-HEAD.YYYY
+  ```
+
 **sonic_installer install**
 
 This command is used to install a new image on the alternate image partition.  This command takes a path to an installable SONiC image or URL and installs the image.
@@ -4318,7 +4337,7 @@ This command is used to install a new image on the alternate image partition.  T
 
 - Example:
   ```
-  admin@sonic:~$ sonic_installer install https://sonic-jenkins.westus.cloudapp.azure.com/job/xxxx/job/buildimage-xxxx-all/xxx/artifact/target/sonic-xxxx.bin
+  admin@sonic:~$ sudo sonic_installer install https://sonic-jenkins.westus.cloudapp.azure.com/job/xxxx/job/buildimage-xxxx-all/xxx/artifact/target/sonic-xxxx.bin
   New image will be installed, continue? [y/N]: y
   Downloading image...
   ...100%, 480 MB, 3357 KB/s, 146 seconds passed
@@ -4350,25 +4369,6 @@ This command is used to install a new image on the alternate image partition.  T
   Done
   ```
 
-**sonic_installer list**
-
-This command displays information about currently installed images. It displays a list of installed images, currently running image and image set to be loaded in next reboot.
-
-- Usage:
-  ```
-  sonic_installer list
-  ```
-
-- Example:
-   ```
-  admin@sonic:~$ sonic_installer list
-  Current: SONiC-OS-HEAD.XXXX
-  Next: SONiC-OS-HEAD.XXXX
-  Available:
-  SONiC-OS-HEAD.XXXX
-  SONiC-OS-HEAD.YYYY
-  ```
-
 **sonic_installer set_default**
 
 This command is be used to change the image which can be loaded by default in all the subsequent reboots.
@@ -4380,7 +4380,7 @@ This command is be used to change the image which can be loaded by default in al
 
 - Example:
   ```
-  admin@sonic:~$ sonic_installer set_default SONiC-OS-HEAD.XXXX
+  admin@sonic:~$ sudo sonic_installer set_default SONiC-OS-HEAD.XXXX
   ```
 
 **sonic_installer set_next_boot**
@@ -4408,7 +4408,7 @@ This command is used to remove the unused SONiC image from the disk. Note that i
 
 - Example:
   ```
-  admin@sonic:~$ sonic_installer remove SONiC-OS-HEAD.YYYY
+  admin@sonic:~$ sudo sonic_installer remove SONiC-OS-HEAD.YYYY
   Image will be removed, continue? [y/N]: y
   Updating GRUB...
   Done


### PR DESCRIPTION
- Unify style and Markdown formatting
- Fix organization of recently-added commands
- Modify heading sizes
- Fix spelling, grammar and other errors
- Fix bad links
- Add 'sonic_installer cleanup' command
- Add 'sudo' to sonic_installer command examples