### PR TITLE
[sonic_installer] Adding support for ARM Uboot firmware and portstat fix

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2176,6 +2176,17 @@ def enable(ctx):
 
     config_db.mod_entry('SFLOW', 'global', sflow_tbl['global'])
 
+    try:
+        proc = subprocess.Popen("systemctl is-active sflow", shell=True, stdout=subprocess.PIPE)
+        (out, err) = proc.communicate()
+    except SystemExit as e:
+        ctx.fail("Unable to check sflow status {}".format(e))
+
+    if out != "active":
+        log_info("sflow service is not enabled. Starting sflow docker...")
+        run_command("sudo systemctl enable sflow")
+        run_command("sudo systemctl start sflow")
+
 #
 # 'sflow' command ('config sflow disable')
 #

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -1356,6 +1356,26 @@ This command displays the summary of all IPv4 & IPv6 bgp neighbors that are conf
 
 - Example:
   ```
+  admin@sonic-z9264f-9251:~# show ip bgp summary
+
+  IPv4 Unicast Summary:
+  BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
+  BGP table version 6465
+  RIB entries 12807, using 2001 KiB of memory
+  Peers 4, using 83 KiB of memory
+  Peer groups 2, using 128 bytes of memory
+
+  Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd NeighborName
+  10.0.0.57       4      64600    3995    4001        0    0    0 00:39:32         6400 Lab-T1-01
+  10.0.0.59       4      64600    3995    3998        0    0    0 00:39:32         6400 Lab-T1-02
+  10.0.0.61       4      64600    3995    4001        0    0    0 00:39:32         6400 Lab-T1-03
+  10.0.0.63       4      64600    3995    3998        0    0    0 00:39:32         6400 NotAvailable
+
+  Total number of neighbors 4
+  ```
+
+- Example:
+  ```
   admin@sonic-z9264f-9251:~# show bgp summary
 
   IPv4 Unicast Summary:
@@ -1515,11 +1535,11 @@ This command displays the summary of all IPv6 bgp neighbors that are configured 
   Peers 4, using 83 KiB of memory
   Peer groups 2, using 128 bytes of memory
 
-  Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
-  fc00::72        4      64600    3995    5208        0    0    0 00:39:30         6400
-  fc00::76        4      64600    3994    5208        0    0    0 00:39:30         6400
-  fc00::7a        4      64600    3993    5208        0    0    0 00:39:30         6400
-  fc00::7e        4      64600    3993    5208        0    0    0 00:39:30         6400
+  Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd NeighborName
+  fc00::72        4      64600    3995    5208        0    0    0 00:39:30         6400 Lab-T1-01
+  fc00::76        4      64600    3994    5208        0    0    0 00:39:30         6400 Lab-T1-02
+  fc00::7a        4      64600    3993    5208        0    0    0 00:39:30         6400 Lab-T1-03
+  fc00::7e        4      64600    3993    5208        0    0    0 00:39:30         6400 Lab-T1-04
 
   Total number of neighbors 4
   ```

--- a/scripts/dropconfig
+++ b/scripts/dropconfig
@@ -92,6 +92,7 @@ class DropConfig(object):
 
         if not device_caps:
             print('Current device does not support drop counters')
+            return
 
         table = []
         for counter, capabilities in device_caps.iteritems():

--- a/scripts/intfstat
+++ b/scripts/intfstat
@@ -269,6 +269,10 @@ def main():
     cnstat_fqn_file = cnstat_dir + "/" + cnstat_file
 
     if delete_all_stats:
+        # There is nothing to delete
+        if not os.path.isdir(cnstat_dir):
+            sys.exit(0)
+
         for file in os.listdir(cnstat_dir):
             os.remove(cnstat_dir + "/" + file)
 

--- a/scripts/portstat
+++ b/scripts/portstat
@@ -155,9 +155,9 @@ class Portstat(object):
 
 
         if use_json:
-            table_as_json(table, header_all if print_all else header)
+            print table_as_json(table, header_all if print_all else header)
         else:
