### PR TITLE
[show] Add subcommand to display the status of auto-restart feature for each container

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -2813,6 +2813,7 @@ def features():
 def container():
     """Show container"""
     pass
+
 #
 # 'feature' group (show container feature ...)
 #
@@ -2824,7 +2825,6 @@ def feature():
 #
 # 'autorestart' subcommand (show container feature autorestart)
 #
-
 @feature.command('autorestart', short_help="Show whether the auto-restart feature for container(s) is enabled or disabled")
 @click.argument('container_name', required=False)
 def autorestart(container_name):

--- a/show/main.py
+++ b/show/main.py
@@ -2845,6 +2845,5 @@ def autorestart(container_name):
             body.append([name, container_feature_table[name]['auto_restart']])
     click.echo(tabulate(body, header))
 
-
 if __name__ == '__main__':
     cli()

--- a/show/main.py
+++ b/show/main.py
@@ -2814,7 +2814,7 @@ def container()
     """Show container feature"""
     pass
 
-@container.command('feature')
+@container.group('feature')
 def feature()
     pass
 

--- a/show/main.py
+++ b/show/main.py
@@ -2807,27 +2807,31 @@ def features():
     click.echo(tabulate(body, header))
 
 #
-# 'container' group
+# 'container' group (show container ...)
 #
-@cli.group(cls=AliasedGroup, default_if_no_args=False)
+@cli.group(name='container', invoke_without_command=False)
 def container()
     """Show container"""
     pass
 #
-# 'feature' group
+# 'feature' group (show container feature ...)
 #
-@container.group(cls=AliasedGroup, default_if_no_args=False)
+@container.group(name='feature', invoke_without_command=False)
 def feature()
     """Show container feature"""
     pass
 
-# show whether the auto-restart feature for containers or a specific container
-# is enabled or disabled.
+#
+# 'autorestart' subcommand (show container feature autorestart)
+#
 
 @feature.command('autorestart')
 @click.argument('container_name', required=False)
 def autorestart(container_name):
-    """Show container feature autorestart"""
+    """show whether the auto-restart feature for containers or a specific container
+       is enabled or disabled.
+    """
+
     config_db = ConfigDBConnector()
     config_db.connect()
     header = ['ContainerName', 'Status']

--- a/show/main.py
+++ b/show/main.py
@@ -2816,7 +2816,7 @@ def container()
 #
 # 'feature' group
 #
-@container.group('feature')
+@container.group(cls=AliasedGroup, default_if_no_args=False)
 def feature()
     """Show container feature"""
     pass

--- a/show/main.py
+++ b/show/main.py
@@ -2810,14 +2810,14 @@ def features():
 # 'container' group (show container ...)
 #
 @cli.group(name='container', invoke_without_command=False)
-def container()
+def container():
     """Show container"""
     pass
 #
 # 'feature' group (show container feature ...)
 #
 @container.group(name='feature', invoke_without_command=False)
-def feature()
+def feature():
     """Show container feature"""
     pass
 
@@ -2825,12 +2825,9 @@ def feature()
 # 'autorestart' subcommand (show container feature autorestart)
 #
 
-@feature.command('autorestart')
+@feature.command('autorestart', short_help="Show whether the auto-restart feature for contain(s) is enabled or disabled")
 @click.argument('container_name', required=False)
 def autorestart(container_name):
-    """show whether the auto-restart feature for containers or a specific container
-       is enabled or disabled.
-    """
 
     config_db = ConfigDBConnector()
     config_db.connect()

--- a/show/main.py
+++ b/show/main.py
@@ -2828,7 +2828,6 @@ def feature():
 @feature.command('autorestart', short_help="Show whether the auto-restart feature for container(s) is enabled or disabled")
 @click.argument('container_name', required=False)
 def autorestart(container_name):
-
     config_db = ConfigDBConnector()
     config_db.connect()
     header = ['ContainerName', 'Status']

--- a/show/main.py
+++ b/show/main.py
@@ -2825,7 +2825,7 @@ def feature():
 # 'autorestart' subcommand (show container feature autorestart)
 #
 
-@feature.command('autorestart', short_help="Show whether the auto-restart feature for contain(s) is enabled or disabled")
+@feature.command('autorestart', short_help="Show whether the auto-restart feature for container(s) is enabled or disabled")
 @click.argument('container_name', required=False)
 def autorestart(container_name):
 

--- a/show/main.py
+++ b/show/main.py
@@ -2806,7 +2806,7 @@ def features():
         body.append([key, status_data[key]['status']])
     click.echo(tabulate(body, header))
 
-# show whether the auto-restart feature for each container or a specific
+# show whether the auto-restart feature for containers or a specific container
 # is enabled or disabled.
 
 @cli.command('autorestart')

--- a/show/main.py
+++ b/show/main.py
@@ -2834,7 +2834,7 @@ def autorestart(container_name):
     body = []
     container_feature_table = config_db.get_table('CONTAINER_FEATURE')
     if container_name:
-        if container_feature_table and container_feature_table.has_key(container-name):
+        if container_feature_table and container_feature_table.has_key(container_name):
             body.append([container_name, container_feature_table[container_name]['auto_restart']])
     else:
         for name in container_feature_table.keys():

