### PR TITLE
[Phase 1] Changes to the config commands for Multi-ASIC devices.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[![Total alerts](https://img.shields.io/lgtm/alerts/g/Azure/sonic-utilities.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/Azure/sonic-utilities/alerts/)
+[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/Azure/sonic-utilities.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/Azure/sonic-utilities/context:python)
+
+[![Build](https://sonic-jenkins.westus2.cloudapp.azure.com/job/common/job/sonic-utilities-build/badge/icon)](https://sonic-jenkins.westus2.cloudapp.azure.com/job/common/job/sonic-utilities-build/)
+
 # SONiC: Software for Open Networking in the Cloud
 
 ## sonic-utilities
@@ -23,21 +28,21 @@ Guide for performing commits:
 * Use a standard commit message format:
 
 >     [component/folder touched]: Description intent of your changes
-> 
+>
 >     [List of changes]
->     
+>
 > 	  Signed-off-by: Your Name your@email.com
-    
+
 For example:
 
 >     swss-common: Stabilize the ConsumerTable
->     
+>
 >     * Fixing autoreconf
 >     * Fixing unit-tests by adding checkers and initialize the DB before start
 >     * Adding the ability to select from multiple channels
->     * Health-Monitor - The idea of the patch is that if something went wrong with the notification channel, 
+>     * Health-Monitor - The idea of the patch is that if something went wrong with the notification channel,
 >       we will have the option to know about it (Query the LLEN table length).
->       
+>
 >       Signed-off-by: John Doe user@dev.null
 
 

--- a/clear/bgp_frr_v6.py
+++ b/clear/bgp_frr_v6.py
@@ -1,5 +1,5 @@
 import click
-from clear.main import *
+from clear.main import ipv6, run_command
 
 
 ###############################################################################
@@ -9,8 +9,7 @@ from clear.main import *
 ###############################################################################
 
 
-@ipv6.group(cls=AliasedGroup, default_if_no_args=True,
-            context_settings=CONTEXT_SETTINGS)
+@ipv6.group()
 def bgp():
     """Clear IPv6 BGP (Border Gateway Protocol) information"""
     pass
@@ -24,8 +23,7 @@ def default():
     run_command(command)
 
 
-@bgp.group(cls=AliasedGroup, default_if_no_args=True,
-           context_settings=CONTEXT_SETTINGS)
+@bgp.group()
 def neighbor():
     """Clear specific BGP peers"""
     pass
@@ -69,8 +67,7 @@ def neigh_out(ipaddress):
     run_command(command)
 
 
-@neighbor.group(cls=AliasedGroup, default_if_no_args=True,
-                context_settings=CONTEXT_SETTINGS)
+@neighbor.group()
 def soft():
     """Soft reconfig BGP's inbound/outbound updates"""
     pass

--- a/clear/bgp_quagga_v4.py
+++ b/clear/bgp_quagga_v4.py
@@ -1,5 +1,5 @@
 import click
-from clear.main import *
+from clear.main import ip, run_command
 
 
 ###############################################################################
@@ -9,8 +9,7 @@ from clear.main import *
 ###############################################################################
 
 
-@ip.group(cls=AliasedGroup, default_if_no_args=True,
-          context_settings=CONTEXT_SETTINGS)
+@ip.group()
 def bgp():
     """Clear BGP (Border Gateway Protocol) peers"""
     pass
@@ -24,8 +23,7 @@ def default():
     run_command(command)
 
 
-@bgp.group(cls=AliasedGroup, default_if_no_args=True,
-           context_settings=CONTEXT_SETTINGS)
+@bgp.group()
 def neighbor():
     """Clear specific BGP peers"""
     pass
@@ -69,8 +67,7 @@ def neigh_out(ipaddress):
     run_command(command)
 
 
-@neighbor.group(cls=AliasedGroup, default_if_no_args=True,
-                context_settings=CONTEXT_SETTINGS)
+@neighbor.group()
 def soft():
     """Soft reconfig BGP's inbound/outbound updates"""
     pass

--- a/clear/bgp_quagga_v6.py
+++ b/clear/bgp_quagga_v6.py
@@ -1,5 +1,5 @@
 import click
-from clear.main import *
+from clear.main import ipv6, run_command
 
 
 ###############################################################################
@@ -9,8 +9,7 @@ from clear.main import *
 ###############################################################################
 
 
-@ipv6.group(cls=AliasedGroup, default_if_no_args=True,
-            context_settings=CONTEXT_SETTINGS)
+@ipv6.group()
 def bgp():
     """Clear IPv6 BGP (Border Gateway Protocol) information"""
     pass
@@ -24,8 +23,7 @@ def default():
     run_command(command)
 
 
-@bgp.group(cls=AliasedGroup, default_if_no_args=True,
-           context_settings=CONTEXT_SETTINGS)
+@bgp.group()
 def neighbor():
     """Clear specific BGP peers"""
     pass
@@ -69,8 +67,7 @@ def neigh_out(ipaddress):
     run_command(command)
 
 
-@neighbor.group(cls=AliasedGroup, default_if_no_args=True,
-                context_settings=CONTEXT_SETTINGS)
+@neighbor.group()
 def soft():
     """Soft reconfig BGP's inbound/outbound updates"""
     pass

--- a/clear/main.py
+++ b/clear/main.py
@@ -95,7 +95,7 @@ def get_routing_stack():
         proc.wait()
         result = stdout.rstrip('\n')
 
-    except OSError, e:
+    except OSError as e:
         raise OSError("Cannot detect routing-stack")
 
     return (result)

--- a/config/aaa.py
+++ b/config/aaa.py
@@ -11,7 +11,7 @@ def is_ipaddress(val):
         return False
     try:
         netaddr.IPAddress(str(val))
-    except:
+    except ValueError:
         return False
     return True
 

--- a/config/main.py
+++ b/config/main.py
@@ -770,7 +770,7 @@ def del_portchannel_member(ctx, portchannel_name, port_name):
 #
 # 'mirror_session' group ('config mirror_session ...')
 #
-@config.group()
+@config.group('mirror_session')
 def mirror_session():
     pass
 
@@ -875,7 +875,7 @@ def interval(poll_interval, verbose):
 
     run_command(cmd, display_cmd=verbose)
 
-@pfcwd.command()
+@pfcwd.command('counter_poll')
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 @click.argument('counter_poll', type=click.Choice(['enable', 'disable']))
 def counter_poll(counter_poll, verbose):
@@ -885,7 +885,7 @@ def counter_poll(counter_poll, verbose):
 
     run_command(cmd, display_cmd=verbose)
 
-@pfcwd.command()
+@pfcwd.command('big_red_switch')
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 @click.argument('big_red_switch', type=click.Choice(['enable', 'disable']))
 def big_red_switch(big_red_switch, verbose):
@@ -895,7 +895,7 @@ def big_red_switch(big_red_switch, verbose):
 
     run_command(cmd, display_cmd=verbose)
 
-@pfcwd.command()
+@pfcwd.command('start_default')
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def start_default(verbose):
     """ Start PFC WD by default configurations  """
@@ -945,7 +945,7 @@ def reload():
 #
 # 'warm_restart' group ('config warm_restart ...')
 #
-@config.group()
+@config.group('warm_restart')
 @click.pass_context
 @click.option('-s', '--redis-unix-socket-path', help='unix socket path for redis connection')
 def warm_restart(ctx, redis_unix_socket_path):
@@ -1392,7 +1392,7 @@ def memory(kdump_memory):
         config_db.mod_entry("KDUMP", "config", {"memory": kdump_memory})
         run_command("sonic-kdump-config --memory %s" % kdump_memory)
 
-@kdump.command()
+@kdump.command('num-dumps')
 @click.argument('kdump_num_dumps', metavar='<kdump_num_dumps>', required=True, type=int)
 def num_dumps(kdump_num_dumps):
     """Set max number of dump files for kdump"""
@@ -2109,7 +2109,7 @@ def delete(counter_name, verbose):
 #
 # 'add_reasons' subcommand ('config dropcounters add_reasons')
 #
-@dropcounters.command()
+@dropcounters.command('add-reasons')
 @click.argument("counter_name", type=str, required=True)
 @click.argument("reasons",      type=str, required=True)
 @click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
@@ -2122,7 +2122,7 @@ def add_reasons(counter_name, reasons, verbose):
 #
 # 'remove_reasons' subcommand ('config dropcounters remove_reasons')
 #
-@dropcounters.command()
+@dropcounters.command('remove-reasons')
 @click.argument("counter_name", type=str, required=True)
 @click.argument("reasons",      type=str, required=True)
 @click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")

--- a/config/main.py
+++ b/config/main.py
@@ -526,7 +526,7 @@ def is_ipaddress(val):
         return False
     try:
         netaddr.IPAddress(str(val))
-    except:
+    except ValueError:
         return False
     return True
 
@@ -715,7 +715,6 @@ def portchannel(ctx):
     config_db = ConfigDBConnector()
     config_db.connect()
     ctx.obj = {'db': config_db}
-    pass
 
 @portchannel.command('add')
 @click.argument('portchannel_name', metavar='<portchannel_name>', required=True)
@@ -962,7 +961,6 @@ def warm_restart(ctx, redis_unix_socket_path):
     TABLE_NAME_SEPARATOR = '|'
     prefix = 'WARM_RESTART_ENABLE_TABLE' + TABLE_NAME_SEPARATOR
     ctx.obj = {'db': config_db, 'state_db': state_db, 'prefix': prefix}
-    pass
 
 @warm_restart.command('enable')
 @click.argument('module', metavar='<module>', default='system', required=False, type=click.Choice(["system", "swss", "bgp", "teamd"]))
@@ -1032,7 +1030,6 @@ def vlan(ctx, redis_unix_socket_path):
     config_db = ConfigDBConnector(**kwargs)
     config_db.connect(wait_for_init=False)
     ctx.obj = {'db': config_db}
-    pass
 
 @vlan.command('add')
 @click.argument('vid', metavar='<vid>', required=True, type=int)
@@ -1183,7 +1180,6 @@ def snmpagentaddress(ctx):
     config_db = ConfigDBConnector()
     config_db.connect()
     ctx.obj = {'db': config_db}
-    pass
 
 @snmpagentaddress.command('add')
 @click.argument('agentip', metavar='<SNMP AGENT LISTENING IP Address>', required=True)
@@ -1233,7 +1229,6 @@ def snmptrap(ctx):
     config_db = ConfigDBConnector()
     config_db.connect()
     ctx.obj = {'db': config_db}
-    pass
 
 @snmptrap.command('modify')
 @click.argument('ver', metavar='<SNMP Version>', type=click.Choice(['1', '2', '3']), required=True)
@@ -1362,7 +1357,6 @@ def kdump():
     """ Configure kdump """
     if os.geteuid() != 0:
         exit("Root privileges are required for this operation")
-    pass
 
 @kdump.command()
 def disable():
@@ -1779,7 +1773,6 @@ def vrf(ctx):
     config_db.connect()
     ctx.obj = {}
     ctx.obj['config_db'] = config_db
-    pass
 
 @vrf.command('add')
 @click.argument('vrf_name', metavar='<vrf_name>', required=True)
@@ -2342,7 +2335,6 @@ def syslog_group(ctx):
     config_db = ConfigDBConnector()
     config_db.connect()
     ctx.obj = {'db': config_db}
-    pass
 
 @syslog_group.command('add')
 @click.argument('syslog_ip_address', metavar='<syslog_ip_address>', required=True)
@@ -2395,7 +2387,6 @@ def ntp(ctx):
     config_db = ConfigDBConnector()
     config_db.connect()
     ctx.obj = {'db': config_db}
-    pass
 
 @ntp.command('add')
 @click.argument('ntp_ip_address', metavar='<ntp_ip_address>', required=True)
@@ -2448,7 +2439,6 @@ def sflow(ctx):
     config_db = ConfigDBConnector()
     config_db.connect()
     ctx.obj = {'db': config_db}
-    pass
 
 #
 # 'sflow' command ('config sflow enable')

--- a/config/main.py
+++ b/config/main.py
@@ -2158,7 +2158,7 @@ def ecn(profile, rmax, rmin, ymax, ymin, gmax, gmin, verbose):
 
 
 #
-# 'pfc' group ('config pfc ...')
+# 'pfc' group ('config interface pfc ...')
 #
 
 @interface.group()
@@ -2169,7 +2169,7 @@ def pfc(ctx):
 
 
 #
-# 'pfc asymmetric' command
+# 'pfc asymmetric' ('config interface pfc asymmetric ...')
 #
 
 @pfc.command()
@@ -2185,6 +2185,24 @@ def asymmetric(ctx, interface_name, status):
 
     run_command("pfc config asymmetric {0} {1}".format(status, interface_name))
 
+#
+# 'pfc priority' command ('config interface pfc priority ...')
+#
+
+@pfc.command()
+@click.argument('interface_name', metavar='<interface_name>', required=True)
+@click.argument('priority', type=click.Choice([str(x) for x in range(8)]))
+@click.argument('status', type=click.Choice(['on', 'off']))
+@click.pass_context
+def priority(ctx, interface_name, priority, status):
+    """Set PFC priority configuration."""
+    if get_interface_naming_mode() == "alias":
+        interface_name = interface_alias_to_name(interface_name)
+        if interface_name is None:
+            ctx.fail("'interface_name' is None!")
+    
+    run_command("pfc config priority {0} {1} {2}".format(status, interface_name, priority))
+    
 #
 # 'platform' group ('config platform ...')
 #

--- a/config/main.py
+++ b/config/main.py
@@ -3,7 +3,6 @@
 import sys
 import os
 import click
-import json
 import subprocess
 import netaddr
 import re

--- a/config/main.py
+++ b/config/main.py
@@ -2297,7 +2297,6 @@ def ztp():
 
     if os.geteuid() != 0:
         exit("Root privileges are required for this operation")
-    pass
 
 @ztp.command()
 @click.option('-y', '--yes', is_flag=True, callback=_abort_if_false,

--- a/config/main.py
+++ b/config/main.py
@@ -27,6 +27,7 @@ SONIC_CFGGEN_PATH = '/usr/local/bin/sonic-cfggen'
 SYSLOG_IDENTIFIER = "config"
 VLAN_SUB_INTERFACE_SEPARATOR = '.'
 ASIC_CONF_FILENAME = 'asic.conf'
+NS_PREFIX = 'asic'
 
 INIT_CFG_FILE = '/etc/sonic/init_cfg.json'
 
@@ -114,12 +115,102 @@ def run_command(command, display_cmd=False, ignore_error=False):
     if proc.returncode != 0 and not ignore_error:
         sys.exit(proc.returncode)
 
+# API to check if this is a multi-asic device or not.
+def is_multi_asic():
+    num_asics = _get_num_asic()
 
-def interface_alias_to_name(interface_alias):
+    if num_asics > 1:
+        return True
+    else:
+        return False
+
+"""In case of Multi-Asic platform, Each ASIC will have a linux network namespace created.
+   So we loop through the databases in different namespaces and depending on the sub_role
+   decide whether this is a front end ASIC/namespace or a back end one.
+"""
+def get_all_namespaces():
+    front_ns = []
+    back_ns = []
+    num_asics = _get_num_asic()
+
+    if is_multi_asic():
+        for asic in range(num_asics):
+            namespace = "{}{}".format(NS_PREFIX, asic)
+            config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+            config_db.connect()
+
+            metadata = config_db.get_table('DEVICE_METADATA')
+            if metadata['localhost']['sub_role'] == 'FrontEnd':
+                front_ns.append(namespace)
+            elif metadata['localhost']['sub_role'] == 'BackEnd':
+                back_ns.append(namespace)
+
+    return {'front_ns':front_ns, 'back_ns':back_ns}
+
+"""In case of Multi-Asic platform, Each ASIC will have a host name and we call it internal hosts.
+   So we loop through the databases in different namespaces and get the hostname
+"""
+def get_all_internal_hosts():
+    internal_hosts = []
+    num_asics = _get_num_asic()
+
+    if is_multi_asic():
+        for asic in range(num_asics):
+            namespace = "{}{}".format(NS_PREFIX, asic)
+            config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+            config_db.connect()
+            metadata = config_db.get_table('DEVICE_METADATA')
+            internal_hosts.append(metadata['localhost']['hostname'])
+
+    return internal_hosts
+
+# Validate whether a given namespace name is valid in the device.
+def validate_namespace(namespace):
+    if not is_multi_asic():
+        return True
+
+    namespaces = get_all_namespaces()
+    if namespace in namespaces['front_ns'] + namespaces['back_ns']:
+        return True
+    else:
+        return False
+
+# Return the namespace where an interface belongs
+def get_intf_namespace(port):
+    """If it is a non multi-asic device, or if the interface is management interface
+       return '' ( empty string ) which maps to current namespace ( in case of config commands
+       it is linux host )
+    """
+    if is_multi_asic() == False or port == 'eth0':
+        return ''
+
+    # If it is PortChannel or Vlan interface or Loopback, user needs to input the namespace.
+    if port.startswith("PortChannel") or port.startswith("Vlan") or port.startswith("Loopback"):
+        return None
+
+    if port.startswith("Ethernet"):
+        if VLAN_SUB_INTERFACE_SEPARATOR in port:
+            intf_name = port.split(VLAN_SUB_INTERFACE_SEPARATOR)[0]
+        else:
+            intf_name = port
+
+    """Currently the CONFIG_DB in each namespace is checked to see if the interface exists
+       This would be changed in future once we have the interface to ASIC mapping stored in global DB.
+       Global DB is the database docker service running in the linux host.
+    """
+    ns_list = get_all_namespaces()
+    namespaces = ns_list['front_ns'] + ns_list['back_ns']
+    for namespace in namespaces:
+        config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+        config_db.connect()
+        entry = config_db.get_entry('PORT', intf_name)
+        if entry:
+            return namespace
+    return None
+
+def interface_alias_to_name(config_db, interface_alias):
     """Return default interface name if alias name is given as argument
     """
-    config_db = ConfigDBConnector()
-    config_db.connect()
     port_dict = config_db.get_table('PORT')
 
     vlan_id = ""
@@ -144,17 +235,15 @@ def interface_alias_to_name(interface_alias):
     return interface_alias if sub_intf_sep_idx == -1 else interface_alias + VLAN_SUB_INTERFACE_SEPARATOR + vlan_id
 
 
-def interface_name_is_valid(interface_name):
+def interface_name_is_valid(config_db, interface_name):
     """Check if the interface name is valid
     """
-    config_db = ConfigDBConnector()
-    config_db.connect()
     port_dict = config_db.get_table('PORT')
     port_channel_dict = config_db.get_table('PORTCHANNEL')
     sub_port_intf_dict = config_db.get_table('VLAN_SUB_INTERFACE')
 
     if get_interface_naming_mode() == "alias":
-        interface_name = interface_alias_to_name(interface_name)
+        interface_name = interface_alias_to_name(config_db, interface_name)
 
     if interface_name is not None:
         if not port_dict:
@@ -173,11 +262,9 @@ def interface_name_is_valid(interface_name):
                     return True
     return False
 
-def interface_name_to_alias(interface_name):
+def interface_name_to_alias(config_db, interface_name):
     """Return alias interface name if default name is given as argument
     """
-    config_db = ConfigDBConnector()
-    config_db.connect()
     port_dict = config_db.get_table('PORT')
 
     if interface_name is not None:
@@ -252,8 +339,18 @@ def set_interface_naming_mode(mode):
     user = os.getenv('SUDO_USER')
     bashrc_ifacemode_line = "export SONIC_CLI_IFACE_MODE={}".format(mode)
 
+    """In case of multi-asic, we can check for the alias mode support in any of
+       the namespaces as this setting of alias mode should be identical everywhere.
+       Here by default we set the namespaces to be a list just having '' which
+       represents the linux host. In case of multi-asic, we take the first namespace
+       created for the front facing ASIC.
+    """
+    namespaces = ['']
+    if is_multi_asic:
+        namespaces = get_all_namespaces()['front_ns']
+
     # Ensure all interfaces have an 'alias' key in PORT dict
-    config_db = ConfigDBConnector()
+    config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespaces[0])
     config_db.connect()
     port_dict = config_db.get_table('PORT')
 
@@ -299,87 +396,87 @@ def get_interface_naming_mode():
         mode = "default"
     return mode
 
-def _is_neighbor_ipaddress(ipaddress):
+def _is_neighbor_ipaddress(config_db, ipaddress):
     """Returns True if a neighbor has the IP address <ipaddress>, False if not
     """
-    config_db = ConfigDBConnector()
-    config_db.connect()
     entry = config_db.get_entry('BGP_NEIGHBOR', ipaddress)
     return True if entry else False
 
-def _get_all_neighbor_ipaddresses():
+def _get_all_neighbor_ipaddresses(config_db, ignore_hosts):
     """Returns list of strings containing IP addresses of all BGP neighbors
+       Ignore the BGP neighbors whose host name matches one in ignore_hosts list
     """
-    config_db = ConfigDBConnector()
-    config_db.connect()
-    return config_db.get_table('BGP_NEIGHBOR').keys()
+    addrs = []
+    bgp_sessions = config_db.get_table('BGP_NEIGHBOR')
+    for addr, session in bgp_sessions.iteritems():
+        if session.has_key('name') and session['name'] not in ignore_hosts:
+            addrs.append(addr)
+    return addrs
 
-def _get_neighbor_ipaddress_list_by_hostname(hostname):
+def _get_neighbor_ipaddress_list_by_hostname(config_db, hostname):
     """Returns list of strings, each containing an IP address of neighbor with
        hostname <hostname>. Returns empty list if <hostname> not a neighbor
     """
     addrs = []
-    config_db = ConfigDBConnector()
-    config_db.connect()
     bgp_sessions = config_db.get_table('BGP_NEIGHBOR')
     for addr, session in bgp_sessions.iteritems():
         if session.has_key('name') and session['name'] == hostname:
             addrs.append(addr)
     return addrs
 
-def _change_bgp_session_status_by_addr(ipaddress, status, verbose):
+def _change_bgp_session_status_by_addr(config_db, ipaddress, status, verbose):
     """Start up or shut down BGP session by IP address
     """
     verb = 'Starting' if status == 'up' else 'Shutting'
     click.echo("{} {} BGP session with neighbor {}...".format(verb, status, ipaddress))
-    config_db = ConfigDBConnector()
-    config_db.connect()
 
     config_db.mod_entry('bgp_neighbor', ipaddress, {'admin_status': status})
 
-def _change_bgp_session_status(ipaddr_or_hostname, status, verbose):
+def _change_bgp_session_status(config_db, ipaddr_or_hostname, status, verbose):
     """Start up or shut down BGP session by IP address or hostname
     """
     ip_addrs = []
 
     # If we were passed an IP address, convert it to lowercase because IPv6 addresses were
     # stored in ConfigDB with all lowercase alphabet characters during minigraph parsing
-    if _is_neighbor_ipaddress(ipaddr_or_hostname.lower()):
+    if _is_neighbor_ipaddress(config_db, ipaddr_or_hostname.lower()):
         ip_addrs.append(ipaddr_or_hostname.lower())
     else:
         # If <ipaddr_or_hostname> is not the IP address of a neighbor, check to see if it's a hostname
-        ip_addrs = _get_neighbor_ipaddress_list_by_hostname(ipaddr_or_hostname)
+        ip_addrs = _get_neighbor_ipaddress_list_by_hostname(config_db, ipaddr_or_hostname)
 
     if not ip_addrs:
-        click.get_current_context().fail("Could not locate neighbor '{}'".format(ipaddr_or_hostname))
+        return False
 
     for ip_addr in ip_addrs:
-        _change_bgp_session_status_by_addr(ip_addr, status, verbose)
+        _change_bgp_session_status_by_addr(config_db, ip_addr, status, verbose)
 
-def _validate_bgp_neighbor(neighbor_ip_or_hostname):
+    return True
+
+def _validate_bgp_neighbor(config_db, neighbor_ip_or_hostname):
     """validates whether the given ip or host name is a BGP neighbor
     """
     ip_addrs = []
-    if _is_neighbor_ipaddress(neighbor_ip_or_hostname.lower()):
+    if _is_neighbor_ipaddress(config_db, neighbor_ip_or_hostname.lower()):
         ip_addrs.append(neighbor_ip_or_hostname.lower())
     else:
-        ip_addrs = _get_neighbor_ipaddress_list_by_hostname(neighbor_ip_or_hostname.upper())
-
-    if not ip_addrs:
-        click.get_current_context().fail("Could not locate neighbor '{}'".format(neighbor_ip_or_hostname))
+        ip_addrs = _get_neighbor_ipaddress_list_by_hostname(config_db, neighbor_ip_or_hostname.upper())
 
     return ip_addrs
 
-def _remove_bgp_neighbor_config(neighbor_ip_or_hostname):
+def _remove_bgp_neighbor_config(config_db, neighbor_ip_or_hostname):
     """Removes BGP configuration of the given neighbor
     """
-    ip_addrs = _validate_bgp_neighbor(neighbor_ip_or_hostname)
-    config_db = ConfigDBConnector()
-    config_db.connect()
+    ip_addrs = _validate_bgp_neighbor(config_db, neighbor_ip_or_hostname)
+
+    if not ip_addrs:
+        return False
 
     for ip_addr in ip_addrs:
         config_db.mod_entry('bgp_neighbor', ip_addr, None)
         click.echo("Removed configuration of BGP neighbor {}".format(ip_addr))
+
+    return True
 
 def _change_hostname(hostname):
     current_hostname = os.uname()[1]
@@ -709,11 +806,22 @@ def hostname(new_hostname):
 # 'portchannel' group ('config portchannel ...')
 #
 @config.group()
+@click.option('-n', '--namespace', help='Namespace name', default=None)
 @click.pass_context
-def portchannel(ctx):
-    config_db = ConfigDBConnector()
+def portchannel(ctx, namespace):
+    #If multi ASIC platform, check if the namespace entered by user is valid
+    if is_multi_asic(): 
+        if namespace is None:
+            ctx.fail("namespace [-n] option required for portchannel/member (add/del)")
+        if not validate_namespace(str(namespace)):
+            ctx.fail("Invalid Namespace entered {}".format(namespace))
+    else:
+        namespace=''
+
+    config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=str(namespace))
     config_db.connect()
-    ctx.obj = {'db': config_db}
+    ctx.obj = {'db': config_db, 'namespace': str(namespace)}
+    pass
 
 @portchannel.command('add')
 @click.argument('portchannel_name', metavar='<portchannel_name>', required=True)
@@ -751,6 +859,14 @@ def portchannel_member(ctx):
 def add_portchannel_member(ctx, portchannel_name, port_name):
     """Add member to port channel"""
     db = ctx.obj['db']
+    if is_multi_asic():
+        # Get the namespace based on the member interface given by user.
+        intf_ns = get_intf_namespace(port_name)
+        if intf_ns is None:
+            ctx.fail("member interface {} is invalid".format(port_name))
+        elif intf_ns != ctx.obj['namespace']:
+            ctx.fail("member interface {} doesn't exist in namespace {}".format(port_name, ctx.obj['namespace']))
+
     db.set_entry('PORTCHANNEL_MEMBER', (portchannel_name, port_name),
             {'NULL': 'NULL'})
 
@@ -761,6 +877,14 @@ def add_portchannel_member(ctx, portchannel_name, port_name):
 def del_portchannel_member(ctx, portchannel_name, port_name):
     """Remove member from portchannel"""
     db = ctx.obj['db']
+    if is_multi_asic():
+        # Get the namespace based on the member interface given by user.
+        intf_ns = get_intf_namespace(port_name)
+        if intf_ns is None:
+            ctx.fail("member interface {} is invalid".format(port_name))
+        elif intf_ns != ctx.obj['namespace']:
+            ctx.fail("member interface {} doesn't exist in namespace {}".format(port_name, ctx.obj['namespace']))
+
     db.set_entry('PORTCHANNEL_MEMBER', (portchannel_name, port_name), None)
     db.set_entry('PORTCHANNEL_MEMBER', portchannel_name + '|' + port_name, None)
 
@@ -1020,15 +1144,27 @@ def warm_restart_bgp_eoiu(ctx, enable):
 #
 @config.group()
 @click.pass_context
+@click.option('-n', '--namespace', help='Namespace name', default=None)
 @click.option('-s', '--redis-unix-socket-path', help='unix socket path for redis connection')
-def vlan(ctx, redis_unix_socket_path):
+def vlan(ctx, redis_unix_socket_path, namespace):
     """VLAN-related configuration tasks"""
     kwargs = {}
     if redis_unix_socket_path:
         kwargs['unix_socket_path'] = redis_unix_socket_path
-    config_db = ConfigDBConnector(**kwargs)
+
+    #If multi ASIC platform, check if the namespace entered by user is valid
+    if is_multi_asic(): 
+        if namespace is None:
+            ctx.fail("namespace [-n] option required for vlan/member (add/del)")
+        if not validate_namespace(str(namespace)):
+            ctx.fail("Invalid Namespace entered {}".format(namespace))
+    else:
+        namespace=''
+
+    config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=str(namespace), **kwargs)
     config_db.connect(wait_for_init=False)
-    ctx.obj = {'db': config_db}
+    ctx.obj = {'db': config_db, 'namespace': str(namespace)}
+    pass
 
 @vlan.command('add')
 @click.argument('vid', metavar='<vid>', required=True, type=int)
@@ -1069,13 +1205,21 @@ def vlan_member(ctx):
 @click.option('-u', '--untagged', is_flag=True)
 @click.pass_context
 def add_vlan_member(ctx, vid, interface_name, untagged):
+    if is_multi_asic():
+        # Get the namespace based on the member interface given by user.
+        intf_ns = get_intf_namespace(interface_name)
+        if intf_ns is None:
+            ctx.fail("member interface {} is invalid".format(interface_name))
+        elif intf_ns != ctx.obj['namespace']:
+            ctx.fail("member interface {} doesn't exist in namespace {}".format(interface_name, ctx.obj['namespace']))
+
     db = ctx.obj['db']
     vlan_name = 'Vlan{}'.format(vid)
     vlan = db.get_entry('VLAN', vlan_name)
     interface_table = db.get_table('INTERFACE')
 
     if get_interface_naming_mode() == "alias":
-        interface_name = interface_alias_to_name(interface_name)
+        interface_name = interface_alias_to_name(db, interface_name)
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
@@ -1084,7 +1228,7 @@ def add_vlan_member(ctx, vid, interface_name, untagged):
     members = vlan.get('members', [])
     if interface_name in members:
         if get_interface_naming_mode() == "alias":
-            interface_name = interface_name_to_alias(interface_name)
+            interface_name = interface_name_to_alias(db, interface_name)
             if interface_name is None:
                 ctx.fail("'interface_name' is None!")
             ctx.fail("{} is already a member of {}".format(interface_name,
@@ -1107,12 +1251,20 @@ def add_vlan_member(ctx, vid, interface_name, untagged):
 @click.argument('interface_name', metavar='<interface_name>', required=True)
 @click.pass_context
 def del_vlan_member(ctx, vid, interface_name):
+    if is_multi_asic():
+        # Get the namespace based on the member interface given by user.
+        intf_ns = get_intf_namespace(interface_name)
+        if intf_ns is None:
+            ctx.fail("member interface {} is invalid".format(interface_name))
+        elif intf_ns != ctx.obj['namespace']:
+            ctx.fail("member interface {} doesn't exist in namespace {}".format(interface_name, ctx.obj['namespace']))
+
     db = ctx.obj['db']
     vlan_name = 'Vlan{}'.format(vid)
     vlan = db.get_entry('VLAN', vlan_name)
 
     if get_interface_naming_mode() == "alias":
-        interface_name = interface_alias_to_name(interface_name)
+        interface_name = interface_alias_to_name(db, interface_name)
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
@@ -1121,7 +1273,7 @@ def del_vlan_member(ctx, vid, interface_name):
     members = vlan.get('members', [])
     if interface_name not in members:
         if get_interface_naming_mode() == "alias":
-            interface_name = interface_name_to_alias(interface_name)
+            interface_name = interface_name_to_alias(db, interface_name)
             if interface_name is None:
                 ctx.fail("'interface_name' is None!")
             ctx.fail("{} is not a member of {}".format(interface_name, vlan_name))
@@ -1399,18 +1551,51 @@ def num_dumps(kdump_num_dumps):
 @shutdown.command()
 @click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
 def all(verbose):
-    """Shut down all BGP sessions"""
-    bgp_neighbor_ip_list = _get_all_neighbor_ipaddresses()
-    for ipaddress in bgp_neighbor_ip_list:
-        _change_bgp_session_status_by_addr(ipaddress, 'down', verbose)
+    """Shut down all BGP sessions
+       In the case of Multi-Asic platform, we shut only the EBGP sessions with external neighbors.
+    """
+    namespaces = ['']
+    int_hosts = []
+    if is_multi_asic:
+        ns_list = get_all_namespaces()
+        namespaces = ns_list['front_ns']
+        int_hosts = get_all_internal_hosts()
+
+    """Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
+       namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
+    """
+    for namespace in namespaces:
+        config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+        config_db.connect()
+        bgp_neighbor_ip_list = _get_all_neighbor_ipaddresses(config_db, int_hosts)
+        for ipaddress in bgp_neighbor_ip_list:
+            _change_bgp_session_status_by_addr(config_db, ipaddress, 'down', verbose)
 
 # 'neighbor' subcommand
 @shutdown.command()
 @click.argument('ipaddr_or_hostname', metavar='<ipaddr_or_hostname>', required=True)
 @click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
 def neighbor(ipaddr_or_hostname, verbose):
-    """Shut down BGP session by neighbor IP address or hostname"""
-    _change_bgp_session_status(ipaddr_or_hostname, 'down', verbose)
+    """Shut down BGP session by neighbor IP address or hostname.
+       User can specify either internal or external BGP neighbor to shutdown
+    """
+    namespaces = ['']
+    found_neighbor = False
+    if is_multi_asic:
+        ns_list = get_all_namespaces()
+        namespaces = ns_list['front_ns'] + ns_list['back_ns']
+
+    """Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
+       namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
+    """
+    for namespace in namespaces:
+        config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+        config_db.connect()
+        if _change_bgp_session_status(config_db, ipaddr_or_hostname, 'down', verbose):
+            found_neighbor = True
+
+    if not found_neighbor:
+        click.get_current_context().fail("Could not locate neighbor '{}'".format(ipaddr_or_hostname))
 
 @bgp.group()
 def startup():
@@ -1421,18 +1606,53 @@ def startup():
 @startup.command()
 @click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
 def all(verbose):
-    """Start up all BGP sessions"""
-    bgp_neighbor_ip_list = _get_all_neighbor_ipaddresses()
-    for ipaddress in bgp_neighbor_ip_list:
-        _change_bgp_session_status(ipaddress, 'up', verbose)
+    """Start up all BGP sessions
+       In the case of Multi-Asic platform, we startup only the EBGP sessions with external neighbors.
+    """
+    namespaces = ['']
+    int_hosts = []
+
+    if is_multi_asic:
+        ns_list = get_all_namespaces()
+        namespaces = ns_list['front_ns']
+        int_hosts = get_all_internal_hosts()
+
+    """Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
+       namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
+    """
+    for namespace in namespaces:
+        config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+        config_db.connect()
+        bgp_neighbor_ip_list = _get_all_neighbor_ipaddresses(config_db, int_hosts)
+        for ipaddress in bgp_neighbor_ip_list: 
+            _change_bgp_session_status_by_addr(config_db, ipaddress, 'up', verbose)
 
 # 'neighbor' subcommand
 @startup.command()
 @click.argument('ipaddr_or_hostname', metavar='<ipaddr_or_hostname>', required=True)
 @click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
 def neighbor(ipaddr_or_hostname, verbose):
-    """Start up BGP session by neighbor IP address or hostname"""
-    _change_bgp_session_status(ipaddr_or_hostname, 'up', verbose)
+    """Start up BGP session by neighbor IP address or hostname.
+       User can specify either internal or external BGP neighbor to startup
+    """
+    namespaces = ['']
+    found_neighbor = False
+
+    if is_multi_asic:
+        ns_list = get_all_namespaces()
+        namespaces = ns_list['front_ns'] + ns_list['back_ns']
+
+    """Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
+       namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
+    """
+    for namespace in namespaces:
+        config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+        config_db.connect()
+        if _change_bgp_session_status(config_db, ipaddr_or_hostname, 'up', verbose):
+            found_neighbor = True
+
+    if not found_neighbor:
+        click.get_current_context().fail("Could not locate neighbor '{}'".format(ipaddr_or_hostname))
 
 #
 # 'remove' subgroup ('config bgp remove ...')
@@ -1446,21 +1666,44 @@ def remove():
 @remove.command('neighbor')
 @click.argument('neighbor_ip_or_hostname', metavar='<neighbor_ip_or_hostname>', required=True)
 def remove_neighbor(neighbor_ip_or_hostname):
-    """Deletes BGP neighbor configuration of given hostname or ip from devices"""
-    _remove_bgp_neighbor_config(neighbor_ip_or_hostname)
+    """Deletes BGP neighbor configuration of given hostname or ip from devices
+       User can specify either internal or external BGP neighbor to remove
+    """
+    namespaces = ['']
+    removed_neighbor = False
+
+    if is_multi_asic:
+        ns_list = get_all_namespaces()
+        namespaces = ns_list['front_ns'] + ns_list['back_ns']
+
+    """Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
+       namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
+    """
+    for namespace in namespaces:
+        config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+        config_db.connect()
+        if _remove_bgp_neighbor_config(config_db, neighbor_ip_or_hostname):
+            removed_neighbor = True
+
+    if not removed_neighbor:
+        click.get_current_context().fail("Could not locate neighbor '{}'".format(neighbor_ip_or_hostname))
 
 #
 # 'interface' group ('config interface ...')
 #
 
 @config.group()
+@click.option('-n', '--namespace', help='Namespace name', default=None)
 @click.pass_context
-def interface(ctx):
+def interface(ctx, namespace):
     """Interface-related configuration tasks"""
-    config_db = ConfigDBConnector()
-    config_db.connect()
-    ctx.obj = {}
-    ctx.obj['config_db'] = config_db
+    #Check if the namespace entered by user is valid
+    if is_multi_asic():
+        if namespace is not None and not validate_namespace(namespace):
+            ctx.fail("Invalid Namespace entered {}".format(namespace))
+    else:
+        namespace=''
+    ctx.obj = {'namespace': None if namespace is None else str(namespace)}
 
 #
 # 'startup' subcommand
@@ -1471,13 +1714,22 @@ def interface(ctx):
 @click.pass_context
 def startup(ctx, interface_name):
     """Start up interface"""
-    config_db = ctx.obj['config_db']
+    namespace = ctx.obj['namespace']
+    if  is_multi_asic() and namespace is None:
+        ns = get_intf_namespace(interface_name)
+        if ns is None:
+            ctx.fail("namespace [-n] option required to modify interface {}".format(interface_name))
+        else:
+            namespace = ns
+    config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+    config_db.connect()
+
     if get_interface_naming_mode() == "alias":
-        interface_name = interface_alias_to_name(interface_name)
+        interface_name = interface_alias_to_name(config_db, interface_name)
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
-    if interface_name_is_valid(interface_name) is False:
+    if interface_name_is_valid(config_db, interface_name) is False:
         ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
 
     if interface_name.startswith("Ethernet"):
@@ -1499,13 +1751,22 @@ def startup(ctx, interface_name):
 @click.pass_context
 def shutdown(ctx, interface_name):
     """Shut down interface"""
-    config_db = ctx.obj['config_db']
+    namespace = ctx.obj['namespace']
+    if  is_multi_asic() and namespace is None:
+        ns = get_intf_namespace(interface_name)
+        if ns is None:
+            ctx.fail("namespace [-n] option required to modify interface {}".format(interface_name))
+        else:
+            namespace = ns
+    config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+    config_db.connect()
+
     if get_interface_naming_mode() == "alias":
-        interface_name = interface_alias_to_name(interface_name)
+        interface_name = interface_alias_to_name(config_db, interface_name)
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
-    if interface_name_is_valid(interface_name) is False:
+    if interface_name_is_valid(config_db, interface_name) is False:
         ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
 
     if interface_name.startswith("Ethernet"):
@@ -1530,12 +1791,22 @@ def shutdown(ctx, interface_name):
 @click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
 def speed(ctx, interface_name, interface_speed, verbose):
     """Set interface speed"""
+    namespace = ctx.obj['namespace']
+    if  is_multi_asic() and namespace is None:
+        ns = get_intf_namespace(interface_name)
+        if ns is None:
+            ctx.fail("namespace [-n] option required to modify interface {}".format(interface_name))
+        else:
+            namespace = ns
+    config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+    config_db.connect()
+
     if get_interface_naming_mode() == "alias":
-        interface_name = interface_alias_to_name(interface_name)
+        interface_name = interface_alias_to_name(config_db, interface_name)
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
-    command = "portconfig -p {} -s {}".format(interface_name, interface_speed)
+    command = "portconfig -p {} -s {} -n {}".format(interface_name, interface_speed, namespace)
     if verbose:
         command += " -vv"
     run_command(command, display_cmd=verbose)
@@ -1573,12 +1844,22 @@ def mgmt_ip_restart_services():
 @click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
 def mtu(ctx, interface_name, interface_mtu, verbose):
     """Set interface mtu"""
+    namespace = ctx.obj['namespace']
+    if  is_multi_asic() and namespace is None:
+        ns = get_intf_namespace(interface_name)
+        if ns is None:
+            ctx.fail("namespace [-n] option required to modify interface {}".format(interface_name))
+        else:
+            namespace = ns
+    config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+    config_db.connect()
+
     if get_interface_naming_mode() == "alias":
-        interface_name = interface_alias_to_name(interface_name)
+        interface_name = interface_alias_to_name(config_db, interface_name)
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
-    command = "portconfig -p {} -m {}".format(interface_name, interface_mtu)
+    command = "portconfig -p {} -m {} -n {}".format(interface_name, interface_mtu, namespace)
     if verbose:
         command += " -vv"
     run_command(command, display_cmd=verbose)
@@ -1604,9 +1885,18 @@ def ip(ctx):
 @click.pass_context
 def add(ctx, interface_name, ip_addr, gw):
     """Add an IP address towards the interface"""
-    config_db = ctx.obj["config_db"]
+    namespace = ctx.obj['namespace']
+    if  is_multi_asic() and namespace is None:
+        ns = get_intf_namespace(interface_name)
+        if ns is None:
+            ctx.fail("namespace [-n] option required to modify interface {}".format(interface_name))
+        else:
+            namespace = ns
+    config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+    config_db.connect()
+
     if get_interface_naming_mode() == "alias":
-        interface_name = interface_alias_to_name(interface_name)
+        interface_name = interface_alias_to_name(config_db, interface_name)
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
@@ -1661,9 +1951,18 @@ def add(ctx, interface_name, ip_addr, gw):
 @click.pass_context
 def remove(ctx, interface_name, ip_addr):
     """Remove an IP address from the interface"""
-    config_db = ctx.obj["config_db"]
+    namespace = ctx.obj['namespace']
+    if  is_multi_asic() and namespace is None:
+        ns = get_intf_namespace(interface_name)
+        if ns is None:
+            ctx.fail("namespace [-n] option required to modify interface {}".format(interface_name))
+        else:
+            namespace = ns
+    config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+    config_db.connect()
+
     if get_interface_naming_mode() == "alias":
-        interface_name = interface_alias_to_name(interface_name)
+        interface_name = interface_alias_to_name(config_db, interface_name)
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
@@ -1708,9 +2007,18 @@ def vrf(ctx):
 @click.pass_context
 def bind(ctx, interface_name, vrf_name):
     """Bind the interface to VRF"""
-    config_db = ctx.obj["config_db"]
+    namespace = ctx.obj['namespace']
+    if  is_multi_asic() and namespace is None:
+        ns = get_intf_namespace(interface_name)
+        if ns is None:
+            ctx.fail("namespace [-n] option required to modify interface {}".format(interface_name))
+        else:
+            namespace = ns
+    config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+    config_db.connect()
+
     if get_interface_naming_mode() == "alias":
-        interface_name = interface_alias_to_name(interface_name)
+        interface_name = interface_alias_to_name(config_db, interface_name)
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
@@ -1726,7 +2034,7 @@ def bind(ctx, interface_name, vrf_name):
         config_db.set_entry(table_name, interface_del, None)
     config_db.set_entry(table_name, interface_name, None)
     # When config_db del entry and then add entry with same key, the DEL will lost.
-    state_db = SonicV2Connector(host='127.0.0.1')
+    state_db = SonicV2Connector(host='127.0.0.1', use_unix_socket_path=True, namespace=namespace)
     state_db.connect(state_db.STATE_DB, False)
     _hash = '{}{}'.format('INTERFACE_TABLE|', interface_name)
     while state_db.get(state_db.STATE_DB, _hash, "state") == "ok":
@@ -1743,9 +2051,18 @@ def bind(ctx, interface_name, vrf_name):
 @click.pass_context
 def unbind(ctx, interface_name):
     """Unbind the interface to VRF"""
-    config_db = ctx.obj["config_db"]
+    namespace = ctx.obj['namespace']
+    if  is_multi_asic() and namespace is None:
+        ns = get_intf_namespace(interface_name)
+        if ns is None:
+            ctx.fail("namespace [-n] option required to modify interface {}".format(interface_name))
+        else:
+            namespace = ns
+    config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+    config_db.connect()
+
     if get_interface_naming_mode() == "alias":
-        interface_name = interface_alias_to_name(interface_name)
+        interface_name = interface_alias_to_name(config_db, interface_name)
         if interface_name is None:
             ctx.fail("interface is None!")
 
@@ -2170,8 +2487,17 @@ def pfc(ctx):
 @click.pass_context
 def asymmetric(ctx, interface_name, status):
     """Set asymmetric PFC configuration."""
+    namespace = ctx.obj['namespace']
+    if  is_multi_asic() and namespace is None:
+        ns = get_intf_namespace(interface_name)
+        if ns is None:
+            ctx.fail("namespace [-n] option required to modify interface {}".format(interface_name))
+        else:
+            namespace = ns
+    config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+    config_db.connect()
     if get_interface_naming_mode() == "alias":
-        interface_name = interface_alias_to_name(interface_name)
+        interface_name = interface_alias_to_name(config_db, interface_name)
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
@@ -2188,6 +2514,15 @@ def asymmetric(ctx, interface_name, status):
 @click.pass_context
 def priority(ctx, interface_name, priority, status):
     """Set PFC priority configuration."""
+    namespace = ctx.obj['namespace']
+    if  is_multi_asic() and namespace is None:
+        ns = get_intf_namespace(interface_name)
+        if ns is None:
+            ctx.fail("namespace [-n] option required to modify interface {}".format(interface_name))
+        else:
+            namespace = ns
+    config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+    config_db.connect()
     if get_interface_naming_mode() == "alias":
         interface_name = interface_alias_to_name(interface_name)
         if interface_name is None:
@@ -2524,11 +2859,11 @@ def interface(ctx):
 @click.argument('ifname', metavar='<interface_name>', required=True, type=str)
 @click.pass_context
 def enable(ctx, ifname):
-    if not interface_name_is_valid(ifname) and ifname != 'all':
+    config_db = ctx.obj['db']
+    if not interface_name_is_valid(config_db, ifname) and ifname != 'all':
         click.echo("Invalid interface name")
         return
 
-    config_db = ctx.obj['db']
     intf_dict = config_db.get_table('SFLOW_SESSION')
 
     if intf_dict and ifname in intf_dict.keys():
@@ -2544,11 +2879,11 @@ def enable(ctx, ifname):
 @click.argument('ifname', metavar='<interface_name>', required=True, type=str)
 @click.pass_context
 def disable(ctx, ifname):
-    if not interface_name_is_valid(ifname) and ifname != 'all':
+    config_db = ctx.obj['db']
+    if not interface_name_is_valid(config_db, ifname) and ifname != 'all':
         click.echo("Invalid interface name")
         return
 
-    config_db = ctx.obj['db']
     intf_dict = config_db.get_table('SFLOW_SESSION')
 
     if intf_dict and ifname in intf_dict.keys():
@@ -2566,14 +2901,14 @@ def disable(ctx, ifname):
 @click.argument('rate', metavar='<sample_rate>', required=True, type=int)
 @click.pass_context
 def sample_rate(ctx, ifname, rate):
-    if not interface_name_is_valid(ifname) and ifname != 'all':
+    config_db = ctx.obj['db']
+    if not interface_name_is_valid(config_db, ifname) and ifname != 'all':
         click.echo('Invalid interface name')
         return
     if not is_valid_sample_rate(rate):
         click.echo('Error: Sample rate must be between 256 and 8388608')
         return
 
-    config_db = ctx.obj['db']
     sess_dict = config_db.get_table('SFLOW_SESSION')
 
     if sess_dict and ifname in sess_dict.keys():

--- a/config/mlnx.py
+++ b/config/mlnx.py
@@ -169,7 +169,7 @@ def sniffer_env_variable_set(enable, env_variable_name, env_variable_string=""):
 def restart_swss():
     try:
         run_command(COMMAND_RESTART_SWSS)
-    except OSError, e:
+    except OSError as e:
         log_error("Not able to restart swss service, %s" % str(e), SNIFFER_SYSLOG_IDENTIFIER, True)
         return 1
     return 0

--- a/config/mlnx.py
+++ b/config/mlnx.py
@@ -10,12 +10,8 @@ try:
     import os
     import subprocess
     import click
-    import imp
     import syslog
-    import types
-    import traceback
     import time
-    from tabulate import tabulate
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
 

--- a/config/nat.py
+++ b/config/nat.py
@@ -66,7 +66,6 @@ def isIpOverlappingWithAnyStaticEntry(ipAddress, table):
 
     for key,values in static_dict.items():
         global_ip = "---"
-        local_ip = "---"
         nat_type = "dnat"
 
         if table == 'STATIC_NAPT':
@@ -542,8 +541,6 @@ def remove_tcp(ctx, global_ip, global_port, local_ip, local_port):
     entryFound = False
     table = "STATIC_NAPT"
     key = "{}|TCP|{}".format(global_ip, global_port)
-    dataKey1 = 'local_ip'
-    dataKey2 = 'local_port'
 
     data = config_db.get_entry(table, key)
     if data:
@@ -665,8 +662,6 @@ def add_pool(ctx, pool_name, global_ip_range, global_port_range):
         else:
             if is_valid_port_address(port_address[0]) is False:
                 ctx.fail("Given port value {} is invalid. Please enter a valid port value !!".format(port_address[0]))
-            portLowLimit = int(port_address[0])
-            portHighLimit = int(port_address[0]) 
     else:
         global_port_range = "NULL"
 

--- a/config/nat.py
+++ b/config/nat.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 import click
-import socket
-import netaddr
 import ipaddress
 from swsssdk import ConfigDBConnector
 from swsssdk import SonicV2Connector

--- a/connect/main.py
+++ b/connect/main.py
@@ -1,11 +1,8 @@
 #! /usr/bin/python -u
 
 import click
-import errno
 import os
 import pexpect
-import subprocess
-import sys
 from click_default_group import DefaultGroup
 
 try:

--- a/consutil/lib.py
+++ b/consutil/lib.py
@@ -8,7 +8,6 @@
 try:
     import click
     import re
-    import swsssdk
     import subprocess
     import sys
 except ImportError as e:

--- a/consutil/main.py
+++ b/consutil/main.py
@@ -9,8 +9,6 @@ try:
     import click
     import os
     import pexpect
-    import re
-    import subprocess
     import sys
     from tabulate import tabulate
     from lib import *

--- a/crm/main.py
+++ b/crm/main.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import os
 import click
 import swsssdk
 from tabulate import tabulate

--- a/debug/main.py
+++ b/debug/main.py
@@ -38,7 +38,7 @@ if 'FRRouting' in p:
         """debug bgp group """
         pass
 
-    @bgp.command()
+    @bgp.command('allow-martians')
     def allow_martians():
         """BGP allow martian next hops"""
         command = 'sudo vtysh -c "debug bgp allow-martians"'
@@ -71,7 +71,7 @@ if 'FRRouting' in p:
         command += '"'
         run_command(command)
 
-    @bgp.command()
+    @bgp.command('neighbor-events')
     @click.argument('prefix_or_iface', required=False)
     def neighbor_events(prefix_or_iface):
         """BGP Neighbor Events"""
@@ -97,7 +97,7 @@ if 'FRRouting' in p:
         command += '"'
         run_command(command)
 
-    @bgp.command()
+    @bgp.command('update-groups')
     def update_groups():
         """BGP update-groups"""
         command = 'sudo vtysh -c "debug bgp update-groups"'

--- a/debug/main.py
+++ b/debug/main.py
@@ -2,10 +2,8 @@
 # date: 07/12/17
 
 import click
-import os
 import subprocess
 from click_default_group import DefaultGroup
-from pprint import pprint
 
 def run_command(command, pager=False):
     click.echo(click.style("Command: ", fg='cyan') + click.style(command, fg='green'))

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -2520,6 +2520,34 @@ VLAN interface names take the form of `vlan<vlan_id>`. E.g., VLAN 100 will be na
   admin@sonic:~$ sudo config interface vlan100 ip remove 10.11.12.13/24
   ```
 
+**config interface pfc priority <interface_name> <priority> (on | off)**
+
+This command is used to set PFC on a given priority of a given interface to either "on" or "off". Once it is successfully configured, it will show current losses priorities on the given interface. Otherwise, it will show error information 
+
+- Example: 
+  *Versions >= 201904*
+  ```
+  admin@sonic:~$ sudo config interface pfc priority Ethernet0 3 off
+
+  Interface      Lossless priorities
+  -----------  ---------------------
+  Ethernet0                        4
+
+  admin@sonic:~$ sudo config interface pfc priority Ethernet0 8 off
+  Usage: pfc config priority [OPTIONS] STATUS INTERFACE PRIORITY
+
+  Error: Invalid value for "priority": invalid choice: 8. (choose from 0, 1, 2, 3, 4, 5, 6, 7)
+
+  admin@sonic:~$ sudo config interface pfc priority Ethernet101 3 off
+  Cannot find interface Ethernet101
+
+  admin@sonic:~$ sudo config interface pfc priority Ethernet0 3 on
+  
+  Interface    Lossless priorities
+  -----------  ---------------------
+  Ethernet0    3,4
+  ```
+
 **config interface pfc asymmetric <interface_name> (Versions >= 201904)**
 
 **config interface <interface_name> pfc asymmetric (Versions <= 201811)**
@@ -4305,6 +4333,65 @@ This command displays the details of Rx & Tx priority-flow-control (pfc) for all
 - NOTE: PFC counters can be cleared by the user with the following command:
   ```
   admin@sonic:~$ sonic-clear pfccounters
+  ```
+
+**show pfc asymmetric**
+
+This command displays the status of asymmetric PFC for all interfaces or a given interface.
+
+- Usage:
+  ```
+  show pfc asymmetric [<interface>]
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ show pfc asymmetric
+  
+  Interface    Asymmetric
+  -----------  ------------
+  Ethernet0    off
+  Ethernet2    off
+  Ethernet4    off
+  Ethernet6    off
+  Ethernet8    off
+  Ethernet10   off
+  Ethernet12   off
+  Ethernet14   off
+
+  admin@sonic:~$ show pfc asymmetric Ethernet0
+
+  Interface    Asymmetric
+  -----------  ------------
+  Ethernet0    off
+  ```
+
+**show pfc priority**
+
+This command displays the lossless priorities for all interfaces or a given interface.
+
+- Usage:
+  ```
+  show pfc priority [<interface>]
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ show pfc priority
+  
+  Interface    Lossless priorities
+  -----------  ---------------------
+  Ethernet0    3,4
+  Ethernet2    3,4
+  Ethernet8    3,4
+  Ethernet10   3,4
+  Ethernet16   3,4
+
+  admin@sonic:~$ show pfc priority Ethernet0
+  
+  Interface    Lossless priorities
+  -----------  ---------------------
+  Ethernet0    3,4
   ```
 
 #### Queue And Priority-Group

--- a/fwutil/lib.py
+++ b/fwutil/lib.py
@@ -106,8 +106,6 @@ class URL(object):
         return False
 
     def retrieve(self):
-        filename, headers = None, None
-
         self.__validate()
 
         result = urlparse(self.__url)
@@ -126,7 +124,7 @@ class URL(object):
                 self.DOWNLOAD_PATH_TEMPLATE.format(basename),
                 self.__reporthook
             )
-        except:
+        except Exception:
             if os.path.exists(self.DOWNLOAD_PATH_TEMPLATE.format(basename)):
                 os.remove(self.DOWNLOAD_PATH_TEMPLATE.format(basename))
             raise
@@ -560,7 +558,6 @@ class ComponentUpdateProvider(PlatformDataProvider):
 
                 firmware_path = NA
                 firmware_version_current = chassis_component.get_firmware_version()
-                firmware_version_available = NA
                 firmware_version = firmware_version_current
 
                 status = self.FW_STATUS_UP_TO_DATE
@@ -608,7 +605,6 @@ class ComponentUpdateProvider(PlatformDataProvider):
 
                     firmware_path = NA
                     firmware_version_current = module_component.get_firmware_version()
-                    firmware_version_available = NA
                     firmware_version = firmware_version_current
 
                     status = self.FW_STATUS_UP_TO_DATE
@@ -662,7 +658,6 @@ class ComponentUpdateProvider(PlatformDataProvider):
                 )
 
                 firmware_version_current = chassis_component.get_firmware_version()
-                firmware_version_available = NA
 
                 status = self.FW_STATUS_UP_TO_DATE
 
@@ -724,7 +719,6 @@ class ComponentUpdateProvider(PlatformDataProvider):
                     )
 
                     firmware_version_current = module_component.get_firmware_version()
-                    firmware_version_available = NA
 
                     status = self.FW_STATUS_UP_TO_DATE
 

--- a/pddf_fanutil/main.py
+++ b/pddf_fanutil/main.py
@@ -178,7 +178,7 @@ def debug():
     """pddf_fanutil debug commands"""
     pass
 
-@debug.command()
+@debug.command('dump-sysfs')
 def dump_sysfs():
     """Dump all Fan related SysFS paths"""
     status = platform_fanutil.dump_sysfs()

--- a/pddf_fanutil/main.py
+++ b/pddf_fanutil/main.py
@@ -8,15 +8,8 @@
 try:
     import sys
     import os
-    import subprocess
     import click
-    import imp
-    import syslog
-    import types
-    import traceback
     from tabulate import tabulate
-    from utilities_common import util_base
-    from utilities_common.util_base import UtilLogger
     from utilities_common.util_base import UtilHelper
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))

--- a/pddf_fanutil/main.py
+++ b/pddf_fanutil/main.py
@@ -110,7 +110,6 @@ def direction(index):
     status_table = []
 
     for fan in fan_ids:
-        msg = ""
         fan_name = "FAN {}".format(fan)
         if fan not in supported_fan:
             click.echo("Error! The {} is not available on the platform.\n" \
@@ -138,7 +137,6 @@ def getspeed(index):
     status_table = []
 
     for fan in fan_ids:
-        msg = ""
         fan_name = "FAN {}".format(fan)
         if fan not in supported_fan:
             click.echo("Error! The {} is not available on the platform.\n" \

--- a/pddf_ledutil/main.py
+++ b/pddf_ledutil/main.py
@@ -8,15 +8,7 @@
 try:
     import sys
     import os
-    import subprocess
     import click
-    import imp
-    import syslog
-    import types
-    import traceback
-    from tabulate import tabulate
-    from utilities_common import util_base
-    from utilities_common.util_base import UtilLogger
     from utilities_common.util_base import UtilHelper
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))

--- a/pddf_psuutil/main.py
+++ b/pddf_psuutil/main.py
@@ -8,15 +8,8 @@
 try:
     import sys
     import os
-    import subprocess
     import click
-    import imp
-    import syslog
-    import types
-    import traceback
     from tabulate import tabulate
-    from utilities_common import util_base
-    from utilities_common.util_base import UtilLogger
     from utilities_common.util_base import UtilHelper
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))

--- a/pddf_psuutil/main.py
+++ b/pddf_psuutil/main.py
@@ -104,14 +104,12 @@ def mfrinfo(index):
     """Display PSU manufacturer info"""
     supported_psu = range(1, platform_psuutil.get_num_psus() + 1)
     psu_ids = []
-    info = ""
     if (index < 0):
         psu_ids = supported_psu
     else:
         psu_ids = [index]
 
     for psu in psu_ids:
-        msg = ""
         psu_name = "PSU {}".format(psu)
         if psu not in supported_psu:
             click.echo("Error! The {} is not available on the platform.\n" \
@@ -145,7 +143,6 @@ def seninfo(index):
         psu_ids = [index]
 
     for psu in psu_ids:
-        msg = ""
         psu_name = "PSU {}".format(psu)
         if psu not in supported_psu:
             click.echo("Error! The {} is not available on the platform.\n" \

--- a/pddf_psuutil/main.py
+++ b/pddf_psuutil/main.py
@@ -180,7 +180,7 @@ def debug():
     """pddf_psuutil debug commands"""
     pass
 
-@debug.command()
+@debug.command('dump-sysfs')
 def dump_sysfs():
     """Dump all PSU related SysFS paths"""
     status = platform_psuutil.dump_sysfs()

--- a/pddf_thermalutil/main.py
+++ b/pddf_thermalutil/main.py
@@ -105,7 +105,7 @@ def debug():
     """pddf_thermalutil debug commands"""
     pass
 
-@debug.command()
+@debug.command('dump-sysfs')
 def dump_sysfs():
     """Dump all Temp Sensor related SysFS paths"""
     status = platform_thermalutil.dump_sysfs()

--- a/pddf_thermalutil/main.py
+++ b/pddf_thermalutil/main.py
@@ -8,15 +8,8 @@
 try:
     import sys
     import os
-    import subprocess
     import click
-    import imp
-    import syslog
-    import types
-    import traceback
     from tabulate import tabulate
-    from utilities_common import util_base
-    from utilities_common.util_base import UtilLogger
     from utilities_common.util_base import UtilHelper
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))

--- a/pddf_thermalutil/main.py
+++ b/pddf_thermalutil/main.py
@@ -81,7 +81,6 @@ def gettemp(index):
     status_table = []
 
     for thermal in thermal_ids:
-        msg = ""
         thermal_name = "TEMP{}".format(thermal)
         if thermal not in supported_thermal:
             click.echo("Error! The {} is not available on the platform.\n" \

--- a/pfc/main.py
+++ b/pfc/main.py
@@ -6,12 +6,13 @@ import swsssdk
 from tabulate import tabulate
 from natsort import natsorted
 
+ALL_PRIORITIES = [str(x) for x in range(8)]
+PRIORITY_STATUS = ['on', 'off']
 
 def configPfcAsym(interface, pfc_asym):
     """
     PFC handler to configure asymmentric PFC.
     """
-
     configdb = swsssdk.ConfigDBConnector()
     configdb.connect()
 
@@ -22,11 +23,6 @@ def showPfcAsym(interface):
     """
     PFC handler to display asymmetric PFC information.
     """
-
-    i = {}
-    table = []
-    key = []
-
     header = ('Interface', 'Asymmetric')
 
     configdb = swsssdk.ConfigDBConnector()
@@ -37,7 +33,10 @@ def showPfcAsym(interface):
     else:
         db_keys = configdb.keys(configdb.CONFIG_DB, 'PORT|*')
 
+    table = []
+        
     for i in db_keys or [None]:
+        key = None 
         if i:
             key = i.split('|')[-1]
 
@@ -51,37 +50,114 @@ def showPfcAsym(interface):
     print tabulate(sorted_table, headers=header, tablefmt="simple", missingval="")
     print '\n'
 
+def configPfcPrio(status, interface, priority):
+    configdb = swsssdk.ConfigDBConnector()
+    configdb.connect()
 
+    if interface not in configdb.get_keys('PORT_QOS_MAP'):
+        print 'Cannot find interface {0}'.format(interface)
+        return 
+
+    """Current lossless priorities on the interface""" 
+    entry = configdb.get_entry('PORT_QOS_MAP', interface)
+    enable_prio = entry.get('pfc_enable').split(',')
+    
+    """Avoid '' in enable_prio"""
+    enable_prio = [x.strip() for x in enable_prio if x.strip()]
+    
+    if status == 'on' and priority in enable_prio:
+        print 'Priority {0} has already been enabled on {1}'.format(priority, interface)
+        return
+    
+    if status == 'off' and priority not in enable_prio:
+        print 'Priority {0} is not enabled on {1}'.format(priority, interface)
+        return
+    
+    if status == 'on':
+        enable_prio.append(priority)
+    
+    else:
+        enable_prio.remove(priority)
+     
+    enable_prio.sort()    
+    configdb.mod_entry("PORT_QOS_MAP", interface, {'pfc_enable': ','.join(enable_prio)})
+    
+    """Show the latest PFC configuration"""
+    showPfcPrio(interface)
+     
+def showPfcPrio(interface):
+    """
+    PFC handler to display PFC enabled priority information.
+    """
+    header = ('Interface', 'Lossless priorities')
+    table = []
+        
+    configdb = swsssdk.ConfigDBConnector()
+    configdb.connect()
+    
+    """Get all the interfaces with QoS map information"""
+    intfs = configdb.get_keys('PORT_QOS_MAP')
+    
+    """The user specifies an interface but we cannot find it"""    
+    if interface and interface not in intfs:
+        print 'Cannot find interface {0}'.format(interface)
+        return 
+    
+    if interface:
+        intfs = [interface]
+    
+    for intf in intfs: 
+        entry = configdb.get_entry('PORT_QOS_MAP', intf)
+        table.append([intf, entry.get('pfc_enable', 'N/A')])
+    
+    sorted_table = natsorted(table)
+    print '\n'
+    print tabulate(sorted_table, headers=header, tablefmt="simple", missingval="")
+    print '\n'
+    
 @click.group()
 def cli():
-    """
-    Utility entry point.
-    """
+    """PFC Command Line"""
     pass
-
 
 @cli.group()
 def config():
-    """Config PFC information"""
+    """Config PFC"""
     pass
-
-
-@config.command()
-@click.argument('status', type=click.Choice(['on', 'off']))
-@click.argument('interface', type=click.STRING)
-def asymmetric(status, interface):
-    """Set asymmetric PFC configuration."""
-    configPfcAsym(interface, status)
-
 
 @cli.group()
 def show():
     """Show PFC information"""
     pass
 
+@click.command()
+@click.argument('status', type=click.Choice(PRIORITY_STATUS))
+@click.argument('interface', type=click.STRING)
+def configAsym(status, interface):
+    """Configure asymmetric PFC on a given port."""
+    configPfcAsym(interface, status)
 
-@show.command()
+@click.command()
+@click.argument('status', type=click.Choice(PRIORITY_STATUS))
+@click.argument('interface', type=click.STRING)
+@click.argument('priority', type=click.Choice(ALL_PRIORITIES))
+def configPrio(status, interface, priority):
+    """Configure PFC on a given priority."""
+    configPfcPrio(status, interface, priority)
+    
+@click.command()
 @click.argument('interface', type=click.STRING, required=False)
-def asymmetric(interface):
+def showAsym(interface):
     """Show asymmetric PFC information"""
     showPfcAsym(interface)
+
+@click.command()
+@click.argument('interface', type=click.STRING, required=False)
+def showPrio(interface):
+    """Show PFC priority information"""
+    showPfcPrio(interface)
+
+config.add_command(configAsym, "asymmetric")
+config.add_command(configPrio, "priority")
+show.add_command(showAsym, "asymmetric")
+show.add_command(showPrio, "priority")

--- a/pfc/main.py
+++ b/pfc/main.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import os
 import click
 import swsssdk
 from tabulate import tabulate

--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -3,6 +3,7 @@
 import click
 import swsssdk
 import os
+import sys
 from tabulate import tabulate
 from natsort import natsorted
 
@@ -194,9 +195,25 @@ def interval(poll_interval):
     configdb.connect()
     pfcwd_info = {}
     if poll_interval is not None:
+        pfcwd_table = configdb.get_table(CONFIG_DB_PFC_WD_TABLE_NAME)
+        entry_min = 3000
+        for entry in pfcwd_table:
+            if("Ethernet" not in entry):
+                continue
+            detection_time_entry_value = int(configdb.get_entry(CONFIG_DB_PFC_WD_TABLE_NAME, entry).get('detection_time'))
+            restoration_time_entry_value = int(configdb.get_entry(CONFIG_DB_PFC_WD_TABLE_NAME, entry).get('restoration_time'))
+            if ((detection_time_entry_value != None) and (detection_time_entry_value < entry_min)):
+                entry_min = detection_time_entry_value
+                entry_min_str = "detection time"
+            if ((restoration_time_entry_value != None) and (restoration_time_entry_value < entry_min)):
+                entry_min = restoration_time_entry_value
+                entry_min_str = "restoration time"
+        if entry_min < poll_interval:
+            print >> sys.stderr, "unable to use polling interval = {}ms, value is bigger than one of the configured {} values, please choose a smaller polling_interval".format(poll_interval,entry_min_str)
+            exit(1)
+        
         pfcwd_info['POLL_INTERVAL'] = poll_interval
-
-    configdb.mod_entry(CONFIG_DB_PFC_WD_TABLE_NAME, "GLOBAL", pfcwd_info)
+        configdb.mod_entry(CONFIG_DB_PFC_WD_TABLE_NAME, "GLOBAL", pfcwd_info)
 
 # Stop WD
 @cli.command()

--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -254,7 +254,7 @@ def start_default():
     configdb.mod_entry(CONFIG_DB_PFC_WD_TABLE_NAME, "GLOBAL", pfcwd_info)
 
 # Enable/disable PFC WD counter polling
-@cli.command()
+@cli.command('counter_poll')
 @click.argument('counter_poll', type=click.Choice(['enable', 'disable']))
 def counter_poll(counter_poll):
     """ Enable/disable counter polling """
@@ -267,7 +267,7 @@ def counter_poll(counter_poll):
     configdb.mod_entry("FLEX_COUNTER_TABLE", "PFCWD", pfcwd_info)
 
 # Enable/disable PFC WD BIG_RED_SWITCH mode
-@cli.command()
+@cli.command('big_red_switch')
 @click.argument('big_red_switch', type=click.Choice(['enable', 'disable']))
 def big_red_switch(big_red_switch):
     """ Enable/disable BIG_RED_SWITCH mode """

--- a/psuutil/main.py
+++ b/psuutil/main.py
@@ -101,7 +101,6 @@ def load_platform_psuutil():
         platform_path = "/".join([PLATFORM_ROOT_PATH, platform])
     else:
         platform_path = PLATFORM_ROOT_PATH_DOCKER
-    hwsku_path = "/".join([platform_path, hwsku])
 
     try:
         module_file = "/".join([platform_path, "plugins", PLATFORM_SPECIFIC_MODULE_NAME + ".py"])

--- a/psuutil/main.py
+++ b/psuutil/main.py
@@ -12,8 +12,6 @@ try:
     import click
     import imp
     import syslog
-    import types
-    import traceback
     from tabulate import tabulate
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))

--- a/psuutil/main.py
+++ b/psuutil/main.py
@@ -84,7 +84,7 @@ def get_platform_and_hwsku():
         stdout = proc.communicate()[0]
         proc.wait()
         hwsku = stdout.rstrip('\n')
-    except OSError, e:
+    except OSError as e:
         raise OSError("Cannot detect platform")
 
     return (platform, hwsku)
@@ -108,14 +108,14 @@ def load_platform_psuutil():
     try:
         module_file = "/".join([platform_path, "plugins", PLATFORM_SPECIFIC_MODULE_NAME + ".py"])
         module = imp.load_source(PLATFORM_SPECIFIC_MODULE_NAME, module_file)
-    except IOError, e:
+    except IOError as e:
         log_error("Failed to load platform module '%s': %s" % (PLATFORM_SPECIFIC_MODULE_NAME, str(e)), True)
         return -1
 
     try:
         platform_psuutil_class = getattr(module, PLATFORM_SPECIFIC_CLASS_NAME)
         platform_psuutil = platform_psuutil_class()
-    except AttributeError, e:
+    except AttributeError as e:
         log_error("Failed to instantiate '%s' class: %s" % (PLATFORM_SPECIFIC_CLASS_NAME, str(e)), True)
         return -2
 

--- a/scripts/aclshow
+++ b/scripts/aclshow
@@ -21,13 +21,10 @@ from __future__ import print_function
 import argparse
 import json
 import os
-import re
-import subprocess
 import swsssdk
 import sys
 
 from tabulate import tabulate
-from natsort import natsorted
 
 ### temp file to save counter positions when doing clear counter action.
 ### if we could have a SAI command to clear counters will be better, so no need to maintain

--- a/scripts/aclshow
+++ b/scripts/aclshow
@@ -92,9 +92,6 @@ class AclStat(object):
         read redis database for acl counters
         """
 
-        def qstrip(string):
-            return string.strip().strip(" \"").rstrip("\"")
-
         def lowercase_keys(dictionary):
             return dict((k.lower(), v) for k,v in dictionary.iteritems()) if dictionary else None
 
@@ -128,7 +125,6 @@ class AclStat(object):
             """
             Get ACL counters from the DB
             """
-            counters_cnt = len(self.acl_rules) # num of counters should be the same as rules
             for table, rule in self.acl_rules.keys():
                 cnt_props = lowercase_keys(self.db.get_all(self.db.COUNTERS_DB, "COUNTERS:%s:%s" % (table, rule)))
                 self.acl_counters[table, rule] = cnt_props

--- a/scripts/boot_part
+++ b/scripts/boot_part
@@ -62,12 +62,13 @@ def get_boot_partition(blkdev):
     ## Parse command output and return the current boot partition index
     for line in out.splitlines():
         m = re.match(r'{0}(\d+) / .*'.format(blkdev), line)
-        if not m: continue
+        if not m:
+            continue
         index = m.group(1)
         return int(index)
-    else:
-        logger.error('Unexpected /proc/mounts output: %s', out)
-        return None
+
+    logger.error('Unexpected /proc/mounts output: %s', out)
+    return None
 
 def set_boot_partition(blkdev, index):
     ## Mount the partition

--- a/scripts/configlet
+++ b/scripts/configlet
@@ -76,13 +76,9 @@ A sample for update:
 """
 
 from __future__ import print_function
-import sys
-import os.path
 import argparse
 import json
 import time
-from collections import OrderedDict
-from natsort import natsorted
 from swsssdk import ConfigDBConnector
 
 test_only = False

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -6,9 +6,6 @@ import argparse
 import syslog
 from swsssdk import ConfigDBConnector
 import sonic_device_util
-import os
-import subprocess
-import json
 
 
 SYSLOG_IDENTIFIER = 'db_migrator'

--- a/scripts/decode-syseeprom
+++ b/scripts/decode-syseeprom
@@ -5,17 +5,11 @@
 # This is the main script that handles eeprom encoding and decoding
 #
 try:
-    import exceptions
-    import binascii
-    import time
     import optparse
     import warnings
     import os
-    import subprocess
     import sys
-    from array import array
     import imp
-    from sonic_eeprom import eeprom_dts
     import glob
     from sonic_device_util import get_machine_info
     from sonic_device_util import get_platform_info
@@ -55,7 +49,7 @@ def main():
     # Currently, don't support eeprom db on Arista platform
     platforms_without_eeprom_db = ['arista', 'kvm']
     if any(platform in platform_path for platform in platforms_without_eeprom_db)\
-            or getattr(t, 'read_eeprom_db', None) == None:
+            or getattr(t, 'read_eeprom_db', None) is None:
         support_eeprom_db = False
 
     #

--- a/scripts/decode-syseeprom
+++ b/scripts/decode-syseeprom
@@ -19,7 +19,7 @@ try:
     import glob
     from sonic_device_util import get_machine_info
     from sonic_device_util import get_platform_info
-except ImportError, e:
+except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 
 PLATFORM_ROOT = '/usr/share/sonic/device'
@@ -63,6 +63,8 @@ def main():
     #
     run(t, opts, args, support_eeprom_db)
 
+    return 0
+
 #-------------------------------------------------------------------------------
 #
 # sets global variable "optcfg"
@@ -103,7 +105,7 @@ def run(target, opts, args, support_eeprom_db):
     if not os.path.exists(CACHE_ROOT):
         try:
             os.makedirs(CACHE_ROOT)
-        except:
+        except OSError:
             pass
     if opts.init:
         for file in glob.glob(os.path.join(CACHE_ROOT, '*')):
@@ -115,7 +117,7 @@ def run(target, opts, args, support_eeprom_db):
     #
     try:
         target.set_cache_name(os.path.join(CACHE_ROOT, CACHE_FILE))
-    except:
+    except Exception:
         pass
 
     e = target.read_eeprom()
@@ -124,7 +126,7 @@ def run(target, opts, args, support_eeprom_db):
 
     try:
         target.update_cache(e)
-    except:
+    except Exception:
         pass
 
     if opts.init:
@@ -139,7 +141,7 @@ def run(target, opts, args, support_eeprom_db):
     elif opts.serial:
         try:
             serial = target.serial_number_str(e)
-        except NotImplemented, e:
+        except NotImplementedError as e:
             print e
         else:
             print serial or "Undefined."

--- a/scripts/dump_nat_entries.py
+++ b/scripts/dump_nat_entries.py
@@ -5,7 +5,6 @@ Description: dump_nat_entries.py -- dump conntrack nat entries from kernel into 
              so as to restore them during warm reboot
 """
 
-import sys
 import subprocess
 
 def main():

--- a/scripts/ecnconfig
+++ b/scripts/ecnconfig
@@ -50,7 +50,6 @@ from __future__ import print_function
 
 import os
 import sys
-import json
 import argparse
 import swsssdk
 from tabulate import tabulate

--- a/scripts/ecnconfig
+++ b/scripts/ecnconfig
@@ -265,7 +265,7 @@ def main():
 
                 # get current configuration data 
                 wred_profile_data = prof_cfg.get_profile_data(args.profile)
-                if wred_profile_data == None:
+                if wred_profile_data is None:
                     raise Exception("Input arguments error. Invalid WRED profile %s" % (args.profile))
 
                 if args.green_max:

--- a/scripts/fanshow
+++ b/scripts/fanshow
@@ -4,8 +4,6 @@
 """
 from __future__ import print_function
 
-import argparse
-
 from tabulate import tabulate
 from swsssdk import SonicV2Connector
 from natsort import natsorted

--- a/scripts/fdbclear
+++ b/scripts/fdbclear
@@ -15,9 +15,7 @@ import argparse
 import json
 import sys
 
-from natsort import natsorted
-from swsssdk import SonicV2Connector, port_util
-from tabulate import tabulate
+from swsssdk import SonicV2Connector
 
 class FdbClear(object):
 

--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -85,7 +85,7 @@ class FdbShow(object):
             elif 'bvid' in fdb:
                 try:
                     vlan_id = port_util.get_vlan_id_from_bvid(self.db, fdb["bvid"])
-                except:
+                except Exception:
                     vlan_id = fdb["bvid"]
                     print "Failed to get Vlan id for bvid {}\n".format(fdb["bvid"])
             self.bridge_mac_list.append((int(vlan_id),) + (fdb["mac"],) + (if_name,) + (fdb_type,))

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -331,6 +331,7 @@ main() {
     save_cmd "show platform summary" "platform.summary"
     save_cmd "show platform syseeprom" "platform.syseeprom"
     save_cmd "cat /host/machine.conf" "machine.conf"
+    save_cmd "docker stats --no-stream" "docker.stats"
 
     save_cmd "sensors" "sensors"
     save_cmd "show platform psustatus" "platform.psustatus"

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -200,6 +200,37 @@ save_redis() {
 }
 
 ###############################################################################
+# Runs a 'show platform' command, append the output to 'filename' and add to the incrementally built tar.
+# Globals:
+#  LOGDIR
+#  BASE
+#  MKDIR
+#  TAR
+#  TARFILE
+#  DUMPDIR
+#  V
+#  RM
+# Arguments:
+#  type: the type of platform information
+#  filename: the filename to save the output as in $BASE/dump
+# Returns:
+#  None
+###############################################################################
+save_platform() {
+    local type="$1"
+    local filename=$2
+    local filepath="${LOGDIR}/$filename"
+    local tarpath="${BASE}/dump/$filename"
+    [ ! -d $LOGDIR ] && $MKDIR $V -p $LOGDIR
+
+    eval "show platform $type" &>> "$filepath"
+    echo $'\r' >> "$filepath"
+
+    ($TAR $V -uhf $TARFILE -C $DUMPDIR "$tarpath" \
+        || abort "${ERROR_TAR_FAILED}" "tar append operation failed. Aborting to prevent data loss.")
+}
+
+###############################################################################
 # Runs a comamnd and saves its output to the incrementally built tar.
 # Globals:
 #  LOGDIR
@@ -327,17 +358,20 @@ main() {
         /proc/zoneinfo \
         || abort "${ERROR_PROCFS_SAVE_FAILED}" "Proc saving operation failed. Aborting for safety."
 
+    save_platform "syseeprom" "platform"
+    save_platform "psustatus" "platform"
+    save_platform "ssdhealth" "platform"
+    save_platform "temperature" "platform"
+    save_platform "fan" "platform"
+
     save_cmd "show version" "version"
     save_cmd "show platform summary" "platform.summary"
-    save_cmd "show platform syseeprom" "platform.syseeprom"
     save_cmd "cat /host/machine.conf" "machine.conf"
     save_cmd "docker stats --no-stream" "docker.stats"
 
     save_cmd "sensors" "sensors"
-    save_cmd "show platform psustatus" "platform.psustatus"
     save_cmd "lspci -vvv -xx" "lspci"
     save_cmd "lsusb -v" "lsusb"
-
     save_cmd "sysctl -a" "sysctl"
     save_ip "link" "link"
     save_ip "addr" "addr"

--- a/scripts/intfstat
+++ b/scripts/intfstat
@@ -312,7 +312,6 @@ def main():
             sys.exit(0)
 
     if wait_time_in_seconds == 0:
-        cnstat_cached_dict = OrderedDict()
         if os.path.isfile(cnstat_fqn_file):
             try:
                 cnstat_cached_dict = pickle.load(open(cnstat_fqn_file, 'r'))

--- a/scripts/intfstat
+++ b/scripts/intfstat
@@ -9,12 +9,8 @@
 import argparse
 import cPickle as pickle
 import datetime
-import getopt
 import sys
 import os
-import json
-import re
-import subprocess
 import swsssdk
 import sys
 import time

--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -220,8 +220,7 @@ def get_portchannel_list(get_raw_po_int_configdb_info):
         portchannel = po[0]
         if portchannel not in portchannel_list:
             portchannel_list.append(portchannel)
-    portchannel = portchannel_list.sort()
-    return portchannel_list
+    return natsorted(portchannel_list)
 
 def create_po_int_tuple_list(get_raw_po_int_configdb_info):
     """

--- a/scripts/natclear
+++ b/scripts/natclear
@@ -12,11 +12,8 @@
 import argparse
 import json
 import sys
-import subprocess
 
-from natsort import natsorted
 from swsssdk import SonicV2Connector
-from tabulate import tabulate
 
 class NatClear(object):
 

--- a/scripts/natconfig
+++ b/scripts/natconfig
@@ -67,9 +67,7 @@ class NatConfig(object):
 
         for key,values in static_nat_dict.items():
             ip_protocol = "all"
-            global_ip = "---"
             global_port = "---"
-            local_ip = "---"
             local_port = "---"
             nat_type = "dnat"
             twice_nat_id = "---"
@@ -106,10 +104,6 @@ class NatConfig(object):
             return
 
         for key,values in static_napt_dict.items():
-            ip_protocol = "all"
-            global_ip = "---"
-            global_port = "---"
-            local_ip = "---"
             local_port = "---"
             nat_type = "dnat"
             twice_nat_id = "---"
@@ -151,8 +145,6 @@ class NatConfig(object):
             return
 
         for key,values in nat_pool_dict.items():
-            pool_name = "---"
-            global_ip = "---"
             global_port = "---"
 
             if isinstance(key, unicode) is True:
@@ -182,8 +174,6 @@ class NatConfig(object):
             return
 
         for key,values in nat_binding_dict.items():
-            binding_name = "---"
-            pool_name = "---"
             access_list = "---"
             nat_type = "snat"
             twice_nat_id = "---"

--- a/scripts/natconfig
+++ b/scripts/natconfig
@@ -39,10 +39,8 @@
 """
 
 import argparse
-import json
 import sys
 
-from natsort import natsorted
 from tabulate import tabulate
 from swsssdk import ConfigDBConnector
 

--- a/scripts/natshow
+++ b/scripts/natshow
@@ -61,7 +61,6 @@ import json
 import sys
 import re
 
-from natsort import natsorted
 from swsssdk import SonicV2Connector
 from tabulate import tabulate
 

--- a/scripts/natshow
+++ b/scripts/natshow
@@ -132,8 +132,6 @@ class NatShow(object):
                 continue
 
             ip_protocol = "all"
-            source = "---"
-            destination = "---"
             translated_dst = "---"
             translated_src = "---"
 
@@ -280,8 +278,6 @@ class NatShow(object):
                     nat_twice_values = self.appl_db.get_all(self.appl_db.APPL_DB,'NAT_TWICE_TABLE:{}'.format(nat_twice_entry))
 
                     ip_protocol = "all"
-                    source = "---"
-                    destination = "---"
 
                     source = nat_twice_keys[0]
                     destination = nat_twice_keys[1]
@@ -306,8 +302,6 @@ class NatShow(object):
                     napt_twice_values = self.appl_db.get_all(self.appl_db.APPL_DB,'NAPT_TWICE_TABLE:{}'.format(napt_twice_entry))
 
                     ip_protocol = napt_twice_keys[0]
-                    source = "---"
-                    destination = "---"
 
                     source = napt_twice_keys[1] + ':' + napt_twice_keys[2]
                     destination = napt_twice_keys[3] + ':' + napt_twice_keys[4]

--- a/scripts/nbrshow
+++ b/scripts/nbrshow
@@ -80,7 +80,6 @@ class NbrBase(object):
 
             ent = self.db.get_all('ASIC_DB', s, blocking=True)
             br_port_id = ent[b"SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID"][oid_pfx:]
-            ent_type = ent[b"SAI_FDB_ENTRY_ATTR_TYPE"]
             if br_port_id not in self.if_br_oid_map:
                 continue
             port_id = self.if_br_oid_map[br_port_id]

--- a/scripts/nbrshow
+++ b/scripts/nbrshow
@@ -93,7 +93,7 @@ class NbrBase(object):
             elif 'bvid' in fdb:
                 try:
                     vlan_id = port_util.get_vlan_id_from_bvid(self.db, fdb["bvid"])
-                except:
+                except Exception:
                     vlan_id = fdb["bvid"]
                     print "Failed to get Vlan id for bvid {}\n".format(fdb["bvid"])
             self.bridge_mac_list.append((int(vlan_id),) + (fdb["mac"],) + (if_name,))

--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -549,7 +549,7 @@ def main():
     ferret_service_vips = args.vips
     operation_mode = args.mode
 
-    if operation_mode == 'set' and ferret_service_vips == None:
+    if operation_mode == 'set' and ferret_service_vips is None:
         log_warning('ferret service vip is required in set mode')
         sys.exit(1)
 

--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -17,9 +17,7 @@ import traceback
 import subprocess
 import time
 import warnings
-import sonic_device_util
 from swsssdk import ConfigDBConnector
-from swsssdk import SonicV2Connector
 from netaddr import IPAddress, IPNetwork
 
 

--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -266,7 +266,6 @@ def get_vlan_addresses(vlan_interface):
                 mac_addr = keys[1]
     except Exception:
         log_error('failed to get %s addresses from o.s.' % vlan_interface)
-        pass
 
     if not mac_addr:
         mac_addr = get_vlan_interface_mac_address(vlan_interface)

--- a/scripts/pcmping
+++ b/scripts/pcmping
@@ -120,7 +120,7 @@ def create_socket(interface, portchannel):
             if iface == interface:
                 exp_socket = s
             sockets.append(s)
-    except:
+    except Exception:
         sys.stderr.write("Unable to create socket. Check your permissions\n")
         sys.exit(1)
     return sockets, exp_socket

--- a/scripts/pfcstat
+++ b/scripts/pfcstat
@@ -11,10 +11,7 @@ import sys
 import argparse
 import cPickle as pickle
 import datetime
-import getopt
-import json
 import os.path
-import time
 
 from collections import namedtuple, OrderedDict
 from natsort import natsorted

--- a/scripts/pfcstat
+++ b/scripts/pfcstat
@@ -225,7 +225,6 @@ Examples:
     """
         Print the counters of pfc rx counter
     """
-    cnstat_cached_dict = OrderedDict()
     if os.path.isfile(cnstat_fqn_file_rx):
         try:
             cnstat_cached_dict = pickle.load(open(cnstat_fqn_file_rx, 'r'))
@@ -240,7 +239,6 @@ Examples:
     """
         Print the counters of pfc tx counter
     """
-    cnstat_cached_dict = OrderedDict()
     if os.path.isfile(cnstat_fqn_file_tx):
         try:
             cnstat_cached_dict = pickle.load(open(cnstat_fqn_file_tx, 'r'))

--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -17,9 +17,7 @@ optional arguments:
 """
 from __future__ import print_function
 
-import os
 import sys
-import json
 import argparse
 import swsssdk
 

--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -4,7 +4,7 @@ portconfig is the utility to show and change ECN configuration
 
 usage: portconfig [-h] [-v] [-s] [-f] [-m] [-p PROFILE] [-gmin GREEN_MIN]
                  [-gmax GREEN_MAX] [-ymin YELLOW_MIN] [-ymax YELLOW_MAX]
-                 [-rmin RED_MIN] [-rmax RED_MAX] [-vv]
+                 [-rmin RED_MIN] [-rmax RED_MAX] [-vv] [-n namespace]
 
 optional arguments:
   -h     --help                show this help message and exit
@@ -14,6 +14,7 @@ optional arguments:
   -s     --speed               port speed in Mbits
   -f     --fec                 port fec mode
   -m     --mtu                 port mtu in bytes
+  -n     --namesapce           Namespace name
 """
 from __future__ import print_function
 
@@ -30,12 +31,16 @@ class portconfig(object):
     """
     Process aclstat
     """
-    def __init__(self, verbose, port):
+    def __init__(self, verbose, port, namespace):
         self.verbose = verbose
 
         # Set up db connections
-        self.db = swsssdk.ConfigDBConnector()
+        if namespace is None:
+            self.db = swsssdk.ConfigDBConnector()
+        else:
+            self.db = swsssdk.ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
         self.db.connect()
+
         # check whether table for this port exists
         port_tables = self.db.get_table(PORT_TABLE_NAME)
         if not port_tables.has_key(port):
@@ -72,10 +77,12 @@ def main():
     parser.add_argument('-f', '--fec', type=str, help='port fec mode value in (none, rs, fc)', default=None)
     parser.add_argument('-m', '--mtu', type=int, help='port mtu value in bytes', default=None)
     parser.add_argument('-vv', '--verbose', action='store_true', help='Verbose output', default=False)
+    parser.add_argument('-n', '--namespace', metavar='namespace details', type = str, required = False,
+                        help = 'The namespace whose DB instance we need to connect', default=None)
     args = parser.parse_args()
 
     try:
-        port = portconfig(args.verbose, args.port)
+        port = portconfig(args.verbose, args.port, args.namespace)
         if args.list:
             port.list_params(args.port)
         elif args.speed or args.fec or args.mtu:

--- a/scripts/portstat
+++ b/scripts/portstat
@@ -109,7 +109,7 @@ class Portstat(object):
         if speed is None:
             speed = PORT_RATE
         else:
-            speed = int(speed)/1000
+            speed = int(speed)//1000
         return speed
 
     def get_port_state(self, port_name):

--- a/scripts/portstat
+++ b/scripts/portstat
@@ -9,10 +9,7 @@
 import argparse
 import cPickle as pickle
 import datetime
-import getopt
 import os.path
-import re
-import subprocess
 import swsssdk
 import sys
 import time

--- a/scripts/queuestat
+++ b/scripts/queuestat
@@ -9,8 +9,6 @@
 import argparse
 import cPickle as pickle
 import datetime
-import getopt
-import json
 import os.path
 import swsssdk
 import sys

--- a/scripts/queuestat
+++ b/scripts/queuestat
@@ -143,7 +143,6 @@ class Queuestat(object):
             Print the cnstat.
         """
         table = []
-        queue_count = len(cnstat_dict)
 
         for key, data in cnstat_dict.iteritems():
             if key == 'time':
@@ -170,7 +169,6 @@ class Queuestat(object):
                 return '{:,}'.format(new - old)
 
         table = []
-        queue_count = len(cnstat_new_dict)
 
         for key, cntr in cnstat_new_dict.iteritems():
             if key == 'time':
@@ -198,7 +196,6 @@ class Queuestat(object):
         for port in natsorted(self.counter_port_name_map):
             cnstat_dict = self.get_cnstat(self.port_queues_map[port])
 
-            cnstat_cached_dict = OrderedDict()
             cnstat_fqn_file_name = cnstat_fqn_file + port
             if os.path.isfile(cnstat_fqn_file_name):
                 try:
@@ -217,7 +214,6 @@ class Queuestat(object):
 
         # Get stat for the port queried
         cnstat_dict = self.get_cnstat(self.port_queues_map[port])
-        cnstat_cached_dict = OrderedDict()
         cnstat_fqn_file_name = cnstat_fqn_file + port
         if os.path.isfile(cnstat_fqn_file_name):
             try:

--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -3,8 +3,6 @@
     Script to show sfp eeprom and presence status.
     Not like sfputil this scripts get the sfp data from DB directly.  
 """
-import argparse
-import json
 import sys
 import click
 import re
@@ -12,7 +10,7 @@ import operator
 import os
 
 from natsort import natsorted
-from swsssdk import SonicV2Connector, port_util
+from swsssdk import SonicV2Connector
 from tabulate import tabulate
 
 # Mock the redis for unit test purposes #

--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -19,10 +19,8 @@ limitations under the License.
 import sys
 import argparse
 import shlex
-from argparse import RawTextHelpFormatter
 import os
 import subprocess
-import errno
 from swsssdk import ConfigDBConnector
 
 aboot_cfg_template ="/host/image-%s/kernel-cmdline"
@@ -280,7 +278,7 @@ def kdump_enable(verbose, kdump_enabled, memory, num_dumps, image, cmdline_file)
     crash_kernel_mem = search_for_crash_kernel(lines[img_index])
     if verbose:
         print("crash_kernel_mem=[%s]" % crash_kernel_mem)
-    if crash_kernel_mem == None:
+    if crash_kernel_mem is None:
         lines[img_index] += " crashkernel=%s" % memory
         changed = True
         if verbose:
@@ -348,7 +346,7 @@ def kdump_disable(verbose, kdump_enabled, memory, num_dumps, image, cmdline_file
 
     changed = False
     crash_kernel_mem = search_for_crash_kernel(lines[img_index])
-    if crash_kernel_mem == None:
+    if crash_kernel_mem is None:
         print("kdump is already disabled")
     else:
         lines[img_index] = lines[img_index].replace("crashkernel="+crash_kernel_mem, "")
@@ -388,7 +386,7 @@ def cmd_kdump_disable(verbose, image=get_current_image()):
 #  @param memory  If not None, new value to set. 
 #                 If None, display current value read from running configuration
 def cmd_kdump_memory(verbose, memory):
-    if memory == None:
+    if memory is None:
         (rc, lines, err_str) = run_command("/usr/bin/show kdump memory", use_shell=False);
         print('\n'.join(lines))
     else:
@@ -405,7 +403,7 @@ def cmd_kdump_memory(verbose, memory):
 #  @param memory  If not None, new value to set. 
 #                 If None, display current value read from running configuration
 def cmd_kdump_num_dumps(verbose, num_dumps):
-    if num_dumps == None:
+    if num_dumps is None:
         (rc, lines, err_str) = run_command("/usr/bin/show kdump num_dumps", use_shell=False);
         print('\n'.join(lines))
     else:
@@ -484,7 +482,7 @@ def cmd_kdump_file(num_lines, filename):
                     if x.find(filename) != -1:
                         fname = x
                         break
-                if fname == None:
+                if fname is None:
                     print("Invalid key")
                     sys.exit(1)
             (rc, lines, err_str) = run_command("/usr/bin/tail -n %d %s" % (num_lines, fname), use_shell=False);
@@ -500,7 +498,7 @@ def main():
 
     # Add allowed arguments
     parser = argparse.ArgumentParser(description="kdump configuration and status tool",
-                                     formatter_class=RawTextHelpFormatter)
+                                     formatter_class=argparse.RawTextHelpFormatter)
 
     # Enable kdump on Current image
     parser.add_argument('--enable', action='store_true',

--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -49,7 +49,6 @@ def run_command(cmd, use_shell=False):
     @param use_shell (bool) Execute subprocess with shell access
     '''
 
-    pid = None
     try:
         if isinstance(cmd, list):
             if use_shell is False:

--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -179,7 +179,7 @@ def get_kdump_memory():
                 #print(lines[0][p+2:])
                 #print('XXX')
                 return lines[0][p+2:]
-    except:
+    except Exception:
         pass
     return "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M"
 
@@ -194,7 +194,7 @@ def get_kdump_num_dumps():
             p = lines[0].find(': ')
             if p != -1:
                 return int(lines[0][p+2:])
-    except:
+    except Exception:
         pass
     return 3
 
@@ -337,6 +337,7 @@ def cmd_kdump_config_next(verbose):
 ## Disable kdump
 #
 #  @param verbose If True, the function will display a few additional information
+#  @return        True if the grub/cmdline cfg has changed, and False if it has not
 def kdump_disable(verbose, kdump_enabled, memory, num_dumps, image, cmdline_file):
     write_use_kdump(0)
 
@@ -357,6 +358,8 @@ def kdump_disable(verbose, kdump_enabled, memory, num_dumps, image, cmdline_file
 
     if changed:
         rewrite_cfg(lines, cmdline_file)
+
+    return changed
 
 ## Command: Disable kdump
 #

--- a/scripts/teamshow
+++ b/scripts/teamshow
@@ -21,14 +21,11 @@
 
 import json
 import os
-import re
 import swsssdk
 import subprocess
 import sys
 from tabulate import tabulate
 from natsort import natsorted
-from sonic_device_util import get_machine_info
-from sonic_device_util import get_platform_info
 
 PORT_CHANNEL_APPL_TABLE_PREFIX = "LAG_TABLE:"
 PORT_CHANNEL_CFG_TABLE_PREFIX = "PORTCHANNEL|"

--- a/scripts/teamshow
+++ b/scripts/teamshow
@@ -50,7 +50,7 @@ class Teamshow(object):
             Get the portchannel names from database.
         """
         team_keys = self.db.keys(self.db.CONFIG_DB, PORT_CHANNEL_CFG_TABLE_PREFIX+"*")
-        if team_keys == None:
+        if team_keys is None:
             return
         self.teams = [key[len(PORT_CHANNEL_CFG_TABLE_PREFIX):] for key in team_keys]
 

--- a/scripts/tempershow
+++ b/scripts/tempershow
@@ -4,8 +4,6 @@
 """
 from __future__ import print_function
 
-import argparse
-
 from tabulate import tabulate
 from swsssdk import SonicV2Connector
 from natsort import natsorted

--- a/scripts/update_json.py
+++ b/scripts/update_json.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 
 import os
-import sys
 import json
 import argparse
 

--- a/scripts/watermarkstat
+++ b/scripts/watermarkstat
@@ -15,9 +15,6 @@ from natsort import natsorted
 from tabulate import tabulate
 
 
-headerPg = ['Port', 'PG0', 'PG1', 'PG2', 'PG3', 'PG4', 'PG5', 'PG6', 'PG7']
-headerUc = ['Port', 'UC0', 'UC1', 'UC2', 'UC3', 'UC4', 'UC5', 'UC6', 'UC7']
-headerMc = ['Port', 'MC8', 'MC9', 'MC10', 'MC11', 'MC12', 'MC13', 'MC14', 'MC15']
 headerBufferPool = ['Pool', 'Bytes']
 
 
@@ -140,22 +137,22 @@ class Watermarkstat(object):
                                "obj_map" : self.port_pg_map,
                                "idx_func": self.get_pg_index,
                                "wm_name" : "SAI_INGRESS_PRIORITY_GROUP_STAT_XOFF_ROOM_WATERMARK_BYTES",
-                               "header"  : headerPg},
+                               "header_prefix": "PG"},
             "pg_shared"     : {"message" : "Ingress shared pool occupancy per PG:",
                                "obj_map" : self.port_pg_map,
                                "idx_func": self.get_pg_index,
                                "wm_name" : "SAI_INGRESS_PRIORITY_GROUP_STAT_SHARED_WATERMARK_BYTES",
-                               "header"  : headerPg},
+                               "header_prefix": "PG"},
             "q_shared_uni"  : {"message" : "Egress shared pool occupancy per unicast queue:",
                                "obj_map" : self.port_uc_queues_map,
                                "idx_func": self.get_queue_index,
                                "wm_name" : "SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES",
-                               "header"  : headerUc},
+                               "header_prefix": "UC"},
             "q_shared_multi": {"message" : "Egress shared pool occupancy per multicast queue:",
                                "obj_map" : self.port_mc_queues_map,
                                "idx_func": self.get_queue_index,
                                "wm_name" : "SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES",
-                               "header"  : headerMc},
+                               "header_prefix": "MC"},
             "buffer_pool"   : {"message": "Shared pool maximum occupancy:",
                                "wm_name": "SAI_BUFFER_POOL_STAT_WATERMARK_BYTES",
                                "header" : headerBufferPool}
@@ -177,28 +174,48 @@ class Watermarkstat(object):
 
         return pg_index
 
+    def build_header(self, wm_type):
+        if wm_type is None:
+            print >> sys.stderr, "Header info is not available!"
+            sys.exit(1)
+
+        self.header_list = ['Port']
+        header_map = wm_type["obj_map"]
+        single_key = header_map.keys()[0]
+        header_len = len(header_map[single_key])
+        min_idx = float("inf")
+
+        for name, counter_oid in header_map[single_key].items():
+            curr_idx = int(wm_type["idx_func"](counter_oid))
+            min_idx = min(min_idx, curr_idx)
+
+        self.min_idx = int(min_idx)
+        self.header_list += ["{}{}".format(wm_type["header_prefix"], idx) for idx in range(self.min_idx, self.min_idx + header_len)]
+
     def get_counters(self, table_prefix, port_obj, idx_func, watermark):
         """
             Get the counters from specific table.
         """
 
-        fields = ["0"] * 8
+        # header list contains the port name followed by the queues/pgs. fields is used to populate the queue/pg values
+        fields = ["0"]* (len(self.header_list) - 1)
 
         for name, obj_id in port_obj.items():
             full_table_id = table_prefix + obj_id
-            pos = int(idx_func(obj_id)) % len(fields)
+            idx = int(idx_func(obj_id))
+            pos = idx - self.min_idx
             counter_data = self.counters_db.get(self.counters_db.COUNTERS_DB, full_table_id, watermark)
             if counter_data is None:
                 fields[pos] = STATUS_NA
             elif fields[pos] != STATUS_NA:
                 fields[pos] = str(int(counter_data))
-        cntr = tuple(fields)
-        return cntr
+        return fields
 
     def print_all_stat(self, table_prefix, key):
         table = []
         type = self.watermark_types[key]
         if key == 'buffer_pool':
+            self.header_list = type['header']
             # Get stats for each buffer pool
             for buf_pool, bp_oid in natsorted(self.buffer_pool_name_to_oid_map.items()):
                 key = table_prefix + bp_oid
@@ -207,15 +224,18 @@ class Watermarkstat(object):
                     data = STATUS_NA
                 table.append((buf_pool, data))
         else:
+            self.build_header(type)
             # Get stat for each port
             for port in natsorted(self.counter_port_name_map):
+                row_data = list()
                 data = self.get_counters(table_prefix,
                                          type["obj_map"][port], type["idx_func"], type["wm_name"])
-                table.append((port, data[0], data[1], data[2], data[3],
-                              data[4], data[5], data[6], data[7]))
+                row_data.append(port)
+                row_data.extend(data)
+                table.append(tuple(row_data))
 
         print(type["message"])
-        print tabulate(table, type["header"], tablefmt='simple', stralign='right')
+        print tabulate(table, self.header_list, tablefmt='simple', stralign='right')
 
     def send_clear_notification(self, data):
         msg = json.dumps(data, separators=(',', ':'))

--- a/scripts/watermarkstat
+++ b/scripts/watermarkstat
@@ -7,7 +7,6 @@
 #####################################################################
 
 import argparse
-import getopt
 import json
 import sys
 import swsssdk

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -12,8 +12,6 @@ try:
     import click
     import imp
     import syslog
-    import types
-    import traceback
     from tabulate import tabulate
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -142,8 +142,6 @@ def get_sfp_eeprom_status_string(port, port_sfp_eeprom_status):
 #   logical_port if logical and not ganged
 #
 def get_physical_port_name(logical_port, physical_port, ganged):
-    port_name = None
-
     if logical_port == physical_port:
         return logical_port
     elif ganged:
@@ -344,7 +342,6 @@ def load_platform_sfputil():
 
     # Load platform module from source
     platform_path = "/".join([PLATFORM_ROOT_PATH, platform])
-    hwsku_path = "/".join([platform_path, hwsku])
 
     try:
         module_file = "/".join([platform_path, "plugins", PLATFORM_SPECIFIC_MODULE_NAME + ".py"])

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -313,7 +313,7 @@ def get_platform_and_hwsku():
         stdout = proc.communicate()[0]
         proc.wait()
         hwsku = stdout.rstrip('\n')
-    except OSError, e:
+    except OSError as e:
         raise OSError("Cannot detect platform")
 
     return (platform, hwsku)
@@ -351,14 +351,14 @@ def load_platform_sfputil():
     try:
         module_file = "/".join([platform_path, "plugins", PLATFORM_SPECIFIC_MODULE_NAME + ".py"])
         module = imp.load_source(PLATFORM_SPECIFIC_MODULE_NAME, module_file)
-    except IOError, e:
+    except IOError as e:
         log_error("Failed to load platform module '%s': %s" % (PLATFORM_SPECIFIC_MODULE_NAME, str(e)), True)
         return -1
 
     try:
         platform_sfputil_class = getattr(module, PLATFORM_SPECIFIC_CLASS_NAME)
         platform_sfputil = platform_sfputil_class()
-    except AttributeError, e:
+    except AttributeError as e:
         log_error("Failed to instantiate '%s' class: %s" % (PLATFORM_SPECIFIC_CLASS_NAME, str(e)), True)
         return -2
 
@@ -386,7 +386,7 @@ def cli():
     try:
         port_config_file_path = get_path_to_port_config_file()
         platform_sfputil.read_porttab_mappings(port_config_file_path)
-    except Exception, e:
+    except Exception as e:
         log_error("Error reading port info (%s)" % str(e), True)
         sys.exit(3)
 

--- a/show/bgp_frr_v6.py
+++ b/show/bgp_frr_v6.py
@@ -1,5 +1,5 @@
 import click
-from show.main import *
+from show.main import ipv6, run_command, get_bgp_summary_extended
 
 
 ###############################################################################
@@ -9,7 +9,7 @@ from show.main import *
 ###############################################################################
 
 
-@ipv6.group(cls=AliasedGroup, default_if_no_args=False)
+@ipv6.group()
 def bgp():
     """Show IPv6 BGP (Border Gateway Protocol) information"""
     pass
@@ -22,7 +22,7 @@ def summary():
     try:
         device_output = run_command('sudo vtysh -c "show bgp ipv6 summary"', return_cmd=True)
         get_bgp_summary_extended(device_output)
-    except:
+    except Exception:
         run_command('sudo vtysh -c "show bgp ipv6 summary"')
 
 

--- a/show/bgp_quagga_v4.py
+++ b/show/bgp_quagga_v4.py
@@ -1,5 +1,5 @@
 import click
-from show.main import *
+from show.main import ip, run_command, get_bgp_summary_extended
 
 
 ###############################################################################
@@ -9,7 +9,7 @@ from show.main import *
 ###############################################################################
 
 
-@ip.group(cls=AliasedGroup, default_if_no_args=False)
+@ip.group()
 def bgp():
     """Show IPv4 BGP (Border Gateway Protocol) information"""
     pass
@@ -22,7 +22,7 @@ def summary():
     try:
         device_output = run_command('sudo vtysh -c "show ip bgp summary"', return_cmd=True)
         get_bgp_summary_extended(device_output)
-    except:
+    except Exception:
         run_command('sudo vtysh -c "show ip bgp summary"')
 
 

--- a/show/bgp_quagga_v6.py
+++ b/show/bgp_quagga_v6.py
@@ -1,5 +1,5 @@
 import click
-from show.main import *
+from show.main import ipv6, run_command, get_bgp_summary_extended
 
 
 ###############################################################################
@@ -9,7 +9,7 @@ from show.main import *
 ###############################################################################
 
 
-@ipv6.group(cls=AliasedGroup, default_if_no_args=False)
+@ipv6.group()
 def bgp():
     """Show IPv6 BGP (Border Gateway Protocol) information"""
     pass
@@ -22,7 +22,7 @@ def summary():
     try:
         device_output = run_command('sudo vtysh -c "show ipv6 bgp summary"', return_cmd=True)
         get_bgp_summary_extended(device_output)
-    except:
+    except Exception:
         run_command('sudo vtysh -c "show ipv6 bgp summary"')
 
 

--- a/show/main.py
+++ b/show/main.py
@@ -643,10 +643,9 @@ def is_mgmt_vrf_enabled(ctx):
         cmd = 'sonic-cfggen -d --var-json "MGMT_VRF_CONFIG"'
 
         p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        res = p.communicate()
+        stdout = p.communicate()[0]
         if p.returncode == 0:
-            p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            mvrf_dict = json.loads(p.stdout.read())
+            mvrf_dict = json.loads(stdout)
 
             # if the mgmtVrfEnabled attribute is configured, check the value
             # and return True accordingly.
@@ -698,8 +697,6 @@ def address ():
 
     config_db = ConfigDBConnector()
     config_db.connect()
-    header = ['IFNAME', 'IP Address', 'PrefixLen',]
-    body = []
 
     # Fetching data from config_db for MGMT_INTERFACE
     mgmt_ip_data = config_db.get_table('MGMT_INTERFACE')
@@ -2166,8 +2163,6 @@ def brief(verbose):
     vlan_ip_data = config_db.get_table('VLAN_INTERFACE')
     vlan_ports_data = config_db.get_table('VLAN_MEMBER')
 
-    vlan_keys = natsorted(vlan_dhcp_helper_data.keys())
-
     # Defining dictionaries for DHCP Helper address, Interface Gateway IP,
     # VLAN ports and port tagging
     vlan_dhcp_helper_dict = {}
@@ -2637,7 +2632,6 @@ def state(redis_unix_socket_path):
     if redis_unix_socket_path:
         kwargs['unix_socket_path'] = redis_unix_socket_path
 
-    data = {}
     db = SonicV2Connector(host='127.0.0.1')
     db.connect(db.STATE_DB, False)   # Make one attempt only
 

--- a/show/main.py
+++ b/show/main.py
@@ -180,7 +180,7 @@ def get_routing_stack():
         proc.wait()
         result = stdout.rstrip('\n')
 
-    except OSError, e:
+    except OSError as e:
         raise OSError("Cannot detect routing-stack")
 
     return (result)
@@ -448,7 +448,7 @@ def get_neighbor_dict_from_table(db,table_name):
             neighbor_dict[entry] = neighbor_data[entry].get(
                 'name') if 'name' in neighbor_data[entry].keys() else 'NotAvailable'
         return neighbor_dict
-    except:
+    except Exception:
         return neighbor_dict
 
 
@@ -498,7 +498,7 @@ def get_dynamic_neighbor_subnet(db):
         dynamic_neighbor["v4"] = v4_subnet
         dynamic_neighbor["v6"] = v6_subnet
         return dynamic_neighbor
-    except:
+    except Exception:
         return neighbor_data
 
 
@@ -1398,7 +1398,7 @@ def interfaces():
                 try:
                     neighbor_name = bgp_peer[local_ip][0]
                     neighbor_ip = bgp_peer[local_ip][1]
-                except:
+                except Exception:
                     pass
 
             if len(ifaddresses) > 0:
@@ -1538,7 +1538,7 @@ def interfaces():
                 try:
                     neighbor_name = bgp_peer[local_ip][0]
                     neighbor_ip = bgp_peer[local_ip][1]
-                except:
+                except Exception:
                     pass
 
             if len(ifaddresses) > 0:
@@ -2183,7 +2183,6 @@ def brief(verbose):
                 vlan_dhcp_helper_dict[str(key.strip('Vlan'))] = vlan_dhcp_helper_data[key]['dhcp_servers']
         except KeyError:
             vlan_dhcp_helper_dict[str(key.strip('Vlan'))] = " "
-            pass
 
     # Parsing VLAN Gateway info
     for key in natsorted(vlan_ip_data.keys()):
@@ -2868,7 +2867,6 @@ def ztp(status, verbose):
 
     if os.geteuid() != 0:
         exit("Root privileges are required for this operation")
-    pass
 
     cmd = "ztp status"
     if verbose:

--- a/show/main.py
+++ b/show/main.py
@@ -1044,6 +1044,32 @@ def counters(verbose):
 
     run_command(cmd, display_cmd=verbose)
 
+@pfc.command()
+@click.argument('interface', type=click.STRING, required=False)
+def priority(interface):
+    """Show pfc priority"""
+    cmd = 'pfc show priority'
+    if interface is not None and get_interface_mode() == "alias":
+        interface = iface_alias_converter.alias_to_name(interface)
+                
+    if interface is not None:    
+        cmd += ' {0}'.format(interface)
+
+    run_command(cmd)
+
+@pfc.command()
+@click.argument('interface', type=click.STRING, required=False)
+def asymmetric(interface):
+    """Show asymmetric pfc"""
+    cmd = 'pfc show asymmetric'
+    if interface is not None and get_interface_mode() == "alias":
+        interface = iface_alias_converter.alias_to_name(interface)
+                
+    if interface is not None:    
+        cmd += ' {0}'.format(interface)
+
+    run_command(cmd)
+
 # 'pfcwd' subcommand ("show pfcwd...")
 @cli.group(cls=AliasedGroup, default_if_no_args=False)
 def pfcwd():

--- a/show/main.py
+++ b/show/main.py
@@ -687,7 +687,7 @@ def mgmt_vrf(ctx,routes):
 # 'management_interface' group ("show management_interface ...")
 #
 
-@cli.group(cls=AliasedGroup, default_if_no_args=False)
+@cli.group(name='management_interface', cls=AliasedGroup, default_if_no_args=False)
 def management_interface():
     """Show management interface parameters"""
     pass
@@ -1095,7 +1095,7 @@ def stats(verbose):
     run_command(cmd, display_cmd=verbose)
 
 # 'naming_mode' subcommand ("show interfaces naming_mode")
-@interfaces.command()
+@interfaces.command('naming_mode')
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def naming_mode(verbose):
     """Show interface naming_mode status"""
@@ -2354,7 +2354,7 @@ def tacacs():
 #
 # 'mirror_session' command  ("show mirror_session ...")
 #
-@cli.command()
+@cli.command('mirror_session')
 @click.argument('session_name', required=False)
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def mirror_session(session_name, verbose):
@@ -2626,7 +2626,7 @@ def line():
     return
 
 
-@cli.group(cls=AliasedGroup, default_if_no_args=False)
+@cli.group(name='warm_restart', cls=AliasedGroup, default_if_no_args=False)
 def warm_restart():
     """Show warm restart configuration and state"""
     pass

--- a/show/main.py
+++ b/show/main.py
@@ -1,6 +1,5 @@
 #! /usr/bin/python -u
 
-import errno
 import json
 import netaddr
 import netifaces
@@ -2147,7 +2146,7 @@ def files():
 @click.argument('lines', metavar='<lines>', required=False)
 def log(record, lines):
     """Show kdump kernel core dump file kernel log"""
-    if lines == None:
+    if lines is None:
         run_command("sonic-kdump-config --file %s" % record)
     else:
         run_command("sonic-kdump-config --file %s --lines %s" % (record, lines))
@@ -2270,7 +2269,7 @@ def config(redis_unix_socket_path):
 
                 entry = config_db.get_entry('VLAN_MEMBER', (k, m))
                 mode = entry.get('tagging_mode')
-                if mode == None:
+                if mode is None:
                     r.append('?')
                 else:
                     r.append(mode)

--- a/show/mlnx.py
+++ b/show/mlnx.py
@@ -9,8 +9,6 @@ try:
     import sys
     import subprocess
     import click
-    import sonic_device_util
-    from swsssdk import ConfigDBConnector
     import xml.etree.ElementTree as ET
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))

--- a/sonic-utilities-tests/drops_group_test.py
+++ b/sonic-utilities-tests/drops_group_test.py
@@ -1,8 +1,5 @@
 import sys
 import os
-import pytest
-import click
-import swsssdk
 from click.testing import CliRunner
 
 test_path = os.path.dirname(os.path.abspath(__file__))

--- a/sonic-utilities-tests/intfstat_test.py
+++ b/sonic-utilities-tests/intfstat_test.py
@@ -1,8 +1,5 @@
 import sys
 import os
-import pytest
-import click
-import swsssdk
 from click.testing import CliRunner
 
 test_path = os.path.dirname(os.path.abspath(__file__))
@@ -12,7 +9,6 @@ sys.path.insert(0, test_path)
 sys.path.insert(0, modules_path)
 
 import mock_tables.dbconnector
-
 import show.main as show 
 import clear.main as clear
 

--- a/sonic-utilities-tests/psu_test.py
+++ b/sonic-utilities-tests/psu_test.py
@@ -42,6 +42,7 @@ PSU 1  OK
 """
         assert result.output == expected
 
+    @classmethod
     def teardown_class(cls):
         print("TEARDOWN")
         os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])

--- a/sonic-utilities-tests/sfp_test.py
+++ b/sonic-utilities-tests/sfp_test.py
@@ -113,6 +113,7 @@ Ethernet200  Not present
         expected = "Ethernet200: SFP EEPROM Not detected"
         assert result_lines == expected
 
+    @classmethod
     def teardown_class(cls):
         print("TEARDOWN")
         os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -387,7 +387,7 @@ def install(url, force, skip_migration=False):
         validate_url_or_abort(url)
         try:
             urllib.urlretrieve(url, DEFAULT_IMAGE_PATH, reporthook)
-        except Exception, e:
+        except Exception as e:
             click.echo("Download error", e)
             raise click.Abort()
         image_path = DEFAULT_IMAGE_PATH
@@ -553,7 +553,7 @@ def upgrade_docker(container_name, url, cleanup_image, skip_check, tag, warm):
         validate_url_or_abort(url)
         try:
             urllib.urlretrieve(url, DEFAULT_IMAGE_PATH, reporthook)
-        except Exception, e:
+        except Exception as e:
             click.echo("Download error", e)
             raise click.Abort()
         image_path = DEFAULT_IMAGE_PATH

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -3,14 +3,12 @@
 import os
 import re
 import signal
-import stat
 import sys
 import time
 import click
 import urllib
 import syslog
 import subprocess
-from swsssdk import ConfigDBConnector
 from swsssdk import SonicV2Connector
 import collections
 import platform

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -374,7 +374,6 @@ def cli():
 @click.argument('url')
 def install(url, force, skip_migration=False):
     """ Install image from local binary or URL"""
-    cleanup_image = False
     if get_running_image_type() == IMAGE_TYPE_ABOOT:
         DEFAULT_IMAGE_PATH = ABOOT_DEFAULT_IMAGE_PATH
     else:
@@ -443,7 +442,7 @@ def list():
     click.echo("Current: " + curimage)
     click.echo("Next: " + nextimage)
     click.echo("Available: ")
-    for image in get_installed_images():
+    for image in images:
         click.echo(image)
 
 # Set default image for boot
@@ -518,7 +517,7 @@ def cleanup():
     curimage = get_current_image()
     nextimage = get_next_image()
     image_removed = 0
-    for image in get_installed_images():
+    for image in images:
         if image != curimage and image != nextimage:
             click.echo("Removing image %s" % image)
             remove_image(image)
@@ -638,7 +637,7 @@ def upgrade_docker(container_name, url, cleanup_image, skip_check, tag, warm):
 
     run_command("docker kill %s > /dev/null" % container_name)
     run_command("docker rm %s " % container_name)
-    if tag == None:
+    if tag is None:
         # example image: docker-lldp-sv2:latest
         tag = get_docker_tag_name(image_latest)
     run_command("docker tag %s:latest %s:%s" % (image_name, image_name, tag))

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -449,7 +449,7 @@ def list():
         click.echo(image)
 
 # Set default image for boot
-@cli.command()
+@cli.command('set_default')
 @click.argument('image')
 def set_default(image):
     """ Choose image to boot from by default """
@@ -459,7 +459,7 @@ def set_default(image):
 
 
 # Set image for next boot
-@cli.command()
+@cli.command('set_next_boot')
 @click.argument('image')
 def set_next_boot(image):
     """ Choose image for next reboot (one time action) """
@@ -499,7 +499,7 @@ def remove(image):
     remove_image(image)
 
 # Retrieve version from binary image file and print to screen
-@cli.command()
+@cli.command('binary_version')
 @click.argument('binary_image_path')
 def binary_version(binary_image_path):
     """ Get version from local binary image file """
@@ -530,7 +530,7 @@ def cleanup():
         click.echo("No image(s) to remove")
 
 # Upgrade docker image
-@cli.command()
+@cli.command('upgrade_docker')
 @click.option('-y', '--yes', is_flag=True, callback=abort_if_false,
         expose_value=False, prompt='New docker image will be installed, continue?')
 @click.option('--cleanup_image', is_flag=True, help="Clean up old docker image")
@@ -694,7 +694,7 @@ def upgrade_docker(container_name, url, cleanup_image, skip_check, tag, warm):
         sys.exit(1)
 
 # rollback docker image
-@cli.command()
+@cli.command('rollback_docker')
 @click.option('-y', '--yes', is_flag=True, callback=abort_if_false,
         expose_value=False, prompt='Docker image will be rolled back, continue?')
 @click.argument('container_name', metavar='<container_name>', required=True,

--- a/ssdutil/main.py
+++ b/ssdutil/main.py
@@ -64,7 +64,7 @@ def get_platform_and_hwsku():
         stdout = proc.communicate()[0]
         proc.wait()
         hwsku = stdout.rstrip('\n')
-    except OSError, e:
+    except OSError as e:
         raise OSError("Cannot detect platform")
 
     return (platform, hwsku)

--- a/undebug/main.py
+++ b/undebug/main.py
@@ -2,10 +2,8 @@
 # date: 07/12/17
 
 import click
-import os
 import subprocess
 from click_default_group import DefaultGroup
-from pprint import pprint
 
 def run_command(command, pager=False):
     click.echo(click.style("Command: ", fg='cyan') + click.style(command, fg='green'))

--- a/undebug/main.py
+++ b/undebug/main.py
@@ -38,7 +38,7 @@ if 'FRRouting' in p:
         """debug bgp group """
         pass
 
-    @bgp.command()
+    @bgp.command('allow-martians')
     def allow_martians():
         """BGP allow martian next hops"""
         command = 'sudo vtysh -c "no debug bgp allow-martians"'
@@ -71,7 +71,7 @@ if 'FRRouting' in p:
         command += '"'
         run_command(command)
 
-    @bgp.command()
+    @bgp.command('neighbor-events')
     @click.argument('prefix_or_iface', required=False)
     def neighbor_events(prefix_or_iface):
         """BGP Neighbor Events"""
@@ -97,7 +97,7 @@ if 'FRRouting' in p:
         command += '"'
         run_command(command)
 
-    @bgp.command()
+    @bgp.command('update-groups')
     def update_groups():
         """BGP update-groups"""
         command = 'sudo vtysh -c "no debug bgp update-groups"'

--- a/utilities_common/util_base.py
+++ b/utilities_common/util_base.py
@@ -7,7 +7,7 @@ try:
     import os
     import sys
     import syslog
-except ImportError, e:
+except ImportError as e:
     raise ImportError (str(e) + " - required module not found")
 
 #
@@ -89,7 +89,7 @@ class UtilHelper(object):
             stdout = proc.communicate()[0]
             proc.wait()
             hwsku = stdout.rstrip('\n')
-        except OSError, e:
+        except OSError as e:
             raise OSError("Failed to detect platform: %s" % (str(e)))
 
         return (platform, hwsku)
@@ -130,7 +130,7 @@ class UtilHelper(object):
         try:
             module_file = "/".join([platform_path, "plugins", module_name + ".py"])
             module = imp.load_source(module_name, module_file)
-        except IOError, e:
+        except IOError as e:
             raise IOError("Failed to load platform module '%s': %s" % (module_name, str(e)))
 
         try:
@@ -140,7 +140,7 @@ class UtilHelper(object):
                 platform_util = platform_util_class('','','','')
             else:
                 platform_util = platform_util_class()
-        except AttributeError, e:
+        except AttributeError as e:
             raise AttributeError("Failed to instantiate '%s' class: %s" % (class_name, str(e)))
 
         return platform_util

--- a/utilities_common/util_base.py
+++ b/utilities_common/util_base.py
@@ -2,10 +2,8 @@
 
 try:
     import imp
-    import signal
     import subprocess
     import os
-    import sys
     import syslog
 except ImportError as e:
     raise ImportError (str(e) + " - required module not found")


### PR DESCRIPTION
**- What I did**
[Phase 1] Changes to the following config commands and scripts for Multi-ASIC devices.
1. config load : supports config load across all namespaces
   > Added an optional argument to specify the namespace [ -n namesapce ]
2. config save  : supports config save across all namespaces
   > Added an optional argument to specify the namespace [ -n namesapce ]
3. config reload
   > Supports reload of all services across namespaces.
4. config interface
   > Added an optional argument to specify the namespace. [ -n namesapce ]
       In Multi-ASIC devices "Mandatory" for Portchannel and Vlan interfaces. 
                                           "Optional" for physical interface, sub interface
5. config vlan
   > Added an optional argument to specify the namespace. [ -n namesapce ]
       In Multi-ASIC devices "Mandatory" for (add/del) of vlan. 
                                          "Optional" for member interface (add/del)
6. config portchannel
   > Added an optional argument to specify the namespace. [ -n namesapce ]
       In Multi-ASIC devices "Mandatory" for (add/del) of portchannel. 
                                          "Optional" for member interface (add/del)
7. config bgp 
    > In Multi-ASIC devices, **shutdown/startup all** is performed only on external BGP neighbors.                              
                                            internal IBGP sessions between ASIC's which won't be affected. 

Additional scripts modified are 
(1) db_migrator.py
(2) portconfig

Refer **https://github.com/Azure/sonic-py-swsssdk/pull/63** for changes in SonicV2Connector and ConfigDBConnector classes.

**- How I did it**
The following are the changes introduced in this PR
(a) Added the namespace argument to the scripts db_migrator.py and portconfig

(b) Added API's to get the multi_asic mode, namesapces based on sub_role field in DEVICE_METADATA, internal host names, get the namespace to which the interface belongs ( I check the port_config.ini for finding this **Reference:** https://github.com/Azure/sonic-buildimage/tree/master/device/virtual/x86_64-kvm_x86_64-r0/msft_multi_asic_vs)

(c) added the parameter of config_db to the interface and bgp neighbor helper API's. This approach is better as the init of config_db = ConfigDBConnector() is done already in the CLI handlers where these helper API's are invoked.

(d) Updated the API _get_all_neighbor_ipaddresses() to pass an additional parameter if there are any hosts to be ignored when returning the list back.

(e) config load/save commands : If the namespace parameter is given, the action is done only for that namespace. If no argument given the action is taken on the global namespace + if we are in multi-asic platform repeat the action in the namespaces.

(f) config reload command : There is no namespace parameter added to this command. It automatically finds the namespaces present and does reload.

(g) For the config interface, config port channel, config vlan -- added the namespace parameter. It is optional by default .This parameter is made mandatory for the following 
                    - create Portchannel interfaces
                    - create vlan.
                    - config interface commands with interfaces Portchannel, vlan Interface

(h) config bgp commands : In multi-ASIC devices we have both internal BGP sessions between the bgp dockers running in different namespaces ( mapped per ASIC ). The **config shutdown/startup all** bgp neighbors command is implemented so that it affects only the external BGP neighbors

**- How to verify it**
Verified on a multi-ASIC devices, by running the Config commands. 

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

