### PR TITLE
[multiDB]: all application should use API to get redis_client

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -476,7 +476,7 @@ def reload(filename, yes, load_sysinfo):
     _stop_services()
     config_db = ConfigDBConnector()
     config_db.connect()
-    client = config_db.redis_clients[config_db.CONFIG_DB]
+    client = config_db.get_redis_client(config_db.CONFIG_DB)
     client.flushdb()
     if load_sysinfo:
         command = "{} -H -k {} --write-to-db".format(SONIC_CFGGEN_PATH, cfg_hwsku)
@@ -542,7 +542,7 @@ def load_minigraph():
 
     config_db = ConfigDBConnector()
     config_db.connect()
-    client = config_db.redis_clients[config_db.CONFIG_DB]
+    client = config_db.get_redis_client(config_db.CONFIG_DB)
     client.flushdb()
     if os.path.isfile('/etc/sonic/init_cfg.json'):
         command = "{} -H -m -j /etc/sonic/init_cfg.json --write-to-db".format(SONIC_CFGGEN_PATH)


### PR DESCRIPTION
* There is existing get_redis_client() API to obtain redis_client, all application should use it.
* multiDB changes redesign interface class get_redis_client() implementation, internal private data redis_clients[] indexed by db_id when updating sonic-py-swsssdk, hence all application should use API to obtain redis-client for safety. 
* did a global search on all codes , looks only this two are missing to use get API, all other places are already modified earlier.
* after this changes, we can move the head for sonic-py-swsssdk without error when reloading config (minigraph) 


Signed-off-by: Dong Zhang d.zhang@alibaba-inc.com