### PR TITLE
[acl-loader] Use V6 EtherType for IPv6 ACL rule

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -474,8 +474,11 @@ class AclLoader(object):
         rule_props = {}
         rule_data = {(table_name, "DEFAULT_RULE"): rule_props}
         rule_props["PRIORITY"] = str(self.min_priority)
-        rule_props["ETHER_TYPE"] = str(self.ethertype_map["ETHERTYPE_IPV4"])
         rule_props["PACKET_ACTION"] = "DROP"
+        if 'v6' in table_name.lower():
+            rule_props["ETHER_TYPE"] = str(self.ethertype_map["ETHERTYPE_IPV6"])
+        else:
+            rule_props["ETHER_TYPE"] = str(self.ethertype_map["ETHERTYPE_IPV4"])
         return rule_data
 
     def convert_rules(self):


### PR DESCRIPTION
If ACL table name contains the substring "v6", set the EtherType of the rule to V6, otherwise set to V4.