### PR TITLE
Fix for dhcp_relay deletion on a VLAN

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1159,7 +1159,8 @@ def add_vlan_dhcp_relay_destination(ctx, vid, dhcp_relay_destination_ip):
         return
     else:
         dhcp_relay_dests.append(dhcp_relay_destination_ip)
-        db.set_entry('VLAN', vlan_name, {"dhcp_servers":dhcp_relay_dests})
+        vlan['dhcp_servers'] = dhcp_relay_dests
+        db.set_entry('VLAN', vlan_name, vlan)
         click.echo("Added DHCP relay destination address {} to {}".format(dhcp_relay_destination_ip, vlan_name))
         try:
             click.echo("Restarting DHCP relay service...")
@@ -1184,7 +1185,11 @@ def del_vlan_dhcp_relay_destination(ctx, vid, dhcp_relay_destination_ip):
     dhcp_relay_dests = vlan.get('dhcp_servers', [])
     if dhcp_relay_destination_ip in dhcp_relay_dests:
         dhcp_relay_dests.remove(dhcp_relay_destination_ip)
-        db.set_entry('VLAN', vlan_name, {"dhcp_servers":dhcp_relay_dests})
+        if len(dhcp_relay_dests) == 0:
+            del vlan['dhcp_servers']
+        else:
+            vlan['dhcp_servers'] = dhcp_relay_dests
+        db.set_entry('VLAN', vlan_name, vlan)
         click.echo("Removed DHCP relay destination address {} from {}".format(dhcp_relay_destination_ip, vlan_name))
         try:
             click.echo("Restarting DHCP relay service...")


### PR DESCRIPTION
Do below steps to recreate the issue:

1. config vlan add 700
2. config vlan member add 700 Ethernet56
3. config vlan dhcp_relay add 700 155.1.24.1
4. config vlan member del 700 Ethernet56

Error message seen while trying to remove the member from vlan:

root@sonic:/home/admin# config vlan member del 700 Ethernet56
Usage: config vlan member del [OPTIONS] <vid> <interface_name>

Error: Ethernet56 is not a member of Vlan700
root@sonic:/home/admin#
 
Config_DB:
After configuring Vlan with members (Step 2):
"VLAN": {
"Vlan700": {
"members": [
"Ethernet56"
]}}

After configuring dhcp relay on Vlan (Step 3), the vlan members are missing.
"VLAN": {
"Vlan700": {
"dhcp_servers": [
"155.1.24.1"
]}}

Fix:
Get all the entries from the VLAN and delete only the dhcp_servers if all the servers are deleted. And set the vlan entry to the remaining entries.

Signed-off-by: Akhilesh Samineni <akhilesh.samineni@broadcom.com>