### PR TITLE
[portstat] fix header used

### DIFF
--- a/scripts/portstat
+++ b/scripts/portstat
@@ -208,7 +208,7 @@ class Portstat(object):
                                   STATUS_NA,
                                   cntr.tx_err,
                                   cntr.tx_drop,
-                                  cntr.tx_err))
+                                  cntr.tx_ovr))
             else:
                 if old_cntr is not None:
                     table.append((key, self.get_port_state(key),
@@ -237,7 +237,7 @@ class Portstat(object):
                                   STATUS_NA,
                                   cntr.tx_err,
                                   cntr.tx_drop,
-                                  cntr.tx_err))
+                                  cntr.tx_ovr))
 
         if use_json:
             print table_as_json(table, header)

--- a/scripts/portstat
+++ b/scripts/portstat
@@ -155,7 +155,7 @@ class Portstat(object):
 
 
         if use_json:
-            table_as_json(table, header_all if print_all else header)
+            print table_as_json(table, header_all if print_all else header)
         else:
             print tabulate(table, header_all if print_all else header, tablefmt='simple', stralign='right')
 

--- a/scripts/portstat
+++ b/scripts/portstat
@@ -157,7 +157,7 @@ class Portstat(object):
         if use_json:
             table_as_json(table, header_all if print_all else header)
         else:
-            print tabulate(table, header_all, tablefmt='simple', stralign='right') #  if print_all else header
+            print tabulate(table, header_all if print_all else header, tablefmt='simple', stralign='right')
 
     def cnstat_diff_print(self, cnstat_new_dict, cnstat_old_dict, use_json, print_all):
         """


### PR DESCRIPTION
Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->
Fixes #742 
Looks like after the revert wrong header was used for the table.
**- What I did**

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

