### PR TITLE
[fwutil]: Fix component table layout

### DIFF
--- a/fwutil/lib.py
+++ b/fwutil/lib.py
@@ -525,6 +525,7 @@ class ComponentUpdateProvider(PlatformDataProvider):
 
         append_chassis_name = self.is_chassis_has_components()
         append_module_na = not self.is_modular_chassis()
+        module_name = NA
 
         for chassis_name, chassis_component_map in self.chassis_component_map.items():
             for chassis_component_name, chassis_component in chassis_component_map.items():
@@ -537,17 +538,6 @@ class ComponentUpdateProvider(PlatformDataProvider):
 
                 status = self.FW_STATUS_UP_TO_DATE
                 info = NA
-
-                if append_chassis_name:
-                    append_chassis_name = False
-                else:
-                    chassis_name = EMPTY
-
-                if append_module_na:
-                    module_name = NA
-                    append_module_na = False
-                else:
-                    module_name = EMPTY
 
                 if component:
                     firmware_path = component[self.__pcp.FIRMWARE_KEY]
@@ -563,8 +553,8 @@ class ComponentUpdateProvider(PlatformDataProvider):
 
                 status_table.append(
                     [
-                        chassis_name,
-                        module_name,
+                        chassis_name if append_chassis_name else EMPTY,
+                        module_name if append_module_na else EMPTY,
                         chassis_component_name,
                         firmware_path,
                         firmware_version,
@@ -573,11 +563,19 @@ class ComponentUpdateProvider(PlatformDataProvider):
                     ]
                 )
 
+                if append_chassis_name:
+                    append_chassis_name = False
+
+                if append_module_na:
+                    append_module_na = False
+
         append_chassis_name = not self.is_chassis_has_components()
+        chassis_name = self.chassis.get_name()
 
         if self.is_modular_chassis():
             for module_name, module_component_map in self.module_component_map.items():
                 append_module_name = True
+
                 for module_component_name, module_component in module_component_map.items():
                     component = self.__pcp.module_component_map[module_name][module_component_name]
 
@@ -588,17 +586,6 @@ class ComponentUpdateProvider(PlatformDataProvider):
 
                     status = self.FW_STATUS_UP_TO_DATE
                     info = NA
-
-                    if append_chassis_name:
-                        chassis_name = self.chassis.get_name()
-                        append_chassis_name = False
-                    else:
-                        chassis_name = EMPTY
-
-                    if append_module_name:
-                        append_module_name = False
-                    else:
-                        module_name = EMPTY
 
                     if component:
                         firmware_path = component[self.__pcp.FIRMWARE_KEY]
@@ -614,8 +601,8 @@ class ComponentUpdateProvider(PlatformDataProvider):
 
                     status_table.append(
                         [
-                            chassis_name,
-                            module_name,
+                            chassis_name if append_chassis_name else EMPTY,
+                            module_name if append_module_name else EMPTY,
                             module_component_name,
                             firmware_path,
                             firmware_version,
@@ -624,6 +611,12 @@ class ComponentUpdateProvider(PlatformDataProvider):
                         ]
                     )
 
+                    if append_chassis_name:
+                        append_chassis_name = False
+
+                    if append_module_name:
+                        append_module_name = False
+
         return tabulate(status_table, self.STATUS_HEADER, tablefmt=self.FORMAT)
 
     def update_firmware(self, force):
@@ -631,6 +624,7 @@ class ComponentUpdateProvider(PlatformDataProvider):
 
         append_chassis_name = self.is_chassis_has_components()
         append_module_na = not self.is_modular_chassis()
+        module_name = NA
 
         for chassis_name, chassis_component_map in self.chassis_component_map.items():
             for chassis_component_name, chassis_component in chassis_component_map.items():
@@ -644,17 +638,6 @@ class ComponentUpdateProvider(PlatformDataProvider):
                 firmware_version_available = NA
 
                 status = self.FW_STATUS_UP_TO_DATE
-
-                if append_chassis_name:
-                    append_chassis_name = False
-                else:
-                    chassis_name = EMPTY
-
-                if append_module_na:
-                    module_name = NA
-                    append_module_na = False
-                else:
-                    module_name = EMPTY
 
                 if component:
                     firmware_path = component[self.__pcp.FIRMWARE_KEY]
@@ -685,14 +668,21 @@ class ComponentUpdateProvider(PlatformDataProvider):
 
                 status_table.append(
                     [
-                        chassis_name,
-                        module_name,
+                        chassis_name if append_chassis_name else EMPTY,
+                        module_name if append_module_na else EMPTY,
                         chassis_component_name,
                         status,
                     ]
                 )
 
+                if append_chassis_name:
+                    append_chassis_name = False
+
+                if append_module_na:
+                    append_module_na = False
+
         append_chassis_name = not self.is_chassis_has_components()
