### PR TITLE
[201911] Explicitly specify command names with underscores (continued)

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -765,7 +765,7 @@ def del_portchannel_member(ctx, portchannel_name, port_name):
 #
 # 'mirror_session' group ('config mirror_session ...')
 #
-@config.group()
+@config.group('mirror_session')
 def mirror_session():
     pass
 
@@ -870,7 +870,7 @@ def interval(poll_interval, verbose):
 
     run_command(cmd, display_cmd=verbose)
 
-@pfcwd.command()
+@pfcwd.command('counter_poll')
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 @click.argument('counter_poll', type=click.Choice(['enable', 'disable']))
 def counter_poll(counter_poll, verbose):
@@ -880,7 +880,7 @@ def counter_poll(counter_poll, verbose):
 
     run_command(cmd, display_cmd=verbose)
 
-@pfcwd.command()
+@pfcwd.command('big_red_switch')
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 @click.argument('big_red_switch', type=click.Choice(['enable', 'disable']))
 def big_red_switch(big_red_switch, verbose):
@@ -890,7 +890,7 @@ def big_red_switch(big_red_switch, verbose):
 
     run_command(cmd, display_cmd=verbose)
 
-@pfcwd.command()
+@pfcwd.command('start_default')
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def start_default(verbose):
     """ Start PFC WD by default configurations  """
@@ -940,7 +940,7 @@ def reload():
 #
 # 'warm_restart' group ('config warm_restart ...')
 #
-@config.group()
+@config.group('warm_restart')
 @click.pass_context
 @click.option('-s', '--redis-unix-socket-path', help='unix socket path for redis connection')
 def warm_restart(ctx, redis_unix_socket_path):
@@ -2038,7 +2038,7 @@ def delete(counter_name, verbose):
 #
 # 'add_reasons' subcommand ('config dropcounters add_reasons')
 #
-@dropcounters.command()
+@dropcounters.command('add-reasons')
 @click.argument("counter_name", type=str, required=True)
 @click.argument("reasons",      type=str, required=True)
 @click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
@@ -2051,7 +2051,7 @@ def add_reasons(counter_name, reasons, verbose):
 #
 # 'remove_reasons' subcommand ('config dropcounters remove_reasons')
 #
-@dropcounters.command()
+@dropcounters.command('remove-reasons')
 @click.argument("counter_name", type=str, required=True)
 @click.argument("reasons",      type=str, required=True)
 @click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")

--- a/debug/main.py
+++ b/debug/main.py
@@ -38,7 +38,7 @@ if 'FRRouting' in p:
         """debug bgp group """
         pass
 
-    @bgp.command()
+    @bgp.command('allow-martians')
     def allow_martians():
         """BGP allow martian next hops"""
         command = 'sudo vtysh -c "debug bgp allow-martians"'
@@ -71,7 +71,7 @@ if 'FRRouting' in p:
         command += '"'
         run_command(command)
 
-    @bgp.command()
+    @bgp.command('neighbor-events')
     @click.argument('prefix_or_iface', required=False)
     def neighbor_events(prefix_or_iface):
         """BGP Neighbor Events"""
@@ -97,7 +97,7 @@ if 'FRRouting' in p:
         command += '"'
         run_command(command)
 
-    @bgp.command()
+    @bgp.command('update-groups')
     def update_groups():
         """BGP update-groups"""
         command = 'sudo vtysh -c "debug bgp update-groups"'

--- a/pddf_fanutil/main.py
+++ b/pddf_fanutil/main.py
@@ -178,7 +178,7 @@ def debug():
     """pddf_fanutil debug commands"""
     pass
 
-@debug.command()
+@debug.command('dump-sysfs')
 def dump_sysfs():
     """Dump all Fan related SysFS paths"""
     status = platform_fanutil.dump_sysfs()

--- a/pddf_psuutil/main.py
+++ b/pddf_psuutil/main.py
@@ -180,7 +180,7 @@ def debug():
     """pddf_psuutil debug commands"""
     pass
 
-@debug.command()
+@debug.command('dump-sysfs')
 def dump_sysfs():
     """Dump all PSU related SysFS paths"""
     status = platform_psuutil.dump_sysfs()

--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -254,7 +254,7 @@ def start_default():
     configdb.mod_entry(CONFIG_DB_PFC_WD_TABLE_NAME, "GLOBAL", pfcwd_info)
 
 # Enable/disable PFC WD counter polling
-@cli.command()
+@cli.command('counter_poll')
 @click.argument('counter_poll', type=click.Choice(['enable', 'disable']))
 def counter_poll(counter_poll):
     """ Enable/disable counter polling """
@@ -267,7 +267,7 @@ def counter_poll(counter_poll):
     configdb.mod_entry("FLEX_COUNTER_TABLE", "PFCWD", pfcwd_info)
 
 # Enable/disable PFC WD BIG_RED_SWITCH mode
