### PR TITLE
[showtech]: dump a few more DB in generate dump

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -328,10 +328,10 @@ main() {
 
     save_vtysh "show ip bgp summary" "bgp.summary"
     save_vtysh "show ip bgp neighbors" "bgp.neighbors"
-    save_vtysh "show ip bgp" "bgp.table" true
+    save_vtysh "show ip bgp" "bgp.table"
     save_vtysh "show bgp ipv6 summary" "bgp.ipv6.summary"
     save_vtysh "show bgp ipv6 neighbors" "bgp.ipv6.neighbors"
-    save_vtysh "show bgp ipv6" "bgp.ipv6.table" true
+    save_vtysh "show bgp ipv6" "bgp.ipv6.table"
     save_bgp_neighbor
 
     save_cmd "show interface status" "interface.status"
@@ -353,14 +353,17 @@ main() {
     save_redis "0" "APP_DB"
     save_redis "1" "ASIC_DB"
     save_redis "2" "COUNTERS_DB"
+    save_redis "4" "CONFIG_DB"
+    save_redis "5" "FLEX_COUNTER_DB"
+    save_redis "6" "STATE_DB"
 
     save_cmd "docker ps -a" "docker.ps"
     save_cmd "docker top pmon" "docker.pmon"
 
     save_cmd "docker exec -it syncd saidump" "saidump"
 
-    local platform="$(/usr/local/bin/sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)"
-    if [[ $platform == *"mlnx"* ]]; then
+    local asic="$(/usr/local/bin/sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)"
+    if [[ "$asic" = "mellanox" ]]; then
         local sai_dump_filename="/tmp/sai_sdk_dump_$(date +"%m_%d_%Y_%I_%M_%p")"
         ${CMD_PREFIX}docker exec -it syncd saisdkdump -f $sai_dump_filename
         ${CMD_PREFIX}docker exec syncd tar Ccf $(dirname $sai_dump_filename) - $(basename $sai_dump_filename) | tar Cxf /tmp/ -
@@ -374,7 +377,6 @@ main() {
         done
     fi
 
-    local asic="$(/usr/local/bin/sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)"
     if [ "$asic" = "broadcom" ]; then
         save_cmd "bcmcmd -t5 version" "broadcom.version"
         save_cmd "bcmcmd -t5 soc" "broadcom.soc"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
dump a few more DB, config db, state db, flex counter db in generate dump.
also do not zip some bgp table since the whole tar file is gziped.

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