+        chassis_name = self.chassis.get_name()
 
         if self.is_modular_chassis():
             for module_name, module_component_map in self.module_component_map.items():
@@ -710,17 +700,6 @@ class ComponentUpdateProvider(PlatformDataProvider):
                     firmware_version_available = NA
 
                     status = self.FW_STATUS_UP_TO_DATE
-
-                    if append_chassis_name:
-                        chassis_name = self.chassis.get_name()
-                        append_chassis_name = False
-                    else:
-                        chassis_name = EMPTY
-
-                    if append_module_name:
-                        append_module_name = False
-                    else:
-                        module_name = EMPTY
 
                     if component:
                         firmware_path = component[self.__pcp.FIRMWARE_KEY]
@@ -751,12 +730,18 @@ class ComponentUpdateProvider(PlatformDataProvider):
 
                     status_table.append(
                         [
-                            chassis_name,
-                            module_name,
+                            chassis_name if append_chassis_name else EMPTY,
+                            module_name if append_module_name else EMPTY,
                             module_component_name,
                             status,
                         ]
                     )
+
+                    if append_chassis_name:
+                        append_chassis_name = False
+
+                    if append_module_name:
+                        append_module_name = False
 
         return tabulate(status_table, self.RESULT_HEADER, tablefmt=self.FORMAT)
 
@@ -776,34 +761,31 @@ class ComponentStatusProvider(PlatformDataProvider):
 
         append_chassis_name = self.is_chassis_has_components()
         append_module_na = not self.is_modular_chassis()
+        module_name = NA
 
         for chassis_name, chassis_component_map in self.chassis_component_map.items():
             for chassis_component_name, chassis_component in chassis_component_map.items():
                 firmware_version = chassis_component.get_firmware_version()
                 description = chassis_component.get_description()
 
-                if append_chassis_name:
-                    append_chassis_name = False
-                else:
-                    chassis_name = EMPTY
-
-                if append_module_na:
-                    module_name = NA
-                    append_module_na = False
-                else:
-                    module_name = EMPTY
-
                 status_table.append(
                     [
-                        chassis_name,
-                        module_name,
+                        chassis_name if append_chassis_name else EMPTY,
+                        module_name if append_module_na else EMPTY,
                         chassis_component_name,
                         firmware_version,
                         description
                     ]
                 )
 
+                if append_chassis_name:
+                    append_chassis_name = False
+
+                if append_module_na:
+                    append_module_na = False
+
         append_chassis_name = not self.is_chassis_has_components()
+        chassis_name = self.chassis.get_name()
 
         if self.is_modular_chassis():
             for module_name, module_component_map in self.module_component_map.items():
@@ -813,25 +795,20 @@ class ComponentStatusProvider(PlatformDataProvider):
                     firmware_version = module_component.get_firmware_version()
                     description = module_component.get_description()
 
-                    if append_chassis_name:
-                        chassis_name = self.chassis.get_name()
-                        append_chassis_name = False
-                    else:
-                        chassis_name = EMPTY
-
-                    if append_module_name:
-                        append_module_name = False
-                    else:
-                        module_name = EMPTY
-
                     status_table.append(
                         [
-                            chassis_name,
-                            module_name,
+                            chassis_name if append_chassis_name else EMPTY,
+                            module_name if append_module_name else EMPTY,
                             module_component_name,
                             firmware_version,
                             description
                         ]
                     )
+
+                    if append_chassis_name:
+                        append_chassis_name = False
+
+                    if append_module_name:
+                        append_module_name = False
 
         return tabulate(status_table, self.HEADER, tablefmt=self.FORMAT)


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->
This PR contains a fix for component table layout
in case chassis/module has more than one component

**- What I did**
* Fixed component table layout

**- How I did it**
* N/A

**- How to verify it**
1. Show platform component status
```bash
show platform firmware
```
2. Run platform component automatic update
```bash
config platform firmware update
```

**- Previous command output (if the output of a command-line utility has changed)**
```bash
root@sonic:/home/admin# fwutil update
Error: ''. Aborting...
Aborted!
```

**- New command output (if the output of a command-line utility has changed)**
```bash
root@sonic:/home/admin# fwutil show status
Chassis                 Module    Component    Version                  Description
----------------------  --------  -----------  -----------------------  ----------------------------------------
x86_64-mlnx_msn3800-r0  N/A       BIOS         0ACLH004_02.02.007_9600  BIOS - Basic Input/Output System
                                  CPLD1        CPLD000000_REV0500       CPLD - Complex Programmable Logic Device
                                  CPLD2        CPLD000000_REV0300       CPLD - Complex Programmable Logic Device
                                  CPLD3        CPLD000000_REV0300       CPLD - Complex Programmable Logic Device
                                  CPLD4        CPLD000000_REV0100       CPLD - Complex Programmable Logic Device
```