### PR TITLE
[config] Add ConfigMgmt class for config validation, delete ports, add ports

### DIFF
--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -10,6 +10,7 @@ try:
     from os import system
     from time import sleep as tsleep
     from imp import load_source
+    from jsondiff import diff
 
     # SONiC specific imports
     import sonic_yang
@@ -839,7 +840,6 @@ class ConfigMgmtDPB(ConfigMgmt):
              u'Vlan777': {u'members': {insert: [(92, 'Ethernet2')]}}},
             'PORT': {delete: {u'Ethernet1': {...}}}}
         '''
-        from jsondiff import diff
         return diff(self.configdbJsonIn, self.configdbJsonOut, syntax='symmetric')
 
 # end of class ConfigMgmtDPB

--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -7,7 +7,6 @@ try:
     import syslog
 
     from json import load
-    from os import system
     from time import sleep as tsleep
     from imp import load_source
     from jsondiff import diff
@@ -146,7 +145,7 @@ class ConfigMgmt():
         # log debug only if enabled
         if self.DEBUG == False and logLevel == syslog.LOG_DEBUG:
             return
-        if flgas.interactive !=0 and doPrint == True:
+        if flags.interactive !=0 and doPrint == True:
             print("{}".format(msg))
         syslog.openlog(self.SYSLOG_IDENTIFIER)
         syslog.syslog(logLevel, msg)
@@ -340,8 +339,8 @@ class ConfigMgmtDPB(ConfigMgmt):
 
         return True
 
-    def breakOutPort(self, delPorts=list(), addPorts=list(), portJson=dict(), \
-        force=False, loadDefConfig=True):
+    def breakOutPort(self, delPorts=list(), portJson=dict(), force=False, \
+            loadDefConfig=True):
         '''
         This is the main function for port breakout. Exposed to caller.
 
@@ -366,8 +365,8 @@ class ConfigMgmtDPB(ConfigMgmt):
                 return deps, ret
 
             # add Ports and get the config diff and True/False
-            addConfigtoLoad, ret = self._addPorts(ports=addPorts, \
-                portJson=portJson, loadDefConfig=loadDefConfig)
+            addConfigtoLoad, ret = self._addPorts(portJson=portJson, \
+                loadDefConfig=loadDefConfig)
             # return if ret is False, Great thing, no change is done in Config
             if ret == False:
                 return None, ret

--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -815,7 +815,6 @@ class ConfigMgmtDPB(ConfigMgmt):
         ### Function Code ###
         try:
             configToLoad = dict()
-            #import pdb; pdb.set_trace()
             _recurCreateConfig(diff, inp, outp, configToLoad)
 
         except Exception as e:

--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -10,12 +10,8 @@ try:
     load_source('sonic_cfggen', '/usr/local/bin/sonic-cfggen')
     from sonic_cfggen import deep_update, FormatConverter, sort_data
     from swsssdk import ConfigDBConnector, SonicV2Connector, port_util
-    from pprint import PrettyPrinter, pprint
-    from json import dump, load, dumps, loads
-    from sys import path as sysPath
-    from os import path as osPath
+    from json import load
     from os import system
-    from datetime import datetime
     from time import sleep as tsleep
 
     import sonic_yang
@@ -92,7 +88,7 @@ class ConfigMgmt():
 
         return
 
-        """
+    """
     Validate current Data Tree
     """
     def validateConfigData(self):
@@ -394,8 +390,7 @@ class ConfigMgmtDPB(ConfigMgmt):
             self.sysLog(msg="addPorts Args portjson {}".format(portJson))
 
             print('\nStart Port Addition')
-            # get default config if forced
-            defConfig = dict()
+
             if loadDefConfig:
                 defConfig = self._getDefaultConfig(ports)
                 self.sysLog(msg='Default Config: {}'.format(defConfig))
@@ -563,7 +558,6 @@ class ConfigMgmtDPB(ConfigMgmt):
     def _updateDiffConfigDB(self):
 
         # main code starts here
-        configToLoad = dict()
         try:
             # Get the Diff
             print('Generate Final Config to write in DB')

--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -346,7 +346,6 @@ class ConfigMgmtDPB(ConfigMgmt):
 
         Parameters:
             delPorts (list): ports to be deleted.
-            addPorts (list): ports to be added.
             portJson (dict): Config DB json Part of all Ports, generated from
                 platform.json.
             force (bool): if false return dependecies, else delete dependencies.

--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -2,7 +2,6 @@
 # Provides a class for configuration validation and for Dynamic Port Breakout.
 
 try:
-
     import re
     import syslog
 
@@ -37,7 +36,6 @@ DEFAULT_CONFIG_DB_JSON_FILE = '/etc/sonic/default_config_db.json'
 class ConfigMgmt():
 
     def __init__(self, source="configDB", debug=False, allowTablesWithoutYang=True):
-
         try:
             self.configdbJsonIn = None
             self.configdbJsonOut = None
@@ -76,7 +74,6 @@ class ConfigMgmt():
     Return tables loaded in config for which YANG model does not exist.
     """
     def tablesWithoutYang(self):
-
         return self.sy.tablesWithOutYang
 
     """
@@ -94,7 +91,6 @@ class ConfigMgmt():
     Validate current Data Tree
     """
     def validateConfigData(self):
-
         try:
             self.sy.validate_data_tree()
         except Exception as e:
@@ -109,7 +105,6 @@ class ConfigMgmt():
     syslog Support
     """
     def sysLog(self, debug=syslog.LOG_INFO, msg=None):
-
         # log debug only if enabled
         if self.DEBUG == False and debug == syslog.LOG_DEBUG:
             return
@@ -120,7 +115,6 @@ class ConfigMgmt():
         return
 
     def readConfigDBJson(self, source=CONFIG_DB_JSON_FILE):
-
         print('Reading data from {}'.format(source))
         self.configdbJsonIn = readJsonFile(source)
         #print(type(self.configdbJsonIn))
@@ -134,9 +128,7 @@ class ConfigMgmt():
         Get config from redis config DB
     """
     def readConfigDB(self):
-
         print('Reading data from Redis configDb')
-
         # Read from config DB on sonic switch
         db_kwargs = dict(); data = dict()
         configdb = ConfigDBConnector(**db_kwargs)
@@ -172,7 +164,6 @@ class ConfigMgmt():
 class ConfigMgmtDPB(ConfigMgmt):
 
     def __init__(self, source="configDB", debug=False, allowTablesWithoutYang=True):
-
         try:
             ConfigMgmt.__init__(self, source=source, debug=debug, \
                 allowTablesWithoutYang=allowTablesWithoutYang)
@@ -191,7 +182,6 @@ class ConfigMgmtDPB(ConfigMgmt):
       Check if a key exists in ASIC DB or not.
     """
     def _checkKeyinAsicDB(self, key, db):
-
         self.sysLog(msg='Check Key in Asic DB: {}'.format(key))
         try:
             # chk key in ASIC DB
@@ -242,10 +232,8 @@ class ConfigMgmtDPB(ConfigMgmt):
     db = database, ports, portMap, timeout
     """
     def _verifyAsicDB(self, db, ports, portMap, timeout):
-
         print("Verify Port Deletion from Asic DB, Wait...")
         self.sysLog(msg="Verify Port Deletion from Asic DB, Wait...")
-
         try:
             for waitTime in range(timeout):
                 self.sysLog(msg='Check Asic DB: {} try'.format(waitTime+1))
@@ -271,7 +259,6 @@ class ConfigMgmtDPB(ConfigMgmt):
 
     def breakOutPort(self, delPorts=list(), addPorts= list(), portJson=dict(), \
         force=False, loadDefConfig=True):
-
         MAX_WAIT = 60
         try:
             # delete Port and get the Config diff, deps and True/False
@@ -318,7 +305,6 @@ class ConfigMgmtDPB(ConfigMgmt):
     With Force: (xpath of dependecies, False) or (None, True)
     """
     def _deletePorts(self, ports=list(), force=False):
-
         configToLoad = None; deps = None
         try:
             self.sysLog(msg="delPorts ports:{} force:{}".format(ports, force))
@@ -383,7 +369,6 @@ class ConfigMgmtDPB(ConfigMgmt):
     return: Sucess: True or Failure: False
     """
     def _addPorts(self, ports=list(), portJson=dict(), loadDefConfig=True):
-
         configToLoad = None
         try:
             self.sysLog(msg='Start Port Addition')
@@ -437,7 +422,6 @@ class ConfigMgmtDPB(ConfigMgmt):
     Unique keys in D2 will be merged in D1 only if uniqueKeys=True
     """
     def _mergeConfigs(self, D1, D2, uniqueKeys=True):
-
         try:
             def _mergeItems(it1, it2):
                 if isinstance(it1, list) and isinstance(it2, list):
@@ -482,7 +466,6 @@ class ConfigMgmtDPB(ConfigMgmt):
     Out: Contains the search result
     """
     def _searchKeysInConfig(self, In, Out, skeys):
-
         found = False
         if isinstance(In, dict):
             for key in In.keys():
@@ -528,7 +511,6 @@ class ConfigMgmtDPB(ConfigMgmt):
     For Example: All Ports related Config in Config DB.
     """
     def configWithKeys(self, configIn=dict(), keys=list()):
-
         configOut = dict()
         try:
             if len(configIn) and len(keys):
@@ -543,7 +525,6 @@ class ConfigMgmtDPB(ConfigMgmt):
     Create a defConfig for given Ports from Default Config File.
     """
     def _getDefaultConfig(self, ports=list()):
-
         # function code
         try:
             print("Generating default config for {}".format(ports))
@@ -558,7 +539,6 @@ class ConfigMgmtDPB(ConfigMgmt):
         return defConfigOut
 
     def _updateDiffConfigDB(self):
-
         try:
             # Get the Diff
             print('Generate Final Config to write in DB')
@@ -581,13 +561,11 @@ class ConfigMgmtDPB(ConfigMgmt):
     outp: output config after delete/add ports.
     """
     def _createConfigToLoad(self, diff, inp, outp):
-
         ### Internal Functions ###
         """
         Handle deletes in diff dict
         """
         def _deleteHandler(diff, inp, outp, config):
-
             # if output is dict, delete keys from config
             if isinstance(inp, dict):
                 for key in diff:
@@ -613,7 +591,6 @@ class ConfigMgmtDPB(ConfigMgmt):
         Handle inserts in diff dict
         """
         def _insertHandler(diff, inp, outp, config):
-
             # if outp is a dict
             if isinstance(outp, dict):
                 for key in diff:
