### PR TITLE
Fixes bug for PFCWD feature parameters

### DIFF
--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -204,12 +204,12 @@ def interval(poll_interval):
             restoration_time_entry_value = int(configdb.get_entry(CONFIG_DB_PFC_WD_TABLE_NAME, entry).get('restoration_time'))
             if ((detection_time_entry_value != None) and (detection_time_entry_value < entry_min)):
                 entry_min = detection_time_entry_value
-                entry_min_str = "detection_time"
+                entry_min_str = "detection time"
             if ((restoration_time_entry_value != None) and (restoration_time_entry_value < entry_min)):
                 entry_min = restoration_time_entry_value
-                entry_min_str = "restoration_time"
+                entry_min_str = "restoration time"
         if entry_min < poll_interval:
-            print >> sys.stderr, "unable to use polling_interval = {}ms, value is bigger than one of the configured {} values, please choose a smaller polling_interval".format(poll_interval,entry_min_str)
+            print >> sys.stderr, "unable to use polling interval = {}ms, value is bigger than one of the configured {} values, please choose a smaller polling_interval".format(poll_interval,entry_min_str)
             exit(1)
         
         pfcwd_info['POLL_INTERVAL'] = poll_interval

--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -3,6 +3,7 @@
 import click
 import swsssdk
 import os
+import sys
 from tabulate import tabulate
 from natsort import natsorted
 
@@ -203,19 +204,14 @@ def interval(poll_interval):
             restoration_time_entry_value = int(configdb.get_entry(CONFIG_DB_PFC_WD_TABLE_NAME, entry).get('restoration_time'))
             if ((detection_time_entry_value != None) and (detection_time_entry_value < entry_min)):
                 entry_min = detection_time_entry_value
-                res_str = "detection_time"
             if ((restoration_time_entry_value != None) and (restoration_time_entry_value < entry_min)):
                 entry_min = restoration_time_entry_value
-                res_str = "restoration_time"
-        if entry_min < poll_interval:
-            poll_interval = entry_min - 1
-            print "polling_interval is greater than {}, using polling_interval = {}ms".format(res_str,poll_interval)
+        if entry_min <= poll_interval:
+            print >> sys.stderr, "unable to use polling_interval = {}ms, value is bigger or equal to the minimum in PFCWD table".format(poll_interval)
+            exit(1)
         
         pfcwd_info['POLL_INTERVAL'] = poll_interval
-        if(poll_interval < 100):
-            print "unable to use polling_interval = {}ms, value is less than 100".format(poll_interval)
-        else:
-            configdb.mod_entry(CONFIG_DB_PFC_WD_TABLE_NAME, "GLOBAL", pfcwd_info)
+        configdb.mod_entry(CONFIG_DB_PFC_WD_TABLE_NAME, "GLOBAL", pfcwd_info)
 
 # Stop WD
 @cli.command()

--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -204,10 +204,12 @@ def interval(poll_interval):
             restoration_time_entry_value = int(configdb.get_entry(CONFIG_DB_PFC_WD_TABLE_NAME, entry).get('restoration_time'))
             if ((detection_time_entry_value != None) and (detection_time_entry_value < entry_min)):
                 entry_min = detection_time_entry_value
+                entry_min_str = "detection_time"
             if ((restoration_time_entry_value != None) and (restoration_time_entry_value < entry_min)):
                 entry_min = restoration_time_entry_value
-        if entry_min <= poll_interval:
-            print >> sys.stderr, "unable to use polling_interval = {}ms, value is bigger or equal to the minimum in PFCWD table".format(poll_interval)
+                entry_min_str = "restoration_time"
+        if entry_min < poll_interval:
+            print >> sys.stderr, "unable to use polling_interval = {}ms, value is bigger than one of the configured {} values, please choose a smaller polling_interval".format(poll_interval,entry_min_str)
             exit(1)
         
         pfcwd_info['POLL_INTERVAL'] = poll_interval

--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -3,7 +3,6 @@
 import click
 import swsssdk
 import os
-import random
 from tabulate import tabulate
 from natsort import natsorted
 
