### PR TITLE
[fwutil]: Use overlay driver when mounting next image filesystem

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -3946,7 +3946,7 @@ Supported options:
 2. -f|--force - install FW regardless the current version
 3. -i|--image - update FW using current/next SONiC image
 
-Note: the default option is --image=current
+Note: the default option is --image=current (current/next values are taken from `sonic_installer list`)
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#platform-component-firmware)
 

--- a/fwutil/lib.py
+++ b/fwutil/lib.py
@@ -191,49 +191,76 @@ class SquashFs(object):
     OS_PREFIX = "SONiC-OS-"
 
     FS_PATH_TEMPLATE = "/host/image-{}/fs.squashfs"
+    FS_RW_TEMPLATE = "/host/image-{}/rw"
+    FS_WORK_TEMPLATE = "/host/image-{}/work"
     FS_MOUNTPOINT_TEMPLATE = "/tmp/image-{}-fs"
 
+    OVERLAY_MOUNTPOINT_TEMPLATE = "/tmp/image-{}-overlay"
+
     def __init__(self):
-        current_image = self.__get_current_image()
-        next_image = self.__get_next_image()
-
-        if current_image == next_image:
-            raise RuntimeError("Next boot image is not set")
-
-        image_stem = next_image.lstrip(self.OS_PREFIX)
+        image_stem = self.next_image.lstrip(self.OS_PREFIX)
 
         self.fs_path = self.FS_PATH_TEMPLATE.format(image_stem)
+        self.fs_rw = self.FS_RW_TEMPLATE.format(image_stem)
+        self.fs_work = self.FS_WORK_TEMPLATE.format(image_stem)
         self.fs_mountpoint = self.FS_MOUNTPOINT_TEMPLATE.format(image_stem)
 
-    def __get_current_image(self):
+        self.overlay_mountpoint = self.OVERLAY_MOUNTPOINT_TEMPLATE.format(image_stem)
+
+    def get_current_image(self):
         cmd = "sonic_installer list | grep 'Current: ' | cut -f2 -d' '"
         output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
 
         return output.rstrip(NEWLINE)
 
-    def __get_next_image(self):
+    def get_next_image(self):
         cmd = "sonic_installer list | grep 'Next: ' | cut -f2 -d' '"
         output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
 
         return output.rstrip(NEWLINE)
 
+    def is_next_boot_set(self):
+        return self.current_image != self.next_image
+
     def mount_next_image_fs(self):
-        if os.path.ismount(self.fs_mountpoint):
+        if os.path.ismount(self.fs_mountpoint) or os.path.ismount(self.overlay_mountpoint):
             self.umount_next_image_fs()
 
         os.mkdir(self.fs_mountpoint)
-        cmd = "mount -t squashfs {} {}".format(self.fs_path, self.fs_mountpoint)
+        cmd = "mount -t squashfs {} {}".format(
+            self.fs_path,
+            self.fs_mountpoint
+        )
         subprocess.check_call(cmd, shell=True)
 
-        return self.fs_mountpoint
+        os.mkdir(self.overlay_mountpoint)
+        cmd = "mount -n -r -t overlay -o lowerdir={},upperdir={},workdir={} overlay {}".format(
+            self.fs_mountpoint,
+            self.fs_rw,
+            self.fs_work,
+            self.overlay_mountpoint
+        )
+        subprocess.check_call(cmd, shell=True)
+
+        return self.overlay_mountpoint
 
     def umount_next_image_fs(self):
+        if os.path.ismount(self.overlay_mountpoint):
+            cmd = "umount -rf {}".format(self.overlay_mountpoint)
+            subprocess.check_call(cmd, shell=True)
+
+        if os.path.exists(self.overlay_mountpoint):
+            os.rmdir(self.overlay_mountpoint)
+
         if os.path.ismount(self.fs_mountpoint):
             cmd = "umount -rf {}".format(self.fs_mountpoint)
             subprocess.check_call(cmd, shell=True)
 
         if os.path.exists(self.fs_mountpoint):
             os.rmdir(self.fs_mountpoint)
+
+    current_image = property(fget=get_current_image)
+    next_image = property(fget=get_next_image)
 
 
 class PlatformComponentsParser(object):

--- a/fwutil/log.py
+++ b/fwutil/log.py
@@ -124,3 +124,6 @@ class LogHelper(object):
 
     def print_error(self, msg):
         click.echo("Error: {}.".format(msg))
+
+    def print_warning(self, msg):
+        click.echo("Warning: {}.".format(msg))

--- a/fwutil/main.py
+++ b/fwutil/main.py
@@ -227,14 +227,16 @@ def update(ctx, yes, force, image):
         squashfs = None
 
         try:
-            cup = None
+            cup = ComponentUpdateProvider()
 
             if image == IMAGE_NEXT:
                 squashfs = SquashFs()
-                fs_path = squashfs.mount_next_image_fs()
-                cup = ComponentUpdateProvider(fs_path)
-            else:
-                cup = ComponentUpdateProvider()
+
+                if squashfs.is_next_boot_set():
+                    fs_path = squashfs.mount_next_image_fs()
+                    cup = ComponentUpdateProvider(fs_path)
+                else:
+                    log_helper.print_warning("Next boot is set to current: fallback to defaults")
 
             click.echo(cup.get_status(force))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

This PR contains some improvements which are intended to fix a several corner cases when FW binaries and `platform_components.json` configuration file were not provided by user during SONiC image build.

In this case it is impossible to manually made any changes in configuration files or update binaries: `fwutil` will always use the original versions which exist in squashed filesystem.

**- What I did**
* Updated the way `fwutil` mounts next image filesystem: squashfs -> overlay
* Updated command line reference: current/next image update notes

**- How I did it**
* N/A

**- How to verify it**
1. Update FW binaries and `platform_components.json`
2. Update platform FW using next image:
```bash
fwutil update --image=next
```

**- Previous command output (if the output of a command-line utility has changed)**
* N/A

**- New command output (if the output of a command-line utility has changed)**
* N/A

