### PR TITLE
[multi-asic]: Update reload of systemd services to support multi-asic platforms

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -97,7 +97,7 @@ def execute_systemctl(list_of_services, action):
                     click.echo("Executing {} of service {}@{}...".format(action, service, inst))
                     run_command("systemctl {} {}@{}.service".format(action, service, inst))
                 except SystemExit as e:
-                    log_error("Failed to execute {} of service {}@{} with error {}".format(action, service, e))
+                    log_error("Failed to execute {} of service {}@{} with error {}".format(action, service, inst, e))
                     raise
 
 def run_command(command, display_cmd=False, ignore_error=False):

--- a/config/main.py
+++ b/config/main.py
@@ -439,13 +439,13 @@ def _get_num_asic():
     platform = _get_platform()
     asic_conf_file = os.path.join('/usr/share/sonic/device/', platform, ASIC_CONF_FILENAME)
     if not os.path.isfile(asic_conf_file):
-        num_asic=1
+        num_asic = 1
     else:
         with open(asic_conf_file) as conf_file:
             for line in conf_file:
-                line_info=line.split('=')
+                line_info = line.split('=')
                 if line_info[0].lower() == "num_asic":
-                     num_asic=int(line_info[1])
+                     num_asic = int(line_info[1])
     return num_asic
 
 def _get_sonic_generated_services():

--- a/config/main.py
+++ b/config/main.py
@@ -445,7 +445,7 @@ def _get_num_asic():
             for line in conf_file:
                 line_info = line.split('=')
                 if line_info[0].lower() == "num_asic":
-                     num_asic = int(line_info[1])
+                    num_asic = int(line_info[1])
     return num_asic
 
 def _get_sonic_generated_services():

--- a/config/main.py
+++ b/config/main.py
@@ -456,7 +456,7 @@ def _get_sonic_generated_services():
     with open(SONIC_GENERATED_SERVICE_PATH) as generated_service_file:
         for line in generated_service_file:
             if '@' in line:
-                line=line.replace('@', '')
+                line = line.replace('@', '')
                 generated_multi_instance_services.append(line.rstrip('\n'))
             else:
                 generated_services_list.append(line.rstrip('\n'))


### PR DESCRIPTION

**- What I did**
For multi-asic platform, there can be multiple instances of some systemd services. currently config reload CLI stops and restarts only single instance of systemd service. 
Modified stop/reset failed-status and restart system services function to perform action on multiple instances of systemd services.

**- How I did it**
1. Read plaform/asic.conf file to get the number of ASICs for a platform.
2. Get the services which are multiple instances from generated_services.conf
3. For single ASIC platform, continue to stop and restart services as it is done today.
4. For multiple ASIC platform, stop and restart each instance for multi-instance service. stop and restart of single instance will be done the same way for single and multi-asic platforms.

**- How to verify it**
Bring up a single ASIC VS image.
Load config_db.json/minigraph.xml
Update config_db.json or load a new config_db.json.
Do a "config reload".
Verify that all required services are stopped and restarted.
Verify all services are up.
Verify if the configuration/interfaces of previous configuration is completely removed and new configuration is applied.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

