### PR TITLE
[fast/warm reboot] watchdog log message mentions the right reboot type

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -515,7 +515,7 @@ fi
 
 # Enable Watchdog Timer
 if [[ -x /usr/bin/watchdog ]]; then
-    debug "Enabling Watchdog before fast-reboot"
+    debug "Enabling Watchdog before ${REBOOT_TYPE}"
     /usr/bin/watchdog -e
 fi
 


### PR DESCRIPTION
**- What I did**
watchdog log message mentions the right reboot type

