### PR TITLE
[config] Implement a process level lock

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -553,18 +553,17 @@ class ConfigDbLock():
             # expire call.
             if self.client.hsetnx(self.lockName, "PID", self.pid):
                 self.client.expire(self.lockName, self.timeout)
-                print(":::Lock Acquired:::")
             # if lock exists but expire timer not running, run expire time and
             # abort.
             elif not self.client.ttl(self.lockName):
                 self.client.expire(self.lockName, self.timeout)
-                print(":::Can not acquire lock, Reset Timer & Abort:::");
+                click.echo(":::Can not acquire lock, Reset Timer & Abort:::");
                 sys.exit(1)
             else:
-                print(":::Can not acquire lock, Abort:::");
+                click.echo(":::Can not acquire lock, Abort:::");
                 sys.exit(1)
         except Exception as e:
-            print(":::Exception: {}:::".format(e))
+            click.echo(":::Exception: {}:::".format(e))
             sys.exit(1)
         return
 
@@ -573,7 +572,6 @@ class ConfigDbLock():
             # Try to set lock first
             if self.client.hsetnx(self.lockName, "PID", self.pid):
                 self.client.expire(self.lockName, self.timeout)
-                print(":::Lock Reacquired:::")
             # if lock exists, check who owns it
             else:
                 p = self.client.pipeline(True)
@@ -582,18 +580,17 @@ class ConfigDbLock():
                 # if current process holding then extend the timer
                 if p.hget(self.lockName, "PID") == str(self.pid):
                     self.client.expire(self.lockName, self.timeout)
-                    print(":::Lock Timer Extended:::");
                     p.unwatch()
                     return
                 else:
                     # some other process is holding the lock.
