### PR TITLE
[intfstat] fix --delete-all fail when counters dump does not exist

### DIFF
--- a/scripts/intfstat
+++ b/scripts/intfstat
@@ -269,6 +269,10 @@ def main():
     cnstat_fqn_file = cnstat_dir + "/" + cnstat_file
 
     if delete_all_stats:
+        # There is nothing to delete
+        if not os.path.isdir(cnstat_dir):
+            sys.exit(0)
+
         for file in os.listdir(cnstat_dir):
             os.remove(cnstat_dir + "/" + file)
 


### PR DESCRIPTION
Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->
Fixes #749 


**- What I did**
Additional check for counter snapshot folder existance.
**- How I did it**

**- How to verify it**

1. intfstat -D
2. intfstat -D

**- Previous command output (if the output of a command-line utility has changed)**
Traceback (most recent call last):
  File "/usr/bin/intfstat", line 346, in <module>
    main()
  File "/usr/bin/intfstat", line 272, in main
    for file in os.listdir(cnstat_dir):
OSError: [Errno 2] No such file or directory: '/tmp/intfstat-0'
**- New command output (if the output of a command-line utility has changed)**

