### PR TITLE
[config] Add support for multi-ASIC devices

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -12,9 +12,7 @@ import netifaces
 
 import sonic_device_util
 import ipaddress
-from swsssdk import ConfigDBConnector
-from swsssdk import SonicV2Connector
-from swsssdk import SonicDBConfig
+from swsssdk import ConfigDBConnector, SonicV2Connector, SonicDBConfig
 from minigraph import parse_device_desc_xml
 
 import aaa
@@ -147,7 +145,7 @@ def get_all_namespaces():
             elif metadata['localhost']['sub_role'] == 'BackEnd':
                 back_ns.append(namespace)
 
-    return {'front_ns':front_ns, 'back_ns':back_ns}
+    return {'front_ns': front_ns, 'back_ns': back_ns}
 
 # Validate whether a given namespace name is valid in the device.
 def validate_namespace(namespace):
@@ -595,7 +593,9 @@ config.add_command(nat.nat)
                 expose_value=False, prompt='Existing files will be overwritten, continue?')
 @click.argument('filename', required=False)
 def save(filename):
-    """Export current config DB to a file on disk."""
+    """Export current config DB to a file on disk.\n
+       [FILENAME] : Filenames separated by comma with no spaces in between.
+    """
     num_asic = _get_num_asic()
     cfg_files = []
 
@@ -608,7 +608,7 @@ def save(filename):
         cfg_files = filename.split(',')
 
         if len(cfg_files) != num_cfg_file:
-            click.echo("Input {} config file[s] separated by comma if needed".format(num_cfg_file))
+            click.echo("Input {} config file[s] separated by comma for multiple files ".format(num_cfg_file))
             return
 
     """In case of multi-asic mode we have additional config_db{NS}.json files for
@@ -633,7 +633,6 @@ def save(filename):
         if namespace is None:
             command = "{} -d --print-data > {}".format(SONIC_CFGGEN_PATH, file)
         else:
-            namespace = "{}{}".format(NAMESPACE_PREFIX, inst)
             command = "{} -n {} -d --print-data > {}".format(SONIC_CFGGEN_PATH, namespace, file)
 
         run_command(command, display_cmd=True)
@@ -642,7 +641,9 @@ def save(filename):
 @click.option('-y', '--yes', is_flag=True)
 @click.argument('filename', required=False)
 def load(filename, yes):
-    """Import a previous saved config DB dump file."""
+    """Import a previous saved config DB dump file.
+       [FILENAME] : Filenames separated by comma with no spaces in between.
+    """
     if filename is None:
         message = 'Load config from the default config file[s] ?'
     else:
@@ -663,7 +664,7 @@ def load(filename, yes):
         cfg_files = filename.split(',')
 
         if len(cfg_files) != num_cfg_file:
-            click.echo("Input {} config file[s] separated by comma if needed".format(num_cfg_file))
+            click.echo("Input {} config file[s] separated by comma for multiple files ".format(num_cfg_file))
             return
 
     """In case of multi-asic mode we have additional config_db{NS}.json files for
@@ -693,7 +694,6 @@ def load(filename, yes):
         if namespace is None:
             command = "{} -j {} --write-to-db".format(SONIC_CFGGEN_PATH, file)
         else:
-            namespace = "{}{}".format(NAMESPACE_PREFIX, inst)
             command = "{} -n {} -j {} --write-to-db".format(SONIC_CFGGEN_PATH, namespace, file)
 
         run_command(command, display_cmd=True)
@@ -704,7 +704,9 @@ def load(filename, yes):
 @click.option('-l', '--load-sysinfo', is_flag=True, help='load system default information (mac, portmap etc) first.')
 @click.argument('filename', required=False)
 def reload(filename, yes, load_sysinfo):
-    """Clear current configuration and import a previous saved config DB dump file."""
+    """Clear current configuration and import a previous saved config DB dump file.
+       [FILENAME] : Filenames separated by comma with no spaces in between.
+    """
     if filename is None:
         message = 'Clear current config and reload config from the default config file[s] ?'
     else:
@@ -727,7 +729,7 @@ def reload(filename, yes, load_sysinfo):
         cfg_files = filename.split(',')
 
         if len(cfg_files) != num_cfg_file:
-            click.echo("Input {} config file[s] separated by comma if needed".format(num_cfg_file))
+            click.echo("Input {} config file[s] separated by comma for multiple files ".format(num_cfg_file))
             return
 
     if load_sysinfo:

