### PR TITLE
[show] Add 'features' subcommand to display status for optional features

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -2146,5 +2146,21 @@ def config(redis_unix_socket_path):
     click.echo(tabulate(tablelize(keys, data, enable_table_keys, prefix), header))
     state_db.close(state_db.STATE_DB)
 
+#
+# show features
+#
+
+@cli.command('features')
+def features():
+    """Show status of optional features"""
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    header = ['Feature', 'Status']
+    body = []
+    status_data = config_db.get_table('FEATURES')
+    for key in status_data.keys():
+        body.append([key, status_data[key]['status']])
+    click.echo(tabulate(body, header))
+
 if __name__ == '__main__':
     cli()

--- a/show/main.py
+++ b/show/main.py
@@ -2157,7 +2157,7 @@ def features():
     config_db.connect()
     header = ['Feature', 'Status']
     body = []
-    status_data = config_db.get_table('FEATURES')
+    status_data = config_db.get_table('FEATURE')
     for key in status_data.keys():
         body.append([key, status_data[key]['status']])
     click.echo(tabulate(body, header))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Added 'show features' command to show status of an optional feature
**- How I did it**

**- How to verify it**
run 'show features'
```
Feature    Status
---------  --------
telemetry  enabled
```

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

