### PR TITLE
Add docker to 'show techsupport' command

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -333,7 +333,7 @@ main() {
     save_cmd "show platform summary" "platform.summary"
     save_cmd "show platform syseeprom" "platform.syseeprom"
     save_cmd "cat /host/machine.conf" "machine.conf"
-    save_cmd "docker stats --no-stream" "docker"
+    save_cmd "docker stats --no-stream" "docker.stats"
 
     save_cmd "sensors" "sensors"
     save_cmd "show platform psustatus" "platform.psustatus"

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -333,6 +333,7 @@ main() {
     save_cmd "show platform summary" "platform.summary"
     save_cmd "show platform syseeprom" "platform.syseeprom"
     save_cmd "cat /host/machine.conf" "machine.conf"
+    save_cmd "docker stats --no-stream" "docker"
 
     save_cmd "sensors" "sensors"
     save_cmd "show platform psustatus" "platform.psustatus"


### PR DESCRIPTION
- What I did
Add docker to 'show techsupport' command.

- How I did it
Created a new file with the docker information.

- How to verify it
Run 'show techsupport' command and see the new file.

- Previous command output (if the output of a command-line utility has changed)
No Output

- New command output (if the output of a command-line utility has changed)
No Output