--- a/show/main.py
+++ b/show/main.py
@@ -2811,11 +2811,12 @@ def features():
 #
 @cli.group(cls=AliasedGroup, default_if_no_args=False)
 def container()
-    """Show container feature"""
+    """Show container"""
     pass
 
 @container.group('feature')
 def feature()
+    """Show container feature"""
     pass
 
 # show whether the auto-restart feature for containers or a specific container

--- a/show/main.py
+++ b/show/main.py
@@ -2813,7 +2813,9 @@ def features():
 def container()
     """Show container"""
     pass
-
+#
+# 'feature' group
+#
 @container.group('feature')
 def feature()
     """Show container feature"""
@@ -2823,17 +2825,17 @@ def feature()
 # is enabled or disabled.
 
 @feature.command('autorestart')
-@click.option('-c', '--container-name', required=False)
-def autorestart(container-name):
+@click.argument('container_name', required=False)
+def autorestart(container_name):
     """Show container feature autorestart"""
     config_db = ConfigDBConnector()
     config_db.connect()
     header = ['ContainerName', 'Status']
     body = []
     container_feature_table = config_db.get_table('CONTAINER_FEATURE')
-    if container-name:
+    if container_name:
         if container_feature_table and container_feature_table.has_key(container-name):
-            body.append([container-name, container_feature_table[container-name]['auto_restart']])
+            body.append([container_name, container_feature_table[container_name]['auto_restart']])
     else:
         for name in container_feature_table.keys():
             body.append([name, container_feature_table[name]['auto_restart']])

--- a/show/main.py
+++ b/show/main.py
@@ -2806,7 +2806,7 @@ def features():
         body.append([key, status_data[key]['status']])
     click.echo(tabulate(body, header))
 
-# show whether the auto-restart feature for each container
+# show whether the auto-restart feature for each container or a specific
 # is enabled or disabled.
 
 @cli.command('autorestart')

--- a/show/main.py
+++ b/show/main.py
@@ -2806,13 +2806,25 @@ def features():
         body.append([key, status_data[key]['status']])
     click.echo(tabulate(body, header))
 
+#
+# 'container' group
+#
+@cli.group(cls=AliasedGroup, default_if_no_args=False)
+def container()
+    """Show container feature"""
+    pass
+
+@container.command('feature')
+def feature()
+    pass
+
 # show whether the auto-restart feature for containers or a specific container
 # is enabled or disabled.
 
-@cli.command('autorestart')
+@feature.command('autorestart')
 @click.option('-c', '--container-name', required=False)
 def autorestart(container-name):
-    """Show status of auto-restart features"""
+    """Show container feature autorestart"""
     config_db = ConfigDBConnector()
     config_db.connect()
     header = ['ContainerName', 'Status']

--- a/show/main.py
+++ b/show/main.py
@@ -2830,7 +2830,7 @@ def feature():
 def autorestart(container_name):
     config_db = ConfigDBConnector()
     config_db.connect()
-    header = ['ContainerName', 'Status']
+    header = ['Container Name', 'Status']
     body = []
     container_feature_table = config_db.get_table('CONTAINER_FEATURE')
     if container_name:

--- a/show/main.py
+++ b/show/main.py
@@ -2806,5 +2806,21 @@ def features():
         body.append([key, status_data[key]['status']])
     click.echo(tabulate(body, header))
 
+# show whether the auto-restart feature for each container
+# is enabled or disabled.
+
+@cli.command('autorestart')
+def features():
+    """Show status of auto-restart features"""
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    header = ['ContainerName', 'Status']
+    body = []
+    container_feature_table = config_db.get_table('CONTAINER_FEATURE')
+    for container_name in container_feature_table.keys():
+        body.append([container_name, container_feature_table[container_name]['auto_restart']])
+    click.echo(tabulate(body, header))
+
+
 if __name__ == '__main__':
     cli()

--- a/show/main.py
+++ b/show/main.py
@@ -2810,15 +2810,20 @@ def features():
 # is enabled or disabled.
 
 @cli.command('autorestart')
-def features():
+@click.option('-c', '--container-name', required=False)
+def autorestart(container-name):
     """Show status of auto-restart features"""
     config_db = ConfigDBConnector()
     config_db.connect()
     header = ['ContainerName', 'Status']
     body = []
     container_feature_table = config_db.get_table('CONTAINER_FEATURE')
-    for container_name in container_feature_table.keys():
-        body.append([container_name, container_feature_table[container_name]['auto_restart']])
+    if container-name:
+        if container_feature_table and container_feature_table.has_key(container-name):
+            body.append([container-name, container_feature_table[container-name]['auto_restart']])
+    else:
+        for name in container_feature_table.keys():
+            body.append([name, container_feature_table[name]['auto_restart']])
     click.echo(tabulate(body, header))
 
 


### PR DESCRIPTION
**- What I did**
Since we introduced the auto-restart feature for each container, we need add a show subcommand to display the current status of auto-restart feature for all containers or a specific container.

**- How I did it**
We define a function named autorestart to show the status of this features. This function will accept an option parameter which is the container name. If this parameter is not specified, this function will by default show the status of all containers. Otherwise it will show the status of specific container.

**- How to verify it**
We can run the command **show container feature autorestart** or **show container feature autorestart container_name** to verify.

