### PR TITLE
[fast-reboot] Fix kernel panic related to irq after fast-reboot

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -529,6 +529,13 @@ then
   systemctl stop nps-modules-`uname -r`.service || debug "Ignore stopping nps service error $?"
 fi
 
+# Stop opennsl modules for Broadcom platform
+if [[ "$sonic_asic_type" = 'broadcom' ]];
+then
+  service_name=$(systemctl list-units --plain --no-pager --no-legend --type=service | grep opennsl | cut -f 1 -d' ')
+  systemctl stop "$service_name"
+fi
+
 # Update the reboot cause file to reflect that user issued this script
 # Upon next boot, the contents of this file will be used to determine the
 # cause of the previous reboot


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
After the change in master branch updating SAI from 3.5.3.1m-25 to 3.7.3.2, we always found kernel panic after running fast-reboot command in testing SONiC with traffic. In the up path of fast-reboot, we can find warning messages like "unhandled irq 16 error" before kernel panic, which implies that some components are not properly closed in the down path. 

This fix will unload certain kernel modules by stopping opennsl before fast-reboot, which is suggested by BRCM. 

Note that another part of the fix is to add 'ExecStop=-/etc/init.d/opennsl-modules stop' to sonic-buildimage:platform/broadcom/saibcm-modules/systemd/opennsl-modules.service, which will be included in another pull request.

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

