### PR TITLE
explicitly specify command with underscores

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -641,7 +641,7 @@ def reload(filename, yes, load_sysinfo):
     log_info("'reload' restarting services...")
     _restart_services()
 
-@config.command()
+@config.command("load_mgmt_config")
 @click.option('-y', '--yes', is_flag=True, callback=_abort_if_false,
                 expose_value=False, prompt='Reload mgmt config?')
 @click.argument('filename', default='/etc/sonic/device_desc.xml', type=click.Path(exists=True))
@@ -665,7 +665,7 @@ def load_mgmt_config(filename):
     run_command(command, display_cmd=True, ignore_error=True)
     click.echo("Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`.")
 
-@config.command()
+@config.command("load_minigraph")
 @click.option('-y', '--yes', is_flag=True, callback=_abort_if_false,
                 expose_value=False, prompt='Reload config from minigraph?')
 def load_minigraph():

--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -221,7 +221,7 @@ def stop(ports):
         configdb.mod_entry(CONFIG_DB_PFC_WD_TABLE_NAME, port, None)
 
 # Set WD default configuration on server facing ports when enable flag is on
-@cli.command()
+@cli.command("start_default")
 def start_default():
     """ Start PFC WD by default configurations  """
     if os.geteuid() != 0:


### PR DESCRIPTION
Starting click 7.0. The default behavior of a command with under
scores will be replace with dashes.

this is to address the above default behavior change, so that
the command remains the same.

more details can be found:

https://github.com/pallets/click/issues/1123

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
tested for under current click and click 7.0

under buster
```
admin@vlab-01:/$ sudo config load
load              load_mgmt_config  load_minigraph    
admin@vlab-01:/$ sudo config load
```
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

