### PR TITLE
add fec configuration 'config interface fec [OPTIONS] <interface_name> <interface_fec>'

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1954,6 +1954,25 @@ def mtu(ctx, interface_name, interface_mtu, verbose):
         command += " -vv"
     run_command(command, display_cmd=verbose)
 
+@interface.command()
+@click.pass_context
+@click.argument('interface_name', metavar='<interface_name>', required=True)
+@click.argument('interface_fec', metavar='<interface_fec>', required=True)
+@click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
+def fec(ctx, interface_name, interface_fec, verbose):
+    """Set interface fec"""
+    if interface_fec not in ["rs", "fc", "none"]:
+        ctx.fail("'fec not in ['rs', 'fc', 'none']!")
+    if get_interface_naming_mode() == "alias":
+        interface_name = interface_alias_to_name(interface_name)
+        if interface_name is None:
+            ctx.fail("'interface_name' is None!")
+
+    command = "portconfig -p {} -f {}".format(interface_name, interface_fec)
+    if verbose:
+        command += " -vv"
+    run_command(command, display_cmd=verbose)
+
 #
 # 'ip' subgroup ('config interface ip ...')
 #

--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -32,6 +32,7 @@ PORT_OPER_STATUS = "oper_status"
 PORT_ADMIN_STATUS = "admin_status"
 PORT_SPEED = "speed"
 PORT_MTU_STATUS = "mtu"
+PORT_FEC = "fec"
 PORT_DESCRIPTION = "description"
 PORT_OPTICS_TYPE = "type"
 PORT_PFC_ASYM_STATUS = "pfc_asym"
@@ -339,7 +340,7 @@ def appl_db_sub_intf_status_get(appl_db, config_db, front_panel_ports_list, port
 
 # ========================== interface-status logic ==========================
 
-header_stat = ['Interface', 'Lanes', 'Speed', 'MTU', 'Alias', 'Vlan', 'Oper', 'Admin', 'Type', 'Asym PFC']
+header_stat = ['Interface', 'Lanes', 'Speed', 'MTU', 'FEC', 'Alias', 'Vlan', 'Oper', 'Admin', 'Type', 'Asym PFC']
 header_stat_sub_intf = ['Sub port interface', 'Speed', 'MTU', 'Vlan', 'Admin', 'Type']
 
 class IntfStatus(object):
@@ -365,6 +366,7 @@ class IntfStatus(object):
                                 appl_db_port_status_get(self.appl_db, key, PORT_LANES_STATUS),
                                 appl_db_port_status_get(self.appl_db, key, PORT_SPEED),
                                 appl_db_port_status_get(self.appl_db, key, PORT_MTU_STATUS),
+                                appl_db_port_status_get(self.appl_db, key, PORT_FEC),
                                 appl_db_port_status_get(self.appl_db, key, PORT_ALIAS),
                                 config_db_vlan_port_keys_get(self.combined_int_to_vlan_po_dict, self.front_panel_ports_list, key),
                                 appl_db_port_status_get(self.appl_db, key, PORT_OPER_STATUS),
@@ -378,6 +380,7 @@ class IntfStatus(object):
                                 appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_LANES_STATUS, self.portchannel_speed_dict),
                                 appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_SPEED, self.portchannel_speed_dict),
                                 appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_MTU_STATUS, self.portchannel_speed_dict),
+                                appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_FEC, self.portchannel_speed_dict),
                                 appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_ALIAS, self.portchannel_speed_dict),
                                 appl_db_portchannel_status_get(self.appl_db, self.config_db, po, "vlan", self.portchannel_speed_dict),
                                 appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_OPER_STATUS, self.portchannel_speed_dict),

--- a/sonic-utilities-tests/intfutil_test.py
+++ b/sonic-utilities-tests/intfutil_test.py
@@ -27,9 +27,9 @@ class TestIntfutil(TestCase):
         result = self.runner.invoke(show.cli.commands["interfaces"].commands["status"], [])
         print >> sys.stderr, result.output
         expected_output = (
-              "Interface    Lanes    Speed    MTU      Alias    Vlan    Oper    Admin             Type    Asym PFC\n"
-            "-----------  -------  -------  -----  ---------  ------  ------  -------  ---------------  ----------\n"
-            "  Ethernet0        0      25G   9100  Ethernet0  routed    down       up  QSFP28 or later         off"
+              "Interface    Lanes    Speed    MTU    FEC      Alias    Vlan    Oper    Admin             Type    Asym PFC\n"
+            "-----------  -------  -------  -----  -----  ---------  ------  ------  -------  ---------------  ----------\n"
+            "  Ethernet0        0      25G   9100     rs  Ethernet0  routed    down       up  QSFP28 or later         off"
         )
         self.assertEqual(result.output.strip(), expected_output)
 

--- a/sonic-utilities-tests/mock_tables/appl_db.json
+++ b/sonic-utilities-tests/mock_tables/appl_db.json
@@ -7,6 +7,7 @@
         "oper_status": "down",
         "pfc_asym": "off",
         "mtu": "9100",
+        "fec": "rs",
         "admin_status": "up"
     },
     "PORT_TABLE:Ethernet200": {


### PR DESCRIPTION
Signed-off-by:yangshiping@jd.com
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
add interface fec configuration for the command "config interface ……"
**- How I did it**
modify config/main.py
**- How to verify it**
check the command whether can be configured in switch shell
**- Previous command output (if the output of a command-line utility has changed)**
```
root@sonic:/home/admin# config interface --help
Usage: config interface [OPTIONS] COMMAND [ARGS]...

  Interface-related configuration tasks

Options:
  -?, -h, --help  Show this message and exit.

Commands:
  ip        Add or remove IP address
  pfc       Set PFC configuration.
  shutdown  Shut down interface
  speed     Set interface speed
  startup   Start up interface
  vrf       Bind or unbind VRF
the configdb:
127.0.0.1:6379[4]> HGETALL "PORT|Ethernet0"
1) "alias"
2) "Ethernet0"
3) "admin_status"
4) "up"
5) "lanes"
6) "1,2,3,4"
7) "mtu"
8) "9100"
```
**- New command output (if the output of a command-line utility has changed)**
```
root@sonic:/home/admin# config interface ?
Usage: config interface [OPTIONS] COMMAND [ARGS]...

  Interface-related configuration tasks

Options:
  -?, -h, --help  Show this message and exit.

Commands:
  fec       Set interface fec from ['rs','fc','none']
  ip        Add or remove IP address
  pfc       Set PFC configuration.
  shutdown  Shut down interface
  speed     Set interface speed
  startup   Start up interface
  vrf       Bind or unbind VRF
the configdb:
127.0.0.1:6379[4]> HGETALL "PORT|Ethernet0"
 1) "alias"
 2) "Ethernet0"
 3) "admin_status"
 4) "up"
 5) "lanes"
 6) "1,2,3,4"
 7) "mtu"
 8) "9100"
 9) "fec"
10) "fc"
```
expose the fec configuration of portconfig to the solution for the #733 