### PR TITLE
[201811 warm-reboot] Fix the warm-reboot script to support FRR based warm-reboot

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -406,6 +406,7 @@ systemctl stop radv
 
 # Kill bgpd to start the bgp graceful restart procedure
 debug "Stopping bgp ..."
+docker exec -i bgp pkill -9 watchfrr || [ $? == 1 ]
 docker exec -i bgp pkill -9 zebra
 docker exec -i bgp pkill -9 bgpd || [ $? == 1 ]
 debug "Stopped  bgp ..."


### PR DESCRIPTION
Fix the warm-reboot script to support FRR based warm-reboot

In case we use FRR stack with watchfrr, the watchfrr should be killed
during the warm-reboot shutdown process. This will make sure that watchfrr
won't restart the zebra/bgpd etc to screw up the warm-reboot process.

The code support the case where watchfrr is not used like quagga.

Signed-off-by: Zhenggen Xu <zxu@linkedin.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Fix the warm-reboot script to support FRR based warm-reboot

**- How I did it**
Kill watchfrr which was used on 201811 branch

**- How to verify it**
Before the fix, syslog during shutdown:
```
Mar 11 04:54:29.996460 sonic NOTICE admin: Stopping bgp ...
Mar 11 04:54:30.211232 sonic ERR bgp#watchfrr[91]: zebra state -> down : read returned EOF
Mar 11 04:54:30.211232 sonic NOTICE bgp#watchfrr[91]: zebra state -> up : connect succeeded
Mar 11 04:54:30.211232 sonic ERR bgp#watchfrr[91]: zebra state -> down : unexpected read error: Connection reset by peer
Mar 11 04:54:30.471975 sonic ERR bgp#watchfrr[91]: bgpd state -> down : read returned EOF
Mar 11 04:54:30.546664 sonic NOTICE admin: Stopped  bgp ...
Mar 11 04:54:35.313431 sonic ERR bgp#watchfrr[91]: Forked background command [pid 123]: /usr/sbin/service frr restart all
Mar 11 04:54:35.392344 sonic NOTICE bgp#watchfrr[91]: Terminating on signal
Mar 11 04:54:36.608237 sonic NOTICE bgp#fpmsyncd: :- checkWarmStart: bgp doing warm start, restore count 1
Mar 11 04:54:36.608481 sonic NOTICE bgp#fpmsyncd: :- checkAndStart: Initializing Warm-Restart cycle for bgp application.
Mar 11 04:54:36.608565 sonic NOTICE bgp#fpmsyncd: :- setWarmStartState: bgp warm start state changed to initialized
Mar 11 04:54:36.608887 sonic NOTICE bgp#fpmsyncd: :- getWarmStartTimer: Getting warmStartTimer for docker: bgp, app: bgp, value: 100
Mar 11 04:54:36.608887 sonic NOTICE bgp#fpmsyncd: :- runRestoration: Warm-Restart: Initiating AppDB restoration process for bgp application.
Mar 11 04:54:36.610349 sonic NOTICE bgp#fpmsyncd: :- runRestoration: Warm-Restart: Received 27 records from AppDB for bgp application.
Mar 11 04:54:36.610846 sonic NOTICE bgp#fpmsyncd: :- setWarmStartState: bgp warm start state changed to restored
Mar 11 04:54:36.610846 sonic NOTICE bgp#fpmsyncd: :- runRestoration: Warm-Restart: Completed AppDB restoration process for bgp application.
Mar 11 04:54:36.757084 sonic NOTICE bgp#watchfrr[218]: watchfrr 4.0 watching [zebra bgpd]
Mar 11 04:54:37.208784 sonic NOTICE bgp#watchfrr[218]: bgpd state -> up : connect succeeded
Mar 11 04:54:37.239840 sonic NOTICE bgp#watchfrr[218]: zebra state -> up : connect succeeded
Mar 11 04:54:37.239840 sonic NOTICE bgp#watchfrr[218]: Watchfrr: Notifying Systemd we are up and running
Mar 11 04:54:38.954809 sonic INFO bgp#bgpd[209]: %ADJCHANGE: neighbor 10.2.1.0(lnos-x1-a-csw06.lab.linkedin.com) in vrf Default Up
Mar 11 04:54:38.954809 sonic INFO bgp#bgpd[209]: %ADJCHANGE: neighbor 10.1.1.0(lnos-x1-a-csw05.lab.linkedin.com) in vrf Default Up
Mar 11 04:54:38.954809 sonic INFO bgp#bgpd[209]: %ADJCHANGE: neighbor 2000:2:1::1(lnos-x1-a-csw06.lab.linkedin.com) in vrf Default Up
Mar 11 04:54:38.963533 sonic INFO bgp#bgpd[209]: %ADJCHANGE: neighbor 2000:1:1::1(lnos-x1-a-csw05.lab.linkedin.com) in vrf Default Up
```

After the fix, syslog for bgp during the shutdown:
```
Mar 12 04:50:03.989357 sonic NOTICE admin: Stopping bgp ...
Mar 12 04:50:05.080940 sonic NOTICE admin: Stopped  bgp ...

```

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

