### PR TITLE
[utility] Filter FDB entries

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -29,6 +29,7 @@ EXIT_NEXT_IMAGE_NOT_EXISTS=4
 EXIT_ORCHAGENT_SHUTDOWN=10
 EXIT_SYNCD_SHUTDOWN=11
 EXIT_FAST_REBOOT_DUMP_FAILURE=12
+EXIT_FILTER_FDB_ENTRIES_FAILURE=13
 EXIT_NO_CONTROL_PLANE_ASSISTANT=20
 
 function error()
@@ -370,13 +371,23 @@ fi
 if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
     # Dump the ARP and FDB tables to files also as default routes for both IPv4 and IPv6
     # into /host/fast-reboot
-    mkdir -p /host/fast-reboot
+    DUMP_DIR=/host/fast-reboot
+    mkdir -p $DUMP_DIR
     FAST_REBOOT_DUMP_RC=0
-    /usr/bin/fast-reboot-dump.py -t /host/fast-reboot || FAST_REBOOT_DUMP_RC=$?
+    /usr/bin/fast-reboot-dump.py -t $DUMP_DIR || FAST_REBOOT_DUMP_RC=$?
     if [[ FAST_REBOOT_DUMP_RC -ne 0 ]]; then
         error "Failed to run fast-reboot-dump.py. Exit code: $FAST_REBOOT_DUMP_RC"
         unload_kernel
         exit "${EXIT_FAST_REBOOT_DUMP_FAILURE}"
+    fi
+
+    FILTER_FDB_ENTRIES_RC=0
+    # Filter FDB entries using MAC addresses from ARP table
+    /usr/bin/filter_fdb_entries.py -f $DUMP_DIR/fdb.json -a $DUMP_DIR/arp.json || FILTER_FDB_ENTRIES_RC=$?
+    if [[ FILTER_FDB_ENTRIES_RC -ne 0 ]]; then
+        error "Failed to filter FDb entries. Exit code: $FILTER_FDB_ENTRIES_RC"
+        unload_kernel
+        exit "${EXIT_FILTER_FDB_ENTRIES_FAILURE}"
     fi
 fi
 

--- a/scripts/filter_fdb_entries.py
+++ b/scripts/filter_fdb_entries.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+
+import json
+import sys
+import os
+import argparse
+import syslog
+import traceback
+import time
+
+from collections import defaultdict
+
+def get_arp_entries_map(filename):
+    """
+        Generate map for ARP entries
+
+        ARP entry map is using the MAC as a key for the arp entry. The map key is reformated in order
+        to match FDB table formatting
+
+        Args:
+            filename(str): ARP entry file name
+
+        Returns:
+            arp_map(dict) map of ARP entries using MAC as key.
+    """
+    with open(filename, 'r') as fp:
+        arp_entries = json.load(fp)
+
+    arp_map = defaultdict()
+    for arp in arp_entries:
+        for key, config in arp.items():
+            if 'NEIGH_TABLE' in key:
+                arp_map[config["neigh"].replace(':', '-')] = ""
+
+    return arp_map
+
+def filter_fdb_entries(fdb_filename, arp_filename, backup_file):
+    """
+        Filter FDB entries based on MAC presence into ARP entries
+
+        FDB entries that do not have MAC entry in the ARP table are filtered out. New FDB entries
+        file will be created if it has fewer entries than original one.
+
+        Args:
+            fdb_filename(str): FDB entries file name
+            arp_filename(str): ARP entry file name
+            backup_file(bool): Create backup copy of FDB file before creating new one
+
+        Returns:
+            None
+    """
+    arp_map = get_arp_entries_map(arp_filename)
+
+    with open(fdb_filename, 'r') as fp:
+        fdb_entries = json.load(fp)
+
+    def filter_fdb_entry(fdb_entry):
+        for key, _ in fdb_entry.items():
+            if 'FDB_TABLE' in key:
+                return key.split(':')[-1] in arp_map
+
+    new_fdb_entries = list(filter(filter_fdb_entry, fdb_entries))
+
+    if len(new_fdb_entries) < len(fdb_entries):
+        if backup_file:
+            os.rename(fdb_filename, fdb_filename + '-' + time.strftime("%Y%m%d-%H%M%S"))
+
+        with open(fdb_filename, 'w') as fp:
+            json.dump(new_fdb_entries, fp, indent=2, separators=(',', ': '))
+
+def file_exits_or_raise(filename):
+    """
+        Check if file exist on the file system
+
+        Args:
+            filename(str): File name
+
+        Returns:
+            None
+
+        Raises:
+            Exception file does not exist
+    """
+    if not os.path.exists(filename):
+        raise Exception("file '{0}' does not exist".format(filename))
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-f', '--fdb', type=str, default='/tmp/fdb.json', help='fdb file name')
+    parser.add_argument('-a', '--arp', type=str, default='/tmp/arp.json', help='arp file name')
+    parser.add_argument('-b', '--backup_file', type=bool, default=True, help='Back up old fdb entries file')
+    args = parser.parse_args()
+
+    fdb_filename = args.fdb
+    file_exits_or_raise(fdb_filename)
+
+    arp_filename = args.arp
+    file_exits_or_raise(arp_filename)
+
+    backup_file = args.backup_file
+    filter_fdb_entries(fdb_filename, arp_filename, backup_file)
+
+    return 0
+
+if __name__ == '__main__':
+    res = 0
+    try:
+        syslog.openlog('filter_fdb_entries')
+        res = main()
+    except KeyboardInterrupt:
+        syslog.syslog(syslog.LOG_NOTICE, "SIGINT received. Quitting")
+        res = 1
+    except Exception as e:
+        syslog.syslog(syslog.LOG_ERR, "Got an exception %s: Traceback: %s" % (str(e), traceback.format_exc()))
+        res = 2
+    finally:
+        syslog.closelog()
+    try:
+        sys.exit(res)
+    except SystemExit:
+        os._exit(res)

--- a/scripts/filter_fdb_entries.py
+++ b/scripts/filter_fdb_entries.py
@@ -68,7 +68,7 @@ def filter_fdb_entries(fdb_filename, arp_filename, backup_file):
         with open(fdb_filename, 'w') as fp:
             json.dump(new_fdb_entries, fp, indent=2, separators=(',', ': '))
 
-def file_exits_or_raise(filename):
+def file_exists_or_raise(filename):
     """
         Check if file exist on the file system
 
@@ -96,8 +96,8 @@ def main():
     backup_file = args.backup_file
 
     try:
-        file_exits_or_raise(fdb_filename)
-        file_exits_or_raise(arp_filename)
+        file_exists_or_raise(fdb_filename)
+        file_exists_or_raise(arp_filename)
     except Exception as e:
         syslog.syslog(syslog.LOG_ERR, "Got an exception %s: Traceback: %s" % (str(e), traceback.format_exc()))
     else:

--- a/scripts/filter_fdb_entries.py
+++ b/scripts/filter_fdb_entries.py
@@ -59,6 +59,9 @@ def filter_fdb_entries(fdb_filename, arp_filename, backup_file):
             if 'FDB_TABLE' in key:
                 return key.split(':')[-1] in arp_map
 
+        # malformed entry, default to False so it will be deleted
+        return False
+
     new_fdb_entries = list(filter(filter_fdb_entry, fdb_entries))
 
     if len(new_fdb_entries) < len(fdb_entries):
@@ -70,7 +73,7 @@ def filter_fdb_entries(fdb_filename, arp_filename, backup_file):
 
 def file_exists_or_raise(filename):
     """
-        Check if file exist on the file system
+        Check if file exists on the file system
 
         Args:
             filename(str): File name

--- a/scripts/filter_fdb_entries.py
+++ b/scripts/filter_fdb_entries.py
@@ -92,13 +92,16 @@ def main():
     args = parser.parse_args()
 
     fdb_filename = args.fdb
-    file_exits_or_raise(fdb_filename)
-
     arp_filename = args.arp
-    file_exits_or_raise(arp_filename)
-
     backup_file = args.backup_file
