### PR TITLE
[show] Add 'ip/ipv6 bgp network' commands

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -1603,6 +1603,38 @@ Optionally, you can specify an IP address in order to display only that particul
   Click [here](#Quagga-BGP-Show-Commands) to see the example for "show ip bgp neighbors" for Quagga.
 
 
+**show ip bgp network [[<NONE>|<ipv4-address>|<ipv4-prefix>] [(bestpath | multipath | longer-prefixes | json)]]
+
+This command displays all the details of IPv4 Border Gateway Protocol (BGP) prefixes.
+
+- Usage:
+
+
+  ```
+  show ip bgp network [[<NONE>|<ipv4-address>|<ipv4-prefix>] [(bestpath | multipath | longer-prefixes | json)]]
+  ```
+
+- Example:
+
+  NOTE: The "longer-prefixes" option is only available when a network prefix with a "/" notation is used.
+
+  ```
+  admin@sonic:~$ show ip bgp network
+
+  admin@sonic:~$ show ip bgp network 10.1.0.32 bestpath
+
+  admin@sonic:~$ show ip bgp network 10.1.0.32 multipath
+
+  admin@sonic:~$ show ip bgp network 10.1.0.32 json
+
+  admin@sonic:~$ show ip bgp network 10.1.0.32/32 bestpath
+
+  admin@sonic:~$ show ip bgp network 10.1.0.32/32 multipath
+
+  admin@sonic:~$ show ip bgp network 10.1.0.32/32 json
+
+  admin@sonic:~$ show ip bgp network 10.1.0.32/32 longer-prefixes
+  ```
 
 **show bgp ipv6 summary (Versions >= 201904 using default FRR routing stack)**
 
@@ -1670,6 +1702,41 @@ This command displays all the details of one particular IPv6 Border Gateway Prot
   ```
   Click [here](#Quagga-BGP-Show-Commands) to see the example for "show ip bgp summary" for Quagga.
 
+
+**show ipv6 bgp network [[<NONE>|<ipv6-address>|<ipv6-prefix>] [(bestpath | multipath | longer-prefixes | json)]]
+
+This command displays all the details of IPv6 Border Gateway Protocol (BGP) prefixes.  
+
+- Usage: 
+
+  
+  ```
+  show ipv6 bgp network [[<NONE>|<ipv6-address>|<ipv6-prefix>] [(bestpath | multipath | longer-prefixes | json)]]   
+  ```
+
+- Example:
+
+  NOTE: The "longer-prefixes" option is only available when a network prefix with a "/" notation is used.
+ 
+  ```
+  admin@sonic:~$ show ipv6 bgp network
+
+  admin@sonic:~$ show ipv6 bgp network fc00::72 bestpath 
+
+  admin@sonic:~$ show ipv6 bgp network fc00::72 multipath
+
+  admin@sonic:~$ show ipv6 bgp network fc00::72 json 
+
+  admin@sonic:~$ show ipv6 bgp network fc00::72/64 bestpath
+
+  admin@sonic:~$ show ipv6 bgp network fc00::72/64 multipath
+
+  admin@sonic:~$ show ipv6 bgp network fc00::72/64 json 
+
+  admin@sonic:~$ show ipv6 bgp network fc00::72/64 longer-prefixes
+  ```
+ 
+  
 
 
 **show route-map**

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -1611,7 +1611,7 @@ This command displays all the details of IPv4 Border Gateway Protocol (BGP) pref
 
 
   ```
-  show ip bgp network [[<NONE>|<ipv4-address>|<ipv4-prefix>] [(bestpath | multipath | longer-prefixes | json)]]
+  show ip bgp network [[<ipv4-address>|<ipv4-prefix>] [(bestpath | multipath | longer-prefixes | json)]]
   ```
 
 - Example:
@@ -1711,7 +1711,7 @@ This command displays all the details of IPv6 Border Gateway Protocol (BGP) pref
 
   
   ```
-  show ipv6 bgp network [[<NONE>|<ipv6-address>|<ipv6-prefix>] [(bestpath | multipath | longer-prefixes | json)]]   
+  show ipv6 bgp network [[<ipv6-address>|<ipv6-prefix>] [(bestpath | multipath | longer-prefixes | json)]]   
   ```
 
 - Example:

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -1603,7 +1603,7 @@ Optionally, you can specify an IP address in order to display only that particul
   Click [here](#Quagga-BGP-Show-Commands) to see the example for "show ip bgp neighbors" for Quagga.
 
 
-**show ip bgp network [[<NONE>|<ipv4-address>|<ipv4-prefix>] [(bestpath | multipath | longer-prefixes | json)]]
+**show ip bgp network [[<ipv4-address>|<ipv4-prefix>] [(bestpath | multipath | longer-prefixes | json)]]
 
 This command displays all the details of IPv4 Border Gateway Protocol (BGP) prefixes.
 
@@ -1703,7 +1703,7 @@ This command displays all the details of one particular IPv6 Border Gateway Prot
   Click [here](#Quagga-BGP-Show-Commands) to see the example for "show ip bgp summary" for Quagga.
 
 
-**show ipv6 bgp network [[<NONE>|<ipv6-address>|<ipv6-prefix>] [(bestpath | multipath | longer-prefixes | json)]]
+**show ipv6 bgp network [[<ipv6-address>|<ipv6-prefix>] [(bestpath | multipath | longer-prefixes | json)]]
 
 This command displays all the details of IPv6 Border Gateway Protocol (BGP) prefixes.  
 

--- a/show/bgp_frr_v4.py
+++ b/show/bgp_frr_v4.py
@@ -48,7 +48,7 @@ def neighbors(ipaddress, info_type):
 
 # 'network' subcommand ("show ip bgp network")
 @bgp.command()
-@click.argument('ipaddress', metavar='[IPADDRESS|PREFIX]', required=False)
+@click.argument('ipaddress', metavar='[<ipv4-address>|<ipv4-prefix>]', required=False)
 @click.argument('info_type', metavar='[bestpath|json|longer-prefixes|multipath]',
                 type=click.Choice(['bestpath', 'json', 'longer-prefixes', 'multipath']), required=False)
 def network(ipaddress, info_type):

--- a/show/bgp_frr_v4.py
+++ b/show/bgp_frr_v4.py
@@ -45,3 +45,34 @@ def neighbors(ipaddress, info_type):
     command += '"'
 
     run_command(command)
+
+# 'network' subcommand ("show ip bgp network")
+@bgp.command()
+@click.argument('ipaddress', metavar='[IPADDRESS|PREFIX]', required=False)
+@click.argument('info_type', metavar='[bestpath|json|longer-prefixes|multipath]',
+                type=click.Choice(['bestpath', 'json', 'longer-prefixes', 'multipath']), required=False)
+def network(ipaddress, info_type):
+    """Show IP (IPv4) BGP network"""
+
+    command = 'sudo vtysh -c "show ip bgp'
+
+    if ipaddress is not None:
+        if '/' in ipaddress:
+        # For network prefixes then this all info_type(s) are available
+            pass
+        else:
+            # For an ipaddress then check info_type, exit if specified option doesn't work.
+            if info_type in ['longer-prefixes']:
+                click.echo('The parameter option: "{}" only available if passing a network prefix'.format(info_type))
+                click.echo("EX: 'show ip bgp network 10.0.0.0/24 longer-prefixes'")
+                raise click.Abort()
+
+        command += ' {}'.format(ipaddress)
+
+        # info_type is only valid if prefix/ipaddress is specified
+        if info_type is not None:
+            command += ' {}'.format(info_type)
+
+    command += '"'
+
+    run_command(command)

--- a/show/bgp_frr_v6.py
+++ b/show/bgp_frr_v6.py
@@ -39,7 +39,7 @@ def neighbors(ipaddress, info_type):
 
 # 'network' subcommand ("show ipv6 bgp network")
 @bgp.command()
-@click.argument('ipaddress', metavar='[IPADDRESS|PREFIX]', required=False)
+@click.argument('ipaddress', metavar='[<ipv6-address>|<ipv6-prefix>]', required=False)
 @click.argument('info_type', metavar='[bestpath|json|longer-prefixes|multipath]',
                 type=click.Choice(['bestpath', 'json', 'longer-prefixes', 'multipath']), required=False)
 def network(ipaddress, info_type):

--- a/show/bgp_frr_v6.py
+++ b/show/bgp_frr_v6.py
@@ -36,3 +36,34 @@ def neighbors(ipaddress, info_type):
     info_type = "" if info_type is None else info_type
     command = 'sudo vtysh -c "show bgp ipv6 neighbor {} {}"'.format(ipaddress, info_type)
     run_command(command)
+
+# 'network' subcommand ("show ipv6 bgp network")
+@bgp.command()
+@click.argument('ipaddress', metavar='[IPADDRESS|PREFIX]', required=False)
+@click.argument('info_type', metavar='[bestpath|json|longer-prefixes|multipath]',
+                type=click.Choice(['bestpath', 'json', 'longer-prefixes', 'multipath']), required=False)
+def network(ipaddress, info_type):
+    """Show BGP ipv6 network"""
+
+    command = 'sudo vtysh -c "show bgp ipv6'
+
+    if ipaddress is not None:
+        if '/' in ipaddress:
+        # For network prefixes then this all info_type(s) are available
+            pass
+        else:
+            # For an ipaddress then check info_type, exit if specified option doesn't work.
+            if info_type in ['longer-prefixes']:
+                click.echo('The parameter option: "{}" only available if passing a network prefix'.format(info_type))
+                click.echo("EX: 'show ipv6 bgp network fc00:1::/64 longer-prefixes'")
+                raise click.Abort()
+
+        command += ' {}'.format(ipaddress)
+
+        # info_type is only valid if prefix/ipaddress is specified
+        if info_type is not None:
+            command += ' {}'.format(info_type)
+
+    command += '"'
+
+    run_command(command)


### PR DESCRIPTION
… normal commands for 'show ip bgp'

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
I updated the bgp_frr_v4.py and bgp_frr_v6.py files to have a new function for "network" since the Click framework required this.  I was going to use "route" but this conflicted with "route-map" in the vtysh so I found "network" was not something that would conflict and used that as it made the most sense.  The will support the normal networking commands of "show ip bgp [ipaddress|prefix] [options]" and "show ipv6 bgp [ipaddress|prefix] [options]"

**- How I did it**
Add a new "network" function so the VTYSH commands can be referenced by the SONIC CLI.

**- How to verify it**
The command didn't exist on the SONIC CLI.  I had to add it. 


**- Previous command output (if the output of a command-line utility has changed)**
For both IPv4 and IPv6 these commands didn't exist. 

For IPv4: 
```
admin@str-s6000-acs-11:~$ show ip bgp -h
Usage: show ip bgp [OPTIONS] COMMAND [ARGS]...

  Show IPv4 BGP (Border Gateway Protocol) information

Options:
  -?, -h, --help  Show this message and exit.

Commands:
  neighbors  Show IP (IPv4) BGP neighbors
  summary    Show summarized information of IPv4 BGP state
admin@str-s6000-acs-11:~$ 
```
For IPv6
```
admin@str-s6000-acs-11:~$ show ipv6 bgp -h
Usage: show ipv6 bgp [OPTIONS] COMMAND [ARGS]...

  Show IPv6 BGP (Border Gateway Protocol) information

Options:
  -?, -h, --help  Show this message and exit.

Commands:
  neighbors  Show IPv6 BGP neighbors
  summary    Show summarized information of IPv6 BGP state
admin@str-s6000-acs-11:~$ 
```


**- New command output (if the output of a command-line utility has changed)**

So these two commands have some subcommands as well. 

Here are the IPv4 commands
```
admin@str-s6000-acs-11:~$ show ip bgp -h
Usage: show ip bgp [OPTIONS] COMMAND [ARGS]...

  Show IPv4 BGP (Border Gateway Protocol) information

Options:
  -?, -h, --help  Show this message and exit.

Commands:
  neighbors  Show IP (IPv4) BGP neighbors
  network    Show IP (IPv4) BGP network
  summary    Show summarized information of IPv4 BGP state
admin@str-s6000-acs-11:~$ 

admin@str-s6000-acs-11:~$ show ip bgp network -h
Usage: show ip bgp network [OPTIONS] [IPADDRESS|PREFIX] [bestpath|json|longer-
                           prefixes|multipath]

  Show IP (IPv4) BGP network

Options:
  -?, -h, --help  Show this message and exit.
admin@str-s6000-acs-11:~$ 

admin@str-s6000-acs-11:~$ show ip bgp network 
BGP table version is 1, local router ID is 10.1.0.32, vrf id 0
Default local pref 100, local AS 65100
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete

   Network          Next Hop            Metric LocPrf Weight Path
*> 10.1.0.32/32     0.0.0.0                  0         32768 i

Displayed  1 routes and 1 total paths
admin@str-s6000-acs-11:~$ 

admin@str-s6000-acs-11:~$ show ip bgp network 10.1.0.32
BGP routing table entry for 10.1.0.32/32
Paths: (1 available, best #1, table default)
  Not advertised to any peer
  Local
    0.0.0.0 from 0.0.0.0 (10.1.0.32)
      Origin IGP, metric 0, weight 32768, valid, sourced, local, best (First path received)
      Last update: Wed Apr 15 22:26:11 2020

admin@str-s6000-acs-11:~$ show ip bgp network 10.1.0.32 bestpath
BGP routing table entry for 10.1.0.32/32
Paths: (1 available, best #1, table default)
  Not advertised to any peer
  Local
    0.0.0.0 from 0.0.0.0 (10.1.0.32)
      Origin IGP, metric 0, weight 32768, valid, sourced, local, best (First path received)
      Last update: Wed Apr 15 22:26:11 2020

admin@str-s6000-acs-11:~$ show ip bgp network 10.1.0.32 multipath
BGP routing table entry for 10.1.0.32/32
Paths: (1 available, best #1, table default)
  Not advertised to any peer
  Local
    0.0.0.0 from 0.0.0.0 (10.1.0.32)
      Origin IGP, metric 0, weight 32768, valid, sourced, local, best (First path received)
      Last update: Wed Apr 15 22:26:11 2020

admin@str-s6000-acs-11:~$ show ip bgp network 10.1.0.32 json
{
  "prefix":"10.1.0.32\/32",
  "paths":[
    {
      "aspath":{
        "string":"Local",
        "segments":[
        ],
        "length":0
      },
      "origin":"IGP",
      "med":0,
      "metric":0,
      "weight":32768,
      "valid":true,
      "sourced":true,
      "local":true,
      "bestpath":{
        "overall":true,
        "selectionReason":"First path received"
      },
      "lastUpdate":{
        "epoch":1586989571,
        "string":"Wed Apr 15 22:26:11 2020\n"
      },
      "nexthops":[
        {
          "ip":"0.0.0.0",
          "afi":"ipv4",
          "metric":0,
          "accessible":true,
          "used":true
        }
      ],
      "peer":{
        "peerId":"0.0.0.0",
        "routerId":"10.1.0.32"
      }
    }
  ]
}
admin@str-s6000-acs-11:~$ show ip bgp network 10.1.0.32 longer-prefixes
The parameter option: "longer-prefixes" only available if passing a network prefix
EX: 'show ip bgp network 10.0.0.0/24 longer-prefixes'
Aborted!
admin@str-s6000-acs-11:~$ 
admin@str-s6000-acs-11:~$ show ip bgp network 10.1.0.32/32 longer-prefixes
BGP table version is 1, local router ID is 10.1.0.32, vrf id 0
Default local pref 100, local AS 65100
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete

   Network          Next Hop            Metric LocPrf Weight Path
*> 10.1.0.32/32     0.0.0.0                  0         32768 i

Displayed  1 routes and 1 total paths
admin@str-s6000-acs-11:~$ show ip bgp network 10.1.0.32/32 bestpath
BGP routing table entry for 10.1.0.32/32
Paths: (1 available, best #1, table default)
  Not advertised to any peer
  Local
    0.0.0.0 from 0.0.0.0 (10.1.0.32)
      Origin IGP, metric 0, weight 32768, valid, sourced, local, best (First path received)
      Last update: Wed Apr 15 22:26:11 2020

admin@str-s6000-acs-11:~$ show ip bgp network 10.1.0.32/32 multipath
BGP routing table entry for 10.1.0.32/32
Paths: (1 available, best #1, table default)
  Not advertised to any peer
  Local
    0.0.0.0 from 0.0.0.0 (10.1.0.32)
      Origin IGP, metric 0, weight 32768, valid, sourced, local, best (First path received)
      Last update: Wed Apr 15 22:26:11 2020

admin@str-s6000-acs-11:~$ show ip bgp network 10.1.0.32/32 json
{
  "prefix":"10.1.0.32\/32",
  "paths":[
    {
      "aspath":{
        "string":"Local",
        "segments":[
        ],
        "length":0
      },
      "origin":"IGP",
      "med":0,
      "metric":0,
      "weight":32768,
      "valid":true,
      "sourced":true,
      "local":true,
      "bestpath":{
        "overall":true,
        "selectionReason":"First path received"
      },
      "lastUpdate":{
        "epoch":1586989571,
        "string":"Wed Apr 15 22:26:11 2020\n"
      },
      "nexthops":[
        {
          "ip":"0.0.0.0",
          "afi":"ipv4",
          "metric":0,
          "accessible":true,
          "used":true
        }
      ],
      "peer":{
        "peerId":"0.0.0.0",
        "routerId":"10.1.0.32"
      }
    }
  ]
}
admin@str-s6000-acs-11:~$ 
```

Here are the IPv6 command outputs: 

```
admin@str-s6000-acs-11:~$ show ipv6 bgp -h
Usage: show ipv6 bgp [OPTIONS] COMMAND [ARGS]...

  Show IPv6 BGP (Border Gateway Protocol) information

Options:
  -?, -h, --help  Show this message and exit.

Commands:
  neighbors  Show IPv6 BGP neighbors
  network    Show BGP ipv6 network
  summary    Show summarized information of IPv6 BGP state
admin@str-s6000-acs-11:~$ show ipv6 bgp network -h
Usage: show ipv6 bgp network [OPTIONS] [IPADDRESS|PREFIX] [bestpath|json
                             |longer-prefixes|multipath]

  Show BGP ipv6 network

Options:
  -?, -h, --help  Show this message and exit.
admin@str-s6000-acs-11:~$ 

admin@str-s6000-acs-11:~$ show ipv6 bgp network 
BGP table version is 1, local router ID is 10.1.0.32, vrf id 0
Default local pref 100, local AS 65100
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete

   Network          Next Hop            Metric LocPrf Weight Path
*> fc00:1::/64      ::                       0         32768 i

Displayed  1 routes and 1 total paths
admin@str-s6000-acs-11:~$ show ipv6 bgp network fc00:1::
BGP routing table entry for fc00:1::/64
Paths: (1 available, best #1, table default)
  Not advertised to any peer
  Local
    :: from :: (10.1.0.32)
      Origin IGP, metric 0, weight 32768, valid, sourced, local, best (First path received)
      Last update: Wed Apr 15 22:26:11 2020

admin@str-s6000-acs-11:~$ show ipv6 bgp network fc00:1:: bestpath
BGP routing table entry for fc00:1::/64
Paths: (1 available, best #1, table default)
  Not advertised to any peer
  Local
    :: from :: (10.1.0.32)
      Origin IGP, metric 0, weight 32768, valid, sourced, local, best (First path received)
      Last update: Wed Apr 15 22:26:11 2020

admin@str-s6000-acs-11:~$ show ipv6 bgp network fc00:1:: multipath
BGP routing table entry for fc00:1::/64
Paths: (1 available, best #1, table default)
  Not advertised to any peer
  Local
    :: from :: (10.1.0.32)
      Origin IGP, metric 0, weight 32768, valid, sourced, local, best (First path received)
      Last update: Wed Apr 15 22:26:11 2020

admin@str-s6000-acs-11:~$ show ipv6 bgp network fc00:1:: json
{
  "prefix":"fc00:1::\/64",
  "paths":[
    {
      "aspath":{
        "string":"Local",
        "segments":[
        ],
        "length":0
      },
      "origin":"IGP",
      "med":0,
      "metric":0,
      "weight":32768,
      "valid":true,
      "sourced":true,
      "local":true,
      "bestpath":{
        "overall":true,
        "selectionReason":"First path received"
      },
      "lastUpdate":{
        "epoch":1586989571,
        "string":"Wed Apr 15 22:26:11 2020\n"
      },
      "nexthops":[
        {
          "ip":"::",
          "afi":"ipv6",
          "scope":"global",
          "metric":0,
          "accessible":true,
          "used":true
        }
      ],
      "peer":{
        "peerId":"::",
        "routerId":"10.1.0.32"
      }
    }
  ]
}
admin@str-s6000-acs-11:~$ show ipv6 bgp network fc00:1:: longer-prefixes
The parameter option: "longer-prefixes" only available if passing a network prefix
EX: 'show ipv6 bgp network fc00:1::/64 longer-prefixes'
Aborted!
admin@str-s6000-acs-11:~$ show ipv6 bgp network fc00:1::/64 longer-prefixes
BGP table version is 1, local router ID is 10.1.0.32, vrf id 0
Default local pref 100, local AS 65100
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete

   Network          Next Hop            Metric LocPrf Weight Path
*> fc00:1::/64      ::                       0         32768 i

Displayed  1 routes and 1 total paths
admin@str-s6000-acs-11:~$ show ipv6 bgp network fc00:1::/64 bestpath
BGP routing table entry for fc00:1::/64
Paths: (1 available, best #1, table default)
  Not advertised to any peer
  Local
    :: from :: (10.1.0.32)
      Origin IGP, metric 0, weight 32768, valid, sourced, local, best (First path received)
      Last update: Wed Apr 15 22:26:11 2020

admin@str-s6000-acs-11:~$ show ipv6 bgp network fc00:1::/64 multipath
BGP routing table entry for fc00:1::/64
Paths: (1 available, best #1, table default)
  Not advertised to any peer
  Local
    :: from :: (10.1.0.32)
      Origin IGP, metric 0, weight 32768, valid, sourced, local, best (First path received)
      Last update: Wed Apr 15 22:26:11 2020

admin@str-s6000-acs-11:~$ show ipv6 bgp network fc00:1::/64 json
{
  "prefix":"fc00:1::\/64",
  "paths":[
    {
      "aspath":{
        "string":"Local",
        "segments":[
        ],
        "length":0
      },
      "origin":"IGP",
      "med":0,
      "metric":0,
      "weight":32768,
      "valid":true,
      "sourced":true,
      "local":true,
      "bestpath":{
        "overall":true,
        "selectionReason":"First path received"
      },
      "lastUpdate":{
        "epoch":1586989571,
        "string":"Wed Apr 15 22:26:11 2020\n"
      },
      "nexthops":[
        {
          "ip":"::",
          "afi":"ipv6",
          "scope":"global",
          "metric":0,
          "accessible":true,
          "used":true
        }
      ],
      "peer":{
        "peerId":"::",
        "routerId":"10.1.0.32"
      }
    }
  ]
}
admin@str-s6000-acs-11:~$ 
```

