### PR TITLE
[dropconfig] Move prefix-handling from CLI to orchagent

### DIFF
--- a/scripts/dropconfig
+++ b/scripts/dropconfig
@@ -44,10 +44,6 @@ drop_counter_config_header = ['Counter',
                               'Description']
 drop_counter_capability_header = ['Counter Type', 'Total']
 
-# Drop Reason Prefixes
-in_drop_reason_prefix = 'SAI_IN_DROP_REASON_'
-out_drop_reason_prefix = 'SAI_OUT_DROP_REASON_'
-
 
 class InvalidArgumentError(RuntimeError):
     def __init__(self, msg):
@@ -106,10 +102,6 @@ class DropConfig(object):
             if supported_reasons and int(capabilities.get('count', 0)) > 0:
                 print('\n{}'.format(counter))
                 for reason in supported_reasons:
-                    if reason.startswith(in_drop_reason_prefix):
-                        reason = reason[len(in_drop_reason_prefix):]
-                    elif reason.startswith(out_drop_reason_prefix):
-                        reason = reason[len(out_drop_reason_prefix):]
                     print('\t{}'.format(reason))
 
     def create_counter(self, counter_name, alias, group, counter_type,
@@ -313,13 +305,7 @@ class DropConfig(object):
         if not cap_query:
             return None
 
-        reasons = []
-        for reason in deserialize_reason_list(cap_query.get('reasons', '')):
-            if reason.startswith(in_drop_reason_prefix):
-                reasons.append(reason[len(in_drop_reason_prefix):])
-            elif reason.startswith(out_drop_reason_prefix):
-                reasons.append(reason[len(out_drop_reason_prefix):])
-        return reasons
+        return deserialize_reason_list(cap_query.get('reasons', ''))
 
 
 def deserialize_reason_list(list_str):

--- a/sonic-utilities-tests/mock_tables/state_db.json
+++ b/sonic-utilities-tests/mock_tables/state_db.json
@@ -67,11 +67,11 @@
         "ACL_ACTION|PACKET_ACTION": "FORWARD"
     },
     "DEBUG_COUNTER_CAPABILITIES|PORT_INGRESS_DROPS": {
-        "reasons": "[SAI_IN_DROP_REASON_IP_HEADER_ERROR,SAI_IN_DROP_REASON_NO_L3_HEADER]",
+        "reasons": "[IP_HEADER_ERROR,NO_L3_HEADER]",
         "count": "4"
     },
     "DEBUG_COUNTER_CAPABILITIES|SWITCH_EGRESS_DROPS": {
-        "reasons": "[SAI_IN_DROP_REASON_ACL_ANY,SAI_IN_DROP_REASON_L2_ANY,SAI_IN_DROP_REASON_L3_ANY]",
+        "reasons": "[ACL_ANY,L2_ANY,L3_ANY]",
         "count": "2"
     }
 }


### PR DESCRIPTION
- Remove prefix-trimming from drop reason capability query
- Remove prefix-trimming from create/add safety checks

Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
I removed some conditions from the drop counter CLI that was handling the presence of "SAI_IN/OUT_DROP_REASON_" in State DB.

**- Why I did it**
A change was made in SWSS that removed the SAI prefixes from the database, making the prefix removal unnecessary in the CLI.

**- How to verify it**
The CLI tests have been updated to reflect this change. Additionally, you can load the updated script onto a device running the SWSS changes and verify that the behavior is unchanged.

Depends on: Azure/sonic-swss#1173