-            print tabulate(table, header_all, tablefmt='simple', stralign='right') #  if print_all else header
+            print tabulate(table, header_all if print_all else header, tablefmt='simple', stralign='right')
 
     def cnstat_diff_print(self, cnstat_new_dict, cnstat_old_dict, use_json, print_all):
         """
@@ -208,7 +208,7 @@ class Portstat(object):
                                   STATUS_NA,
                                   cntr.tx_err,
                                   cntr.tx_drop,
-                                  cntr.tx_err))
+                                  cntr.tx_ovr))
             else:
                 if old_cntr is not None:
                     table.append((key, self.get_port_state(key),
@@ -237,7 +237,7 @@ class Portstat(object):
                                   STATUS_NA,
                                   cntr.tx_err,
                                   cntr.tx_drop,
-                                  cntr.tx_err))
+                                  cntr.tx_ovr))
 
         if use_json:
             print table_as_json(table, header)

--- a/scripts/portstat
+++ b/scripts/portstat
@@ -109,7 +109,7 @@ class Portstat(object):
         if speed is None:
             speed = PORT_RATE
         else:
-            speed = int(speed)/1000
+            speed = float(speed)/float(1000)
         return speed
 
     def get_port_state(self, port_name):

--- a/scripts/portstat
+++ b/scripts/portstat
@@ -109,7 +109,7 @@ class Portstat(object):
         if speed is None:
             speed = PORT_RATE
         else:
-            speed = float(speed)/float(1000)
+            speed = int(speed)/1000
         return speed
 
     def get_port_state(self, port_name):

--- a/scripts/syseeprom-to-json
+++ b/scripts/syseeprom-to-json
@@ -1,0 +1,31 @@
+#!/usr/bin/awk -f
+
+BEGIN { print "{"; n = 0 }
+
+function sep()
+{
+	if (n > 0)  print ", ";
+	++n;
+}
+
+/Product Name/       { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/Part Number/        { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/Serial Number/      { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/Base MAC Address/   { sep(); print "\"" $1 " " $2 " " $3 "\": \"" $6 "\""; }
+/Manufacture Date/   { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/Device Version/     { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/Label Revision/     { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/Platform Name/      { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/ONIE Version/       { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/MAC Addresses/      { sep(); print "\"" $1 " " $2 "\": " $5; }
+/Manfacturer/        { sep(); print "\"" $1 "\": \"" $4 "\""; } 
+/Manfacture Country/ { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/Vendor Name/        { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/Diag Version/       { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/Service Tag/        { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/Hardware Version/   { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/Software Version/   { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/Manfacture Date/    { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+/Model Name/         { sep(); print "\"" $1 " " $2 "\": \"" $5 "\""; } 
+
+END { print "}" }

--- a/scripts/update_json.py
+++ b/scripts/update_json.py
@@ -1,0 +1,55 @@
+#! /usr/bin/env python
+
+import os
+import sys
+import json
+import argparse
+
+TMP_SUFFIX = ".tmp"
+BAK_SUFFIX = ".bak"
+
+def dict_update(dst, patch):
+    for k in patch.keys():
+        if type(patch[k]) == dict:
+            dst[k] = dict_update(dst[k], patch[k])
+        else:
+            dst[k] = patch[k]
+    return dst
+
+def do_update(rcf, patchf):
+    dst = {}
+    patch = {}
+
+    tmpf = rcf + TMP_SUFFIX
+    bakf = rcf + BAK_SUFFIX
+
+    with open(rcf, "r") as f:
+        dst = json.load(f)
+
+    with open(patchf, "r") as f:
+        patch = json.load(f)
+
+    dst = dict_update(dst, patch)
+
+    with open(tmpf, "w") as f:
+        json.dump(dst, f, indent = 4)
+
+    os.rename(rcf, bakf)
+    os.rename(tmpf, rcf)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Update JSON based file")
+    parser.add_argument("-u", "--update", help="JSON file to be updated")
+    parser.add_argument("-p", "--patch", help="JSON file holding patch")
+    args = parser.parse_args()
+
+    if not args.update or not args.patch:
+        raise Exception("check usage")
+
+    do_update(args.update, args.patch)
+
+if __name__ == '__main__':
+    main()
+
+

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ setup(
         'scripts/route_check_test.sh',
         'scripts/sfpshow',
         'scripts/teamshow',
+        'scripts/update_json.py',
         'scripts/warm-reboot',
         'scripts/watermarkstat',
         'scripts/watermarkcfg'

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ setup(
         'scripts/route_check.py',
         'scripts/route_check_test.sh',
         'scripts/sfpshow',
+        'scripts/syseeprom-to-json',
         'scripts/teamshow',
         'scripts/update_json.py',
         'scripts/warm-reboot',

--- a/show/bgp_frr_v6.py
+++ b/show/bgp_frr_v6.py
@@ -19,7 +19,11 @@ def bgp():
 @bgp.command()
 def summary():
     """Show summarized information of IPv6 BGP state"""
-    run_command('sudo vtysh -c "show bgp ipv6 summary"')
+    try:
+        device_output = run_command('sudo vtysh -c "show bgp ipv6 summary"', return_cmd=True)
+        get_bgp_summary_extended(device_output)
+    except:
+        run_command('sudo vtysh -c "show bgp ipv6 summary"')
 
 
 # 'neighbors' subcommand ("show ipv6 bgp neighbors")

--- a/show/bgp_quagga_v4.py
+++ b/show/bgp_quagga_v4.py
@@ -19,7 +19,11 @@ def bgp():
 @bgp.command()
 def summary():
     """Show summarized information of IPv4 BGP state"""
-    run_command('sudo vtysh -c "show ip bgp summary"')
+    try:
+        device_output = run_command('sudo vtysh -c "show ip bgp summary"', return_cmd=True)
+        get_bgp_summary_extended(device_output)
+    except:
+        run_command('sudo vtysh -c "show ip bgp summary"')
 
 
 # 'neighbors' subcommand ("show ip bgp neighbors")

--- a/show/bgp_quagga_v6.py
+++ b/show/bgp_quagga_v6.py
@@ -19,7 +19,11 @@ def bgp():
 @bgp.command()
 def summary():
     """Show summarized information of IPv6 BGP state"""
-    run_command('sudo vtysh -c "show ipv6 bgp summary"')
+    try:
+        device_output = run_command('sudo vtysh -c "show ipv6 bgp summary"', return_cmd=True)
+        get_bgp_summary_extended(device_output)
+    except:
+        run_command('sudo vtysh -c "show ipv6 bgp summary"')
 
 
 # 'neighbors' subcommand ("show ipv6 bgp neighbors")

--- a/show/main.py
+++ b/show/main.py
@@ -8,6 +8,7 @@ import os
 import re
 import subprocess
 import sys
+import ipaddr
 
 import click
 from click_default_group import DefaultGroup
@@ -188,7 +189,7 @@ def get_routing_stack():
 routing_stack = get_routing_stack()
 
 
-def run_command(command, display_cmd=False):
+def run_command(command, display_cmd=False, return_cmd=False):
     if display_cmd:
         click.echo(click.style("Command: ", fg='cyan') + click.style(command, fg='green'))
 
@@ -201,6 +202,9 @@ def run_command(command, display_cmd=False):
     proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
 
     while True:
+        if return_cmd:
+            output = proc.communicate()[0].decode("utf-8")
+            return output
         output = proc.stdout.readline()
         if output == "" and proc.poll() is not None:
             break
@@ -391,6 +395,146 @@ def run_command_in_alias_mode(command):
     rc = process.poll()
     if rc != 0:
         sys.exit(rc)
+
+
+def get_bgp_summary_extended(command_output):
+    """
+    Adds Neighbor name to the show ip[v6] bgp summary command
+    :param command: command to get bgp summary
+    """
+    static_neighbors, dynamic_neighbors = get_bgp_neighbors_dict()
+    modified_output = []
+    my_list = iter(command_output.splitlines())
+    for element in my_list:
+        if element.startswith("Neighbor"):
+            element = "{}\tNeighborName".format(element)
+            modified_output.append(element)
+        elif not element or element.startswith("Total number "):
+            modified_output.append(element)
+        elif re.match(r"(\*?([0-9A-Fa-f]{1,4}:|\d+.\d+.\d+.\d+))", element.split()[0]):
+            first_element = element.split()[0]
+            ip = first_element[1:] if first_element.startswith("*") else first_element
+            name = get_bgp_neighbor_ip_to_name(ip, static_neighbors, dynamic_neighbors)
+            if len(element.split()) == 1:
+                modified_output.append(element)
+                element = next(my_list)
+            element = "{}\t{}".format(element, name)
+            modified_output.append(element)
+        else:
+            modified_output.append(element)
+    click.echo("\n".join(modified_output))
+
+
+def connect_config_db():
+    """
+    Connects to config_db
+    """
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    return config_db
+
+
+def get_neighbor_dict_from_table(db,table_name):
+    """
+    returns a dict with bgp neighbor ip as key and neighbor name as value
+    :param table_name: config db table name
+    :param db: config_db
+    """
+    neighbor_dict = {}
+    neighbor_data = db.get_table(table_name)
+    try:
+        for entry in neighbor_data.keys():
+            neighbor_dict[entry] = neighbor_data[entry].get(
+                'name') if 'name' in neighbor_data[entry].keys() else 'NotAvailable'
+        return neighbor_dict
+    except:
+        return neighbor_dict
+
+
+def is_ipv4_address(ipaddress):
+    """
+    Checks if given ip is ipv4
+    :param ipaddress: unicode ipv4
+    :return: bool
+    """
+    try:
+        ipaddress.IPv4Address(ipaddress)
+        return True
+    except ipaddress.AddressValueError as err:
+        return False
+
+
+def is_ipv6_address(ipaddress):
+    """
+    Checks if given ip is ipv6
+    :param ipaddress: unicode ipv6
+    :return: bool
+    """
+    try:
+        ipaddress.IPv6Address(ipaddress)
+        return True
+    except ipaddress.AddressValueError as err:
+        return False
+
+
+def get_dynamic_neighbor_subnet(db):
+    """
+    Returns dict of description and subnet info from bgp_peer_range table
+    :param db: config_db
+    """
+    dynamic_neighbor = {}
+    v4_subnet = {}
+    v6_subnet = {}
+    neighbor_data = db.get_table('BGP_PEER_RANGE')
+    try:
+        for entry in neighbor_data.keys():
+            new_key = neighbor_data[entry]['ip_range'][0]
+            new_value = neighbor_data[entry]['name']
+            if is_ipv4_address(unicode(neighbor_data[entry]['src_address'])):
+                v4_subnet[new_key] = new_value
+            elif is_ipv6_address(unicode(neighbor_data[entry]['src_address'])):
+                v6_subnet[new_key] = new_value
+        dynamic_neighbor["v4"] = v4_subnet
+        dynamic_neighbor["v6"] = v6_subnet
+        return dynamic_neighbor
+    except:
+        return neighbor_data
+
+
+def get_bgp_neighbors_dict():
+    """
+    Uses config_db to get the bgp neighbors and names in dictionary format
+    :return:
+    """
+    dynamic_neighbors = {}
+    config_db = connect_config_db()
+    static_neighbors = get_neighbor_dict_from_table(config_db, 'BGP_NEIGHBOR')
+    bgp_monitors = get_neighbor_dict_from_table(config_db, 'BGP_MONITORS')
+    static_neighbors.update(bgp_monitors)
+    dynamic_neighbors = get_dynamic_neighbor_subnet(config_db)
+    return static_neighbors, dynamic_neighbors
+
+
+def get_bgp_neighbor_ip_to_name(ip, static_neighbors, dynamic_neighbors):
+    """
+    return neighbor name for the ip provided
+    :param ip: ip address unicode
+    :param static_neighbors: statically defined bgp neighbors dict
+    :param dynamic_neighbors: subnet of dynamically defined neighbors dict
+    :return: name of neighbor
+    """
+    if ip in static_neighbors.keys():
+        return static_neighbors[ip]
+    elif is_ipv4_address(unicode(ip)):
+        for subnet in dynamic_neighbors["v4"].keys():
+            if ipaddress.IPv4Address(unicode(ip)) in ipaddress.IPv4Network(unicode(subnet)):
+                return dynamic_neighbors["v4"][subnet]
+    elif is_ipv6_address(unicode(ip)):
+        for subnet in dynamic_neighbors["v6"].keys():
+            if ipaddress.IPv6Address(unicode(ip)) in ipaddress.IPv6Network(unicode(subnet)):
+                return dynamic_neighbors["v6"][subnet]
+    else:
+        return "NotAvailable"
 
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help', '-?'])

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -13,6 +13,7 @@ import subprocess
 from swsssdk import ConfigDBConnector
 from swsssdk import SonicV2Connector
 import collections
+import platform
 
 HOST_PATH = '/host'
 IMAGE_PREFIX = 'SONiC-OS-'
@@ -22,6 +23,10 @@ ABOOT_DEFAULT_IMAGE_PATH = '/tmp/sonic_image.swi'
 IMAGE_TYPE_ABOOT = 'aboot'
 IMAGE_TYPE_ONIE = 'onie'
 ABOOT_BOOT_CONFIG = '/boot-config'
+BOOTLOADER_TYPE_GRUB = 'grub'
+BOOTLOADER_TYPE_UBOOT = 'uboot'
+ARCH = platform.machine()
+BOOTLOADER = BOOTLOADER_TYPE_UBOOT if "arm" in ARCH else BOOTLOADER_TYPE_GRUB
 
 #
 # Helper functions
@@ -106,9 +111,15 @@ def set_default_image(image):
     if get_running_image_type() == IMAGE_TYPE_ABOOT:
         image_path = aboot_image_path(image)
         aboot_boot_config_set(SWI=image_path, SWI_DEFAULT=image_path)
-    else:
+    elif BOOTLOADER == BOOTLOADER_TYPE_GRUB:
         command = 'grub-set-default --boot-directory=' + HOST_PATH + ' ' + str(images.index(image))
         run_command(command)
+    elif BOOTLOADER == BOOTLOADER_TYPE_UBOOT:
+        if image in images[0]:
+            run_command('/usr/bin/fw_setenv boot_next "run sonic_image_1"')
+        elif image in images[1]:
+            run_command('/usr/bin/fw_setenv boot_next "run sonic_image_2"')
+
     return True
 
 def aboot_read_boot_config(path):
@@ -156,7 +167,7 @@ def get_installed_images():
         for filename in os.listdir(HOST_PATH):
             if filename.startswith(IMAGE_DIR_PREFIX):
                 images.append(filename.replace(IMAGE_DIR_PREFIX, IMAGE_PREFIX))
-    else:
+    elif BOOTLOADER == BOOTLOADER_TYPE_GRUB:
         config = open(HOST_PATH + '/grub/grub.cfg', 'r')
         for line in config:
             if line.startswith('menuentry'):
@@ -164,6 +175,17 @@ def get_installed_images():
                 if IMAGE_PREFIX in image:
                     images.append(image)
         config.close()
+    elif BOOTLOADER == BOOTLOADER_TYPE_UBOOT:
+        proc = subprocess.Popen("/usr/bin/fw_printenv -n sonic_version_1", shell=True, stdout=subprocess.PIPE)
+        (out, err) = proc.communicate()
+        image = out.rstrip()
+        if IMAGE_PREFIX in image:
+            images.append(image)
+        proc = subprocess.Popen("/usr/bin/fw_printenv -n sonic_version_2", shell=True, stdout=subprocess.PIPE)
+        (out, err) = proc.communicate()
+        image = out.rstrip()
+        if IMAGE_PREFIX in image:
+            images.append(image)
     return images
 
 # Returns name of current image
@@ -179,7 +201,7 @@ def get_next_image():
         config = open(HOST_PATH + ABOOT_BOOT_CONFIG, 'r')
         next_image = re.search("SWI=flash:(\S+)/", config.read()).group(1).replace(IMAGE_DIR_PREFIX, IMAGE_PREFIX)
         config.close()
-    else:
+    elif BOOTLOADER == BOOTLOADER_TYPE_GRUB:
         images = get_installed_images()
         grubenv = subprocess.check_output(["/usr/bin/grub-editenv", HOST_PATH + "/grub/grubenv", "list"])
         m = re.search("next_entry=(\d+)", grubenv)
@@ -191,6 +213,16 @@ def get_next_image():
                 next_image_index = int(m.group(1))
             else:
                 next_image_index = 0
+        next_image = images[next_image_index]
+    elif BOOTLOADER == BOOTLOADER_TYPE_UBOOT:
+        images = get_installed_images()
+        proc = subprocess.Popen("/usr/bin/fw_printenv -n boot_next", shell=True, stdout=subprocess.PIPE)
+        (out, err) = proc.communicate()
+        image = out.rstrip()
+        if "sonic_image_2" in image:
+            next_image_index = 1
+        else:
+            next_image_index = 0
         next_image = images[next_image_index]
     return next_image
 
@@ -207,7 +239,7 @@ def remove_image(image):
         click.echo('Removing image root filesystem...')
         subprocess.call(['rm','-rf', os.path.join(HOST_PATH, image_dir)])
         click.echo('Image removed')
-    else:
+    elif BOOTLOADER == BOOTLOADER_TYPE_GRUB:
         click.echo('Updating GRUB...')
         config = open(HOST_PATH + '/grub/grub.cfg', 'r')
         old_config = config.read()
@@ -226,6 +258,19 @@ def remove_image(image):
 
         run_command('grub-set-default --boot-directory=' + HOST_PATH + ' 0')
         click.echo('Image removed')
+    elif BOOTLOADER == BOOTLOADER_TYPE_UBOOT:
+        click.echo('Updating next boot ...')
+        images = get_installed_images()
+        if image in images[0]:
+            run_command('/usr/bin/fw_setenv boot_next "run sonic_image_2"')
+            run_command('/usr/bin/fw_setenv sonic_version_1 "NONE"')
+        elif image in images[1]:
+            run_command('/usr/bin/fw_setenv boot_next "run sonic_image_1"')
+            run_command('/usr/bin/fw_setenv sonic_version_2 "NONE"')
+        image_dir = image.replace(IMAGE_PREFIX, IMAGE_DIR_PREFIX)
+        click.echo('Removing image root filesystem...')
+        subprocess.call(['rm','-rf', HOST_PATH + '/' + image_dir])
+        click.echo('Done')
 
 # TODO: Embed tag name info into docker image meta data at build time,
 # and extract tag name from docker image file.
@@ -362,7 +407,8 @@ def install(url, force, skip_migration=False):
             run_command("swipath=%s target_path=/host sonic_upgrade=1 . /tmp/boot0" % image_path)
         else:
             run_command("bash " + image_path)
-            run_command('grub-set-default --boot-directory=' + HOST_PATH + ' 0')
+            if BOOTLOADER == BOOTLOADER_TYPE_GRUB:
+                run_command('grub-set-default --boot-directory=' + HOST_PATH + ' 0')
         # Take a backup of current configuration
         if skip_migration:
             click.echo("Skipping configuration migration as requested in the command option.")
@@ -410,9 +456,14 @@ def set_next_boot(image):
     if get_running_image_type() == IMAGE_TYPE_ABOOT:
         image_path = aboot_image_path(image)
         aboot_boot_config_set(SWI=image_path)
-    else:
+    elif BOOTLOADER == BOOTLOADER_TYPE_GRUB:
         command = 'grub-reboot --boot-directory=' + HOST_PATH + ' ' + str(images.index(image))
         run_command(command)
+    elif BOOTLOADER == BOOTLOADER_TYPE_UBOOT:
+        if image in images[0]:
+            run_command('/usr/bin/fw_setenv boot_once "run sonic_image_1"')
+        elif image in images[1]:
+            run_command('/usr/bin/fw_setenv boot_once "run sonic_image_2"')
 
 
 # Uninstall image


### PR DESCRIPTION
[sonic_installer] Adding support for ARM by introducing bootloader type 
grub vs uboot
For uboot fw_setenv/fw_printenv commands are utilized here
fw_env.cfg config needs to be updated per platform

[portstat] division by zero error fix when speed is < 1000 (1G)

Signed-off-by: Antony Rheneus <arheneus@marvell.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

