### PR TITLE
ipaddr module to ipaddress

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -8,7 +8,7 @@ import os
 import re
 import subprocess
 import sys
-import ipaddr
+import ipaddress
 
 import click
 from click_default_group import DefaultGroup


### PR DESCRIPTION
This is a bug fix for PR: 

https://github.com/Azure/sonic-utilities/pull/754

changing ipaddr module to ipaddress