### PR TITLE
[config/main.py] Modify reload() function to load configuration from init_cfg.json implicitly

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -546,7 +546,7 @@ def reload(filename, yes, load_sysinfo):
         command = "{} -H -k {} --write-to-db".format(SONIC_CFGGEN_PATH, cfg_hwsku)
         run_command(command, display_cmd=True)
 
-    if os.path.isfile('/etc/sonic/init_cfg.json'):
+    if os.path.isfile(INIT_CFG_FILE):
         command = "{} -j {} -j {} --write-to-db".format(SONIC_CFGGEN_PATH, INIT_CFG_FILE, filename)
     else:
         command = "{} -j {} --write-to-db".format(SONIC_CFGGEN_PATH, filename)

--- a/config/main.py
+++ b/config/main.py
@@ -522,7 +522,7 @@ def load(filename, yes):
 def reload(filename, yes, load_sysinfo):
     """Clear current configuration and import a previous saved config DB dump file."""
     if not yes:
-        click.confirm('Clear current config and reload config from the file?' % filename, abort=True)
+        click.confirm('Clear current config and reload config from the file %s?' % filename, abort=True)
 
     log_info("'reload' executing...")
 

--- a/config/main.py
+++ b/config/main.py
@@ -511,7 +511,7 @@ def save(filename):
 def load(filename, yes):
     """Import a previous saved config DB dump file."""
     if not yes:
-        click.confirm('Load config from the files %s' % filename, abort=True)
+        click.confirm('Load config from the file %s?' % filename, abort=True)
     command = "{} -j {} --write-to-db".format(SONIC_CFGGEN_PATH, filename)
     run_command(command, display_cmd=True)
 

--- a/config/main.py
+++ b/config/main.py
@@ -547,7 +547,7 @@ def reload(filename, yes, load_sysinfo):
         run_command(command, display_cmd=True)
 
     if os.path.isfile('/etc/sonic/init_cfg.json'):
-        command = "{} -j {} -j {} --write-to-db".format(SONIC_CFGGEN_PATH, filename, INIT_CFG_FILE)
+        command = "{} -j {} -j {} --write-to-db".format(SONIC_CFGGEN_PATH, INIT_CFG_FILE, filename)
     else:
         command = "{} -j {} --write-to-db".format(SONIC_CFGGEN_PATH, filename)
 

--- a/config/main.py
+++ b/config/main.py
@@ -506,21 +506,23 @@ def save(filename):
 @config.command()
 @click.option('-y', '--yes', is_flag=True)
 @click.argument('filename', default='/etc/sonic/config_db.json', type=click.Path(exists=True))
-def load(filename, yes):
-    """Import a previous saved config DB dump file."""
+@click.argument('init_cfg_file', default='/etc/sonic/init_cfg.json', type=click.Path(exists=True))
+def load(filename, init_cfg_file, yes):
+    """Import previous saved config DB dump file and init_cfg.json."""
     if not yes:
-        click.confirm('Load config from the file %s?' % filename, abort=True)
-    command = "{} -j {} --write-to-db".format(SONIC_CFGGEN_PATH, filename)
+        click.confirm('Load config from the files %s and %s?' % (filename, init_cfg_file), abort=True)
+    command = "{} -j {} -j {} --write-to-db".format(SONIC_CFGGEN_PATH, filename, init_cfg_file)
     run_command(command, display_cmd=True)
 
 @config.command()
 @click.option('-y', '--yes', is_flag=True)
 @click.option('-l', '--load-sysinfo', is_flag=True, help='load system default information (mac, portmap etc) first.')
 @click.argument('filename', default='/etc/sonic/config_db.json', type=click.Path(exists=True))
-def reload(filename, yes, load_sysinfo):
-    """Clear current configuration and import a previous saved config DB dump file."""
+@click.argument('init_cfg_file', default='/etc/sonic/init_cfg.json', type=click.Path(exists=True))
+def reload(filename, init_cfg_file, yes, load_sysinfo):
+    """Clear current configuration and import previous saved config DB dump file and init_cfg.json."""
     if not yes:
-        click.confirm('Clear current config and reload config from the file %s?' % filename, abort=True)
+        click.confirm('Clear current config and reload config from the files %s and %s?' % (filename, init_cfg_file), abort=True)
 
     log_info("'reload' executing...")
 
@@ -544,7 +546,7 @@ def reload(filename, yes, load_sysinfo):
         command = "{} -H -k {} --write-to-db".format(SONIC_CFGGEN_PATH, cfg_hwsku)
         run_command(command, display_cmd=True)
 
-    command = "{} -j {} --write-to-db".format(SONIC_CFGGEN_PATH, filename)
+    command = "{} -j {} -j {} --write-to-db".format(SONIC_CFGGEN_PATH, filename, init_cfg_file)
     run_command(command, display_cmd=True)
     client.set(config_db.INIT_INDICATOR, 1)
 

--- a/config/main.py
+++ b/config/main.py
@@ -520,9 +520,9 @@ def load(filename, yes):
 @click.option('-l', '--load-sysinfo', is_flag=True, help='load system default information (mac, portmap etc) first.')
 @click.argument('filename', default='/etc/sonic/config_db.json', type=click.Path(exists=True))
 def reload(filename, yes, load_sysinfo):
-    """Clear current configuration and import previous saved config DB dump file and init_cfg.json."""
+    """Clear current configuration and import a previous saved config DB dump file."""
     if not yes:
-        click.confirm('Clear current config and reload config from the files %s and %s?' % (filename, init_cfg_file), abort=True)
+        click.confirm('Clear current config and reload config from the file?' % filename, abort=True)
 
     log_info("'reload' executing...")
 
@@ -548,8 +548,9 @@ def reload(filename, yes, load_sysinfo):
 
     if os.path.isfile('/etc/sonic/init_cfg.json'):
         command = "{} -j {} -j {} --write-to-db".format(SONIC_CFGGEN_PATH, filename, INIT_CFG_FILE)
+    else:
+        command = "{} -j {} --write-to-db".format(SONIC_CFGGEN_PATH, filename)
 
-    command = "{} -j {} --write-to-db".format(SONIC_CFGGEN_PATH, filename)
     run_command(command, display_cmd=True)
     client.set(config_db.INIT_INDICATOR, 1)
 


### PR DESCRIPTION
**- What I did**
I modified the function reload() such that it will load the configuration files config_db.json and init_cfg.json into Config_DB.

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