-@cli.command()
+@cli.command('big_red_switch')
 @click.argument('big_red_switch', type=click.Choice(['enable', 'disable']))
 def big_red_switch(big_red_switch):
     """ Enable/disable BIG_RED_SWITCH mode """

--- a/show/main.py
+++ b/show/main.py
@@ -686,7 +686,7 @@ def mgmt_vrf(ctx,routes):
 # 'management_interface' group ("show management_interface ...")
 #
 
-@cli.group(cls=AliasedGroup, default_if_no_args=False)
+@cli.group(name='management_interface', cls=AliasedGroup, default_if_no_args=False)
 def management_interface():
     """Show management interface parameters"""
     pass
@@ -1068,7 +1068,7 @@ def stats(verbose):
     run_command(cmd, display_cmd=verbose)
 
 # 'naming_mode' subcommand ("show interfaces naming_mode")
-@interfaces.command()
+@interfaces.command('naming_mode')
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def naming_mode(verbose):
     """Show interface naming_mode status"""
@@ -2240,7 +2240,7 @@ def tacacs():
 #
 # 'mirror_session' command  ("show mirror_session ...")
 #
-@cli.command()
+@cli.command('mirror_session')
 @click.argument('session_name', required=False)
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def mirror_session(session_name, verbose):
@@ -2512,7 +2512,7 @@ def line():
     return
 
 
-@cli.group(cls=AliasedGroup, default_if_no_args=False)
+@cli.group(name='warm_restart', cls=AliasedGroup, default_if_no_args=False)
 def warm_restart():
     """Show warm restart configuration and state"""
     pass

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -385,7 +385,7 @@ def list():
         click.echo(image)
 
 # Set default image for boot
-@cli.command()
+@cli.command('set_default')
 @click.argument('image')
 def set_default(image):
     """ Choose image to boot from by default """
@@ -395,7 +395,7 @@ def set_default(image):
 
 
 # Set image for next boot
-@cli.command()
+@cli.command('set_next_boot')
 @click.argument('image')
 def set_next_boot(image):
     """ Choose image for next reboot (one time action) """
@@ -430,7 +430,7 @@ def remove(image):
     remove_image(image)
 
 # Retrieve version from binary image file and print to screen
-@cli.command()
+@cli.command('binary_version')
 @click.argument('binary_image_path')
 def binary_version(binary_image_path):
     """ Get version from local binary image file """
@@ -461,7 +461,7 @@ def cleanup():
         click.echo("No image(s) to remove")
 
 # Upgrade docker image
-@cli.command()
+@cli.command('upgrade_docker')
 @click.option('-y', '--yes', is_flag=True, callback=abort_if_false,
         expose_value=False, prompt='New docker image will be installed, continue?')
 @click.option('--cleanup_image', is_flag=True, help="Clean up old docker image")
@@ -628,7 +628,7 @@ def upgrade_docker(container_name, url, cleanup_image, skip_check, tag, warm):
         sys.exit(1)
 
 # rollback docker image
-@cli.command()
+@cli.command('rollback_docker')
 @click.option('-y', '--yes', is_flag=True, callback=abort_if_false,
         expose_value=False, prompt='Docker image will be rolled back, continue?')
 @click.argument('container_name', metavar='<container_name>', required=True,

--- a/undebug/main.py
+++ b/undebug/main.py
@@ -38,7 +38,7 @@ if 'FRRouting' in p:
         """debug bgp group """
         pass
 
-    @bgp.command()
+    @bgp.command('allow-martians')
     def allow_martians():
         """BGP allow martian next hops"""
         command = 'sudo vtysh -c "no debug bgp allow-martians"'
@@ -71,7 +71,7 @@ if 'FRRouting' in p:
         command += '"'
         run_command(command)
 
-    @bgp.command()
+    @bgp.command('neighbor-events')
     @click.argument('prefix_or_iface', required=False)
     def neighbor_events(prefix_or_iface):
         """BGP Neighbor Events"""
@@ -97,7 +97,7 @@ if 'FRRouting' in p:
         command += '"'
         run_command(command)
 
-    @bgp.command()
+    @bgp.command('update-groups')
     def update_groups():
         """BGP update-groups"""
         command = 'sudo vtysh -c "no debug bgp update-groups"'


### PR DESCRIPTION
Backport of https://github.com/Azure/sonic-utilities/pull/852 to the 201911 branch

Starting with Click 7.0, the default behavior of a command with underscores will be to replace with dashes.

This is to address the above default behavior change, so that the commands remain the same, extending the work done in https://github.com/Azure/sonic-utilities/pull/846 to all Click-based SONiC command line utilities.

Resolves https://github.com/Azure/sonic-utilities/issues/847

More details can be found here: https://github.com/pallets/click/issues/1123

For new subcommands which haven't been included in a release branch yet, use hyphens, as this will be the direction we move in the future. I have also opened an issue to track the eventual transition: https://github.com/Azure/sonic-utilities/issues/853