### PR TITLE
Do not start pfcwd for M0 devices

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -532,8 +532,8 @@ def load_minigraph():
     proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
     device_type, err = proc.communicate()
     if err:
-        click.echo("Could not get the device type from minigraph, exiting")
-        sys.exit(1)
+        click.echo("Could not get the device type from minigraph, setting device type to Unknown")
+        device_type = 'Unknown'
     else:
         device_type = device_type.strip()
 

--- a/config/main.py
+++ b/config/main.py
@@ -527,6 +527,16 @@ def load_minigraph():
     """Reconfigure based on minigraph."""
     log_info("'load_minigraph' executing...")
 
+    # get the device type
+    command = "{} -m -v DEVICE_METADATA.localhost.type".format(SONIC_CFGGEN_PATH)
+    proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
+    device_type, err = proc.communicate()
+    if err:
+        click.echo("Could not get the device type from minigraph, exiting")
+        sys.exit(1)
+    else:
+        device_type = device_type.strip()
+
     #Stop services before config push
     _stop_services()
 
@@ -540,7 +550,8 @@ def load_minigraph():
         command = "{} -H -m --write-to-db".format(SONIC_CFGGEN_PATH)
     run_command(command, display_cmd=True)
     client.set(config_db.INIT_INDICATOR, 1)
-    run_command('pfcwd start_default', display_cmd=True)
+    if device_type != 'MgmtToRRouter':
+        run_command('pfcwd start_default', display_cmd=True)
     if os.path.isfile('/etc/sonic/acl.json'):
         run_command("acl-loader update full /etc/sonic/acl.json", display_cmd=True)
     run_command("config qos reload", display_cmd=True)


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

**- What I did**
Disable pfcwd for M0 devices

**- How I did it**
Get the device type from the minigraph and use that for comparison

**- How to verify it**
 - Modified device type in the minigraph to 'MgmtToRRouter' and verified that pfcwd is not started when load_minigraph is executed.
  - For other types, pfcwd was started when load_minigraph was executed