### PR TITLE
On sflow enable, start the docker since it is disabled by default

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2176,6 +2176,17 @@ def enable(ctx):
 
     config_db.mod_entry('SFLOW', 'global', sflow_tbl['global'])
 
+    try:
+        proc = subprocess.Popen("systemctl is-active sflow", shell=True, stdout=subprocess.PIPE)
+        (out, err) = proc.communicate()
+    except SystemExit as e:
+        ctx.fail("Unable to check sflow status {}".format(e))
+
+    if out != "active":
+        log_info("sflow service is not enabled. Starting sflow docker...")
+        run_command("sudo systemctl enable sflow")
+        run_command("sudo systemctl start sflow")
+
 #
 # 'sflow' command ('config sflow disable')
 #


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

When user enables sflow, (since it is disabled by default), start the sflow docker service.
Note that this is a workaround until the "features" infrastructure can be fully utilized.

**- How I did it**

Check if the sflow service is running and if not active, enable and restart the service.

**- How to verify it**

Check that sflow is disabled by default (with https://github.com/Azure/sonic-buildimage/pull/3930).
Perform "config sflow enable" and check that the sflow docker comes up.
Check the logs and the "show sflow" outputs.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

