### PR TITLE
[bugfix]: allow loopback vrf migration from version 1_0_1

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -35,7 +35,7 @@ class DBMigrator():
                      none-zero values.
               build: sequentially increase within a minor version domain.
         """
-        self.CURRENT_VERSION = 'version_1_0_1'
+        self.CURRENT_VERSION = 'version_1_0_2'
 
         self.TABLE_NAME      = 'VERSIONS'
         self.TABLE_KEY       = 'DATABASE'
@@ -116,18 +116,26 @@ class DBMigrator():
         #       upgrade will take care of the subsequent migrations.
         self.migrate_pfc_wd_table()
         self.migrate_interface_table()
-        self.set_version('version_1_0_1')
-        return 'version_1_0_1'
-
+        self.set_version('version_1_0_2')
+        return 'version_1_0_2'
 
     def version_1_0_1(self):
         """
-        Current latest version. Nothing to do here.
+        Version 1_0_1.
         """
         log_info('Handling version_1_0_1')
 
+        self.migrate_interface_table()
+        self.set_version('version_1_0_2')
         return None
 
+    def version_1_0_2(self):
+        """
+        Current latest version. Nothing to do here.
+        """
+        log_info('Handling version_1_0_2')
+
+        return None
 
     def get_version(self):
         version = self.configDB.get_entry(self.TABLE_NAME, self.TABLE_KEY)


### PR DESCRIPTION
commit fe4446a4808bc98ca2b24b0a9afe822aaa50a7ce fix loopback vrf migration.

but the commit does not enable db migration from version 1_0_1.

Now, bump version 1_0_2 and allow db fix from 1_0_1

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

