### PR TITLE
Changes for supporting install-then-advertise behavior

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1055,6 +1055,37 @@ def bgp():
 def shutdown():
     """Shut down BGP session(s)"""
     pass
+@bgp.group('error-handling')
+def error_handling():
+    """Handle BGP route install errors"""
+    pass
+@error_handling.group(invoke_without_command=True)
+@click.pass_context
+def disable(ctx):
+    """Administratively Disable BGP error-handling"""
+    config_db = ConfigDBConnector(host="127.0.0.1")
+    config_db.connect()
+    curr_mode = config_db.get_entry('BGP_ERROR_CFG_TABLE', "config").get('enable')
+    if (curr_mode == "true"):
+        cmd = 'sudo vtysh -c "configure terminal" -c "no bgp error-handling enable"'
+        run_command(cmd)
+        config_db.set_entry("BGP_ERROR_CFG_TABLE", "config", {"enable":  "false"})
+    pass
+    pass
+@error_handling.group(invoke_without_command=True)
+@click.pass_context
+def enable(ctx):
+    """Administratively Enable BGP error handling"""
+    if ctx.invoked_subcommand is None:
+        config_db = ConfigDBConnector(host="127.0.0.1")
+        config_db.connect()
+        curr_mode = config_db.get_entry('BGP_ERROR_CFG_TABLE', "config").get('enable')
+        if (curr_mode != "true"):
+            cmd = 'sudo vtysh -c "configure terminal" -c "bgp error-handling enable"'
+            run_command(cmd)
+            config_db.set_entry("BGP_ERROR_CFG_TABLE", "config", {"enable":  "true"})
+        pass
+    pass
 
 # 'all' subcommand
 @shutdown.command()


### PR DESCRIPTION
Functional specification:
Azure/SONiC#424
The routes will be pushed by BGP to Zebra to fpm to be installed
in hardware. If fpm returns error, the routes will not be sent by BGP to
its peers. Only successful routes are sent by BGP to its peers. The
feature can be enabled/disabled in BGP by a CLI. By default, the feature
is disabled. Functional specification:
Azure/SONiC#424
Signed-off by: Preetham Singh preetham.singh@broadcom.com
Signed-off by: Sudhanshu Kumar sudhanshu.kumar@broadcom.com

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

