### PR TITLE
[dropconfig] Clean-up error output for devices that do not support drop counters

### DIFF
--- a/scripts/dropconfig
+++ b/scripts/dropconfig
@@ -92,6 +92,7 @@ class DropConfig(object):
 
         if not device_caps:
             print('Current device does not support drop counters')
+            return
 
         table = []
         for counter, capabilities in device_caps.iteritems():


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
I fixed the if-check for devices that do not publish any drop counter capabilities to state DB.

**- How I did it**
I added a return inside the if-check so that the function will stop if no capabilities are found.

**- How to verify it**
I ran the `show dropcounters capabilities` command immediately after boot to ensure that the CAPABILITIES table would be empty, triggering the if-check.

**- Previous command output (if the output of a command-line utility has changed)**
```
admin@sonic:~$ show dropcounters capabilities
Traceback (most recent call last):
  File "/usr/bin/dropconfig", line 414, in <module>
    main()
  File "/usr/bin/dropconfig", line 409, in main
    dconfig.print_device_capabilities()
  File "/usr/bin/dropconfig", line 97, in print_device_capabilities
Current device does not support drop counters
    for counter, capabilities in device_caps.iteritems():
AttributeError: 'NoneType' object has no attribute 'iteritems'
```

**- New command output (if the output of a command-line utility has changed)**
```
admin@sonic:~$ show dropcounters capabilities
Current device does not support drop counters
```
