### PR TITLE
Fix 'show platform eeprom' on virtual switch

### DIFF
--- a/scripts/decode-syseeprom
+++ b/scripts/decode-syseeprom
@@ -36,9 +36,6 @@ def main():
 
     platform_path = '/'.join([PLATFORM_ROOT, platform])
 
-    # Currently, don't support eeprom db on Arista platform
-    if 'arista' in platform_path:
-        support_eeprom_db = False
     #
     # Currently we only support board eeprom decode.
     #
@@ -54,6 +51,12 @@ def main():
 
     class_ = getattr(m, 'board')
     t = class_('board', '','','')
+
+    # Currently, don't support eeprom db on Arista platform
+    platforms_without_eeprom_db = ['arista', 'kvm']
+    if any(platform in platform_path for platform in platforms_without_eeprom_db)\
+            or t.getattr('read_eeprom_db', None) == None:
+        support_eeprom_db = False
 
     #
     # execute the command


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
 Fixed show platform syseeprom on vs platform
**- How I did it**
 add kvm to platforms which do not support syseeprom db and check for the 'read_syseeprom_db' method availibilty to avoid same issue on other platforms
**- How to verify it**
 Verify output of show platform syseeprom shell command
**- Previous command output (if the output of a command-line utility has changed)**
root@vlab-01:/home/admin# show platform syseeprom 
Traceback (most recent call last):
  File "/usr/bin/decode-syseeprom", line 172, in <module>
    exit(main())
  File "/usr/bin/decode-syseeprom", line 61, in main
    run(t, opts, args, support_eeprom_db)
  File "/usr/bin/decode-syseeprom", line 88, in run
    err = target.read_eeprom_db()
AttributeError: board instance has no attribute 'read_eeprom_db'
**- New command output (if the output of a command-line utility has changed)**
root@vlab-01:/home/admin# show platform syseeprom 

TLV Name             Code Len Value
-------------------- ---- --- -----
Product Name         0x21   5 SONiC
Part Number          0x22   6 000000
Serial Number        0x23  20 0000000000000000000
Base MAC Address     0x24   6 00:00:00:00:00:01
Manufacture Date     0x25  19 10/19/2019 00:00:03
Device Version       0x26   1 1
Label Revision       0x27   3 A01
Platform Name        0x28  20 x86_64-kvm_x86_64-r0
ONIE Version         0x29  19 master-201811170418
MAC Addresses        0x2A   2 16
Vendor Name          0x2D   5 SONiC

(checksum valid)

