### PR TITLE
support "show ntp" with mgmt vrf based on linux os version

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -2002,8 +2002,8 @@ def ntp(ctx, verbose):
     """Show NTP information"""
     ntpcmd = "ntpq -p -n"
     if is_mgmt_vrf_enabled(ctx) is True:
-        #ManagementVRF is enabled. Call ntpq using cgexec
-        ntpcmd = "cgexec -g l3mdev:mgmt ntpq -p -n"
+        #ManagementVRF is enabled. Call ntpq using ip vrf exec mgmt 
+        ntpcmd = "ip vrf exec mgmt ntpq -p -n"
     run_command(ntpcmd, display_cmd=verbose)
 
 

--- a/show/main.py
+++ b/show/main.py
@@ -9,6 +9,7 @@ import re
 import subprocess
 import sys
 import ipaddress
+from pkg_resources import parse_version
 
 import click
 from click_default_group import DefaultGroup
@@ -2002,8 +2003,14 @@ def ntp(ctx, verbose):
     """Show NTP information"""
     ntpcmd = "ntpq -p -n"
     if is_mgmt_vrf_enabled(ctx) is True:
-        #ManagementVRF is enabled. Call ntpq using ip vrf exec mgmt 
-        ntpcmd = "ip vrf exec mgmt ntpq -p -n"
+        #ManagementVRF is enabled. Call ntpq using "ip vrf exec" or cgexec based on linux version 
+        os_info =  os.uname()
+        release = os_info[2].split('-')
+        if parse_version(release[0]) > parse_version("4.9.0"):
+            ntpcmd = "ip vrf exec mgmt ntpq -p -n"
+        else:
+            ntpcmd = "cgexec -g l3mdev:mgmt ntpq -p -n"
+
     run_command(ntpcmd, display_cmd=verbose)
 
 


### PR DESCRIPTION
**- What I did**
When mgmt vrf is configured,  "show ntp" checks Linux version to determine if to use
```
- cgexec -g l3mdev:mgmt ntpq -p -n --> for 4.9.0
- ip vrf exec mgmt ntpq -p -n  ---> for 4.9.0+
```

**- How I did it**
changes in show/main.py to get linux version from os.uname() and then compare with 4.9.0

**- How to verify it**
```
on 4.19.0
//////////////////////
root@sonic:/usr/lib/python2.7/dist-packages/show# show ntp
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
*10.11.0.1       10.14.2.1        3 u    -   64    1    0.220  484.401   0.074
 10.11.0.2       10.14.2.1        3 u    1   64    1    0.258  481.733   0.206
root@sonic:/usr/lib/python2.7/dist-packages/show# uname -r
4.19.0-6-amd64
root@sonic:/usr/lib/python2.7/dist-packages/show#

on 4.9.0
////////////
root@sonic:/usr/lib/python2.7/dist-packages/show# show ntp
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
 10.11.0.1       10.14.2.1        3 u    1   64    1    0.213   -0.423   0.069
 10.11.0.2       10.14.2.1        3 u    2   64    1    0.331   -3.644   0.433
root@sonic:/usr/lib/python2.7/dist-packages/show#
root@sonic:/usr/lib/python2.7/dist-packages/show#
root@sonic:/usr/lib/python2.7/dist-packages/show# uname -r
4.9.0-11-2-amd64
```

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

