### PR TITLE
Fix for adding L3 interface to Vlan group

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -975,6 +975,7 @@ def add_vlan_member(ctx, vid, interface_name, untagged):
     db = ctx.obj['db']
     vlan_name = 'Vlan{}'.format(vid)
     vlan = db.get_entry('VLAN', vlan_name)
+    interface_table = db.get_table('INTERFACE')
 
     if get_interface_naming_mode() == "alias":
         interface_name = interface_alias_to_name(interface_name)
@@ -994,6 +995,10 @@ def add_vlan_member(ctx, vid, interface_name, untagged):
         else:
             ctx.fail("{} is already a member of {}".format(interface_name,
                                                         vlan_name))
+    for entry in interface_table:
+        if (interface_name == entry[0]):
+            ctx.fail("{} is a L3 interface!".format(interface_name))
+            
     members.append(interface_name)
     vlan['members'] = members
     db.set_entry('VLAN', vlan_name, vlan)


### PR DESCRIPTION
**- What I did**
Add validity check for the interface.
If the interface is L3 (has an IP) than it is impossible to add it to a vlan group.

**- How I did it**
Check if the interface is L3, if yes, do not add it to the vlan group and print a proper msg.

**- How to verify it**
Try to add a L3 interface to a vlan group.

**- Previous command output (if the output of a command-line utility has changed)**
No output.

**- New command output (if the output of a command-line utility has changed)**
Ethernet# is a L3 interface!