-    filter_fdb_entries(fdb_filename, arp_filename, backup_file)
+
+    try:
+        file_exits_or_raise(fdb_filename)
+        file_exits_or_raise(arp_filename)
+    except Exception as e:
+        syslog.syslog(syslog.LOG_ERR, "Got an exception %s: Traceback: %s" % (str(e), traceback.format_exc()))
+    else:
+        filter_fdb_entries(fdb_filename, arp_filename, backup_file)
 
     return 0
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
     package_data={
         'show': ['aliases.ini'],
-        'sonic-utilities-tests': ['acl_input/*', 'mock_tables/*.py', 'mock_tables/*.json', 'filter_fdb_input/*.json']
+        'sonic-utilities-tests': ['acl_input/*', 'mock_tables/*.py', 'mock_tables/*.json', 'filter_fdb_input/*']
     },
     scripts=[
         'scripts/aclshow',

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
     package_data={
         'show': ['aliases.ini'],
-        'sonic-utilities-tests': ['acl_input/*', 'mock_tables/*.py', 'mock_tables/*.json']
+        'sonic-utilities-tests': ['acl_input/*', 'mock_tables/*.py', 'mock_tables/*.json', 'filter_fdb_input/*.json']
     },
     scripts=[
         'scripts/aclshow',
@@ -74,6 +74,7 @@ setup(
         'scripts/fast-reboot-dump.py',
         'scripts/fdbclear',
         'scripts/fdbshow',
+        'scripts/filter_fdb_entries.py',
         'scripts/generate_dump',
         'scripts/intfutil',
         'scripts/intfstat',

--- a/sonic-utilities-tests/filter_fdb_entries_test.py
+++ b/sonic-utilities-tests/filter_fdb_entries_test.py
@@ -7,76 +7,7 @@ import subprocess
 import sys
 
 from collections import defaultdict
-
-"""
-    Filter FDB entries test vector
-"""
-filterFdbEntriesTestVector = [
-    {
-        "arp":[
-        ],
-        "fdb": [
-        ],
-        "expected_fdb": [
-        ],
-    },
-    {
-        "arp":[
-            {
-                "NEIGH_TABLE:Vlan1000:192.168.0.10": {
-                    "neigh": "72:06:00:01:00:08",
-                    "family": "IPv4"
-                },
-                "OP": "SET"
-            },
-        ],
-        "fdb": [
-            {
-                "FDB_TABLE:Vlan1000:72-06-00-01-01-16": {
-                    "type": "dynamic",
-                    "port": "Ethernet22"
-                },
-                "OP": "SET"
-            },
-        ],
-        "expected_fdb": [
-        ],
-    },
-    {
-        "arp":[
-            {
-                "NEIGH_TABLE:Vlan1000:192.168.0.10": {
-                    "neigh": "72:06:00:01:01:16",
-                    "family": "IPv4"
-                },
-                "OP": "SET"
-            },
-        ],
-        "fdb": [
-            {
-                "FDB_TABLE:Vlan1000:72-06-00-01-01-16": {
-                    "type": "dynamic",
-                    "port": "Ethernet22"
-                },
-                "OP": "SET"
-            },
-        ],
-        "expected_fdb": [
-            {
-                "FDB_TABLE:Vlan1000:72-06-00-01-01-16": {
-                    "type": "dynamic",
-                    "port": "Ethernet22"
-                },
-                "OP": "SET"
-            },
-        ],
-    },
-    {
-        "arp": "sonic-utilities-tests/filter_fdb_input/arp.json",
-        "fdb": "sonic-utilities-tests/filter_fdb_input/fdb.json",
-        "expected_fdb": "sonic-utilities-tests/filter_fdb_input/expected_fdb.json"
-    },
-]
+from filter_fdb_input.test_vectors import filterFdbEntriesTestVector
 
 class TestFilterFdbEntries(object):
     """

--- a/sonic-utilities-tests/filter_fdb_entries_test.py
+++ b/sonic-utilities-tests/filter_fdb_entries_test.py
@@ -4,7 +4,6 @@ import os
 import pytest
 import shutil
 import subprocess
-import sys
 
 from collections import defaultdict
 from filter_fdb_input.test_vectors import filterFdbEntriesTestVector

--- a/sonic-utilities-tests/filter_fdb_entries_test.py
+++ b/sonic-utilities-tests/filter_fdb_entries_test.py
@@ -1,0 +1,243 @@
+import glob
+import json
+import os
+import pytest
+import shutil
+import subprocess
+import sys
+
+from collections import defaultdict
+
+"""
+    Filter FDB entries test vector
+"""
+filterFdbEntriesTestVector = [
+    {
+        "arp":[
+        ],
+        "fdb": [
+        ],
+        "expected_fdb": [
+        ],
+    },
+    {
+        "arp":[
+            {
+                "NEIGH_TABLE:Vlan1000:192.168.0.10": {
+                    "neigh": "72:06:00:01:00:08",
+                    "family": "IPv4"
+                },
+                "OP": "SET"
+            },
+        ],
+        "fdb": [
+            {
+                "FDB_TABLE:Vlan1000:72-06-00-01-01-16": {
+                    "type": "dynamic",
+                    "port": "Ethernet22"
+                },
+                "OP": "SET"
+            },
+        ],
+        "expected_fdb": [
+        ],
+    },
+    {
+        "arp":[
+            {
+                "NEIGH_TABLE:Vlan1000:192.168.0.10": {
+                    "neigh": "72:06:00:01:01:16",
+                    "family": "IPv4"
+                },
+                "OP": "SET"
+            },
+        ],
+        "fdb": [
+            {
+                "FDB_TABLE:Vlan1000:72-06-00-01-01-16": {
+                    "type": "dynamic",
+                    "port": "Ethernet22"
+                },
+                "OP": "SET"
+            },
+        ],
+        "expected_fdb": [
+            {
+                "FDB_TABLE:Vlan1000:72-06-00-01-01-16": {
+                    "type": "dynamic",
+                    "port": "Ethernet22"
+                },
+                "OP": "SET"
+            },
+        ],
+    },
+    {
+        "arp": "sonic-utilities-tests/filter_fdb_input/arp.json",
+        "fdb": "sonic-utilities-tests/filter_fdb_input/fdb.json",
+        "expected_fdb": "sonic-utilities-tests/filter_fdb_input/expected_fdb.json"
+    },
+]
+
+class TestFilterFdbEntries(object):
+    """
+        Test Filter FDb entries
+    """
+    ARP_FILENAME = "/tmp/arp.json"
+    FDB_FILENAME = "/tmp/fdb.json"
+    EXPECTED_FDB_FILENAME = "/tmp/expected_fdb.json"
+
+    def __setUp(self, testData):
+        """
+            Sets up test data
+
+            Builds arp.json and fdb.json input files to /tmp and also build expected fdb entries files int /tmp
+
+            Args:
+                testData(dist): Current test vector data
+
+            Returns:
+                None
+        """
+        def create_file_or_raise(data, filename):
+            """
+                Create test data files
+
+                If the data is string, it will be dump to a json filename.
+                If data is a file, it will be coppied to filename
+
+                Args:
+                    data(str|list): source of test data
+                    filename(str): filename for test data
+
+                Returns:
+                    None
+
+                Raises:
+                    Exception if data type is not supported
+            """
+            if isinstance(data, list):
+                with open(filename, 'w') as fp:
+                    json.dump(data, fp, indent=2, separators=(',', ': '))
+            elif isinstance(data, str):
+                shutil.copyfile(data, filename)
+            else:
+                raise Exception("Unknown test data type: {0}".format(type(test_data)))
+
+        create_file_or_raise(testData["arp"], self.ARP_FILENAME)
+        create_file_or_raise(testData["fdb"], self.FDB_FILENAME)
+        create_file_or_raise(testData["expected_fdb"], self.EXPECTED_FDB_FILENAME)
+
+    def __tearDown(self):
+        """
+            Tear down current test case setup
+
+            Args:
+                None
+
+            Returns:
+                None
+        """
+        os.remove(self.ARP_FILENAME)
+        os.remove(self.EXPECTED_FDB_FILENAME)
+        fdbFiles = glob.glob(self.FDB_FILENAME + '*')
+        for file in fdbFiles:
+            os.remove(file)
+
+    def __runCommand(self, cmds):
+        """
+            Runs command 'cmds' on host
+
+            Args:
+                cmds(list): command to be run on localhost
+
+            Returns:
+                stdout(str): stdout gathered during command execution
+                stderr(str): stderr gathered during command execution
+                returncode(int): command exit code
+        """
+        process = subprocess.Popen(
+            cmds,
+            shell=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+        stdout, stderr = process.communicate()
+
+        return stdout, stderr, process.returncode
+
+    def __getFdbEntriesMap(self, filename):
+        """
+            Generate map for FDB entries
+
+            FDB entry map is using the FDB_TABLE:... as a key for the FDB entry.
+
+            Args:
+                filename(str): FDB entry file name
+
+            Returns:
+                fdbMap(defaultdict) map of FDB entries using MAC as key.
+        """
+        with open(filename, 'r') as fp:
+            fdbEntries = json.load(fp)
+
+        fdbMap = defaultdict()
+        for fdb in fdbEntries:
+            for key, config in fdb.items():
+                if "FDB_TABLE" in key:
+                    fdbMap[key] = fdb
+
+        return fdbMap
+
+    def __verifyOutput(self):
+        """
+            Verifies FDB entries match expected FDB entries
+
+            Args:
+                None
+
+            Retruns:
+                isEqual(bool): True if FDB entries match, False otherwise
+        """
+        fdbMap = self.__getFdbEntriesMap(self.FDB_FILENAME)
+        with open(self.EXPECTED_FDB_FILENAME, 'r') as fp:
+            expectedFdbEntries = json.load(fp)
+
+        isEqual = len(fdbMap) == len(expectedFdbEntries)
+        if isEqual:
+            for expectedFdbEntry in expectedFdbEntries:
+                fdbEntry = {}
+                for key, config in expectedFdbEntry.items():
+                    if "FDB_TABLE" in key:
+                        fdbEntry = fdbMap[key]
+
+                isEqual = len(fdbEntry) == len(expectedFdbEntry)
+                for key, config in expectedFdbEntry.items():
+                    isEqual = isEqual and fdbEntry[key] == config
+
+                if not isEqual:
+                    break
+
+        return isEqual
+
+    @pytest.mark.parametrize("testData", filterFdbEntriesTestVector)
+    def testFilterFdbEntries(self, testData):
+        """
+            Test Filter FDB entries script
+
+            Args:
+                testData(dict): Map containing ARP entries, FDB entries, and expected FDB entries
+        """
+        try:
+            self.__setUp(testData)
+    
+            stdout, stderr, rc = self.__runCommand([
+                "scripts/filter_fdb_entries.py",
+                "-a",
+                self.ARP_FILENAME,
+                "-f",
+                self.FDB_FILENAME,
+            ])
+            assert rc == 0, "CFilter_fbd_entries.py failed with '{0}'".format(stderr)
+            assert self.__verifyOutput(), "Test failed for test data: {0}".format(testData)
+        finally:
+            self.__tearDown()

--- a/sonic-utilities-tests/filter_fdb_input/arp.json
+++ b/sonic-utilities-tests/filter_fdb_input/arp.json
@@ -1,0 +1,408 @@
+[
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.1.85": {
+      "neigh": "72:06:00:01:03:39",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.131": {
+      "neigh": "72:06:00:01:01:29",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.1.83": {
+      "neigh": "72:06:00:01:03:37",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.1.216": {
+      "neigh": "72:06:00:01:04:70",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.1.59": {
+      "neigh": "72:06:00:01:03:13",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.144": {
+      "neigh": "72:06:00:01:01:42",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.95": {
+      "neigh": "72:06:00:01:00:93",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.184": {
+      "neigh": "72:06:00:01:01:82",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.22": {
+      "neigh": "72:06:00:01:00:20",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.12": {
+      "neigh": "24:8a:07:4c:f5:18",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.1.14": {
+      "neigh": "72:06:00:01:02:68",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.1.226": {
+      "neigh": "72:06:00:01:04:80",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.1.160": {
+      "neigh": "72:06:00:01:04:14",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.121": {
+      "neigh": "72:06:00:01:01:19",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.1.220": {
+      "neigh": "72:06:00:01:04:74",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.1.127": {
+      "neigh": "72:06:00:01:03:81",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.247": {
+      "neigh": "72:06:00:01:02:45",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.108": {
+      "neigh": "72:06:00:01:01:06",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.227": {
+      "neigh": "72:06:00:01:02:25",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.17": {
+      "neigh": "72:06:00:01:00:15",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.58": {
+      "neigh": "72:06:00:01:00:56",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.101": {
+      "neigh": "72:06:00:01:00:99",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.1.222": {
+      "neigh": "72:06:00:01:04:76",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.180": {
+      "neigh": "72:06:00:01:01:78",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.151": {
+      "neigh": "72:06:00:01:01:49",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.175": {
+      "neigh": "72:06:00:01:01:73",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.153": {
+      "neigh": "72:06:00:01:01:51",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.211": {
+      "neigh": "72:06:00:01:02:09",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.1.89": {
+      "neigh": "72:06:00:01:03:43",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.1.223": {
+      "neigh": "72:06:00:01:04:77",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.252": {
+      "neigh": "72:06:00:01:02:50",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.1.123": {
+      "neigh": "72:06:00:01:03:77",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.48": {
+      "neigh": "72:06:00:01:00:46",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.120": {
+      "neigh": "72:06:00:01:01:18",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "NEIGH_TABLE:Vlan1000:192.168.1.188": {
+      "neigh": "72:06:00:01:04:42",
+      "family": "IPv4"
+    }
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.1.101": {
+      "neigh": "72:06:00:01:03:55",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.111": {
+      "neigh": "72:06:00:01:01:09",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "NEIGH_TABLE:Vlan1000:192.168.0.224": {
+      "neigh": "72:06:00:01:02:22",
+      "family": "IPv4"
+    }
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.226": {
+      "neigh": "72:06:00:01:02:24",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "NEIGH_TABLE:Vlan1000:192.168.1.180": {
+      "neigh": "72:06:00:01:04:34",
+      "family": "IPv4"
+    }
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.179": {
+      "neigh": "72:06:00:01:01:77",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.204": {
+      "neigh": "72:06:00:01:02:02",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "NEIGH_TABLE:Vlan1000:192.168.1.55": {
+      "neigh": "72:06:00:01:03:09",
+      "family": "IPv4"
+    }
+  },
+  {
+    "OP": "SET",
+    "NEIGH_TABLE:Vlan1000:192.168.0.105": {
+      "neigh": "72:06:00:01:01:03",
+      "family": "IPv4"
+    }
+  },
+  {
+    "OP": "SET",
+    "NEIGH_TABLE:Vlan1000:192.168.1.82": {
+      "neigh": "72:06:00:01:03:36",
+      "family": "IPv4"
+    }
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.1.18": {
+      "neigh": "72:06:00:01:02:72",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "NEIGH_TABLE:Vlan1000:192.168.1.77": {
+      "neigh": "72:06:00:01:03:31",
+      "family": "IPv4"
+    }
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.1.65": {
+      "neigh": "72:06:00:01:03:19",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "NEIGH_TABLE:Vlan1000:192.168.1.236": {
+      "neigh": "72:06:00:01:04:90",
+      "family": "IPv4"
+    }
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.1.244": {
+      "neigh": "72:06:00:01:04:98",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.1.111": {
+      "neigh": "72:06:00:01:03:65",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.143": {
+      "neigh": "72:06:00:01:01:41",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.1.26": {
+      "neigh": "72:06:00:01:02:80",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.98": {
+      "neigh": "72:06:00:01:00:96",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.1.52": {
+      "neigh": "72:06:00:01:03:06",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.51": {
+      "neigh": "72:06:00:01:00:49",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "NEIGH_TABLE:Vlan1000:192.168.0.6": {
+      "neigh": "72:06:00:01:00:04",
+      "family": "IPv4"
+    }
+  },
+  {
+    "NEIGH_TABLE:Vlan1000:192.168.0.150": {
+      "neigh": "72:06:00:01:01:48",
+      "family": "IPv4"
+    },
+    "OP": "SET"
+  }
+]

--- a/sonic-utilities-tests/filter_fdb_input/expected_fdb.json
+++ b/sonic-utilities-tests/filter_fdb_input/expected_fdb.json
@@ -1,0 +1,401 @@
+[
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-90": {
+      "type": "dynamic",
+      "port": "Ethernet39"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-25": {
+      "type": "dynamic",
+      "port": "Ethernet23"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-73": {
+      "type": "dynamic",
+      "port": "Ethernet54"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-39": {
+      "type": "dynamic",
+      "port": "Ethernet29"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-09": {
+      "type": "dynamic",
+      "port": "Ethernet9"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-36": {
+      "type": "dynamic",
+      "port": "Ethernet26"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-41": {
+      "type": "dynamic",
+      "port": "Ethernet58"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-19": {
+      "type": "dynamic",
+      "port": "Ethernet56"
+    }
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-37": {
+      "type": "dynamic",
+      "port": "Ethernet27"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-49": {
+      "type": "dynamic",
+      "port": "Ethernet13"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-77": {
+      "type": "dynamic",
+      "port": "Ethernet23"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-80": {
+      "type": "dynamic",
+      "port": "Ethernet53"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-82": {
+      "type": "dynamic",
+      "port": "Ethernet10"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-09": {
+      "type": "dynamic",
+      "port": "Ethernet38"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-06": {
+      "type": "dynamic",
+      "port": "Ethernet32"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-20": {
+      "type": "dynamic",
+      "port": "Ethernet37"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-96": {
+      "type": "dynamic",
+      "port": "Ethernet41"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-34": {
+      "type": "dynamic",
+      "port": "Ethernet10"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-15": {
+      "type": "dynamic",
+      "port": "Ethernet29"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-31": {
+      "type": "dynamic",
+      "port": "Ethernet15"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-93": {
+      "type": "dynamic",
+      "port": "Ethernet38"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-48": {
+      "type": "dynamic",
+      "port": "Ethernet12"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-02": {
+      "type": "dynamic",
+      "port": "Ethernet39"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-65": {
+      "type": "dynamic",
+      "port": "Ethernet13"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-19": {
+      "type": "dynamic",
+      "port": "Ethernet25"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-09": {
+      "type": "dynamic",
+      "port": "Ethernet54"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-72": {
+      "type": "dynamic",
+      "port": "Ethernet37"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-51": {
+      "type": "dynamic",
+      "port": "Ethernet15"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-74": {
+      "type": "dynamic",
+      "port": "Ethernet14"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-98": {
+      "type": "dynamic",
+      "port": "Ethernet55"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-80": {
+      "type": "dynamic",
+      "port": "Ethernet26"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-42": {
+      "type": "dynamic",
+      "port": "Ethernet24"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-99": {
+      "type": "dynamic",
+      "port": "Ethernet52"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-18": {
+      "type": "dynamic",
+      "port": "Ethernet24"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-43": {
+      "type": "dynamic",
+      "port": "Ethernet36"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-46": {
+      "type": "dynamic",
+      "port": "Ethernet24"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-76": {
+      "type": "dynamic",
+      "port": "Ethernet22"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-81": {
+      "type": "dynamic",
+      "port": "Ethernet38"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-70": {
+      "type": "dynamic",
+      "port": "Ethernet10"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-68": {
+      "type": "dynamic",
+      "port": "Ethernet30"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-78": {
+      "type": "dynamic",
+      "port": "Ethernet6"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-50": {
+      "type": "dynamic",
+      "port": "Ethernet6"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-77": {
+      "type": "dynamic",
+      "port": "Ethernet31"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-55": {
+      "type": "dynamic",
+      "port": "Ethernet56"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-49": {
+      "type": "dynamic",
+      "port": "Ethernet27"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-22": {
+      "type": "dynamic",
+      "port": "Ethernet14"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-03": {
+      "type": "dynamic",
+      "port": "Ethernet56"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-77": {
+      "type": "dynamic",
+      "port": "Ethernet58"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-42": {
+      "type": "dynamic",
+      "port": "Ethernet6"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-56": {
+      "type": "dynamic",
+      "port": "Ethernet37"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-24": {
+      "type": "dynamic",
+      "port": "Ethernet22"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-13": {
+      "type": "dynamic",
+      "port": "Ethernet42"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-45": {
+      "type": "dynamic",
+      "port": "Ethernet54"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-29": {
+      "type": "dynamic",
+      "port": "Ethernet38"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-04": {
+      "type": "dynamic",
+      "port": "Ethernet12"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-06": {
+      "type": "dynamic",
+      "port": "Ethernet6"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-14": {
+      "type": "dynamic",
+      "port": "Ethernet32"
+    },
+    "OP": "SET"
+  }
+]

--- a/sonic-utilities-tests/filter_fdb_input/fdb.json
+++ b/sonic-utilities-tests/filter_fdb_input/fdb.json
@@ -1,0 +1,3516 @@
+[
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-16": {
+      "type": "dynamic",
+      "port": "Ethernet22"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-73": {
+      "type": "dynamic",
+      "port": "Ethernet9"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-96": {
+      "type": "dynamic",
+      "port": "Ethernet8"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-57": {
+      "type": "dynamic",
+      "port": "Ethernet58"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-27": {
+      "type": "dynamic",
+      "port": "Ethernet11"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-48": {
+      "type": "dynamic",
+      "port": "Ethernet57"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-99": {
+      "type": "dynamic",
+      "port": "Ethernet11"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-02": {
+      "type": "dynamic",
+      "port": "Ethernet10"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-19": {
+      "type": "dynamic",
+      "port": "Ethernet40"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-65": {
+      "type": "dynamic",
+      "port": "Ethernet27"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-39": {
+      "type": "dynamic",
+      "port": "Ethernet56"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-64": {
+      "type": "dynamic",
+      "port": "Ethernet37"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-31": {
+      "type": "dynamic",
+      "port": "Ethernet29"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-90": {
+      "type": "dynamic",
+      "port": "Ethernet39"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-25": {
+      "type": "dynamic",
+      "port": "Ethernet23"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-56": {
+      "type": "dynamic",
+      "port": "Ethernet57"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-27": {
+      "type": "dynamic",
+      "port": "Ethernet36"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-10": {
+      "type": "dynamic",
+      "port": "Ethernet55"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-24": {
+      "type": "dynamic",
+      "port": "Ethernet41"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-03": {
+      "type": "dynamic",
+      "port": "Ethernet11"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-26": {
+      "type": "dynamic",
+      "port": "Ethernet10"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-76": {
+      "type": "dynamic",
+      "port": "Ethernet12"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-73": {
+      "type": "dynamic",
+      "port": "Ethernet13"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-03": {
+      "type": "dynamic",
+      "port": "Ethernet29"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-22": {
+      "type": "dynamic",
+      "port": "Ethernet6"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-07": {
+      "type": "dynamic",
+      "port": "Ethernet7"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-08": {
+      "type": "dynamic",
+      "port": "Ethernet26"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-93": {
+      "type": "dynamic",
+      "port": "Ethernet42"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-90": {
+      "type": "dynamic",
+      "port": "Ethernet10"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-79": {
+      "type": "dynamic",
+      "port": "Ethernet52"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-61": {
+      "type": "dynamic",
+      "port": "Ethernet9"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-53": {
+      "type": "dynamic",
+      "port": "Ethernet31"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-00": {
+      "type": "dynamic",
+      "port": "Ethernet37"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-73": {
+      "type": "dynamic",
+      "port": "Ethernet54"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-54": {
+      "type": "dynamic",
+      "port": "Ethernet55"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-06": {
+      "type": "dynamic",
+      "port": "Ethernet14"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-97": {
+      "type": "dynamic",
+      "port": "Ethernet54"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-22": {
+      "type": "dynamic",
+      "port": "Ethernet48"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-01": {
+      "type": "dynamic",
+      "port": "Ethernet38"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-85": {
+      "type": "dynamic",
+      "port": "Ethernet31"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-83": {
+      "type": "dynamic",
+      "port": "Ethernet56"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-39": {
+      "type": "dynamic",
+      "port": "Ethernet29"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-22": {
+      "type": "dynamic",
+      "port": "Ethernet28"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-90": {
+      "type": "dynamic",
+      "port": "Ethernet24"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-10": {
+      "type": "dynamic",
+      "port": "Ethernet24"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-53": {
+      "type": "dynamic",
+      "port": "Ethernet23"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-34": {
+      "type": "dynamic",
+      "port": "Ethernet24"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-91": {
+      "type": "dynamic",
+      "port": "Ethernet36"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-32": {
+      "type": "dynamic",
+      "port": "Ethernet57"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-20": {
+      "type": "dynamic",
+      "port": "Ethernet41"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-39": {
+      "type": "dynamic",
+      "port": "Ethernet15"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-23": {
+      "type": "dynamic",
+      "port": "Ethernet7"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-82": {
+      "type": "dynamic",
+      "port": "Ethernet24"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-64": {
+      "type": "dynamic",
+      "port": "Ethernet12"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-98": {
+      "type": "dynamic",
+      "port": "Ethernet48"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-64": {
+      "type": "dynamic",
+      "port": "Ethernet57"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-09": {
+      "type": "dynamic",
+      "port": "Ethernet9"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-78": {
+      "type": "dynamic",
+      "port": "Ethernet14"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-63": {
+      "type": "dynamic",
+      "port": "Ethernet56"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-64": {
+      "type": "dynamic",
+      "port": "Ethernet26"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-71": {
+      "type": "dynamic",
+      "port": "Ethernet7"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-05": {
+      "type": "dynamic",
+      "port": "Ethernet23"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-51": {
+      "type": "dynamic",
+      "port": "Ethernet36"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-36": {
+      "type": "dynamic",
+      "port": "Ethernet26"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-41": {
+      "type": "dynamic",
+      "port": "Ethernet23"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-15": {
+      "type": "dynamic",
+      "port": "Ethernet15"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-87": {
+      "type": "dynamic",
+      "port": "Ethernet52"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-85": {
+      "type": "dynamic",
+      "port": "Ethernet42"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-41": {
+      "type": "dynamic",
+      "port": "Ethernet58"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-30": {
+      "type": "dynamic",
+      "port": "Ethernet14"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-95": {
+      "type": "dynamic",
+      "port": "Ethernet15"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-93": {
+      "type": "dynamic",
+      "port": "Ethernet13"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-66": {
+      "type": "dynamic",
+      "port": "Ethernet55"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-47": {
+      "type": "dynamic",
+      "port": "Ethernet56"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-57": {
+      "type": "dynamic",
+      "port": "Ethernet13"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-37": {
+      "type": "dynamic",
+      "port": "Ethernet54"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-36": {
+      "type": "dynamic",
+      "port": "Ethernet12"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-94": {
+      "type": "dynamic",
+      "port": "Ethernet39"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-22": {
+      "type": "dynamic",
+      "port": "Ethernet39"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-19": {
+      "type": "dynamic",
+      "port": "Ethernet56"
+    }
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-37": {
+      "type": "dynamic",
+      "port": "Ethernet27"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-78": {
+      "type": "dynamic",
+      "port": "Ethernet48"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-95": {
+      "type": "dynamic",
+      "port": "Ethernet40"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-23": {
+      "type": "dynamic",
+      "port": "Ethernet15"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-92": {
+      "type": "dynamic",
+      "port": "Ethernet41"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-35": {
+      "type": "dynamic",
+      "port": "Ethernet25"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-83": {
+      "type": "dynamic",
+      "port": "Ethernet40"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-96": {
+      "type": "dynamic",
+      "port": "Ethernet30"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-84": {
+      "type": "dynamic",
+      "port": "Ethernet26"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-62": {
+      "type": "dynamic",
+      "port": "Ethernet10"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-67": {
+      "type": "dynamic",
+      "port": "Ethernet40"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-86": {
+      "type": "dynamic",
+      "port": "Ethernet32"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-88": {
+      "type": "dynamic",
+      "port": "Ethernet37"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-89": {
+      "type": "dynamic",
+      "port": "Ethernet31"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-88": {
+      "type": "dynamic",
+      "port": "Ethernet8"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-79": {
+      "type": "dynamic",
+      "port": "Ethernet7"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-59": {
+      "type": "dynamic",
+      "port": "Ethernet7"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-55": {
+      "type": "dynamic",
+      "port": "Ethernet25"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-89": {
+      "type": "dynamic",
+      "port": "Ethernet9"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-51": {
+      "type": "dynamic",
+      "port": "Ethernet29"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-93": {
+      "type": "dynamic",
+      "port": "Ethernet58"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-00": {
+      "type": "dynamic",
+      "port": "Ethernet53"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-39": {
+      "type": "dynamic",
+      "port": "Ethernet11"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-28": {
+      "type": "dynamic",
+      "port": "Ethernet12"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-62": {
+      "type": "dynamic",
+      "port": "Ethernet48"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-49": {
+      "type": "dynamic",
+      "port": "Ethernet13"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-38": {
+      "type": "dynamic",
+      "port": "Ethernet28"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-77": {
+      "type": "dynamic",
+      "port": "Ethernet23"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-25": {
+      "type": "dynamic",
+      "port": "Ethernet9"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-88": {
+      "type": "dynamic",
+      "port": "Ethernet22"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-07": {
+      "type": "dynamic",
+      "port": "Ethernet52"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-16": {
+      "type": "dynamic",
+      "port": "Ethernet53"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-67": {
+      "type": "dynamic",
+      "port": "Ethernet7"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-80": {
+      "type": "dynamic",
+      "port": "Ethernet53"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-05": {
+      "type": "dynamic",
+      "port": "Ethernet58"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-02": {
+      "type": "dynamic",
+      "port": "Ethernet28"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-33": {
+      "type": "dynamic",
+      "port": "Ethernet31"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-21": {
+      "type": "dynamic",
+      "port": "Ethernet38"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-59": {
+      "type": "dynamic",
+      "port": "Ethernet52"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-54": {
+      "type": "dynamic",
+      "port": "Ethernet24"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-75": {
+      "type": "dynamic",
+      "port": "Ethernet56"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-81": {
+      "type": "dynamic",
+      "port": "Ethernet27"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-49": {
+      "type": "dynamic",
+      "port": "Ethernet42"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-29": {
+      "type": "dynamic",
+      "port": "Ethernet27"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-08": {
+      "type": "dynamic",
+      "port": "Ethernet8"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-82": {
+      "type": "dynamic",
+      "port": "Ethernet10"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-41": {
+      "type": "dynamic",
+      "port": "Ethernet13"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-25": {
+      "type": "dynamic",
+      "port": "Ethernet31"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-21": {
+      "type": "dynamic",
+      "port": "Ethernet58"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-02": {
+      "type": "dynamic",
+      "port": "Ethernet55"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-81": {
+      "type": "dynamic",
+      "port": "Ethernet23"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-78": {
+      "type": "dynamic",
+      "port": "Ethernet32"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-09": {
+      "type": "dynamic",
+      "port": "Ethernet38"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-06": {
+      "type": "dynamic",
+      "port": "Ethernet32"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-64": {
+      "type": "dynamic",
+      "port": "Ethernet53"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-46": {
+      "type": "dynamic",
+      "port": "Ethernet39"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-60": {
+      "type": "dynamic",
+      "port": "Ethernet41"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-66": {
+      "type": "dynamic",
+      "port": "Ethernet28"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-44": {
+      "type": "dynamic",
+      "port": "Ethernet37"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-17": {
+      "type": "dynamic",
+      "port": "Ethernet31"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-58": {
+      "type": "dynamic",
+      "port": "Ethernet28"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-13": {
+      "type": "dynamic",
+      "port": "Ethernet27"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-30": {
+      "type": "dynamic",
+      "port": "Ethernet55"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-28": {
+      "type": "dynamic",
+      "port": "Ethernet53"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-52": {
+      "type": "dynamic",
+      "port": "Ethernet37"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-20": {
+      "type": "dynamic",
+      "port": "Ethernet37"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-55": {
+      "type": "dynamic",
+      "port": "Ethernet36"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-33": {
+      "type": "dynamic",
+      "port": "Ethernet9"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-72": {
+      "type": "dynamic",
+      "port": "Ethernet26"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-47": {
+      "type": "dynamic",
+      "port": "Ethernet40"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-52": {
+      "type": "dynamic",
+      "port": "Ethernet8"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-91": {
+      "type": "dynamic",
+      "port": "Ethernet11"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-43": {
+      "type": "dynamic",
+      "port": "Ethernet25"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-37": {
+      "type": "dynamic",
+      "port": "Ethernet13"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-54": {
+      "type": "dynamic",
+      "port": "Ethernet39"
+    }
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-93": {
+      "type": "dynamic",
+      "port": "Ethernet27"
+    }
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-61": {
+      "type": "dynamic",
+      "port": "Ethernet54"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-91": {
+      "type": "dynamic",
+      "port": "Ethernet25"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-63": {
+      "type": "dynamic",
+      "port": "Ethernet52"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-73": {
+      "type": "dynamic",
+      "port": "Ethernet27"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-96": {
+      "type": "dynamic",
+      "port": "Ethernet41"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-45": {
+      "type": "dynamic",
+      "port": "Ethernet9"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-60": {
+      "type": "dynamic",
+      "port": "Ethernet8"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-34": {
+      "type": "dynamic",
+      "port": "Ethernet10"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-60": {
+      "type": "dynamic",
+      "port": "Ethernet30"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-12": {
+      "type": "dynamic",
+      "port": "Ethernet26"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-63": {
+      "type": "dynamic",
+      "port": "Ethernet25"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-31": {
+      "type": "dynamic",
+      "port": "Ethernet56"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-59": {
+      "type": "dynamic",
+      "port": "Ethernet15"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-68": {
+      "type": "dynamic",
+      "port": "Ethernet57"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-98": {
+      "type": "dynamic",
+      "port": "Ethernet32"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-45": {
+      "type": "dynamic",
+      "port": "Ethernet27"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-24": {
+      "type": "dynamic",
+      "port": "Ethernet30"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-15": {
+      "type": "dynamic",
+      "port": "Ethernet29"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-16": {
+      "type": "dynamic",
+      "port": "Ethernet37"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-82": {
+      "type": "dynamic",
+      "port": "Ethernet55"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-03": {
+      "type": "dynamic",
+      "port": "Ethernet15"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-61": {
+      "type": "dynamic",
+      "port": "Ethernet23"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-94": {
+      "type": "dynamic",
+      "port": "Ethernet48"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-84": {
+      "type": "dynamic",
+      "port": "Ethernet57"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-11": {
+      "type": "dynamic",
+      "port": "Ethernet29"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-97": {
+      "type": "dynamic",
+      "port": "Ethernet9"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-45": {
+      "type": "dynamic",
+      "port": "Ethernet23"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-34": {
+      "type": "dynamic",
+      "port": "Ethernet48"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-50": {
+      "type": "dynamic",
+      "port": "Ethernet28"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-30": {
+      "type": "dynamic",
+      "port": "Ethernet6"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-44": {
+      "type": "dynamic",
+      "port": "Ethernet8"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-31": {
+      "type": "dynamic",
+      "port": "Ethernet15"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-51": {
+      "type": "dynamic",
+      "port": "Ethernet52"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-93": {
+      "type": "dynamic",
+      "port": "Ethernet38"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-48": {
+      "type": "dynamic",
+      "port": "Ethernet12"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-70": {
+      "type": "dynamic",
+      "port": "Ethernet6"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-75": {
+      "type": "dynamic",
+      "port": "Ethernet40"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-46": {
+      "type": "dynamic",
+      "port": "Ethernet28"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-02": {
+      "type": "dynamic",
+      "port": "Ethernet39"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-35": {
+      "type": "dynamic",
+      "port": "Ethernet52"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-26": {
+      "type": "dynamic",
+      "port": "Ethernet55"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-65": {
+      "type": "dynamic",
+      "port": "Ethernet13"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-45": {
+      "type": "dynamic",
+      "port": "Ethernet38"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-62": {
+      "type": "dynamic",
+      "port": "Ethernet24"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-04": {
+      "type": "dynamic",
+      "port": "Ethernet30"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-91": {
+      "type": "dynamic",
+      "port": "Ethernet56"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-37": {
+      "type": "dynamic",
+      "port": "Ethernet9"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-10": {
+      "type": "dynamic",
+      "port": "Ethernet28"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-83": {
+      "type": "dynamic",
+      "port": "Ethernet11"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-75": {
+      "type": "dynamic",
+      "port": "Ethernet11"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-86": {
+      "type": "dynamic",
+      "port": "Ethernet14"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-71": {
+      "type": "dynamic",
+      "port": "Ethernet52"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-21": {
+      "type": "dynamic",
+      "port": "Ethernet42"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-19": {
+      "type": "dynamic",
+      "port": "Ethernet25"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-09": {
+      "type": "dynamic",
+      "port": "Ethernet54"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-08": {
+      "type": "dynamic",
+      "port": "Ethernet22"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-69": {
+      "type": "dynamic",
+      "port": "Ethernet31"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-71": {
+      "type": "dynamic",
+      "port": "Ethernet11"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-86": {
+      "type": "dynamic",
+      "port": "Ethernet28"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-02": {
+      "type": "dynamic",
+      "port": "Ethernet14"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-20": {
+      "type": "dynamic",
+      "port": "Ethernet57"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-69": {
+      "type": "dynamic",
+      "port": "Ethernet42"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-84": {
+      "type": "dynamic",
+      "port": "Ethernet41"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-71": {
+      "type": "dynamic",
+      "port": "Ethernet25"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-79": {
+      "type": "dynamic",
+      "port": "Ethernet15"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:24-8A-07-4C-F5-18": {
+      "type": "dynamic",
+      "port": "Ethernet24"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-33": {
+      "type": "dynamic",
+      "port": "Ethernet23"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-41": {
+      "type": "dynamic",
+      "port": "Ethernet42"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-39": {
+      "type": "dynamic",
+      "port": "Ethernet40"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-01": {
+      "type": "dynamic",
+      "port": "Ethernet27"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-52": {
+      "type": "dynamic",
+      "port": "Ethernet22"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-72": {
+      "type": "dynamic",
+      "port": "Ethernet37"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-27": {
+      "type": "dynamic",
+      "port": "Ethernet52"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-69": {
+      "type": "dynamic",
+      "port": "Ethernet9"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-40": {
+      "type": "dynamic",
+      "port": "Ethernet22"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-38": {
+      "type": "dynamic",
+      "port": "Ethernet14"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-87": {
+      "type": "dynamic",
+      "port": "Ethernet29"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-53": {
+      "type": "dynamic",
+      "port": "Ethernet9"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-87": {
+      "type": "dynamic",
+      "port": "Ethernet36"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-10": {
+      "type": "dynamic",
+      "port": "Ethernet10"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-59": {
+      "type": "dynamic",
+      "port": "Ethernet40"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-96": {
+      "type": "dynamic",
+      "port": "Ethernet53"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-61": {
+      "type": "dynamic",
+      "port": "Ethernet31"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-51": {
+      "type": "dynamic",
+      "port": "Ethernet15"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-00": {
+      "type": "dynamic",
+      "port": "Ethernet8"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-07": {
+      "type": "dynamic",
+      "port": "Ethernet25"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-79": {
+      "type": "dynamic",
+      "port": "Ethernet25"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-56": {
+      "type": "dynamic",
+      "port": "Ethernet41"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-84": {
+      "type": "dynamic",
+      "port": "Ethernet12"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-68": {
+      "type": "dynamic",
+      "port": "Ethernet22"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-38": {
+      "type": "dynamic",
+      "port": "Ethernet10"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-54": {
+      "type": "dynamic",
+      "port": "Ethernet32"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-21": {
+      "type": "dynamic",
+      "port": "Ethernet27"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-56": {
+      "type": "dynamic",
+      "port": "Ethernet12"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-96": {
+      "type": "dynamic",
+      "port": "Ethernet22"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-74": {
+      "type": "dynamic",
+      "port": "Ethernet14"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-09": {
+      "type": "dynamic",
+      "port": "Ethernet27"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-98": {
+      "type": "dynamic",
+      "port": "Ethernet55"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-33": {
+      "type": "dynamic",
+      "port": "Ethernet58"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-98": {
+      "type": "dynamic",
+      "port": "Ethernet24"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-48": {
+      "type": "dynamic",
+      "port": "Ethernet26"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-80": {
+      "type": "dynamic",
+      "port": "Ethernet26"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-82": {
+      "type": "dynamic",
+      "port": "Ethernet39"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-17": {
+      "type": "dynamic",
+      "port": "Ethernet23"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-62": {
+      "type": "dynamic",
+      "port": "Ethernet55"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-34": {
+      "type": "dynamic",
+      "port": "Ethernet32"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-80": {
+      "type": "dynamic",
+      "port": "Ethernet37"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-50": {
+      "type": "dynamic",
+      "port": "Ethernet14"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-69": {
+      "type": "dynamic",
+      "port": "Ethernet23"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-42": {
+      "type": "dynamic",
+      "port": "Ethernet24"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-72": {
+      "type": "dynamic",
+      "port": "Ethernet8"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-52": {
+      "type": "dynamic",
+      "port": "Ethernet53"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-52": {
+      "type": "dynamic",
+      "port": "Ethernet30"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-99": {
+      "type": "dynamic",
+      "port": "Ethernet52"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-73": {
+      "type": "dynamic",
+      "port": "Ethernet38"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-65": {
+      "type": "dynamic",
+      "port": "Ethernet38"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-63": {
+      "type": "dynamic",
+      "port": "Ethernet11"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-83": {
+      "type": "dynamic",
+      "port": "Ethernet25"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-32": {
+      "type": "dynamic",
+      "port": "Ethernet41"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-35": {
+      "type": "dynamic",
+      "port": "Ethernet36"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-58": {
+      "type": "dynamic",
+      "port": "Ethernet6"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-13": {
+      "type": "dynamic",
+      "port": "Ethernet58"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-76": {
+      "type": "dynamic",
+      "port": "Ethernet30"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-77": {
+      "type": "dynamic",
+      "port": "Ethernet13"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-25": {
+      "type": "dynamic",
+      "port": "Ethernet42"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-51": {
+      "type": "dynamic",
+      "port": "Ethernet7"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-76": {
+      "type": "dynamic",
+      "port": "Ethernet57"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-08": {
+      "type": "dynamic",
+      "port": "Ethernet53"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-43": {
+      "type": "dynamic",
+      "port": "Ethernet7"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-16": {
+      "type": "dynamic",
+      "port": "Ethernet30"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-11": {
+      "type": "dynamic",
+      "port": "Ethernet11"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-55": {
+      "type": "dynamic",
+      "port": "Ethernet11"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-11": {
+      "type": "dynamic",
+      "port": "Ethernet40"
+    }
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-86": {
+      "type": "dynamic",
+      "port": "Ethernet48"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-19": {
+      "type": "dynamic",
+      "port": "Ethernet36"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-15": {
+      "type": "dynamic",
+      "port": "Ethernet36"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-63": {
+      "type": "dynamic",
+      "port": "Ethernet36"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-04": {
+      "type": "dynamic",
+      "port": "Ethernet57"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-11": {
+      "type": "dynamic",
+      "port": "Ethernet56"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-18": {
+      "type": "dynamic",
+      "port": "Ethernet24"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-43": {
+      "type": "dynamic",
+      "port": "Ethernet36"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-94": {
+      "type": "dynamic",
+      "port": "Ethernet6"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-46": {
+      "type": "dynamic",
+      "port": "Ethernet24"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-69": {
+      "type": "dynamic",
+      "port": "Ethernet58"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-72": {
+      "type": "dynamic",
+      "port": "Ethernet53"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-99": {
+      "type": "dynamic",
+      "port": "Ethernet36"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-53": {
+      "type": "dynamic",
+      "port": "Ethernet38"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-18": {
+      "type": "dynamic",
+      "port": "Ethernet32"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-20": {
+      "type": "dynamic",
+      "port": "Ethernet26"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-23": {
+      "type": "dynamic",
+      "port": "Ethernet29"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-37": {
+      "type": "dynamic",
+      "port": "Ethernet38"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-89": {
+      "type": "dynamic",
+      "port": "Ethernet54"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-76": {
+      "type": "dynamic",
+      "port": "Ethernet22"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-26": {
+      "type": "dynamic",
+      "port": "Ethernet48"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-12": {
+      "type": "dynamic",
+      "port": "Ethernet12"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-34": {
+      "type": "dynamic",
+      "port": "Ethernet6"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-82": {
+      "type": "dynamic",
+      "port": "Ethernet28"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-67": {
+      "type": "dynamic",
+      "port": "Ethernet15"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-92": {
+      "type": "dynamic",
+      "port": "Ethernet26"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-07": {
+      "type": "dynamic",
+      "port": "Ethernet36"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-84": {
+      "type": "dynamic",
+      "port": "Ethernet30"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-60": {
+      "type": "dynamic",
+      "port": "Ethernet22"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-68": {
+      "type": "dynamic",
+      "port": "Ethernet41"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-08": {
+      "type": "dynamic",
+      "port": "Ethernet37"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-78": {
+      "type": "dynamic",
+      "port": "Ethernet24"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-81": {
+      "type": "dynamic",
+      "port": "Ethernet54"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-35": {
+      "type": "dynamic",
+      "port": "Ethernet7"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-36": {
+      "type": "dynamic",
+      "port": "Ethernet53"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-97": {
+      "type": "dynamic",
+      "port": "Ethernet31"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-58": {
+      "type": "dynamic",
+      "port": "Ethernet14"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-44": {
+      "type": "dynamic",
+      "port": "Ethernet53"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-80": {
+      "type": "dynamic",
+      "port": "Ethernet22"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-81": {
+      "type": "dynamic",
+      "port": "Ethernet9"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-60": {
+      "type": "dynamic",
+      "port": "Ethernet53"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-95": {
+      "type": "dynamic",
+      "port": "Ethernet29"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-38": {
+      "type": "dynamic",
+      "port": "Ethernet39"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-17": {
+      "type": "dynamic",
+      "port": "Ethernet54"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-74": {
+      "type": "dynamic",
+      "port": "Ethernet39"
+    }
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-07": {
+      "type": "dynamic",
+      "port": "Ethernet15"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-98": {
+      "type": "dynamic",
+      "port": "Ethernet10"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-50": {
+      "type": "dynamic",
+      "port": "Ethernet48"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-81": {
+      "type": "dynamic",
+      "port": "Ethernet38"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-29": {
+      "type": "dynamic",
+      "port": "Ethernet58"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-15": {
+      "type": "dynamic",
+      "port": "Ethernet52"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-75": {
+      "type": "dynamic",
+      "port": "Ethernet15"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-14": {
+      "type": "dynamic",
+      "port": "Ethernet48"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-54": {
+      "type": "dynamic",
+      "port": "Ethernet10"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-70": {
+      "type": "dynamic",
+      "port": "Ethernet10"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-85": {
+      "type": "dynamic",
+      "port": "Ethernet13"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-58": {
+      "type": "dynamic",
+      "port": "Ethernet39"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-68": {
+      "type": "dynamic",
+      "port": "Ethernet30"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-21": {
+      "type": "dynamic",
+      "port": "Ethernet13"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-26": {
+      "type": "dynamic",
+      "port": "Ethernet24"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-49": {
+      "type": "dynamic",
+      "port": "Ethernet31"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-74": {
+      "type": "dynamic",
+      "port": "Ethernet10"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-09": {
+      "type": "dynamic",
+      "port": "Ethernet23"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-89": {
+      "type": "dynamic",
+      "port": "Ethernet38"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-28": {
+      "type": "dynamic",
+      "port": "Ethernet57"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-78": {
+      "type": "dynamic",
+      "port": "Ethernet6"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-23": {
+      "type": "dynamic",
+      "port": "Ethernet40"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-24": {
+      "type": "dynamic",
+      "port": "Ethernet8"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-31": {
+      "type": "dynamic",
+      "port": "Ethernet7"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-14": {
+      "type": "dynamic",
+      "port": "Ethernet14"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-94": {
+      "type": "dynamic",
+      "port": "Ethernet28"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-48": {
+      "type": "dynamic",
+      "port": "Ethernet30"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-95": {
+      "type": "dynamic",
+      "port": "Ethernet52"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-40": {
+      "type": "dynamic",
+      "port": "Ethernet12"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-86": {
+      "type": "dynamic",
+      "port": "Ethernet6"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-47": {
+      "type": "dynamic",
+      "port": "Ethernet11"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-99": {
+      "type": "dynamic",
+      "port": "Ethernet25"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-00": {
+      "type": "dynamic",
+      "port": "Ethernet26"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-66": {
+      "type": "dynamic",
+      "port": "Ethernet39"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-18": {
+      "type": "dynamic",
+      "port": "Ethernet10"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-50": {
+      "type": "dynamic",
+      "port": "Ethernet6"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-47": {
+      "type": "dynamic",
+      "port": "Ethernet25"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-03": {
+      "type": "dynamic",
+      "port": "Ethernet40"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-49": {
+      "type": "dynamic",
+      "port": "Ethernet58"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-30": {
+      "type": "dynamic",
+      "port": "Ethernet39"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-27": {
+      "type": "dynamic",
+      "port": "Ethernet25"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-65": {
+      "type": "dynamic",
+      "port": "Ethernet58"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-99": {
+      "type": "dynamic",
+      "port": "Ethernet56"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-26": {
+      "type": "dynamic",
+      "port": "Ethernet32"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-43": {
+      "type": "dynamic",
+      "port": "Ethernet15"
+    }
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-67": {
+      "type": "dynamic",
+      "port": "Ethernet29"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-79": {
+      "type": "dynamic",
+      "port": "Ethernet36"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-48": {
+      "type": "dynamic",
+      "port": "Ethernet41"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-90": {
+      "type": "dynamic",
+      "port": "Ethernet55"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-05": {
+      "type": "dynamic",
+      "port": "Ethernet42"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-32": {
+      "type": "dynamic",
+      "port": "Ethernet22"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-77": {
+      "type": "dynamic",
+      "port": "Ethernet31"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-94": {
+      "type": "dynamic",
+      "port": "Ethernet14"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-55": {
+      "type": "dynamic",
+      "port": "Ethernet56"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-13": {
+      "type": "dynamic",
+      "port": "Ethernet31"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-32": {
+      "type": "dynamic",
+      "port": "Ethernet8"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-57": {
+      "type": "dynamic",
+      "port": "Ethernet42"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-27": {
+      "type": "dynamic",
+      "port": "Ethernet56"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-74": {
+      "type": "dynamic",
+      "port": "Ethernet28"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-18": {
+      "type": "dynamic",
+      "port": "Ethernet55"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-01": {
+      "type": "dynamic",
+      "port": "Ethernet54"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-05": {
+      "type": "dynamic",
+      "port": "Ethernet31"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-92": {
+      "type": "dynamic",
+      "port": "Ethernet57"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-40": {
+      "type": "dynamic",
+      "port": "Ethernet30"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-29": {
+      "type": "dynamic",
+      "port": "Ethernet54"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-42": {
+      "type": "dynamic",
+      "port": "Ethernet48"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-44": {
+      "type": "dynamic",
+      "port": "Ethernet22"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-44": {
+      "type": "dynamic",
+      "port": "Ethernet26"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-06": {
+      "type": "dynamic",
+      "port": "Ethernet48"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-46": {
+      "type": "dynamic",
+      "port": "Ethernet55"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-91": {
+      "type": "dynamic",
+      "port": "Ethernet40"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-38": {
+      "type": "dynamic",
+      "port": "Ethernet55"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-18": {
+      "type": "dynamic",
+      "port": "Ethernet39"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-61": {
+      "type": "dynamic",
+      "port": "Ethernet42"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-11": {
+      "type": "dynamic",
+      "port": "Ethernet25"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-49": {
+      "type": "dynamic",
+      "port": "Ethernet27"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-22": {
+      "type": "dynamic",
+      "port": "Ethernet14"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-43": {
+      "type": "dynamic",
+      "port": "Ethernet52"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-12": {
+      "type": "dynamic",
+      "port": "Ethernet41"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-12": {
+      "type": "dynamic",
+      "port": "Ethernet30"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-03": {
+      "type": "dynamic",
+      "port": "Ethernet56"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-56": {
+      "type": "dynamic",
+      "port": "Ethernet26"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-28": {
+      "type": "dynamic",
+      "port": "Ethernet26"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-00": {
+      "type": "dynamic",
+      "port": "Ethernet12"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-77": {
+      "type": "dynamic",
+      "port": "Ethernet42"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-77": {
+      "type": "dynamic",
+      "port": "Ethernet58"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-83": {
+      "type": "dynamic",
+      "port": "Ethernet29"
+    }
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-47": {
+      "type": "dynamic",
+      "port": "Ethernet29"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-06": {
+      "type": "dynamic",
+      "port": "Ethernet24"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-33": {
+      "type": "dynamic",
+      "port": "Ethernet42"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-74": {
+      "type": "dynamic",
+      "port": "Ethernet55"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-13": {
+      "type": "dynamic",
+      "port": "Ethernet13"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-17": {
+      "type": "dynamic",
+      "port": "Ethernet9"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-68": {
+      "type": "dynamic",
+      "port": "Ethernet8"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-42": {
+      "type": "dynamic",
+      "port": "Ethernet6"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-28": {
+      "type": "dynamic",
+      "port": "Ethernet37"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-88": {
+      "type": "dynamic",
+      "port": "Ethernet30"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-04": {
+      "type": "dynamic",
+      "port": "Ethernet22"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-90": {
+      "type": "dynamic",
+      "port": "Ethernet32"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-76": {
+      "type": "dynamic",
+      "port": "Ethernet41"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-10": {
+      "type": "dynamic",
+      "port": "Ethernet39"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-36": {
+      "type": "dynamic",
+      "port": "Ethernet8"
+    }
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-92": {
+      "type": "dynamic",
+      "port": "Ethernet12"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-56": {
+      "type": "dynamic",
+      "port": "Ethernet37"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-24": {
+      "type": "dynamic",
+      "port": "Ethernet22"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-57": {
+      "type": "dynamic",
+      "port": "Ethernet27"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-97": {
+      "type": "dynamic",
+      "port": "Ethernet42"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-16": {
+      "type": "dynamic",
+      "port": "Ethernet8"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-30": {
+      "type": "dynamic",
+      "port": "Ethernet28"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-53": {
+      "type": "dynamic",
+      "port": "Ethernet54"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-88": {
+      "type": "dynamic",
+      "port": "Ethernet53"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-85": {
+      "type": "dynamic",
+      "port": "Ethernet27"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-71": {
+      "type": "dynamic",
+      "port": "Ethernet36"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-01": {
+      "type": "dynamic",
+      "port": "Ethernet9"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:00-06-07-08-09-0A": {
+      "type": "dynamic",
+      "port": "Ethernet7"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-87": {
+      "type": "dynamic",
+      "port": "Ethernet7"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-58": {
+      "type": "dynamic",
+      "port": "Ethernet48"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-85": {
+      "type": "dynamic",
+      "port": "Ethernet58"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-13": {
+      "type": "dynamic",
+      "port": "Ethernet42"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-45": {
+      "type": "dynamic",
+      "port": "Ethernet54"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-29": {
+      "type": "dynamic",
+      "port": "Ethernet38"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-14": {
+      "type": "dynamic",
+      "port": "Ethernet28"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-20": {
+      "type": "dynamic",
+      "port": "Ethernet12"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-23": {
+      "type": "dynamic",
+      "port": "Ethernet52"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-14": {
+      "type": "dynamic",
+      "port": "Ethernet6"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-04": {
+      "type": "dynamic",
+      "port": "Ethernet12"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-75": {
+      "type": "dynamic",
+      "port": "Ethernet29"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-70": {
+      "type": "dynamic",
+      "port": "Ethernet24"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-95": {
+      "type": "dynamic",
+      "port": "Ethernet7"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-70": {
+      "type": "dynamic",
+      "port": "Ethernet48"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-62": {
+      "type": "dynamic",
+      "port": "Ethernet32"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-29": {
+      "type": "dynamic",
+      "port": "Ethernet13"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-41": {
+      "type": "dynamic",
+      "port": "Ethernet31"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-06": {
+      "type": "dynamic",
+      "port": "Ethernet6"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-36": {
+      "type": "dynamic",
+      "port": "Ethernet37"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-55": {
+      "type": "dynamic",
+      "port": "Ethernet40"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-65": {
+      "type": "dynamic",
+      "port": "Ethernet54"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-50": {
+      "type": "dynamic",
+      "port": "Ethernet32"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-80": {
+      "type": "dynamic",
+      "port": "Ethernet8"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-92": {
+      "type": "dynamic",
+      "port": "Ethernet37"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-14": {
+      "type": "dynamic",
+      "port": "Ethernet32"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-72": {
+      "type": "dynamic",
+      "port": "Ethernet12"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-35": {
+      "type": "dynamic",
+      "port": "Ethernet11"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-40": {
+      "type": "dynamic",
+      "port": "Ethernet57"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-70": {
+      "type": "dynamic",
+      "port": "Ethernet32"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-12": {
+      "type": "dynamic",
+      "port": "Ethernet57"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-67": {
+      "type": "dynamic",
+      "port": "Ethernet56"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-19": {
+      "type": "dynamic",
+      "port": "Ethernet11"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-24": {
+      "type": "dynamic",
+      "port": "Ethernet53"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-01": {
+      "type": "dynamic",
+      "port": "Ethernet13"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-87": {
+      "type": "dynamic",
+      "port": "Ethernet15"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-05": {
+      "type": "dynamic",
+      "port": "Ethernet13"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-04": {
+      "type": "dynamic",
+      "port": "Ethernet41"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-42": {
+      "type": "dynamic",
+      "port": "Ethernet32"
+    }
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-59": {
+      "type": "dynamic",
+      "port": "Ethernet29"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-32": {
+      "type": "dynamic",
+      "port": "Ethernet30"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-89": {
+      "type": "dynamic",
+      "port": "Ethernet23"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-31": {
+      "type": "dynamic",
+      "port": "Ethernet40"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-42": {
+      "type": "dynamic",
+      "port": "Ethernet14"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-40": {
+      "type": "dynamic",
+      "port": "Ethernet41"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-15": {
+      "type": "dynamic",
+      "port": "Ethernet7"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-66": {
+      "type": "dynamic",
+      "port": "Ethernet6"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-17": {
+      "type": "dynamic",
+      "port": "Ethernet38"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-01-46": {
+      "type": "dynamic",
+      "port": "Ethernet10"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-02-97": {
+      "type": "dynamic",
+      "port": "Ethernet23"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-00-57": {
+      "type": "dynamic",
+      "port": "Ethernet38"
+    },
+    "OP": "SET"
+  },
+  {
+    "FDB_TABLE:Vlan1000:72-06-00-01-03-66": {
+      "type": "dynamic",
+      "port": "Ethernet14"
+    },
+    "OP": "SET"
+  },
+  {
+    "OP": "SET",
+    "FDB_TABLE:Vlan1000:72-06-00-01-04-25": {
+      "type": "dynamic",
+      "port": "Ethernet54"
+    }
+  }
+]

--- a/sonic-utilities-tests/filter_fdb_input/test_vectors.py
+++ b/sonic-utilities-tests/filter_fdb_input/test_vectors.py
@@ -1,0 +1,69 @@
+"""
+    Filter FDB entries test vector
+"""
+filterFdbEntriesTestVector = [
+    {
+        "arp":[
+        ],
+        "fdb": [
+        ],
+        "expected_fdb": [
+        ],
+    },
+    {
+        "arp":[
+            {
+                "NEIGH_TABLE:Vlan1000:192.168.0.10": {
+                    "neigh": "72:06:00:01:00:08",
+                    "family": "IPv4"
+                },
+                "OP": "SET"
+            },
+        ],
+        "fdb": [
+            {
+                "FDB_TABLE:Vlan1000:72-06-00-01-01-16": {
+                    "type": "dynamic",
+                    "port": "Ethernet22"
+                },
+                "OP": "SET"
+            },
+        ],
+        "expected_fdb": [
+        ],
+    },
+    {
+        "arp":[
+            {
+                "NEIGH_TABLE:Vlan1000:192.168.0.10": {
+                    "neigh": "72:06:00:01:01:16",
+                    "family": "IPv4"
+                },
+                "OP": "SET"
+            },
+        ],
+        "fdb": [
+            {
+                "FDB_TABLE:Vlan1000:72-06-00-01-01-16": {
+                    "type": "dynamic",
+                    "port": "Ethernet22"
+                },
+                "OP": "SET"
+            },
+        ],
+        "expected_fdb": [
+            {
+                "FDB_TABLE:Vlan1000:72-06-00-01-01-16": {
+                    "type": "dynamic",
+                    "port": "Ethernet22"
+                },
+                "OP": "SET"
+            },
+        ],
+    },
+    {
+        "arp": "sonic-utilities-tests/filter_fdb_input/arp.json",
+        "fdb": "sonic-utilities-tests/filter_fdb_input/fdb.json",
+        "expected_fdb": "sonic-utilities-tests/filter_fdb_input/expected_fdb.json"
+    },
+]


### PR DESCRIPTION
**- What I did**
FDB table can get large due to VM creation/deletion which cause
fast reboot to slow down. This utility fitlers FDB entries based on
current MAC entries in the ARP table.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

**- How I did it**
code change

**- How to verify it**
run unit test
sudo pytest sonic-utilities-tests/filter_fdb_entries_test.py

**- Previous command output (if the output of a command-line utility has changed)**
N/A
**- New command output (if the output of a command-line utility has changed)**
N/A