@@ -637,7 +614,6 @@ class ConfigMgmtDPB(ConfigMgmt):
         Recursively iterate diff to generate config to write in configDB
         """
         def _recurCreateConfig(diff, inp, outp, config):
-
             changed = False
             # updates are represented by list in diff and as dict in outp\inp
             # we do not allow updates right now
@@ -688,7 +664,6 @@ class ConfigMgmtDPB(ConfigMgmt):
         return configToLoad
 
     def _diffJson(self):
-
         from jsondiff import diff
         return diff(self.configdbJsonIn, self.configdbJsonOut, syntax='symmetric')
 
@@ -696,7 +671,6 @@ class ConfigMgmtDPB(ConfigMgmt):
 
 # Helper Functions
 def readJsonFile(fileName):
-
     try:
         with open(fileName) as f:
             result = load(f)

--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -1,0 +1,715 @@
+#!/usr/bin/env python
+#
+# config_mgmt.py
+# Provides a class for configuration validation and for Dynamic Port Breakout.
+
+try:
+
+    # import from sonic-cfggen, re use this
+    from imp import load_source
+    load_source('sonic_cfggen', '/usr/local/bin/sonic-cfggen')
+    from sonic_cfggen import deep_update, FormatConverter, sort_data
+    from swsssdk import ConfigDBConnector, SonicV2Connector, port_util
+    from pprint import PrettyPrinter, pprint
+    from json import dump, load, dumps, loads
+    from sys import path as sysPath
+    from os import path as osPath
+    from os import system
+    from datetime import datetime
+    from time import sleep as tsleep
+
+    import sonic_yang
+    import syslog
+    import re
+
+except ImportError as e:
+    raise ImportError("%s - required module not found" % str(e))
+
+# Globals
+# This class may not need to know about YANG_DIR ?, sonic_yang shd use
+# default dir.
+YANG_DIR = "/usr/local/yang-models"
+CONFIG_DB_JSON_FILE = '/etc/sonic/confib_db.json'
+# TODO: Find a place for it on sonic switch.
+DEFAULT_CONFIG_DB_JSON_FILE = '/etc/sonic/default_config_db.json'
+
+# Class to handle config managment for SONIC, this class will use PLY to verify
+# config for the commands which are capable of change in config DB.
+
+class ConfigMgmt():
+
+    def __init__(self, source="configDB", debug=False, allowTablesWithOutYang=True):
+
+        try:
+            self.configdbJsonIn = None
+            self.configdbJsonOut = None
+            self.allowTablesWithOutYang = allowTablesWithOutYang
+
+            # logging vars
+            self.SYSLOG_IDENTIFIER = "ConfigMgmt"
+            self.DEBUG = debug
+
+            self.sy = sonic_yang.SonicYang(YANG_DIR, debug=debug)
+            # load yang models
+            self.sy.loadYangModel()
+            # load jIn from config DB or from config DB json file.
+            if source.lower() == 'configdb':
+                self.readConfigDB()
+            # treat any other source as file input
+            else:
+                self.readConfigDBJson(source)
+            # this will crop config, xlate and load.
+            self.sy.loadData(self.configdbJsonIn)
+
+            # Raise if tables without YANG models are not allowed but exist.
+            if not allowTablesWithOutYang and len(self.sy.tablesWithOutYang):
+                raise Exception('Config has tables without YANG models')
+
+        except Exception as e:
+            print(e)
+            raise(Exception('ConfigMgmt Class creation failed'))
+
+        return
+
+    def __del__(self):
+        pass
+
+    """
+    Return tables loaded in config for which YANG model does not exist.
+    """
+    def tablesWithOutYang(self):
+
+        return self.sy.tablesWithOutYang
+
+    """
+    Explicit function to load config data in Yang Data Tree
+    """
+    def loadData(self, configdbJson):
+        self.sy.loadData(configdbJson)
+        # Raise if tables without YANG models are not allowed but exist.
+        if not self.allowTablesWithOutYang and len(self.sy.tablesWithOutYang):
+            raise Exception('Config has tables without YANG models')
+
+        return
+
+        """
+    Validate current Data Tree
+    """
+    def validateConfigData(self):
+
+        try:
+            self.sy.validate_data_tree()
+        except Exception as e:
+            self.sysLog(msg='Data Validation Failed')
+            return False
+
+        print('Data Validation successful')
+        self.sysLog(msg='Data Validation successful')
+        return True
+
+    """
+    syslog Support
+    """
+    def sysLog(self, debug=syslog.LOG_INFO, msg=None):
+
+        # log debug only if enabled
+        if self.DEBUG == False and debug == syslog.LOG_DEBUG:
+            return
+        syslog.openlog(self.SYSLOG_IDENTIFIER)
+        syslog.syslog(debug, msg)
+        syslog.closelog()
+
+        return
+
+    def readConfigDBJson(self, source=CONFIG_DB_JSON_FILE):
+
+        print('Reading data from {}'.format(source))
+        self.configdbJsonIn = readJsonFile(source)
+        #print(type(self.configdbJsonIn))
+        if not self.configdbJsonIn:
+            raise(Exception("Can not load config from config DB json file"))
+        self.sysLog(msg='Reading Input {}'.format(self.configdbJsonIn))
+
+        return
+
+    """
+        Get config from redis config DB
+    """
+    def readConfigDB(self):
+
+        print('Reading data from Redis configDb')
+
+        # Read from config DB on sonic switch
+        db_kwargs = dict(); data = dict()
+        configdb = ConfigDBConnector(**db_kwargs)
+        configdb.connect()
+        deep_update(data, FormatConverter.db_to_output(configdb.get_config()))
+        self.configdbJsonIn =  FormatConverter.to_serialized(data)
+        self.sysLog(syslog.LOG_DEBUG, 'Reading Input from ConfigDB {}'.\
+            format(self.configdbJsonIn))
+
+        return
+
+    def writeConfigDB(self, jDiff):
+        print('Writing in Config DB')
+        """
+        On Sonic Switch
+        """
+        db_kwargs = dict(); data = dict()
+        configdb = ConfigDBConnector(**db_kwargs)
+        configdb.connect(False)
+        deep_update(data, FormatConverter.to_deserialized(jDiff))
+        data = sort_data(data)
+        self.sysLog(msg="Write in DB: {}".format(data))
+        configdb.mod_config(FormatConverter.output_to_db(data))
+
+        return
+
+# End of Class ConfigMgmt
+
+"""
+    Config MGMT class for Dynamic Port Breakout(DPB).
+    This is derived from ConfigMgmt.
+"""
+class ConfigMgmtDPB(ConfigMgmt):
+
+    def __init__(self, source="configDB", debug=False, allowTablesWithOutYang=True):
+
+        try:
+            ConfigMgmt.__init__(self, source=source, debug=debug, \
+                allowTablesWithOutYang=allowTablesWithOutYang)
+            self.oidKey = 'ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x'
+
+        except Exception as e:
+            print(e)
+            raise(Exception('ConfigMgmtDPB Class creation failed'))
+
+        return
+
+    def __del__(self):
+        pass
+
+    """
+      Check if a key exists in ASIC DB or not.
+    """
+    def _checkKeyinAsicDB(self, key, db):
+
+        self.sysLog(msg='Check Key in Asic DB: {}'.format(key))
+        try:
+            # chk key in ASIC DB
+            if db.exists('ASIC_DB', key):
+                return True
+        except Exception as e:
+            print(e)
+            raise(e)
+
+        return False
+
+    def _testRedisCli(self, key):
+        # To Debug
+        if self.DEBUG:
+            cmd = 'sudo redis-cli -n 1 hgetall "{}"'.format(key)
+            self.sysLog(syslog.LOG_DEBUG, "Running {}".format(cmd))
+            print(cmd)
+            system(cmd)
+        return
+
+    """
+     Check ASIC DB for PORTs in port List
+     ports: List of ports
+     portMap: port to OID map.
+     Return: True, if all ports are not present.
+    """
+    def _checkNoPortsInAsicDb(self, db, ports, portMap):
+        try:
+            # connect to ASIC DB,
+            db.connect(db.ASIC_DB)
+            for port in ports:
+                key = self.oidKey + portMap[port]
+                if self._checkKeyinAsicDB(key, db) == False:
+                    # Test again via redis-cli
+                    self._testRedisCli(key)
+                else:
+                    return False
+
+        except Exception as e:
+            print(e)
+            return False
+
+        return True
+
+    """
+    Verify in the Asic DB that port are deleted,
+    Keep on trying till timeout period.
+    db = database, ports, portMap, timeout
+    """
+    def _verifyAsicDB(self, db, ports, portMap, timeout):
+
+        print("Verify Port Deletion from Asic DB, Wait...")
+        self.sysLog(msg="Verify Port Deletion from Asic DB, Wait...")
+
+        try:
+            for waitTime in range(timeout):
+                self.sysLog(msg='Check Asic DB: {} try'.format(waitTime+1))
+                # checkNoPortsInAsicDb will return True if all ports are not
+                # present in ASIC DB
+                if self._checkNoPortsInAsicDb(db, ports, portMap):
+                    break
+                tsleep(1)
+
+            # raise if timer expired
+            if waitTime + 1 == timeout:
+                print("!!!  Critical Failure, Ports are not Deleted from \
+                    ASIC DB, Bail Out  !!!")
+                self.sysLog(syslog.LOG_CRIT, "!!!  Critical Failure, Ports \
+                    are not Deleted from ASIC DB, Bail Out  !!!")
+                raise(Exception("Ports are present in ASIC DB after timeout"))
+
+        except Exception as e:
+            print(e)
+            raise e
+
+        return True
+
+    def breakOutPort(self, delPorts=list(), addPorts= list(), portJson=dict(), \
+        force=False, loadDefConfig=True):
+
+        MAX_WAIT = 60
+        try:
+            # delete Port and get the Config diff, deps and True/False
+            delConfigToLoad, deps, ret = self._deletePorts(ports=delPorts, \
+                force=force)
+            # return dependencies if delete port fails
+            if ret == False:
+                return deps, ret
+
+            # add Ports and get the config diff and True/False
+            addConfigtoLoad, ret = self._addPorts(ports=addPorts, \
+                portJson=portJson, loadDefConfig=loadDefConfig)
+            # return if ret is False, Great thing, no change is done in Config
+            if ret == False:
+                return None, ret
+
+            # Save Port OIDs Mapping Before Deleting Port
+            dataBase = SonicV2Connector(host="127.0.0.1")
+            if_name_map, if_oid_map = port_util.get_interface_oid_map(dataBase)
+            self.sysLog(syslog.LOG_DEBUG, 'if_name_map {}'.format(if_name_map))
+
+            # If we are here, then get ready to update the Config DB, Update
+            # deletion of Config first, then verify in Asic DB for port deletion,
+            # then update addition of ports in config DB.
+            self.writeConfigDB(delConfigToLoad)
+            # Verify in Asic DB,
+            self._verifyAsicDB(db=dataBase, ports=delPorts, portMap=if_name_map, \
+                timeout=MAX_WAIT)
+            self.writeConfigDB(addConfigtoLoad)
+
+        except Exception as e:
+            print(e)
+            return None, False
+
+        return None, True
+
+    """
+    Delete all ports.
+    delPorts: list of port names.
+    force: if false return dependecies, else delete dependencies.
+
+    Return:
+    WithOut Force: (xpath of dependecies, False) or (None, True)
+    With Force: (xpath of dependecies, False) or (None, True)
+    """
+    def _deletePorts(self, ports=list(), force=False):
+
+        configToLoad = None; deps = None
+        try:
+            self.sysLog(msg="delPorts ports:{} force:{}".format(ports, force))
+
+            print('\nStart Port Deletion')
+            deps = list()
+
+            # Get all dependecies for ports
+            for port in ports:
+                xPathPort = self.sy.findXpathPortLeaf(port)
+                print('Find dependecies for port {}'.format(port))
+                self.sysLog(msg='Find dependecies for port {}'.format(port))
+                # print("Generated Xpath:" + xPathPort)
+                dep = self.sy.find_data_dependencies(str(xPathPort))
+                if dep:
+                    deps.extend(dep)
+
+            # No further action with no force and deps exist
+            if force == False and deps:
+                return configToLoad, deps, False;
+
+            # delets all deps, No topological sort is needed as of now, if deletion
+            # of deps fails, return immediately
+            elif deps and force:
+                for dep in deps:
+                    self.sysLog(msg='Deleting {}'.format(dep))
+                    self.sy.deleteNode(str(dep))
+            # mark deps as None now,
+            deps = None
+
+            # all deps are deleted now, delete all ports now
+            for port in ports:
+                xPathPort = self.sy.findXpathPort(port)
+                print("Deleting Port: " + port)
+                self.sysLog(msg='Deleting Port:{}'.format(port))
+                self.sy.deleteNode(str(xPathPort))
+
+            # Let`s Validate the tree now
+            if self.validateConfigData()==False:
+                return configToLoad, deps, False;
+
+            # All great if we are here, Lets get the diff
+            self.configdbJsonOut = self.sy.getData()
+            # Update configToLoad
+            configToLoad = self._updateDiffConfigDB()
+
+        except Exception as e:
+            print(e)
+            print("Port Deletion Failed")
+            return configToLoad, deps, False
+
+        return configToLoad, deps, True
+
+    """
+    Add Ports and default config for ports to config DB, after validation of
+    data tree
+
+    PortJson: Config DB Json Part of all Ports same as PORT Table of Config DB.
+    ports = list of ports
+    loadDefConfig: If loadDefConfig add default config as well.
+
+    return: Sucess: True or Failure: False
+    """
+    def _addPorts(self, ports=list(), portJson=dict(), loadDefConfig=True):
+
+        configToLoad = None
+        try:
+            self.sysLog(msg='Start Port Addition')
+            self.sysLog(msg="addPorts ports:{} loadDefConfig:{}".\
+                format(ports, loadDefConfig))
+            self.sysLog(msg="addPorts Args portjson {}".format(portJson))
+
+            print('\nStart Port Addition')
+            # get default config if forced
+            defConfig = dict()
+            if loadDefConfig:
+                defConfig = self._getDefaultConfig(ports)
+                self.sysLog(msg='Default Config: {}'.format(defConfig))
+
+            # get the latest Data Tree, save this in input config, since this
+            # is our starting point now
+            self.configdbJsonIn = self.sy.getData()
+
+            # Get the out dict as well, if not done already
+            if self.configdbJsonOut is None:
+                self.configdbJsonOut = self.sy.getData()
+
+            # update portJson in configdbJsonOut PORT part
+            self.configdbJsonOut['PORT'].update(portJson['PORT'])
+            # merge new config with data tree, this is json level merge.
+            # We do not allow new table merge while adding default config.
+            if loadDefConfig:
+                print("Merge Default Config for {}".format(ports))
+                self.sysLog(msg="Merge Default Config for {}".format(ports))
+                self._mergeConfigs(self.configdbJsonOut, defConfig, True)
+
+            # create a tree with merged config and validate, if validation is
+            # sucessful, then configdbJsonOut contains final and valid config.
+            self.sy.loadData(self.configdbJsonOut)
+            if self.validateConfigData()==False:
+                return configToLoad, False
+
+            # All great if we are here, Let`s get the diff and update COnfig
+            configToLoad = self._updateDiffConfigDB()
+
+        except Exception as e:
+            print(e)
+            print("Port Addition Failed")
+            return configToLoad, False
+
+        return configToLoad, True
+
+    """
+    Merge second dict in first, Note both first and second dict will be changed
+    First Dict will have merged part D1 + D2
+    Second dict will have D2 - D1 [unique keys in D2]
+    Unique keys in D2 will be merged in D1 only if uniqueKeys=True
+    """
+    def _mergeConfigs(self, D1, D2, uniqueKeys=True):
+
+        try:
+            def _mergeItems(it1, it2):
+                if isinstance(it1, list) and isinstance(it2, list):
+                    it1.extend(it2)
+                elif isinstance(it1, dict) and isinstance(it2, dict):
+                    self._mergeConfigs(it1, it2)
+                elif isinstance(it1, list) or isinstance(it2, list):
+                    raise ("Can not merge Configs, List problem")
+                elif isinstance(it1, dict) or isinstance(it2, dict):
+                    raise ("Can not merge Configs, Dict problem")
+                else:
+                    #print("Do nothing")
+                    # First Dict takes priority
+                    pass
+                return
+
+            for it in D1.keys():
+                #print(it)
+                # D2 has the key
+                if D2.get(it):
+                    _mergeItems(D1[it], D2[it])
+                    del D2[it]
+                # D2  does not have the keys
+                else:
+                    pass
+
+            # if uniqueKeys are needed, merge rest of the keys of D2 in D1
+            if uniqueKeys:
+                D1.update(D2)
+        except Exce as e:
+            print("Merge Config failed")
+            print(e)
+            raise e
+
+        return D1
+
+    """
+    search Relevant Keys in Config using DFS, This function is mainly
+    used to search port related config in Default ConfigDbJson file.
+    In: Config to be searched
+    skeys: Keys to be searched in In Config i.e. search Keys.
+    Out: Contains the search result
+    """
+    def _searchKeysInConfig(self, In, Out, skeys):
+
+        found = False
+        if isinstance(In, dict):
+            for key in In.keys():
+                #print("key:" + key)
+                for skey in skeys:
+                    # pattern is very specific to current primary keys in
+                    # config DB, may need to be updated later.
+                    pattern = '^' + skey + '\|' + '|' + skey + '$' + \
+                        '|' + '^' + skey + '$'
+                    #print(pattern)
+                    reg = re.compile(pattern)
+                    #print(reg)
+                    if reg.search(key):
+                        # In primary key, only 1 match can be found, so return
+                        # print("Added key:" + key)
+                        Out[key] = In[key]
+                        found = True
+                        break
+                # Put the key in Out by default, if not added already.
+                # Remove later, if subelements does not contain any port.
+                if Out.get(key) is None:
+                    Out[key] = type(In[key])()
+                    if self._searchKeysInConfig(In[key], Out[key], skeys) == False:
+                        del Out[key]
+                    else:
+                        found = True
+
+        elif isinstance(In, list):
+            for skey in skeys:
+                if skey in In:
+                    found = True
+                    Out.append(skey)
+                    #print("Added in list:" + port)
+
+        else:
+            # nothing for other keys
+            pass
+
+        return found
+
+    """
+    This function returns the relavant keys in Input Config.
+    For Example: All Ports related Config in Config DB.
+    """
+    def configWithKeys(self, configIn=dict(), keys=list()):
+
+        configOut = dict()
+        try:
+            if len(configIn) and len(keys):
+                self._searchKeysInConfig(configIn, configOut, skeys=keys)
+        except Exception as e:
+            print("configWithKeys Failed, Error: {}".format(str(e)))
+            raise e
+
+        return configOut
+
+    """
+    Create a defConfig for given Ports from Default Config File.
+    """
+    def _getDefaultConfig(self, ports=list()):
+
+        # function code
+        try:
+            print("Generating default config for {}".format(ports))
+            defConfigIn = readJsonFile(DEFAULT_CONFIG_DB_JSON_FILE)
+            #print(defConfigIn)
+            defConfigOut = dict()
+            self._searchKeysInConfig(defConfigIn, defConfigOut, skeys=ports)
+        except Exception as e:
+            print("getDefaultConfig Failed, Error: {}".format(str(e)))
+            raise e
+
+        return defConfigOut
+
+    def _updateDiffConfigDB(self):
+
+        # main code starts here
+        configToLoad = dict()
+        try:
+            # Get the Diff
+            print('Generate Final Config to write in DB')
+            configDBdiff = self._diffJson()
+            # Process diff and create Config which can be updated in Config DB
+            configToLoad = self._createConfigToLoad(configDBdiff, \
+                self.configdbJsonIn, self.configdbJsonOut)
+
+        except Exception as e:
+            print("Config Diff Generation failed")
+            print(e)
+            raise e
+
+        return configToLoad
+
+    """
+    Create the config to write in Config DB from json diff
+    diff: diff in input config and output config.
+    inp: input config before delete/add ports.
+    outp: output config after delete/add ports.
+    """
+    def _createConfigToLoad(self, diff, inp, outp):
+
+        ### Internal Functions ###
+        """
+        Handle deletes in diff dict
+        """
+        def _deleteHandler(diff, inp, outp, config):
+
+            # if output is dict, delete keys from config
+            if isinstance(inp, dict):
+                for key in diff:
+                    #print(key)
+                    # make sure keys from diff are present in inp but not in outp
+                    # then delete it.
+                    if key in inp and key not in outp:
+                        # assign key to None(null), redis will delete entire key
+                        config[key] = None
+                    else:
+                        # log such keys
+                        print("Diff: Probably wrong key: {}".format(key))
+
+            elif isinstance(inp, list):
+                # just take list from output
+                # print("Delete from List: {} {} {}".format(inp, outp, list))
+                #print(type(config))
+                config.extend(outp)
+
+            return
+
+        """
+        Handle inserts in diff dict
+        """
+        def _insertHandler(diff, inp, outp, config):
+
+            # if outp is a dict
+            if isinstance(outp, dict):
+                for key in diff:
+                    #print(key)
+                    # make sure keys are only in outp
+                    if key not in inp and key in outp:
+                        # assign key in config same as outp
+                        config[key] = outp[key]
+                    else:
+                        # log such keys
+                        print("Diff: Probably wrong key: {}".format(key))
+
+            elif isinstance(outp, list):
+                # just take list from output
+                # print("Delete from List: {} {} {}".format(inp, outp, list))
+                config.extend(outp)
+
+            return
+
+        """
+        Recursively iterate diff to generate config to write in configDB
+        """
+        def _recurCreateConfig(diff, inp, outp, config):
+
+            changed = False
+            # updates are represented by list in diff and as dict in outp\inp
+            # we do not allow updates right now
+            if isinstance(diff, list) and isinstance(outp, dict):
+                return changed
+
+            idx = -1
+            for key in diff:
+                #print(key)
+                idx = idx + 1
+                if str(key) == '$delete':
+                    _deleteHandler(diff[key], inp, outp, config)
+                    changed = True
+                elif str(key) == '$insert':
+                    _insertHandler(diff[key], inp, outp, config)
+                    changed = True
+                else:
+                    # insert in config by default, remove later if not needed
+                    if isinstance(diff, dict):
+                        # config should match with outp
+                        config[key] = type(outp[key])()
+                        if _recurCreateConfig(diff[key], inp[key], outp[key], \
+                            config[key]) == False:
+                            del config[key]
+                        else:
+                            changed = True
+                    elif isinstance(diff, list):
+                        config.append(key)
+                        if _recurCreateConfig(diff[idx], inp[idx], outp[idx], \
+                            config[-1]) == False:
+                            del config[-1]
+                        else:
+                            changed = True
+
+            return changed
+
+        ### Function Code ###
+        try:
+            configToLoad = dict()
+            #import pdb; pdb.set_trace()
+            _recurCreateConfig(diff, inp, outp, configToLoad)
+
+        except Exception as e:
+            print("Create Config to load in DB, Failed")
+            print(e)
+            raise e
+
+        # if debug
+        #with open('configToLoad.json', 'w') as f:
+        #    dump(configToLoad, f, indent=4)
+
+        return configToLoad
+
+    def _diffJson(self):
+
+        from jsondiff import diff
+        return diff(self.configdbJsonIn, self.configdbJsonOut, syntax='symmetric')
+
+# end of class ConfigMgmtDPB
+
+# Helper Functions
+def readJsonFile(fileName):
+
+    try:
+        with open(fileName) as f:
+            result = load(f)
+    except Exception as e:
+        raise Exception(e)
+
+    return result

--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,9 @@ setup(
     # - tabulate
     install_requires=[
         'click',
-        'natsort'
+        'natsort',
+        'xmltodict',
+        'jsondiff'
     ],
     setup_requires= [
         'pytest-runner'

--- a/setup.py
+++ b/setup.py
@@ -149,8 +149,7 @@ setup(
     install_requires=[
         'click',
         'natsort',
-        'xmltodict==0.12.0',
-        'jsondiff==1.2.0'
+        'xmltodict==0.12.0'
     ],
     setup_requires= [
         'pytest-runner'

--- a/setup.py
+++ b/setup.py
@@ -149,8 +149,8 @@ setup(
     install_requires=[
         'click',
         'natsort',
-        'xmltodict',
-        'jsondiff'
+        'xmltodict==0.12.0',
+        'jsondiff==1.2.0'
     ],
     setup_requires= [
         'pytest-runner'

--- a/setup.py
+++ b/setup.py
@@ -148,8 +148,7 @@ setup(
     # - tabulate
     install_requires=[
         'click',
-        'natsort',
-        'xmltodict==0.12.0'
+        'natsort'
     ],
     setup_requires= [
         'pytest-runner'

--- a/sonic-utilities-tests/config_mgmt_test.py
+++ b/sonic-utilities-tests/config_mgmt_test.py
@@ -1,0 +1,475 @@
+import imp
+import os
+import mock_tables.dbconnector
+# import file under test i.e. config_mgmt.py
+imp.load_source('config_mgmt', \
+    os.path.join(os.path.dirname(__file__), '..', 'config', 'config_mgmt.py'))
+import config_mgmt
+
+from unittest import TestCase
+from mock import MagicMock, call
+from json import dump
+
+class TestConfigMgmt(TestCase):
+
+    def setUp(self):
+        config_mgmt.YANG_DIR = "../../sonic-yang-models/yang-models/"
+        config_mgmt.CONFIG_DB_JSON_FILE = "startConfigDb.json"
+        config_mgmt.DEFAULT_CONFIG_DB_JSON_FILE = "portBreakOutConfigDb.json"
+        return
+
+    def test_config_validation(self):
+        iConfig = dict(configDbJson)
+        self.writeJson(iConfig, config_mgmt.CONFIG_DB_JSON_FILE)
+        cm = config_mgmt.ConfigMgmt(source=config_mgmt.CONFIG_DB_JSON_FILE)
+        assert cm.validateConfigData() == True
+        return
+
+    def test_table_without_yang(self):
+        iConfig = dict(configDbJson)
+        unknown = {"unknown_table": {"ukey": "uvalue"}}
+        self.updateConfig(iConfig, unknown)
+        self.writeJson(iConfig, config_mgmt.CONFIG_DB_JSON_FILE)
+        cm = config_mgmt.ConfigMgmt(source=config_mgmt.CONFIG_DB_JSON_FILE)
+        #assert "unknown_table" in cm.tablesWithoutYang()
+        return
+
+    def test_search_keys(self):
+        iConfig = dict(configDbJson)
+        self.writeJson(iConfig, config_mgmt.CONFIG_DB_JSON_FILE)
+        cmdpb = config_mgmt.ConfigMgmtDPB(source=config_mgmt.CONFIG_DB_JSON_FILE)
+        out = cmdpb.configWithKeys(portBreakOutConfigDbJson, \
+            ["Ethernet8","Ethernet9"])
+        assert "VLAN" not in out.keys()
+        assert "INTERFACE" not in out.keys()
+        for k in out['ACL_TABLE'].keys():
+            # only ports must be chosen
+            len(out['ACL_TABLE'][k]) == 1
+        out = cmdpb.configWithKeys(portBreakOutConfigDbJson, \
+            ["Ethernet10","Ethernet11"])
+        assert "INTERFACE" in out.keys()
+        for k in out['ACL_TABLE'].keys():
+            # only ports must be chosen
+            len(out['ACL_TABLE'][k]) == 1
+        return
+
+    def test_break_out(self):
+        # prepare default config
+        self.writeJson(portBreakOutConfigDbJson, \
+            config_mgmt.DEFAULT_CONFIG_DB_JSON_FILE)
+        # prepare config dj json to start with
+        iConfig = dict(configDbJson)
+        #Ethernet8: start from 4x25G-->2x50G with -f -l
+        self.dpb_port8_4x25G_2x50G_f_l(iConfig)
+        #Ethernet8: move from 2x50G-->1x100G without force, list deps
+        self.dpb_port8_2x50G_1x100G(iConfig)
+        # Ethernet8: move from 2x50G-->1x100G with force, where deps exists
+        self.dpb_port8_2x50G_1x100G_f(iConfig)
+        # Ethernet8: move from 1x100G-->4x25G without force, no deps
+        self.dpb_port8_1x100G_4x25G(iConfig)
+        # Ethernet8: move from 4x25G-->1x100G with force, no deps
+        self.dpb_port8_4x25G_1x100G_f(iConfig)
+        # Ethernet8: move from 1x100G-->1x50G(2)+2x25G(2) with -f -l,
+        self.dpb_port8_1x100G_1x50G_2x25G_f_l(iConfig)
+        # Ethernet4: breakout from 4x25G to 2x50G with -f -l
+        self.dpb_port4_4x25G_2x50G_f_l(iConfig)
+        return
+
+    def tearDown(self):
+        try:
+            os.remove(config_mgmt.CONFIG_DB_JSON_FILE)
+            os.remove(config_mgmt.DEFAULT_CONFIG_DB_JSON_FILE)
+        except Exception as e:
+            pass
+        return
+
+    ########### HELPER FUNCS #####################################
+    def writeJson(self, d, file):
+        with open(file, 'w') as f:
+            dump(d, f, indent=4)
+        return
+    # config_mgmt.ConfigMgmtDPB class instance with mocked functions. Not using
+    # pytest fixture, because it is used in non test funcs.
+    def config_mgmt_dpb(self, iConfig):
+        # create object
+        self.writeJson(iConfig, config_mgmt.CONFIG_DB_JSON_FILE)
+        cmdpb = config_mgmt.ConfigMgmtDPB(source=config_mgmt.CONFIG_DB_JSON_FILE)
+        # mock funcs
+        cmdpb.writeConfigDB = MagicMock(return_value=True)
+        cmdpb._verifyAsicDB = MagicMock(return_value=True)
+        return cmdpb
+
+    # Generate port to deleted, added and lanes and speed setting based on
+    # current and new mode.
+    def generate_args(self, portIdx, laneIdx, curMode, newMode):
+        # default params
+        pre = "Ethernet"
+        laneMap = {"4x25G": [1,1,1,1], "2x50G": [2,2], "1x100G":[4], \
+            "1x50G(2)+2x25G(2)":[2,1,1], "2x25G(2)+1x50G(2)":[1,1,2]}
+        laneSpeed = 25000
+        # generate dPorts
+        l = list(laneMap[curMode]); l.insert(0, 0); id = portIdx; dPorts = list()
+        for i in l[:-1]:
+            id = id + i
+            portName = portName = "{}{}".format(pre, id)
+            dPorts.append(portName)
+        # generate aPorts
+        l = list(laneMap[newMode]); l.insert(0, 0); id = portIdx; aPorts = list()
+        for i in l[:-1]:
+            id = id + i
+            portName = portName = "{}{}".format(pre, id)
+            aPorts.append(portName)
+        # generate pJson
+        l = laneMap[newMode]; pJson = {"PORT": {}}; li = laneIdx; pi = 0
+        for i in l:
+            speed = laneSpeed*i
+            lanes = [str(li+j) for j in range(i)]; lanes = ','.join(lanes)
+            pJson['PORT'][aPorts[pi]] = {"speed": str(speed), "lanes": str(lanes)}
+            li = li+i; pi = pi + 1
+        return dPorts, aPorts ,pJson
+
+    # update the config to emulate continous breakingout a single port
+    def updateConfig(self, conf, uconf):
+        try:
+            for it in uconf.keys():
+                # if conf has the key
+                if conf.get(it):
+                    # if marked for deletion
+                    if uconf[it] == None:
+                        del conf[it]
+                    else:
+                        if isinstance(conf[it], list) and isinstance(uconf[it], list):
+                            conf[it] = list(uconf[it])
+                        elif isinstance(conf[it], dict) and isinstance(uconf[it], dict):
+                            self.updateConfig(conf[it], uconf[it])
+                        else:
+                            conf[it] = uconf[it]
+                    del uconf[it]
+            # update new keys in conf
+            conf.update(uconf)
+        except Exception as e:
+            print("update Config failed")
+            print(e)
+            raise e
+        return
+
+    # Usual result check in many test is: Make sure dConfig and aConfig is
+    # pushed in order to configDb
+    def checkResult(self, cmdpb, dConfig, aConfig):
+        calls = [call(dConfig), call(aConfig)]
+        assert cmdpb.writeConfigDB.call_count == 2
+        cmdpb.writeConfigDB.assert_has_calls(calls, any_order=False)
+        return
+
+    # After breakout, update the config to emulate continous breakingout a
+    # single port
+    def postUpdateConfig(self, iConfig, dConfig, aConfig):
+        # update the iConfig with change
+        self.updateConfig(iConfig, dConfig)
+        self.updateConfig(iConfig, aConfig)
+        return
+
+    def dpb_port8_1x100G_1x50G_2x25G_f_l(self, iConfig):
+        cmdpb = self.config_mgmt_dpb(iConfig)
+        # create ARGS
+        dPorts, aPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
+            curMode='1x100G', newMode='1x50G(2)+2x25G(2)')
+        deps, ret = cmdpb.breakOutPort(delPorts=dPorts, addPorts= aPorts, portJson=pJson,
+            force=True, loadDefConfig=True)
+        # Expected Result dConfig and aConfig is pushed in order
+        dConfig = {u'PORT': {u'Ethernet8': None}}
+        aConfig = {u'ACL_TABLE': {u'NO-NSW-PACL-V4': {u'ports': ['Ethernet0', \
+        'Ethernet4', 'Ethernet8', 'Ethernet10']}, u'NO-NSW-PACL-TEST': {u'ports': \
+        ['Ethernet11']}}, u'INTERFACE': {u'Ethernet11|2a04:1111:40:a709::1/126': \
+        {u'scope': u'global', u'family': u'IPv6'}, u'Ethernet11': {}}, \
+        u'VLAN_MEMBER': {u'Vlan100|Ethernet8': {u'tagging_mode': u'untagged'}, \
+        u'Vlan100|Ethernet11': {u'tagging_mode': u'untagged'}}, u'PORT': \
+        {'Ethernet8': {'speed': '50000', 'lanes': '73,74'}, 'Ethernet10': \
+        {'speed': '25000', 'lanes': '75'}, 'Ethernet11': {'speed': '25000', 'lanes': '76'}}}
+        self.checkResult(cmdpb, dConfig, aConfig)
+        self.postUpdateConfig(iConfig, dConfig, aConfig)
+        return
+
+    def dpb_port8_4x25G_1x100G_f(self, iConfig):
+        cmdpb = self.config_mgmt_dpb(iConfig)
+        # create ARGS
+        dPorts, aPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
+            curMode='4x25G', newMode='1x100G')
+        deps, ret = cmdpb.breakOutPort(delPorts=dPorts, addPorts= aPorts, portJson=pJson,
+            force=False, loadDefConfig=False)
+        # Expected Result dConfig and aConfig is pushed in order
+        dConfig = {u'PORT': {u'Ethernet8': None, u'Ethernet9': None, \
+            u'Ethernet10': None, u'Ethernet11': None}}
+        aConfig = pJson
+        self.checkResult(cmdpb, dConfig, aConfig)
+        self.postUpdateConfig(iConfig, dConfig, aConfig)
+        return
+
+    def dpb_port8_1x100G_4x25G(self, iConfig):
+        cmdpb = self.config_mgmt_dpb(iConfig)
+        dPorts, aPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
+            curMode='1x100G', newMode='4x25G')
+        deps, ret = cmdpb.breakOutPort(delPorts=dPorts, addPorts= aPorts, portJson=pJson,
+            force=False, loadDefConfig=False)
+        # Expected Result dConfig and aConfig is pushed in order
+        dConfig = {u'PORT': {u'Ethernet8': None}}
+        aConfig = pJson
+        self.checkResult(cmdpb, dConfig, aConfig)
+        self.postUpdateConfig(iConfig, dConfig, aConfig)
+        return
+
+    def dpb_port8_2x50G_1x100G_f(self, iConfig):
+        cmdpb = self.config_mgmt_dpb(iConfig)
+        # create ARGS
+        dPorts, aPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
+            curMode='2x50G', newMode='1x100G')
+        deps, ret = cmdpb.breakOutPort(delPorts=dPorts, addPorts= aPorts, portJson=pJson,
+            force=True, loadDefConfig=False)
+        # Expected Result dConfig and aConfig is pushed in order
+        dConfig = {u'ACL_TABLE': {u'NO-NSW-PACL-V4': {u'ports': ['Ethernet0', 'Ethernet4']}}, \
+        u'VLAN_MEMBER': {u'Vlan100|Ethernet8': None}, u'PORT': {u'Ethernet8': None, \
+        u'Ethernet10': None}}
+        aConfig = pJson
+        self.checkResult(cmdpb, dConfig, aConfig)
+        self.postUpdateConfig(iConfig, dConfig, aConfig)
+
+    def dpb_port8_2x50G_1x100G(self, iConfig):
+        cmdpb = self.config_mgmt_dpb(iConfig)
+        # create ARGS
+        dPorts, aPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
+            curMode='2x50G', newMode='1x100G')
+        deps, ret = cmdpb.breakOutPort(delPorts=dPorts, addPorts= aPorts, portJson=pJson,
+            force=False, loadDefConfig=False)
+        # Expected Result
+        assert ret == False and len(deps) == 3
+        assert cmdpb.writeConfigDB.call_count == 0
+        return
+
+    def dpb_port8_4x25G_2x50G_f_l(self, iConfig):
+        cmdpb = self.config_mgmt_dpb(iConfig)
+        # create ARGS
+        dPorts, aPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
+            curMode='4x25G', newMode='2x50G')
+        cmdpb.breakOutPort(delPorts=dPorts, addPorts= aPorts, portJson=pJson,
+            force=True, loadDefConfig=True)
+        # Expected Result dConfig and aConfig is pushed in order
+        dConfig = {u'ACL_TABLE': {u'NO-NSW-PACL-V4': \
+        {u'ports': ['Ethernet0', 'Ethernet4']}, u'NO-NSW-PACL-TEST': {u'ports': None}}, \
+        u'INTERFACE': None, u'VLAN_MEMBER': {u'Vlan100|Ethernet8': None, \
+        u'Vlan100|Ethernet11': None}, u'PORT': {u'Ethernet8': None, \
+        u'Ethernet9': None, u'Ethernet10': None, u'Ethernet11': None}}
+        aConfig = {u'ACL_TABLE': {u'NO-NSW-PACL-V4': \
+        {u'ports': ['Ethernet0', 'Ethernet4', 'Ethernet8', 'Ethernet10']}}, \
+        u'VLAN_MEMBER': {u'Vlan100|Ethernet8': {u'tagging_mode': u'untagged'}}, \
+        u'PORT': {'Ethernet8': {'speed': '50000', 'lanes': '73,74'}, \
+        'Ethernet10': {'speed': '50000', 'lanes': '75,76'}}}
+        assert cmdpb.writeConfigDB.call_count == 2
+        self.checkResult(cmdpb, dConfig, aConfig)
+        self.postUpdateConfig(iConfig, dConfig, aConfig)
+        return
+
+    def dpb_port4_4x25G_2x50G_f_l(self, iConfig):
+        cmdpb = self.config_mgmt_dpb(iConfig)
+        # create ARGS
+        dPorts, aPorts, pJson = self.generate_args(portIdx=4, laneIdx=69, \
+            curMode='4x25G', newMode='2x50G')
+        cmdpb.breakOutPort(delPorts=dPorts, addPorts= aPorts, portJson=pJson,
+            force=True, loadDefConfig=True)
+        # Expected Result dConfig and aConfig is pushed in order
+        dConfig = {u'ACL_TABLE': {u'NO-NSW-PACL-V4': \
+        {u'ports': ['Ethernet0', 'Ethernet8', 'Ethernet10']}}, u'PORT': \
+        {u'Ethernet4': None, u'Ethernet5': None, u'Ethernet6': None, \
+        u'Ethernet7': None}}
+        aConfig = {u'ACL_TABLE': {u'NO-NSW-PACL-V4': \
+        {u'ports': ['Ethernet0', 'Ethernet8', 'Ethernet10', 'Ethernet4']}}, \
+        u'PORT': {'Ethernet4': {'speed': '50000', 'lanes': '69,70'}, \
+        'Ethernet6': {'speed': '50000', 'lanes': '71,72'}}}
+        self.checkResult(cmdpb, dConfig, aConfig)
+        self.postUpdateConfig(iConfig, dConfig, aConfig)
+        return
+
+###########GLOBAL Configs#####################################
+configDbJson =  {
+    "ACL_TABLE": {
+        "NO-NSW-PACL-TEST": {
+            "policy_desc": "NO-NSW-PACL-TEST",
+            "type": "L3",
+            "stage": "INGRESS",
+            "ports": [
+                "Ethernet9",
+                "Ethernet11",
+                ]
+        },
+        "NO-NSW-PACL-V4": {
+            "policy_desc": "NO-NSW-PACL-V4",
+            "type": "L3",
+            "stage": "INGRESS",
+            "ports": [
+                "Ethernet0",
+                "Ethernet4",
+                "Ethernet8",
+                "Ethernet10"
+                ]
+        }
+    },
+    "VLAN": {
+        "Vlan100": {
+            "admin_status": "up",
+            "description": "server_vlan",
+            "dhcp_servers": [
+                "10.186.72.116"
+            ]
+        },
+    },
+    "VLAN_MEMBER": {
+        "Vlan100|Ethernet0": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan100|Ethernet2": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan100|Ethernet8": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan100|Ethernet11": {
+            "tagging_mode": "untagged"
+        },
+    },
+    "INTERFACE": {
+        "Ethernet10": {},
+        "Ethernet10|2a04:0000:40:a709::1/126": {
+            "scope": "global",
+            "family": "IPv6"
+        }
+    },
+    "PORT": {
+        "Ethernet0": {
+            "alias": "Eth1/1",
+            "lanes": "65",
+            "description": "",
+            "speed": "25000",
+            "admin_status": "up"
+        },
+        "Ethernet1": {
+            "alias": "Eth1/2",
+            "lanes": "66",
+            "description": "",
+            "speed": "25000",
+            "admin_status": "up"
+        },
+        "Ethernet2": {
+            "alias": "Eth1/3",
+            "lanes": "67",
+            "description": "",
+            "speed": "25000",
+            "admin_status": "up"
+        },
+        "Ethernet3": {
+            "alias": "Eth1/4",
+            "lanes": "68",
+            "description": "",
+            "speed": "25000",
+            "admin_status": "up"
+        },
+        "Ethernet4": {
+            "alias": "Eth2/1",
+            "lanes": "69",
+            "description": "",
+            "speed": "25000",
+            "admin_status": "up"
+        },
+        "Ethernet5": {
+            "alias": "Eth2/2",
+            "lanes": "70",
+            "description": "",
+            "speed": "25000",
+            "admin_status": "up"
+        },
+        "Ethernet6": {
+            "alias": "Eth2/3",
+            "lanes": "71",
+            "description": "",
+            "speed": "25000",
+            "admin_status": "up"
+        },
+        "Ethernet7": {
+            "alias": "Eth2/4",
+            "lanes": "72",
+            "description": "",
+            "speed": "25000",
+            "admin_status": "up"
+        },
+        "Ethernet8": {
+            "alias": "Eth3/1",
+            "lanes": "73",
+            "description": "",
+            "speed": "25000",
+            "admin_status": "up"
+        },
+        "Ethernet9": {
+            "alias": "Eth3/2",
+            "lanes": "74",
+            "description": "",
+            "speed": "25000",
+            "admin_status": "up"
+        },
+        "Ethernet10": {
+            "alias": "Eth3/3",
+            "lanes": "75",
+            "description": "",
+            "speed": "25000",
+            "admin_status": "up"
+        },
+        "Ethernet11": {
+            "alias": "Eth3/4",
+            "lanes": "76",
+            "description": "",
+            "speed": "25000",
+            "admin_status": "up"
+        }
+    }
+}
+
+portBreakOutConfigDbJson = {
+    "ACL_TABLE": {
+        "NO-NSW-PACL-TEST": {
+            "ports": [
+                "Ethernet9",
+                "Ethernet11",
+                ]
+        },
+        "NO-NSW-PACL-V4": {
+            "policy_desc": "NO-NSW-PACL-V4",
+            "ports": [
+                "Ethernet0",
+                "Ethernet4",
+                "Ethernet8",
+                "Ethernet10"
+                ]
+        }
+    },
+    "VLAN": {
+        "Vlan100": {
+            "admin_status": "up",
+            "description": "server_vlan",
+            "dhcp_servers": [
+                "10.186.72.116"
+            ]
+        }
+    },
+    "VLAN_MEMBER": {
+        "Vlan100|Ethernet8": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan100|Ethernet11": {
+            "tagging_mode": "untagged"
+       }
+    },
+    "INTERFACE": {
+        "Ethernet11": {},
+        "Ethernet11|2a04:1111:40:a709::1/126": {
+            "scope": "global",
+            "family": "IPv6"
+        }
+    }
+}

--- a/sonic-utilities-tests/config_mgmt_test.py
+++ b/sonic-utilities-tests/config_mgmt_test.py
@@ -15,7 +15,6 @@ class TestConfigMgmt(TestCase):
     '''
 
     def setUp(self):
-        config_mgmt.YANG_DIR = "./../../../sonic-yang-models/yang-models/"
         config_mgmt.CONFIG_DB_JSON_FILE = "startConfigDb.json"
         config_mgmt.DEFAULT_CONFIG_DB_JSON_FILE = "portBreakOutConfigDb.json"
         return

--- a/sonic-utilities-tests/config_mgmt_test.py
+++ b/sonic-utilities-tests/config_mgmt_test.py
@@ -131,7 +131,7 @@ class TestConfigMgmt(TestCase):
             newMode (str): new breakout mode of Port.
 
         Return:
-            dPorts, aPorts ,pJson (tuple)[list, list, dict]
+            dPorts, pJson (tuple)[list, dict]
         '''
         # default params
         pre = "Ethernet"
@@ -157,7 +157,7 @@ class TestConfigMgmt(TestCase):
             lanes = [str(li+j) for j in range(i)]; lanes = ','.join(lanes)
             pJson['PORT'][aPorts[pi]] = {"speed": str(speed), "lanes": str(lanes)}
             li = li+i; pi = pi + 1
-        return dPorts, aPorts ,pJson
+        return dPorts, pJson
 
     def updateConfig(self, conf, uconf):
         '''
@@ -248,9 +248,9 @@ class TestConfigMgmt(TestCase):
         '''
         cmdpb = self.config_mgmt_dpb(curConfig)
         # create ARGS
-        dPorts, aPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
+        dPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
             curMode='1x100G', newMode='1x50G(2)+2x25G(2)')
-        deps, ret = cmdpb.breakOutPort(delPorts=dPorts, addPorts= aPorts, portJson=pJson,
+        deps, ret = cmdpb.breakOutPort(delPorts=dPorts, portJson=pJson,
             force=True, loadDefConfig=True)
         # Expected Result delConfig and addConfig is pushed in order
         delConfig = {
@@ -314,9 +314,9 @@ class TestConfigMgmt(TestCase):
         '''
         cmdpb = self.config_mgmt_dpb(curConfig)
         # create ARGS
-        dPorts, aPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
+        dPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
             curMode='4x25G', newMode='1x100G')
-        deps, ret = cmdpb.breakOutPort(delPorts=dPorts, addPorts= aPorts, portJson=pJson,
+        deps, ret = cmdpb.breakOutPort(delPorts=dPorts, portJson=pJson,
             force=False, loadDefConfig=False)
         # Expected Result delConfig and addConfig is pushed in order
         delConfig = {
@@ -344,9 +344,9 @@ class TestConfigMgmt(TestCase):
             assert for success and failure.
         '''
         cmdpb = self.config_mgmt_dpb(curConfig)
-        dPorts, aPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
+        dPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
             curMode='1x100G', newMode='4x25G')
-        deps, ret = cmdpb.breakOutPort(delPorts=dPorts, addPorts= aPorts, portJson=pJson,
+        deps, ret = cmdpb.breakOutPort(delPorts=dPorts, portJson=pJson,
             force=False, loadDefConfig=False)
         # Expected Result delConfig and addConfig is pushed in order
         delConfig = {
@@ -372,9 +372,9 @@ class TestConfigMgmt(TestCase):
         '''
         cmdpb = self.config_mgmt_dpb(curConfig)
         # create ARGS
-        dPorts, aPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
+        dPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
             curMode='2x50G', newMode='1x100G')
-        deps, ret = cmdpb.breakOutPort(delPorts=dPorts, addPorts= aPorts, portJson=pJson,
+        deps, ret = cmdpb.breakOutPort(delPorts=dPorts, portJson=pJson,
             force=True, loadDefConfig=False)
         # Expected Result delConfig and addConfig is pushed in order
         delConfig = {
@@ -408,9 +408,9 @@ class TestConfigMgmt(TestCase):
         '''
         cmdpb = self.config_mgmt_dpb(curConfig)
         # create ARGS
-        dPorts, aPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
+        dPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
             curMode='2x50G', newMode='1x100G')
-        deps, ret = cmdpb.breakOutPort(delPorts=dPorts, addPorts= aPorts, portJson=pJson,
+        deps, ret = cmdpb.breakOutPort(delPorts=dPorts, portJson=pJson,
             force=False, loadDefConfig=False)
         # Expected Result
         assert ret == False and len(deps) == 3
@@ -430,10 +430,10 @@ class TestConfigMgmt(TestCase):
         '''
         cmdpb = self.config_mgmt_dpb(curConfig)
         # create ARGS
-        dPorts, aPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
+        dPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
             curMode='4x25G', newMode='2x50G')
-        cmdpb.breakOutPort(delPorts=dPorts, addPorts= aPorts, portJson=pJson,
-            force=True, loadDefConfig=True)
+        cmdpb.breakOutPort(delPorts=dPorts, portJson=pJson, force=True, \
+            loadDefConfig=True)
         # Expected Result delConfig and addConfig is pushed in order
         delConfig = {
             u'ACL_TABLE': {
@@ -496,10 +496,10 @@ class TestConfigMgmt(TestCase):
         '''
         cmdpb = self.config_mgmt_dpb(curConfig)
         # create ARGS
-        dPorts, aPorts, pJson = self.generate_args(portIdx=4, laneIdx=69, \
+        dPorts, pJson = self.generate_args(portIdx=4, laneIdx=69, \
             curMode='4x25G', newMode='2x50G')
-        cmdpb.breakOutPort(delPorts=dPorts, addPorts= aPorts, portJson=pJson,
-            force=True, loadDefConfig=True)
+        cmdpb.breakOutPort(delPorts=dPorts, portJson=pJson, force=True, \
+            loadDefConfig=True)
         # Expected Result delConfig and addConfig is pushed in order
         delConfig = {
             u'ACL_TABLE': {

--- a/sonic-utilities-tests/config_mgmt_test.py
+++ b/sonic-utilities-tests/config_mgmt_test.py
@@ -1,6 +1,5 @@
 import imp
 import os
-import mock_tables.dbconnector
 # import file under test i.e. config_mgmt.py
 imp.load_source('config_mgmt', \
     os.path.join(os.path.dirname(__file__), '..', 'config', 'config_mgmt.py'))
@@ -16,7 +15,7 @@ class TestConfigMgmt(TestCase):
     '''
 
     def setUp(self):
-        config_mgmt.YANG_DIR = "../../sonic-yang-models/yang-models/"
+        config_mgmt.YANG_DIR = "./../../../sonic-yang-models/yang-models/"
         config_mgmt.CONFIG_DB_JSON_FILE = "startConfigDb.json"
         config_mgmt.DEFAULT_CONFIG_DB_JSON_FILE = "portBreakOutConfigDb.json"
         return
@@ -109,6 +108,7 @@ class TestConfigMgmt(TestCase):
         # mock funcs
         cmdpb.writeConfigDB = MagicMock(return_value=True)
         cmdpb._verifyAsicDB = MagicMock(return_value=True)
+        import mock_tables.dbconnector
         return cmdpb
 
     def generate_args(self, portIdx, laneIdx, curMode, newMode):

--- a/sonic-utilities-tests/mock_tables/counters_db.json
+++ b/sonic-utilities-tests/mock_tables/counters_db.json
@@ -145,6 +145,12 @@
         "Ethernet4": "oid:0x1000000000004",
         "Ethernet8": "oid:0x1000000000006"
     },
+    "COUNTERS_LAG_NAME_MAP": {
+        "PortChannel0001": "oid:0x60000000005a1",
+        "PortChannel0002": "oid:0x60000000005a2",
+        "PortChannel0003": "oid:0x600000000063c",
+        "PortChannel0004": "oid:0x600000000063d"
+    },
     "COUNTERS_DEBUG_NAME_PORT_STAT_MAP": {
         "DEBUG_0": "SAI_PORT_STAT_IN_DROP_REASON_RANGE_BASE",
         "DEBUG_2": "SAI_PORT_STAT_OUT_CONFIGURED_DROP_REASONS_1_DROPPED_PKTS"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
 Provided a class in sonic_util config for 
-- Config Validation,
-- BreakOut Ports

### Note: It depends on https://github.com/Azure/sonic-buildimage/pull/3861
### Test cases are added in this PR but described in a dummy PR https://github.com/Azure/sonic-utilities/pull/947

**- How I did it**
--ConfigMgmt Class uploads config data from config_Db.json or from config db using SONiC-py-swsssdk APIs . 
--Port, vlan and acl related config is cropped out of entire config, this is because yang models are available only for Vlan, Acl and Port as of now. 
--Cropped portion of config DB will be given as input to Python Yang LIB while loading config data.
 
--ConfigMgmt Class provides APIs to breakout, delete and add Ports. 
--Using Python yang LIB APIs, this class finds dependencies for each of the port which must be deleted and will delete dependencies. 
-- At last after successful validation, new config is written in config DB.
-- While addition, relevant default config is found for ports which are being added. Then entire new config [default + port] is added to current config in data tree.
-- At last after successful validation, new config is written in config DB.


**- How to verify it**
On Sonic Switch Ran below Tests 
### Note: Below tests are done with PR 766 and PR 857 changes.
```
:::Lock Acquired:::
:::Lock Timer Extended:::

Running Breakout Mode : 4x25G 
Target Breakout Mode : 2x50G

Ports to be deleted : 
 {
    "Ethernet2": "25000", 
    "Ethernet3": "25000", 
    "Ethernet0": "25000", 
    "Ethernet1": "25000"
}
Ports to be added : 
 {
    "Ethernet2": "50000", 
    "Ethernet0": "50000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet2": "25000", 
    "Ethernet3": "25000", 
    "Ethernet0": "25000", 
    "Ethernet1": "25000"
} 
Final list of ports to be added :  
 {
    "Ethernet2": "50000", 
    "Ethernet0": "50000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-extension', 'sonic-head', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
VERSIONS, DEVICE_METADATA, DEVICE_NEIGHBOR, LOCK, FLEX_COUNTER_TABLE, BREAKOUT_CFG, 
Below Config can not be verified, It may cause harm to the system
 {
  "BREAKOUT_CFG": {
    "Ethernet0": {
      "brkout_mode": "4x25G"
    }
  }
}
Do you wish to Continue? [y/N]: 
Start Port Deletion
Find dependecies for port Ethernet2
Find dependecies for port Ethernet3
Find dependecies for port Ethernet0
Find dependecies for port Ethernet1
Deleting Port: Ethernet2
Deleting Port: Ethernet3
Deleting Port: Ethernet0
Deleting Port: Ethernet1
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Generating default config for ['Ethernet2', 'Ethernet0']
Merge Default Config for ['Ethernet2', 'Ethernet0']
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
:::Lock Released:::
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet0  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet2  | untagged       |                       |
|           | fe80::1/10             | Ethernet4  | untagged       |                       |
|           |                        | Ethernet5  | untagged       |                       |
|           |                        | Ethernet6  | untagged       |                       |
|           |                        | Ethernet7  | untagged       |                       |
|           |                        | Ethernet8  | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No      
       xe1( 69)  !ena   1     -       SW  No   Forward          None    D   None  9412    No      
       xe2( 70)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No      
       xe3( 71)  !ena   1     -       SW  No   Forward          None    D   None  9412    No      
       xe4( 72)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe5( 73)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe6( 74)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
:::Lock Acquired:::
:::Lock Timer Extended:::

Running Breakout Mode : 2x50G 
Target Breakout Mode : 1x100G

Ports to be deleted : 
 {
    "Ethernet2": "50000", 
    "Ethernet0": "50000"
}
Ports to be added : 
 {
    "Ethernet0": "100000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet2": "50000", 
    "Ethernet0": "50000"
} 
Final list of ports to be added :  
 {
    "Ethernet0": "100000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-extension', 'sonic-head', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
VERSIONS, DEVICE_METADATA, DEVICE_NEIGHBOR, LOCK, FLEX_COUNTER_TABLE, BREAKOUT_CFG, 
Below Config can not be verified, It may cause harm to the system
 {
  "BREAKOUT_CFG": {
    "Ethernet0": {
      "brkout_mode": "2x50G"
    }
  }
}
Do you wish to Continue? [y/N]: 
Start Port Deletion
Find dependecies for port Ethernet2
Find dependecies for port Ethernet0
Dependecies Exist. No further action will be taken
*** Printing dependecies ***
/sonic-vlan:sonic-vlan/VLAN/VLAN_LIST[vlan_name='Vlan100']/members[.='Ethernet2']
/sonic-vlan:sonic-vlan/VLAN/VLAN_LIST[vlan_name='Vlan777']/members[.='Ethernet2']
/sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan100'][port='Ethernet2']/port
/sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan777'][port='Ethernet2']/port
/sonic-vlan:sonic-vlan/VLAN/VLAN_LIST[vlan_name='Vlan100']/members[.='Ethernet0']
/sonic-vlan:sonic-vlan/VLAN/VLAN_LIST[vlan_name='Vlan777']/members[.='Ethernet0']
/sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan100'][port='Ethernet0']/port
/sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan777'][port='Ethernet0']/port
:::Lock PID: None and self.pid:29100:::
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet0  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet2  | untagged       |                       |
|           | fe80::1/10             | Ethernet4  | untagged       |                       |
|           |                        | Ethernet5  | untagged       |                       |
|           |                        | Ethernet6  | untagged       |                       |
|           |                        | Ethernet7  | untagged       |                       |
|           |                        | Ethernet8  | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  !ena   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No      
       xe1( 69)  !ena   1     -       SW  No   Forward          None    D   None  9412    No      
       xe2( 70)  !ena   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No      
       xe3( 71)  !ena   1     -       SW  No   Forward          None    D   None  9412    No      
       xe4( 72)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe5( 73)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe6( 74)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
:::Lock Acquired:::
:::Lock Timer Extended:::

Running Breakout Mode : 2x50G 
Target Breakout Mode : 1x100G

Ports to be deleted : 
 {
    "Ethernet2": "50000", 
    "Ethernet0": "50000"
}
Ports to be added : 
 {
    "Ethernet0": "100000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet2": "50000", 
    "Ethernet0": "50000"
} 
Final list of ports to be added :  
 {
    "Ethernet0": "100000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-extension', 'sonic-head', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
VERSIONS, DEVICE_METADATA, DEVICE_NEIGHBOR, LOCK, FLEX_COUNTER_TABLE, BREAKOUT_CFG, 
Below Config can not be verified, It may cause harm to the system
 {
  "BREAKOUT_CFG": {
    "Ethernet0": {
      "brkout_mode": "2x50G"
    }
  }
}
Do you wish to Continue? [y/N]: 
Start Port Deletion
Find dependecies for port Ethernet2
Find dependecies for port Ethernet0
Deleting Port: Ethernet2
Deleting Port: Ethernet0
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
:::Lock Released:::
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet4  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet5  | untagged       |                       |
|           | fe80::1/10             | Ethernet6  | untagged       |                       |
|           |                        | Ethernet7  | untagged       |                       |
|           |                        | Ethernet8  | untagged       |                       |
|           |                        | Ethernet9  | untagged       |                       |
|           |                        | Ethernet10 | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       ce0( 68)  down   4  100G  FD   SW  No   Forward          None    D    KR4  9412    No      
       xe0( 69)  !ena   1     -       SW  No   Forward          None    D   None  9412    No      
       xe1( 70)  !ena   2     -       SW  No   Forward          None    D   None  9412    No      
       xe2( 71)  !ena   1     -       SW  No   Forward          None    D   None  9412    No      
       xe3( 72)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe4( 73)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe5( 74)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
:::Lock Acquired:::
:::Lock Timer Extended:::

Running Breakout Mode : 1x100G 
Target Breakout Mode : 4x25G

Ports to be deleted : 
 {
    "Ethernet0": "100000"
}
Ports to be added : 
 {
    "Ethernet2": "25000", 
    "Ethernet3": "25000", 
    "Ethernet0": "25000", 
    "Ethernet1": "25000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet0": "100000"
} 
Final list of ports to be added :  
 {
    "Ethernet2": "25000", 
    "Ethernet3": "25000", 
    "Ethernet0": "25000", 
    "Ethernet1": "25000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-extension', 'sonic-head', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
VERSIONS, DEVICE_METADATA, DEVICE_NEIGHBOR, LOCK, FLEX_COUNTER_TABLE, BREAKOUT_CFG, 
Below Config can not be verified, It may cause harm to the system
 {
  "BREAKOUT_CFG": {
    "Ethernet0": {
      "brkout_mode": "1x100G"
    }
  }
}
Do you wish to Continue? [y/N]: 
Start Port Deletion
Find dependecies for port Ethernet0
Deleting Port: Ethernet0
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
:::Lock Released:::
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet4  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet5  | untagged       |                       |
|           | fe80::1/10             | Ethernet6  | untagged       |                       |
|           |                        | Ethernet7  | untagged       |                       |
|           |                        | Ethernet8  | untagged       |                       |
|           |                        | Ethernet9  | untagged       |                       |
|           |                        | Ethernet10 | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  down   1   25G  FD   SW  No   Forward          None    D     KR  9412    No      
       xe1( 69)  down   1   25G  FD   SW  No   Forward          None    D     KR  9412    No      
       xe2( 70)  down   1   25G  FD   SW  No   Forward          None    D     KR  9412    No      
       xe3( 71)  down   1   25G  FD   SW  No   Forward          None    D     KR  9412    No      
       xe4( 72)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe5( 73)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe6( 74)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
:::Lock Acquired:::
:::Lock Timer Extended:::

Running Breakout Mode : 4x25G 
Target Breakout Mode : 1x100G

Ports to be deleted : 
 {
    "Ethernet2": "25000", 
    "Ethernet3": "25000", 
    "Ethernet0": "25000", 
    "Ethernet1": "25000"
}
Ports to be added : 
 {
    "Ethernet0": "100000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet2": "25000", 
    "Ethernet3": "25000", 
    "Ethernet0": "25000", 
    "Ethernet1": "25000"
} 
Final list of ports to be added :  
 {
    "Ethernet0": "100000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-extension', 'sonic-head', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
VERSIONS, DEVICE_METADATA, DEVICE_NEIGHBOR, LOCK, FLEX_COUNTER_TABLE, BREAKOUT_CFG, 
Below Config can not be verified, It may cause harm to the system
 {
  "BREAKOUT_CFG": {
    "Ethernet0": {
      "brkout_mode": "4x25G"
    }
  }
}
Do you wish to Continue? [y/N]: 
Start Port Deletion
Find dependecies for port Ethernet2
Find dependecies for port Ethernet3
Find dependecies for port Ethernet0
Find dependecies for port Ethernet1
Deleting Port: Ethernet2
Deleting Port: Ethernet3
Deleting Port: Ethernet0
Deleting Port: Ethernet1
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
:::Lock Released:::
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet4  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet5  | untagged       |                       |
|           | fe80::1/10             | Ethernet6  | untagged       |                       |
|           |                        | Ethernet7  | untagged       |                       |
|           |                        | Ethernet8  | untagged       |                       |
|           |                        | Ethernet9  | untagged       |                       |
|           |                        | Ethernet10 | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       ce0( 68)  down   4  100G  FD   SW  No   Forward          None    D    KR4  9412    No      
       xe0( 69)  !ena   1     -       SW  No   Forward          None    D   None  9412    No      
       xe1( 70)  !ena   2     -       SW  No   Forward          None    D   None  9412    No      
       xe2( 71)  !ena   1     -       SW  No   Forward          None    D   None  9412    No      
       xe3( 72)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe4( 73)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe5( 74)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
:::Lock Acquired:::
:::Lock Timer Extended:::

Running Breakout Mode : 1x100G 
Target Breakout Mode : 2x50G

Ports to be deleted : 
 {
    "Ethernet0": "100000"
}
Ports to be added : 
 {
    "Ethernet2": "50000", 
    "Ethernet0": "50000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet0": "100000"
} 
Final list of ports to be added :  
 {
    "Ethernet2": "50000", 
    "Ethernet0": "50000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-extension', 'sonic-head', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
VERSIONS, DEVICE_METADATA, DEVICE_NEIGHBOR, LOCK, FLEX_COUNTER_TABLE, BREAKOUT_CFG, 
Below Config can not be verified, It may cause harm to the system
 {
  "BREAKOUT_CFG": {
    "Ethernet0": {
      "brkout_mode": "1x100G"
    }
  }
}
Do you wish to Continue? [y/N]: 
Start Port Deletion
Find dependecies for port Ethernet0
Deleting Port: Ethernet0
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Generating default config for ['Ethernet2', 'Ethernet0']
Merge Default Config for ['Ethernet2', 'Ethernet0']
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
:::Lock Released:::
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet0  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet2  | untagged       |                       |
|           | fe80::1/10             | Ethernet4  | untagged       |                       |
|           |                        | Ethernet5  | untagged       |                       |
|           |                        | Ethernet6  | untagged       |                       |
|           |                        | Ethernet7  | untagged       |                       |
|           |                        | Ethernet8  | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No      
       xe1( 69)  !ena   1     -       SW  No   Forward          None    D   None  9412    No      
       xe2( 70)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No      
       xe3( 71)  !ena   1     -       SW  No   Forward          None    D   None  9412    No      
       xe4( 72)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe5( 73)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe6( 74)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
:::Lock Acquired:::
:::Lock Timer Extended:::

Running Breakout Mode : 2x50G 
Target Breakout Mode : 4x25G

Ports to be deleted : 
 {
    "Ethernet2": "50000", 
    "Ethernet0": "50000"
}
Ports to be added : 
 {
    "Ethernet2": "25000", 
    "Ethernet3": "25000", 
    "Ethernet0": "25000", 
    "Ethernet1": "25000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet2": "50000", 
    "Ethernet0": "50000"
} 
Final list of ports to be added :  
 {
    "Ethernet2": "25000", 
    "Ethernet3": "25000", 
    "Ethernet0": "25000", 
    "Ethernet1": "25000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-extension', 'sonic-head', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
VERSIONS, DEVICE_METADATA, DEVICE_NEIGHBOR, LOCK, FLEX_COUNTER_TABLE, BREAKOUT_CFG, 
Below Config can not be verified, It may cause harm to the system
 {
  "BREAKOUT_CFG": {
    "Ethernet0": {
      "brkout_mode": "2x50G"
    }
  }
}
Do you wish to Continue? [y/N]: 
Start Port Deletion
Find dependecies for port Ethernet2
Find dependecies for port Ethernet0
Deleting Port: Ethernet2
Deleting Port: Ethernet0
Data Validation successful
Generate Final Config to write in DB

Start Port Addition
Generating default config for ['Ethernet2', 'Ethernet3', 'Ethernet0', 'Ethernet1']
Merge Default Config for ['Ethernet2', 'Ethernet3', 'Ethernet0', 'Ethernet1']
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
:::Lock Released:::
+-----------+------------------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address             | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+========================+============+================+=======================+
|       100 | 2a04:f547:43:6a0::1/64 | Ethernet0  | untagged       | 10.186.72.116         |
|           | 10.187.40.1/26         | Ethernet1  | untagged       |                       |
|           | fe80::1/10             | Ethernet2  | untagged       |                       |
|           |                        | Ethernet3  | untagged       |                       |
|           |                        | Ethernet4  | untagged       |                       |
|           |                        | Ethernet5  | untagged       |                       |
|           |                        | Ethernet6  | untagged       |                       |
ps

                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No      
       xe1( 69)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No      
       xe2( 70)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No      
       xe3( 71)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No      
       xe4( 72)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe5( 73)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe6( 74)  !ena   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      

```



Description for Test cases:

**- What I did**
Write Unit tests for Config_mgmt library introduced in PR #765.

**- How I did it**
Key Decisions:
-- Config_mgmt interaction with Redis DB:
These tests will be executed at build time, the entire interaction with Redis DB is mocked using:
    import mock_tables.dbconnector
This mocks below classes used in config_mgmt
from swsssdk import ConfigDBConnector, SonicV2Connector, port_util

-- Mock sonic_yang or not:
Most of the functions in config_mgmt calls APIs from sonic_yang_mgmt (https://github.com/Azure/sonic-buildimage/tree/master/src/sonic-yang-mgmt) library. It is important to catch any compatibility issues during build time rather than run time. So it is decided not to mock sonic_yang but use real instance. Due to this sonic_utilities will have a build time dependency on sonic_yang_mgmt.

-- Unit Test each function or the functions exposed to caller:
	1.	To unit test each function, we need to mock sonic_yang, which is against the previous decision.  
	2.	Also calling the functions which are exposed to the caller is sufficient to unit test all functions. Because functions like breakOutPort internally call every function in the library, and the expected result is not produced if internal functions are not working properly. 
	3.	In the real scenario, the caller will use this library for config validation and to break out the port in a continuous manner. To emulate a real scenario it is decided to exercise only the functions exposed to the caller. 

Check Result:
-- How to check expected result for breakout Command:
	1.	A successful call to breakOutPort API results in a call to writeConfigDB API twice. 
One time with config to be deleted and second time with config to be added. Both calls are necessary and should be done in order. This is tested by mocking writeConfigDB API as below:
```
cmdpb = config_mgmt.ConfigMgmtDPB(source=config_mgmt.CONFIG_DB_JSON_FILE)
cmdpb.writeConfigDB = MagicMock(return_value=True)
```
Then we can check result as below:
```
calls = [call(dConfig), call(aConfig)]
        assert cmdpb.writeConfigDB.call_count == 2
        cmdpb.writeConfigDB.assert_has_calls(calls, any_order=False)
```
Note: it is important to check that both calls are done, rather than just checking final config.


Tests: 
-- Create the configMgmt Class object and validate config.

-- Have a table without yang model in config, Check if this table is returned by tablesWithoutYang()

-- Test configWithKeys() to search ports in the config.

-- Important Test case, Test below sequence for port breakout:
```
        #Ethernet8: start from 4x25G-->2x50G with -f -l

        #Ethernet8: move from 2x50G-->1x100G without force, list deps

        # Ethernet8: move from 2x50G-->1x100G with force, where deps exists

        # Ethernet8: move from 1x100G-->4x25G without force, no deps

        # Ethernet8: move from 4x25G-->1x100G with force, no deps

        # Ethernet8: move from 1x100G-->1x50G(2)+2x25G(2) with -f -l,

        # Ethernet4: breakout from 4x25G to 2x50G with -f -l
```
Note: this is important to do this sequence in one test case, because it is good to test with continuous  change in Config. Also this way, a new configuration for each test is not needed.
 
Expected Result:
All automated tests should pass.

Each breakout test is checked for expected result  as below:
Have a hard coded value of expected dConfig and aConfig, where
dConfig: Config to be deleted.
aConfig: Config to be deleted.

    And check if writeConfigDB is called using the above configurations.
Example: 
```
dConfig = {u'PORT': {u'Ethernet8': None}}

aConfig = {u'ACL_TABLE': {u'NO-NSW-PACL-V4': {u'ports': ['Ethernet0', \
        'Ethernet4', 'Ethernet8', 'Ethernet10']}, u'NO-NSW-PACL-TEST': {u'ports': \
        ['Ethernet11']}}, u'INTERFACE': {u'Ethernet11|2a04:1111:40:a709::1/126': \
        {u'scope': u'global', u'family': u'IPv6'}, u'Ethernet11': {}}, \
        u'VLAN_MEMBER': {u'Vlan100|Ethernet8': {u'tagging_mode': u'untagged'}, \
        u'Vlan100|Ethernet11': {u'tagging_mode': u'untagged'}}, u'PORT': \
        {'Ethernet8': {'speed': '50000', 'lanes': '73,74'}, 'Ethernet10': \
        {'speed': '25000', 'lanes': '75'}, 'Ethernet11': {'speed': '25000', 'lanes': '76'}}}
        
self.checkResult(cmdpb, dConfig, aConfig)
```
Actual Result:
```
============================================================ test session starts ============================================================
platform linux2 -- Python 2.7.13, pytest-3.0.6, py-1.4.32, pluggy-0.4.0
rootdir: /sonic/src/sonic-utilities/sonic-utilities-tests, inifile: pytest.ini
plugins: cov-2.4.0
collected 4 items

config_mgmt_test.py ....

========================================================= 4 passed in 0.67 seconds ==========================================================
```

**- How to verify it**
Actual Result:
```
============================================================ test session starts ============================================================
platform linux2 -- Python 2.7.13, pytest-3.0.6, py-1.4.32, pluggy-0.4.0
rootdir: /sonic/src/sonic-utilities/sonic-utilities-tests, inifile: pytest.ini
plugins: cov-2.4.0
collected 4 items

config_mgmt_test.py ....

========================================================= 4 passed in 0.67 seconds ==========================================================
```
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**



