### PR TITLE
[config]Add sflow to _reset_failed_services

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -474,7 +474,8 @@ def _reset_failed_services():
         'swss',
         'syncd',
         'teamd',
-        'nat'
+        'nat',
+        'slfow'
     ]
 
     generated_services_list = _get_sonic_generated_services()

--- a/config/main.py
+++ b/config/main.py
@@ -475,7 +475,7 @@ def _reset_failed_services():
         'syncd',
         'teamd',
         'nat',
-        'slfow'
+        'sflow'
     ]
 
     generated_services_list = _get_sonic_generated_services()


### PR DESCRIPTION
**- What I did**
Add `sflow` to _reset_failed_services in order to avoid errors `Job for sflow.service failed` when executing `config reload` or `config load_minigraph`
**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