-                    print(":::Can not acquire lock LOCK PID: {} and self.pid:{}:::".\
+                    click.echo(":::Can not acquire lock LOCK PID: {} and self.pid:{}:::".\
                         format(p.hget(self.lockName, "PID"), self.pid))
                     p.unwatch()
                     sys.exit(1)
 
         except Exception as e:
-            print(":::Exception: {}:::".format(e))
+            click.echo(":::Exception: {}:::".format(e))
             sys.exit(1)
         return
 
@@ -607,15 +604,14 @@ class ConfigDbLock():
                 p.multi()
                 p.delete(self.lockName)
                 p.execute()
-                print(":::Lock Released:::");
                 return
             else:
                 # some other process s holding the lock.
-                print(":::Lock PID: {} and self.pid:{}:::".\
+                click.echo(":::Lock PID: {} and self.pid:{}:::".\
                     format(p.hget(self.lockName, "PID"), self.pid))
             p.unwatch()
         except Exception as e:
-            print("Exception: {}".format(e))
+            click.echo("Exception: {}".format(e))
         return
 
     def __del__(self):

--- a/config/main.py
+++ b/config/main.py
@@ -622,7 +622,7 @@ class ConfigDbLock():
         return
 # end of class configdblock
 
-cdblock = ConfigDbLock()
+configdb_lock = ConfigDbLock()
 # This is our main entrypoint - the main 'config' command
 @click.group(context_settings=CONTEXT_SETTINGS)
 def config():
@@ -641,7 +641,7 @@ config.add_command(nat.nat)
 def save(filename):
     """Export current config DB to a file on disk."""
     # reacquire lock after prompt
-    cdblock.reacquireLock()
+    configdb_lock.reacquireLock()
     command = "{} -d --print-data > {}".format(SONIC_CFGGEN_PATH, filename)
     run_command(command, display_cmd=True)
 
@@ -653,7 +653,7 @@ def load(filename, yes):
     if not yes:
         click.confirm('Load config from the file %s?' % filename, abort=True)
         # reacquire lock after prompt
-        cdblock.reacquireLock()
+        configdb_lock.reacquireLock()
 
     command = "{} -j {} --write-to-db".format(SONIC_CFGGEN_PATH, filename)
     run_command(command, display_cmd=True)
@@ -667,7 +667,7 @@ def reload(filename, yes, load_sysinfo):
     if not yes:
         click.confirm('Clear current config and reload config from the file %s?' % filename, abort=True)
         # reacquire lock after prompt
-        cdblock.reacquireLock()
+        configdb_lock.reacquireLock()
 
     log_info("'reload' executing...")
 
@@ -718,7 +718,7 @@ def reload(filename, yes, load_sysinfo):
 def load_mgmt_config(filename):
     """Reconfigure hostname and mgmt interface based on device description file."""
     # reacquire lock after prompt
-    cdblock.reacquireLock()
+    configdb_lock.reacquireLock()
     command = "{} -M {} --write-to-db".format(SONIC_CFGGEN_PATH, filename)
     run_command(command, display_cmd=True)
     #FIXME: After config DB daemon for hostname and mgmt interface is implemented, we'll no longer need to do manual configuration here
@@ -744,7 +744,7 @@ def load_minigraph():
 
     """Reconfigure based on minigraph."""
     # reacquire lock after prompt
-    cdblock.reacquireLock()
+    configdb_lock.reacquireLock()
     log_info("'load_minigraph' executing...")
 
     # get the device type
@@ -2418,7 +2418,7 @@ def ztp():
 def run(run):
     """Restart ZTP of the device."""
     # reacquire lock after prompt
-    cdblock.reacquireLock()
+    configdb_lock.reacquireLock()
     command = "ztp run -y"
     run_command(command, display_cmd=True)
 
@@ -2429,7 +2429,7 @@ def run(run):
 def disable(disable):
     """Administratively Disable ZTP."""
     # reacquire lock after prompt
-    cdblock.reacquireLock()
+    configdb_lock.reacquireLock()
     command = "ztp disable -y"
     run_command(command, display_cmd=True)
 

--- a/config/main.py
+++ b/config/main.py
@@ -530,7 +530,100 @@ def is_ipaddress(val):
         return False
     return True
 
+# class for locking entire config process
+class configdblock():
+    def __init__(self):
+        self.lockName = "LOCK|configDbLock"
+        self.timeout = 10
+        self.pid = os.getpid()
+        self.client = None
 
+        self._acquireLock()
+        return
+
+    def _acquireLock(self):
+        try:
+            # connect to db
+            db_kwargs = dict()
+            configdb = ConfigDBConnector(**db_kwargs)
+            configdb.connect()
+
+            self.client = configdb.get_redis_client('CONFIG_DB')
+            # Set lock and expire time. Process may get killed b/w set lock and
+            # expire call.
+            if self.client.hsetnx(self.lockName, "PID", self.pid):
+                self.client.expire(self.lockName, self.timeout)
+                print(":::Lock Acquired:::")
+            # if lock exists but expire timer not running, run expire time and
+            # abort.
+            elif not self.client.ttl(self.lockName):
+                self.client.expire(self.lockName, self.timeout)
+                print(":::Can not acquire lock, Reset Timer & Abort:::");
+                sys.exit(1)
+            else:
+                print(":::Can not acquire lock, Abort:::");
+                sys.exit(1)
+        except Exception as e:
+            print(":::Exception: {}:::".format(e))
+            sys.exit(1)
+        return
+
+    def reacquireLock(self):
+        try:
+            # Try to set lock first
+            if self.client.hsetnx(self.lockName, "PID", self.pid):
+                self.client.expire(self.lockName, self.timeout)
+                print(":::Lock Reacquired:::")
+            # if lock exists, check who owns it
+            else:
+                p = self.client.pipeline(True)
+                # watch, we do not want to work on modified lock
+                p.watch(self.lockName)
+                # if current process holding then extend the timer
+                if p.hget(self.lockName, "PID") == str(self.pid):
+                    self.client.expire(self.lockName, self.timeout)
+                    print(":::Lock Timer Extended:::");
+                    p.unwatch()
+                    return
+                else:
+                    # some other process is holding the lock.
+                    print(":::Can not acquire lock LOCK PID: {} and self.pid:{}:::".\
+                        format(p.hget(self.lockName, "PID"), self.pid))
+                    p.unwatch()
+                    sys.exit(1)
+
+        except Exception as e:
+            print(":::Exception: {}:::".format(e))
+            sys.exit(1)
+        return
+
+    def _releaseLock(self):
+        try:
+            p = self.client.pipeline(True)
+            # watch, we do not want to work on modified lock
+            p.watch(self.lockName)
+            # if current process holding the lock then release it.
+            if p.hget(self.lockName, "PID") == str(self.pid):
+                p.multi()
+                p.delete(self.lockName)
+                p.execute()
+                print(":::Lock Released:::");
+                return
+            else:
+                # some other process s holding the lock.
+                print(":::Lock PID: {} and self.pid:{}:::".\
+                    format(p.hget(self.lockName, "PID"), self.pid))
+            p.unwatch()
+        except Exception as e:
+            print("Exception: {}".format(e))
+        return
+
+    def __del__(self):
+        self._releaseLock()
+        return
+# end of class configdblock
+
+cdblock = configdblock()
 # This is our main entrypoint - the main 'config' command
 @click.group(context_settings=CONTEXT_SETTINGS)
 def config():
@@ -548,6 +641,8 @@ config.add_command(nat.nat)
 @click.argument('filename', default='/etc/sonic/config_db.json', type=click.Path())
 def save(filename):
     """Export current config DB to a file on disk."""
+    # reacquire lock after prompt
+    cdblock.reacquireLock()
     command = "{} -d --print-data > {}".format(SONIC_CFGGEN_PATH, filename)
     run_command(command, display_cmd=True)
 
@@ -558,6 +653,9 @@ def load(filename, yes):
     """Import a previous saved config DB dump file."""
     if not yes:
         click.confirm('Load config from the file %s?' % filename, abort=True)
+        # reacquire lock after prompt
+        cdblock.reacquireLock()
+
     command = "{} -j {} --write-to-db".format(SONIC_CFGGEN_PATH, filename)
     run_command(command, display_cmd=True)
 
@@ -569,6 +667,8 @@ def reload(filename, yes, load_sysinfo):
     """Clear current configuration and import a previous saved config DB dump file."""
     if not yes:
         click.confirm('Clear current config and reload config from the file %s?' % filename, abort=True)
+        # reacquire lock after prompt
+        cdblock.reacquireLock()
 
     log_info("'reload' executing...")
 
@@ -618,6 +718,8 @@ def reload(filename, yes, load_sysinfo):
 @click.argument('filename', default='/etc/sonic/device_desc.xml', type=click.Path(exists=True))
 def load_mgmt_config(filename):
     """Reconfigure hostname and mgmt interface based on device description file."""
+    # reacquire lock after prompt
+    cdblock.reacquireLock()
     command = "{} -M {} --write-to-db".format(SONIC_CFGGEN_PATH, filename)
     run_command(command, display_cmd=True)
     #FIXME: After config DB daemon for hostname and mgmt interface is implemented, we'll no longer need to do manual configuration here
@@ -640,7 +742,10 @@ def load_mgmt_config(filename):
 @click.option('-y', '--yes', is_flag=True, callback=_abort_if_false,
                 expose_value=False, prompt='Reload config from minigraph?')
 def load_minigraph():
+
     """Reconfigure based on minigraph."""
+    # reacquire lock after prompt
+    cdblock.reacquireLock()
     log_info("'load_minigraph' executing...")
 
     # get the device type
@@ -2313,6 +2418,8 @@ def ztp():
 @click.argument('run', required=False, type=click.Choice(["run"]))
 def run(run):
     """Restart ZTP of the device."""
+    # reacquire lock after prompt
+    cdblock.reacquireLock()
     command = "ztp run -y"
     run_command(command, display_cmd=True)
 
@@ -2322,6 +2429,8 @@ def run(run):
 @click.argument('disable', required=False, type=click.Choice(["disable"]))
 def disable(disable):
     """Administratively Disable ZTP."""
+    # reacquire lock after prompt
+    cdblock.reacquireLock()
     command = "ztp disable -y"
     run_command(command, display_cmd=True)
 

--- a/config/main.py
+++ b/config/main.py
@@ -531,7 +531,7 @@ def is_ipaddress(val):
     return True
 
 # class for locking entire config process
-class configdblock():
+class ConfigDbLock():
     def __init__(self):
         self.lockName = "LOCK|configDbLock"
         self.timeout = 10
@@ -623,7 +623,7 @@ class configdblock():
         return
 # end of class configdblock
 
-cdblock = configdblock()
+cdblock = ConfigDbLock()
 # This is our main entrypoint - the main 'config' command
 @click.group(context_settings=CONTEXT_SETTINGS)
 def config():

--- a/config/main.py
+++ b/config/main.py
@@ -588,7 +588,6 @@ class ConfigDbLock():
                         format(p.hget(self.lockName, "PID"), self.pid))
                     p.unwatch()
                     sys.exit(1)
-
         except Exception as e:
             click.echo(":::Exception: {}:::".format(e))
             sys.exit(1)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Implement a config process level lock.

**- How I did it**
Changes:
1.) Implement a class, which uses hsetnx for lock.
2.) lock is expired within timeout period or will be released by owner.
3.) After -y prompt, lock is reacquired, because timer could have expired,
    before user enters yes.
