### PR TITLE
[config] Add subcommand to configure the status of auto-restart feature for each container

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2468,5 +2468,41 @@ def feature_status(name, state):
 
     config_db.mod_entry('FEATURE', name, {'status': state})
 
+#
+# 'container' group ('config container ...')
+#
+@config.group(name='container', invoke_with_command=False)
+def container():
+    """Config container"""
+    pass
+
+#
+# 'feature' group ('config container feature ...')
+#
+@container.group(name='feature', invoke_with_command=False)
+def feature():
+    """Config container feature"""
+    pass
+
+#
+# 'autorestart' subcommand ('config container feature autorestart ...')
+#
+@feature.command(name='autorestart', short_help="Configure the status of autorestart feature for specific container")
+@click.argument('container_name', metavar='<container_name>', required=True)
+@click.argument('autorestart_status', metavar='<autorestart_status>', required=True, type=click.Choice(["enabled", "disabled"]))
+def autorestart(container_name, autorestart_status):
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    container_feature_table = config_db.get_table('CONTAINER_FEATURE')
+    if not container_feature_table:
+        click.echo("Unable to retrieve container feature table from Config DB.")
+        return
+
+    if not container_feature_table.has_key(container_name):
+        click.echo("Unable to retrieve features for container '{}'".format(container_name))
+        return
+
+    config_db.mod_entry('CONTAINER_FEATURE', container_name, {'auto_restart': autorestart_status})
+
 if __name__ == '__main__':
     config()

--- a/config/main.py
+++ b/config/main.py
@@ -2471,7 +2471,7 @@ def feature_status(name, state):
 #
 # 'container' group ('config container ...')
 #
-@config.group(name='container', invoke_with_command=False)
+@config.group(name='container', invoke_without_command=False)
 def container():
     """Modify configuration of containers"""
     pass
@@ -2479,7 +2479,7 @@ def container():
 #
 # 'feature' group ('config container feature ...')
 #
-@container.group(name='feature', invoke_with_command=False)
+@container.group(name='feature', invoke_without_command=False)
 def feature():
     """Modify configuration of container features"""
     pass

--- a/config/main.py
+++ b/config/main.py
@@ -2473,7 +2473,7 @@ def feature_status(name, state):
 #
 @config.group(name='container', invoke_with_command=False)
 def container():
-    """Config container"""
+    """Modify configuration of containers"""
     pass
 
 #
@@ -2481,7 +2481,7 @@ def container():
 #
 @container.group(name='feature', invoke_with_command=False)
 def feature():
-    """Config container feature"""
+    """Modify configuration of container features"""
     pass
 
 #


### PR DESCRIPTION
- What I did
Since we introduced the auto-restart feature for each container, we need add a config subcommand to change the current status (enabled/disabled) of auto-restart feature for a specific container.

- How I did it
We define a function named autorestart to change the status of a container. This function will accept two parameters which are the container name and new status. If one of parameters is not specified, this function will show the information and then exit.

- How to verify it
We can run the command **config container feature autorestart container_name autorestart_status**.