### PR TITLE
[201811][intfutil] set speed to 0 when interface speed is not available

### DIFF
--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -233,7 +233,7 @@ def po_speed_dict(po_int_dict, appl_db):
             elif len(value) > 1:
                 for intf in value:
                     temp_speed = appl_db.get(appl_db.APPL_DB, "PORT_TABLE:" + intf, "speed")
-                    temp_speed = int(temp_speed)
+                    temp_speed = int(temp_speed) if temp_speed else 0
                     agg_speed_list.append(temp_speed)
                     interface_speed = sum(agg_speed_list)
                     interface_speed = str(interface_speed)


### PR DESCRIPTION
**- What I did**

This is not an issue with normal and correct configuration. The
issue was exposed when there is an incorrect configuration, e.g.
contain wrong port names. These wrong port names will still get
populated to the app_db but will not have speed associated.

Lack of speed entry will cause "show interface status" to throw
exception.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- How to verify it**
Without change, when speed is not available:
admin@str-dcfx-t1-2-03:~$ show interfaces status
Traceback (most recent call last):
File "/usr/bin/intfutil", line 424, in
main(sys.argv[1:])
File "/usr/bin/intfutil", line 417, in main
interface_stat = IntfStatus(intf_name)
File "/usr/bin/intfutil", line 345, in init
self.portchannel_speed_dict = po_speed_dict(self.po_int_dict, self.appl_db)
File "/usr/bin/intfutil", line 236, in po_speed_dict
temp_speed = int(temp_speed)
TypeError: int() argument must be a string or a number, not 'NoneType'

With change command works fine.