@@ -213,7 +212,10 @@ def interval(poll_interval):
             print "polling_interval is greater than {}, using polling_interval = {}ms".format(res_str,poll_interval)
         
         pfcwd_info['POLL_INTERVAL'] = poll_interval
-    configdb.mod_entry(CONFIG_DB_PFC_WD_TABLE_NAME, "GLOBAL", pfcwd_info)
+        if(poll_interval < 100):
+            print "unable to use polling_interval = {}ms, value is less than 100".format(poll_interval)
+        else:
+            configdb.mod_entry(CONFIG_DB_PFC_WD_TABLE_NAME, "GLOBAL", pfcwd_info)
 
 # Stop WD
 @cli.command()

--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -202,14 +202,14 @@ def interval(poll_interval):
                 continue
             detection_time_entry_value = int(configdb.get_entry(CONFIG_DB_PFC_WD_TABLE_NAME, entry).get('detection_time'))
             restoration_time_entry_value = int(configdb.get_entry(CONFIG_DB_PFC_WD_TABLE_NAME, entry).get('restoration_time'))
-            if ((detection_time_entry_value != None) and (detection_time_entry_value < min)):
+            if ((detection_time_entry_value != None) and (detection_time_entry_value < entry_min)):
                 entry_min = detection_time_entry_value
                 res_str = "detection_time"
-            if ((restoration_time_entry_value != None) and (restoration_time_entry_value < min)):
+            if ((restoration_time_entry_value != None) and (restoration_time_entry_value < entry_min)):
                 entry_min = restoration_time_entry_value
                 res_str = "restoration_time"
         if entry_min < poll_interval:
-            poll_interval = random.randint(1,entry_min-1)
+            poll_interval = entry_min - 1
             print "polling_interval is greater than {}, using polling_interval = {}ms".format(res_str,poll_interval)
         
         pfcwd_info['POLL_INTERVAL'] = poll_interval

--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -3,6 +3,7 @@
 import click
 import swsssdk
 import os
+import random
 from tabulate import tabulate
 from natsort import natsorted
 
@@ -194,8 +195,24 @@ def interval(poll_interval):
     configdb.connect()
     pfcwd_info = {}
     if poll_interval is not None:
+        pfcwd_table = configdb.get_table(CONFIG_DB_PFC_WD_TABLE_NAME)
+        entry_min = 3000
+        for entry in pfcwd_table:
+            if("Ethernet" not in entry):
+                continue
+            detection_time_entry_value = int(configdb.get_entry(CONFIG_DB_PFC_WD_TABLE_NAME, entry).get('detection_time'))
+            restoration_time_entry_value = int(configdb.get_entry(CONFIG_DB_PFC_WD_TABLE_NAME, entry).get('restoration_time'))
+            if ((detection_time_entry_value != None) and (detection_time_entry_value < min)):
+                entry_min = detection_time_entry_value
+                res_str = "detection_time"
+            if ((restoration_time_entry_value != None) and (restoration_time_entry_value < min)):
+                entry_min = restoration_time_entry_value
+                res_str = "restoration_time"
+        if entry_min < poll_interval:
+            poll_interval = random.randint(1,entry_min-1)
+            print "polling_interval is greater than {}, using polling_interval = {}ms".format(res_str,poll_interval)
+        
         pfcwd_info['POLL_INTERVAL'] = poll_interval
-
     configdb.mod_entry(CONFIG_DB_PFC_WD_TABLE_NAME, "GLOBAL", pfcwd_info)
 
 # Stop WD


### PR DESCRIPTION
- What I did
The feature allows setting 'detection_time', 'restoration_time' and 'pollling_interval' PFCWD to an interface. The 'pollling_interval' must be lower than 'detection_time' and 'restoration_time'.
The fix is checking if there is a lower value of 'detection_time' or 'restoration_time' than the 'pollling_interval' value entered by the user in config DB, if yes exit with error code 1.

- How I did it
Checking the config DB for interfaces PFCWD values.

- How to verify it
Try adding 'pollling_interval' greater than one of the values of PFCWD interfaces.

- Previous command output (if the output of a command-line utility has changed)
No Output.

- New command output (if the output of a command-line utility has changed)
unable to use polling_interval = #ms, value is bigger or equal to the minimum in PFCWD table