Signed-off-by: Praveen Chaudhary pchaudhary@linkedin.com

#### Why lock is acquired at process level, not just when we interact with DB.
command such as port breakout interect with DB 3 times:
1.) Read Config DB,
---Processing---
2.) Delete Ports
---Processing---
3.) Add Ports.
Here we need to take the lock before step one and then have to release the lock after step three. If we take the lock only while interacting with DB then we have to take lock three times in above situation and that also doesn't solve the problem, because some process can update the DB in between Step 1 and step 2.

Similar command can be written in future with config validation in picture.


**- How to verify it**

Testing:

Test 1: acquire a lock with command config. Run another config command in between to make sure lock is not acquired. Then say yes on the prompt of first command before timer expires.

Expectation: Second command should not acquire lock, first command should re-extend the timer.

Terminal 1:
```
admin@lnos-x1-a-fab01:~$ sudo config save
:::Lock Acquired:::
Existing file will be overwritten, continue? [y/N]: y
:::Lock Timer Extended:::
Running command: /usr/local/bin/sonic-cfggen -d --print-data > /etc/sonic/config_db.json
:::Lock Released:::
```
Terminal 2:
```
admin@lnos-x1-a-fab01:~$ sudo config save
:::Can not acuire lock, Abort:::
Lock PID: 10877 and self.pid:10890
```

Test 2: run first command, let the timer expires, run second command, then immediately say yes on the prompt of first command.

Expectation: Second command should acquire lock, first command should not be acquire lock after prompt. 

Terminal 1:
```
admin@lnos-x1-a-fab01:~$ sudo config save
:::Lock Acquired:::
Existing file will be overwritten, continue? [y/N]: y
:::Can not acquire lock LOCK PID: 10903 and self.pid:10877:::
:::Lock PID: 10903 and self.pid:10877:::
```

Terminal 2:
```
admin@lnos-x1-a-fab01:~$ sudo config load
:::Lock Acquired:::
Load config from the file /etc/sonic/config_db.json? [y/N]: N
Aborted!
:::Lock PID: None and self.pid: 10903:::
```

Test 3: run first command, let the timer expires, then say yes on the prompt of first command to reacquire the lock.

```
admin@lnos-x1-a-fab01:~$ sudo config save
:::Lock Acquired:::
Existing file will be overwritten, continue? [y/N]: y
:::Lock Reacquired:::
Running command: /usr/local/bin/sonic-cfggen -d --print-data > /etc/sonic/config_db.json
:::Lock Released:::
admin@lnos-x1-a-fab01:~$
```


**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

