### PR TITLE
[fanshow] Add column drawer name and led status to output of show platform fan

### DIFF
--- a/scripts/fanshow
+++ b/scripts/fanshow
@@ -11,7 +11,7 @@ from swsssdk import SonicV2Connector
 from natsort import natsorted
 
 
-header = ['Drawer', 'FAN', 'Speed', 'Direction', 'Presence', 'Status', 'LED', 'Timestamp']
+header = ['Drawer', 'LED', 'FAN', 'Speed', 'Direction', 'Presence', 'Status', 'Timestamp']
 
 FAN_TABLE_NAME = 'FAN_INFO'
 DRAWER_FIELD_NAME = 'drawer_name'
@@ -62,8 +62,8 @@ class FanShow(object):
             else:
                 status = 'N/A'
 
-            table.append((data_dict[DRAWER_FIELD_NAME], name, speed, data_dict[DIRECTION_FIELD_NAME], presence, status, 
-                          data_dict[LED_STATUS_FIELD_NAME], data_dict[TIMESTAMP_FIELD_NAME]))
+            table.append((data_dict[DRAWER_FIELD_NAME], data_dict[LED_STATUS_FIELD_NAME], name, speed, data_dict[DIRECTION_FIELD_NAME], presence, status, 
+                          data_dict[TIMESTAMP_FIELD_NAME]))
         
         if table:
             print(tabulate(table, header, tablefmt='simple', stralign='right'))

--- a/scripts/fanshow
+++ b/scripts/fanshow
@@ -10,9 +10,10 @@ from tabulate import tabulate
 from swsssdk import SonicV2Connector
 
 
-header = ['FAN', 'Speed', 'Direction', 'Presence', 'Status', 'Timestamp']
+header = ['Drawer', 'FAN', 'Speed', 'Direction', 'Presence', 'Status', 'Timestamp']
 
 FAN_TABLE_NAME = 'FAN_INFO'
+DRAWER_FIELD_NAME = 'drawer_name'
 SPEED_FIELD_NAME = 'speed'
 DIRECTION_FIELD_NAME = 'direction'
 PRESENCE_FIELD_NAME = 'presence'
@@ -55,7 +56,7 @@ class FanShow(object):
             status = data_dict[STATUS_FIELD_NAME].lower()
             status = 'OK' if status == 'true' else 'Not OK'
 
-            table.append((name, speed, data_dict[DIRECTION_FIELD_NAME], presence, status, data_dict[TIMESTAMP_FIELD_NAME]))
+            table.append((data_dict[DRAWER_FIELD_NAME], name, speed, data_dict[DIRECTION_FIELD_NAME], presence, status, data_dict[TIMESTAMP_FIELD_NAME]))
         
         if table:
             table.sort()

--- a/scripts/fanshow
+++ b/scripts/fanshow
@@ -11,7 +11,7 @@ from swsssdk import SonicV2Connector
 from natsort import natsorted
 
 
-header = ['Drawer', 'FAN', 'Speed', 'Direction', 'Presence', 'Status', 'Timestamp']
+header = ['Drawer', 'FAN', 'Speed', 'Direction', 'Presence', 'Status', 'LED', 'Timestamp']
 
 FAN_TABLE_NAME = 'FAN_INFO'
 DRAWER_FIELD_NAME = 'drawer_name'
@@ -19,6 +19,7 @@ SPEED_FIELD_NAME = 'speed'
 DIRECTION_FIELD_NAME = 'direction'
 PRESENCE_FIELD_NAME = 'presence'
 STATUS_FIELD_NAME = 'status'
+LED_STATUS_FIELD_NAME = 'led_status'
 TIMESTAMP_FIELD_NAME = 'timestamp'
 
 
@@ -61,7 +62,8 @@ class FanShow(object):
             else:
                 status = 'N/A'
 
-            table.append((data_dict[DRAWER_FIELD_NAME], name, speed, data_dict[DIRECTION_FIELD_NAME], presence, status, data_dict[TIMESTAMP_FIELD_NAME]))
+            table.append((data_dict[DRAWER_FIELD_NAME], name, speed, data_dict[DIRECTION_FIELD_NAME], presence, status, 
+                          data_dict[LED_STATUS_FIELD_NAME], data_dict[TIMESTAMP_FIELD_NAME]))
         
         if table:
             print(tabulate(table, header, tablefmt='simple', stralign='right'))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

1. Add a column to display fan drawer name
2. Add a column to display fan led status

**- How I did it**

**- How to verify it**

Manual test

**- Previous command output (if the output of a command-line utility has changed)**
```
        FAN     Speed    Direction     Presence    Status          Timestamp
-----------  --------  -----------  -----------  --------  -----------------
       fan1       91%       intake      Present        OK  20200414 09:41:52
       fan2       81%       intake      Present        OK  20200414 09:41:52

```

**- New command output (if the output of a command-line utility has changed)**
```
  Drawer    LED          FAN     Speed    Direction     Presence    Status          Timestamp
--------  -----  -----------  --------  -----------  -----------  --------  -----------------
 drawer1  green         fan1       92%       intake      Present        OK  20200414 09:39:52
 drawer1  green         fan2       81%       intake      Present        OK  20200414 09:39:52

```
