### PR TITLE
[sfputil] Add support of platform.json

### DIFF
--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -331,7 +331,7 @@ def get_path_to_port_config_file():
     hwsku_path = "/".join([platform_path, hwsku])
 
     # First check for the presence of the new 'port_config.ini' file
-    port_config_file_path = "/".join([hwsku_path, PLATFORM_JSON])
+    port_config_file_path = "/".join([platform_path, PLATFORM_JSON])
     if not os.path.isfile(port_config_file_path):
         # platform.json doesn't exist. Try loading the legacy 'port_config.ini' file
         port_config_file_path = "/".join([hwsku_path, PORT_CONFIG_INI])

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -32,7 +32,9 @@ PLATFORM_KEY = 'DEVICE_METADATA.localhost.platform'
 
 # Global platform-specific sfputil class instance
 platform_sfputil = None
-
+PLATFORM_JSON = 'platform.json'
+PORT_CONFIG_INI = 'port_config.ini'
+PORTMAP_INI = 'portmap.ini'
 
 # ========================== Syslog wrappers ==========================
 
@@ -329,13 +331,15 @@ def get_path_to_port_config_file():
     hwsku_path = "/".join([platform_path, hwsku])
 
     # First check for the presence of the new 'port_config.ini' file
-    port_config_file_path = "/".join([hwsku_path, "port_config.ini"])
+    port_config_file_path = "/".join([hwsku_path, PLATFORM_JSON])
+    if not os.path.isfile(port_config_file_path):
+        # platform.json doesn't exist. Try loading the legacy 'port_config.ini' file
+        port_config_file_path = "/".join([hwsku_path, PORT_CONFIG_INI])
     if not os.path.isfile(port_config_file_path):
         # port_config.ini doesn't exist. Try loading the legacy 'portmap.ini' file
-        port_config_file_path = "/".join([hwsku_path, "portmap.ini"])
+        port_config_file_path = "/".join([hwsku_path, PORTMAP_INI])
 
     return port_config_file_path
-
 
 # Loads platform specific sfputil module from source
 def load_platform_sfputil():

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -34,7 +34,6 @@ PLATFORM_KEY = 'DEVICE_METADATA.localhost.platform'
 platform_sfputil = None
 PLATFORM_JSON = 'platform.json'
 PORT_CONFIG_INI = 'port_config.ini'
-PORTMAP_INI = 'portmap.ini'
 
 # ========================== Syslog wrappers ==========================
 
@@ -335,9 +334,6 @@ def get_path_to_port_config_file():
     if not os.path.isfile(port_config_file_path):
         # platform.json doesn't exist. Try loading the legacy 'port_config.ini' file
         port_config_file_path = "/".join([hwsku_path, PORT_CONFIG_INI])
-    if not os.path.isfile(port_config_file_path):
-        # port_config.ini doesn't exist. Try loading the legacy 'portmap.ini' file
-        port_config_file_path = "/".join([hwsku_path, PORTMAP_INI])
 
     return port_config_file_path
 


### PR DESCRIPTION
Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>

> This PR is dependent on [sonic-platform-common/pull/72](https://github.com/Azure/sonic-platform-common/pull/72)

All three PRs are necessary to run `show interfaces transceiver` command.

1. [Azure/sonic-buildimage#3912](https://github.com/Azure/sonic-buildimage/pull/3912)
2. [Azure/sonic-platform-common#72](https://github.com/Azure/sonic-platform-common/pull/72)
3. [Azure/sonic-utilities#767](https://github.com/Azure/sonic-utilities/pull/767)




**- What I did**
Add support of platform.json in sfputil to get correct output of `show interfaces transceiver`


**- How to verify it**
Check whether all the below-mentioned CLI's are working correctly.
```
Usage: show interfaces transceiver [OPTIONS] COMMAND [ARGS]...

  Show SFP Transceiver information

Options:
  -?, -h, --help  Show this message and exit.

Commands:
  eeprom    Show interface transceiver EEPROM information
  lpmode    Show interface transceiver low-power mode status
  presence  Show interface transceiver presence
```