--- a/config/main.py
+++ b/config/main.py
@@ -705,7 +705,7 @@ def load(filename, yes):
 @click.argument('filename', required=False)
 def reload(filename, yes, load_sysinfo):
     """Clear current configuration and import a previous saved config DB dump file.
-       <filename> : Names of configuration file(s) to reload, separated by comma with no spaces in between
+       <filename> : Names of configuration file(s) to load, separated by comma with no spaces in between
     """
     if filename is None:
         message = 'Clear current config and reload config from the default config file(s) ?'

--- a/config/main.py
+++ b/config/main.py
@@ -594,7 +594,7 @@ config.add_command(nat.nat)
 @click.argument('filename', required=False)
 def save(filename):
     """Export current config DB to a file on disk.\n
-       <filename> : Names of configuration file(s) to use, separated by comma with no spaces in between
+       <filename> : Names of configuration file(s) to save, separated by comma with no spaces in between
     """
     num_asic = _get_num_asic()
     cfg_files = []
@@ -642,7 +642,7 @@ def save(filename):
 @click.argument('filename', required=False)
 def load(filename, yes):
     """Import a previous saved config DB dump file.
-       <filename> : Names of configuration file(s) to use, separated by comma with no spaces in between
+       <filename> : Names of configuration file(s) to load, separated by comma with no spaces in between
     """
     if filename is None:
         message = 'Load config from the default config file(s) ?'
@@ -705,7 +705,7 @@ def load(filename, yes):
 @click.argument('filename', required=False)
 def reload(filename, yes, load_sysinfo):
     """Clear current configuration and import a previous saved config DB dump file.
-       <filename> : Names of configuration file(s) to use, separated by comma with no spaces in between
+       <filename> : Names of configuration file(s) to reload, separated by comma with no spaces in between
     """
     if filename is None:
         message = 'Clear current config and reload config from the default config file(s) ?'

--- a/config/main.py
+++ b/config/main.py
@@ -594,7 +594,7 @@ config.add_command(nat.nat)
 @click.argument('filename', required=False)
 def save(filename):
     """Export current config DB to a file on disk.\n
-       [FILENAME] : Filenames separated by comma with no spaces in between.
+       <filename> : Names of configuration file(s) to use, separated by comma with no spaces in between
     """
     num_asic = _get_num_asic()
     cfg_files = []
@@ -608,7 +608,7 @@ def save(filename):
         cfg_files = filename.split(',')
 
         if len(cfg_files) != num_cfg_file:
-            click.echo("Input {} config file[s] separated by comma for multiple files ".format(num_cfg_file))
+            click.echo("Input {} config file(s) separated by comma for multiple files ".format(num_cfg_file))
             return
 
     """In case of multi-asic mode we have additional config_db{NS}.json files for
@@ -642,12 +642,12 @@ def save(filename):
 @click.argument('filename', required=False)
 def load(filename, yes):
     """Import a previous saved config DB dump file.
-       [FILENAME] : Filenames separated by comma with no spaces in between.
+       <filename> : Names of configuration file(s) to use, separated by comma with no spaces in between
     """
     if filename is None:
-        message = 'Load config from the default config file[s] ?'
+        message = 'Load config from the default config file(s) ?'
     else:
-        message = 'Load config from the file[s] {} ?'.format(filename)
+        message = 'Load config from the file(s) {} ?'.format(filename)
 
     if not yes:
         click.confirm(message, abort=True)
@@ -664,7 +664,7 @@ def load(filename, yes):
         cfg_files = filename.split(',')
 
         if len(cfg_files) != num_cfg_file:
-            click.echo("Input {} config file[s] separated by comma for multiple files ".format(num_cfg_file))
+            click.echo("Input {} config file(s) separated by comma for multiple files ".format(num_cfg_file))
             return
 
     """In case of multi-asic mode we have additional config_db{NS}.json files for
@@ -705,12 +705,12 @@ def load(filename, yes):
 @click.argument('filename', required=False)
 def reload(filename, yes, load_sysinfo):
     """Clear current configuration and import a previous saved config DB dump file.
-       [FILENAME] : Filenames separated by comma with no spaces in between.
+       <filename> : Names of configuration file(s) to use, separated by comma with no spaces in between
     """
     if filename is None:
-        message = 'Clear current config and reload config from the default config file[s] ?'
+        message = 'Clear current config and reload config from the default config file(s) ?'
     else:
