### PR TITLE
queuestat add -c -P Ethernetx to clear stats and save new ones for just one port and <issues#723>add clear queuecounter port

### DIFF
--- a/clear/main.py
+++ b/clear/main.py
@@ -183,9 +183,12 @@ def rifcounters(interface):
     run_command(command)
 
 @cli.command()
-def queuecounters():
+@click.argument('port', metavar='<port_name>', required=False, type=str)
+def queuecounters(port):
     """Clear queue counters"""
     command = "queuestat -c"
+    if port is not None:
+        command = "queuestat -c -P {}".format(port)
     run_command(command)
 
 @cli.command()

--- a/scripts/queuestat
+++ b/scripts/queuestat
@@ -231,7 +231,7 @@ class Queuestat(object):
         else:
             self.cnstat_print(port, cnstat_dict)
 
-    def save_fresh_stats(self):
+    def save_fresh_stats(self, port_clear):
         if not os.path.exists(cnstat_dir):
             try:
                 os.makedirs(cnstat_dir)
@@ -241,6 +241,8 @@ class Queuestat(object):
 
         # Get stat for each port and save
         for port in natsorted(self.counter_port_name_map):
+            if port_clear and port != port_clear:
+                continue
             cnstat_dict = self.get_cnstat(self.port_queues_map[port])
             try:
                 pickle.dump(cnstat_dict, open(cnstat_fqn_file + port, 'w'))
@@ -263,9 +265,11 @@ Examples:
   queuestat -p Ethernet0
   queuestat -c
   queuestat -d
+  queuestat -c -P Ethernet0
 """)
 
     parser.add_argument('-p', '--port', type=str, help='Show the queue conters for just one port', default=None)
+    parser.add_argument('-P', '--port_clear', type=str, help='Clear previous stats and save new ones for just one port', default=None)
     parser.add_argument('-c', '--clear', action='store_true', help='Clear previous stats and save new ones')
     parser.add_argument('-d', '--delete', action='store_true', help='Delete saved stats')
     args = parser.parse_args()
@@ -274,6 +278,8 @@ Examples:
     delete_all_stats = args.delete
 
     port_to_show_stats = args.port
+
+    port_to_clear_stats = args.port_clear
 
     uid = str(os.getuid())
     cnstat_file = uid
@@ -295,7 +301,7 @@ Examples:
     queuestat = Queuestat()
 
     if save_fresh_stats:
-        queuestat.save_fresh_stats()
+        queuestat.save_fresh_stats(port_to_clear_stats)
         sys.exit(0)
 
     if port_to_show_stats!=None:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
add queuestat -c -P Ethernetx to clear one port queque stat
**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**
![image](https://user-images.githubusercontent.com/43633727/68930194-d1a00400-07c8-11ea-834b-a866471e63b6.png)
**- New command output (if the output of a command-line utility has changed)**
![image](https://user-images.githubusercontent.com/43633727/68930243-e4b2d400-07c8-11ea-9500-2bd53fda671c.png)