### PR TITLE
[neighbor advertiser] catch all exceptions while trying https endpoint

### DIFF
--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -355,6 +355,7 @@ def wrapped_ferret_request(request_slice, https_endpoint, http_endpoint):
                                      json=request_slice,
                                      timeout=DEFAULT_REQUEST_TIMEOUT,
                                      verify=False)
+            response.raise_for_status()
     except Exception as e:
         log_info("Connect HTTPS Ferret endpoint failed (error: {}), trying HTTP...".format(e))
         response = requests.post(http_endpoint,

--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -21,7 +21,6 @@ import sonic_device_util
 from swsssdk import ConfigDBConnector
 from swsssdk import SonicV2Connector
 from netaddr import IPAddress, IPNetwork
-from requests.exceptions import ConnectTimeout
 
 
 #
@@ -356,8 +355,8 @@ def wrapped_ferret_request(request_slice, https_endpoint, http_endpoint):
                                      json=request_slice,
                                      timeout=DEFAULT_REQUEST_TIMEOUT,
                                      verify=False)
-    except ConnectTimeout:
-        log_info("HTTPS Ferret endpoint not found, trying HTTP...")
+    except Exception as e:
+        log_info("Connect HTTPS Ferret endpoint failed (error: {}), trying HTTP...".format(e))
         response = requests.post(http_endpoint,
                                  json=request_slice,
                                  timeout=DEFAULT_REQUEST_TIMEOUT)


### PR DESCRIPTION
**- What I did**

When connecting https endpoint failed, we need to try http endpoint.
Therefore we need to catch all exceptions.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- How to verify it**
warm-reboot-control-plane-assistant test. Also tested with https endpoint success code and timeout.