### PR TITLE
[fast-reboot] save fast-reboot state into the db

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -96,6 +96,8 @@ function clear_fast_boot()
 {
     debug "${REBOOT_TYPE} failure ($?) cleanup ..."
 
+    /usr/bin/redis-cli -n 6 del "FAST_REBOOT|system" > /dev/null || /bin/true
+
     /sbin/kexec -u || /bin/true
 
     teardown_control_plane_assistant
@@ -307,6 +309,7 @@ BOOT_TYPE_ARG="cold"
 case "$REBOOT_TYPE" in
     "fast-reboot")
         BOOT_TYPE_ARG=$REBOOT_TYPE
+        /usr/bin/redis-cli -n 6 set "FAST_REBOOT|system" "1" > /dev/null
         trap clear_fast_boot EXIT HUP INT QUIT TERM KILL ABRT ALRM
         ;;
     "warm-reboot")


### PR DESCRIPTION
Fixes Azure/sonic-buildimage#4006

1. save fast-reboot state into the db when execute fast-reboot(aligned with Azure/sonic-buildimage#3741)
2. Later, during the syncd service stop stage, `sonic-buildimage/files/scripts/syncd.sh` could detect the `FAST` mode by the saved state, and request syncd to trigger fast shutdown.

