### PR TITLE
Show mac learned on lag interface

### DIFF
--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -43,6 +43,8 @@ class FdbShow(object):
         self.db = SonicV2Connector(host="127.0.0.1")
         self.if_name_map, \
         self.if_oid_map = port_util.get_interface_oid_map(self.db)
+        self.lag_if_name_map, \
+        self.lag_if_oid_map = port_util.get_lag_interface_oid_map(self.db)
         self.if_br_oid_map = port_util.get_bridge_port_map(self.db)
         self.fetch_fdb_data()
         return
@@ -76,7 +78,12 @@ class FdbShow(object):
             if br_port_id not in self.if_br_oid_map:
                 continue
             port_id = self.if_br_oid_map[br_port_id]
-            if_name = self.if_oid_map[port_id]
+            if port_id in self.if_oid_map:
+                if_name = self.if_oid_map[port_id]
+            elif port_id in self.lag_if_oid_map:
+                if_name = self.lag_if_oid_map[port_id]
+            else:
+                if_name = ""
             if 'vlan' in fdb:
                 vlan_id = fdb["vlan"]
             elif 'bvid' in fdb:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
The code is to show mac learned on lag.
The funtion need to read the LAG_NAME_MAP_TABLE data.

**- How I did it**
To read mac table and get its learned portchannel name from LAG_NAME_MAP_TABLE in COUNTERS_DB with oid.

**- How to verify it**
1. Create PortChannel1 and add member port Ethernet10.
2. Create vlan 10 and add member port PortChannel1.
3. Create neighbor port PortChannel1 and add it to vlan 10.
4.  "show mac‘’ to see if it could show mac on PortChannel1.

**- Previous command output (if the output of a command-line utility has changed)**
root@sonic:/home/admin# show mac        
2000000000658

**- New command output (if the output of a command-line utility has changed)**
root@sonic:/home/admin# show mac        
  No.    Vlan  MacAddress         Port          Type
-----  ------  -----------------  ------------  -------
    1      10  00:8C:FA:9A:31:E3  PortChannel1  Dynamic
