### PR TITLE
Allow show ztp to display non-sensitive information visible to non-root user

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -2864,9 +2864,6 @@ def ztp(status, verbose):
     if os.path.isfile('/usr/bin/ztp') is False:
         exit("ZTP feature unavailable in this image version")
 
-    if os.geteuid() != 0:
-        exit("Root privileges are required for this operation")
-
     cmd = "ztp status"
     if verbose:
        cmd = cmd + " --verbose"


### PR DESCRIPTION
Allow show ztp to display non-sensitive information visible to non-root user

Signed-off-by: Rajendra Dendukuri <rajendra.dendukuri@broadcom.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Removed user privileges checks. These changes fix https://github.com/Azure/sonic-utilities/issues/800. The ZTP PR https://github.com/Azure/sonic-ztp/pull/13 is also required for these changes to work as expected.

**- How I did it**
Removed root user check.

**- How to verify it**
show ztp status

**- Previous command output (if the output of a command-line utility has changed)**
admin@sonic:~$ show ztp status
Root privileges are required for this operation

**- New command output (if the output of a command-line utility has changed)**
admin@sonic:~$ show ztp status
ZTP Admin Mode : True
ZTP Service    : Processing
ZTP Status     : IN-PROGRESS
ZTP Source     : local-fs (/host/ztp/ztp_data_local.json)
Runtime        : 06m 26s
Timestamp      : 2020-04-08 13:08:22 UTC

ZTP Service is active

01-test-plugin: IN-PROGRESS