-        message = 'Clear current config and reload config from the file[s] {} ?'.format(filename)
+        message = 'Clear current config and reload config from the file(s) {} ?'.format(filename)
 
     if not yes:
         click.confirm(message, abort=True)
@@ -729,7 +729,7 @@ def reload(filename, yes, load_sysinfo):
         cfg_files = filename.split(',')
 
         if len(cfg_files) != num_cfg_file:
-            click.echo("Input {} config file[s] separated by comma for multiple files ".format(num_cfg_file))
+            click.echo("Input {} config file(s) separated by comma for multiple files ".format(num_cfg_file))
             return
 
     if load_sysinfo:

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -24,7 +24,7 @@ def log_error(msg):
 
 
 class DBMigrator():
-    def __init__(self, socket=None):
+    def __init__(self, namespace, socket=None):
         """
         Version string format:
            version_<major>_<minor>_<build>
@@ -46,9 +46,11 @@ class DBMigrator():
         if socket:
             db_kwargs['unix_socket_path'] = socket
 
-        self.configDB        = ConfigDBConnector(**db_kwargs)
+        if namespace is None:
+            self.configDB = ConfigDBConnector(**db_kwargs)
+        else:
+            self.configDB = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace, **db_kwargs)
         self.configDB.db_connect('CONFIG_DB')
-
 
     def migrate_pfc_wd_table(self):
         '''
@@ -291,14 +293,22 @@ def main():
                         required = False,
                         help = 'the unix socket that the desired database listens on',
                         default = None )
+        parser.add_argument('-n',
+                        dest='namespace',
+                        metavar='namespace details',
+                        type = str,
+                        required = False,
+                        help = 'The namespace whose DB instance we need to connect',
+                        default = None )
         args = parser.parse_args()
         operation = args.operation
         socket_path = args.socket
+        namespace = args.namespace
 
         if socket_path:
-            dbmgtr = DBMigrator(socket=socket_path)
+            dbmgtr = DBMigrator(namespace, socket=socket_path)
         else:
-            dbmgtr = DBMigrator()
+            dbmgtr = DBMigrator(namespace)
 
         result = getattr(dbmgtr, operation)()
         if result:

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -4,7 +4,7 @@ import traceback
 import sys
 import argparse
 import syslog
-from swsssdk import ConfigDBConnector
+from swsssdk import ConfigDBConnector, SonicDBConfig
 import sonic_device_util
 
 
@@ -295,15 +295,18 @@ def main():
                         default = None )
         parser.add_argument('-n',
                         dest='namespace',
-                        metavar='namespace details',
+                        metavar='asic namespace',
                         type = str,
                         required = False,
-                        help = 'The namespace whose DB instance we need to connect',
+                        help = 'The asic namespace whose DB instance we need to connect',
                         default = None )
         args = parser.parse_args()
         operation = args.operation
         socket_path = args.socket
         namespace = args.namespace
+
+        if args.namespace is not None:
+            SonicDBConfig.load_sonic_global_db_config(namespace=args.namespace)
 
         if socket_path:
             dbmgtr = DBMigrator(namespace, socket=socket_path)


### PR DESCRIPTION
**- What I did**
Changes to the following config commands and scripts for Multi-ASIC devices.

> **config load** : supports config load across all namespaces 
> **config save** : supports config save across all namespaces 
> **config reload** : supports reload of all services across namespaces.

**- How I did it**

The following are the changes introduced in this PR

**The changes done here are  based on the namespace support added in https://github.com/Azure/sonic-py-swsssdk/pull/63**

(a) Added API's to 
      > is_multi_asic()
      > get_all_namespaces()
      > validate_namespace(namespace)

(b) config load/save/reload commands :  the action is taken on the linux host + if we are in multi-asic platform repeat the action in the namespaces. The filename argument is optional as before. If not given these are the default files used ( below eg: for a multi-ASIC device with 3 ASIC's )
/etc/sonic/config_db.json     --> for global linux host database
/etc/sonic/config_db0.json   --> for "asic0" namespace
/etc/sonic/config_db1.json   --> for "asic1" namespace
/etc/sonic/config_db2.json   --> for "asic2" namespace

If the filename argument needs to be provided it needs to be given as a string of config file names separated by comma

(c) Updates to the db_migrator.py script. 

**- How to verify it**
Verified on multi-ASIC platform

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

