### PR TITLE
[decode-syseeprom] fix getattribute check for some platforms

### DIFF
--- a/scripts/decode-syseeprom
+++ b/scripts/decode-syseeprom
@@ -55,7 +55,7 @@ def main():
     # Currently, don't support eeprom db on Arista platform
     platforms_without_eeprom_db = ['arista', 'kvm']
     if any(platform in platform_path for platform in platforms_without_eeprom_db)\
-            or t.getattr('read_eeprom_db', None) == None:
+            or getattr(t, 'read_eeprom_db', None) == None:
         support_eeprom_db = False
 
     #


### PR DESCRIPTION
Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->
Fixes: #828 
**- What I did**
For some platforms which implement the eeprom plugin by inheriting from TlvInfoDecoder, the line
`t.getattr('read_eeprom_db', None) == None:`
results in an error:
`AttributeError: 'board' object has no attribute 'getattr'`

The cause for that is that TlvInfoDecoder inherits from `object`, and looks like for object and derived classes there is no `__getattr__`.
**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**
```
sudo decode-syseeprom
Traceback (most recent call last):
  File "/usr/bin/decode-syseeprom", line 175, in <module>
    exit(main())
  File "/usr/bin/decode-syseeprom", line 58, in main
    or t.getattr('read_eeprom_db', None) == None:
AttributeError: 'board' object has no attribute 'getattr'
```
**- New command output (if the output of a command-line utility has changed)**
```
sudo decode-syseeprom
TlvInfo Header:
   Id String:    TlvInfo
   Version:      1
   Total Length: 573
TLV Name             Code Len Value
-------------------- ---- --- -----
```
