### PR TITLE
[scripts] Adds support for management (1.0) commands

### DIFF
--- a/scripts/syseeprom-to-json
+++ b/scripts/syseeprom-to-json
@@ -1,0 +1,31 @@
+#!/usr/bin/awk -f
+
+BEGIN { print "{"; n = 0 }
+
+function sep()
+{
+	if (n > 0)  print ", ";
+	++n;
+}
+
+/Product Name/       { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/Part Number/        { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/Serial Number/      { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/Base MAC Address/   { sep(); print "\"" $1 " " $2 " " $3 "\": \"" $6 "\""; }
+/Manufacture Date/   { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/Device Version/     { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/Label Revision/     { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/Platform Name/      { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/ONIE Version/       { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/MAC Addresses/      { sep(); print "\"" $1 " " $2 "\": " $5; }
+/Manfacturer/        { sep(); print "\"" $1 "\": \"" $4 "\""; } 
+/Manfacture Country/ { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/Vendor Name/        { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/Diag Version/       { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/Service Tag/        { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/Hardware Version/   { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/Software Version/   { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/Manfacture Date/    { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/Model Name/         { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+
+END { print "}" }

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
         'scripts/route_check.py',
         'scripts/route_check_test.sh',
         'scripts/sfpshow',
+        'scripts/syseeprom-to-json',
         'scripts/teamshow',
         'scripts/warm-reboot',
         'scripts/watermarkstat',


### PR DESCRIPTION
Add utility to translate text output of syseeprom dump into JSON, for
consumption by new management (1.0) command.

Signed-off-by: Howard Persh <hpersh@yahoo.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

