### PR TITLE
Separated the notifications for "sonic-clear nat translations" and "sonic-clear nat statistics" commands

### DIFF
--- a/scripts/natclear
+++ b/scripts/natclear
@@ -23,11 +23,18 @@ class NatClear(object):
         self.db.connect(self.db.APPL_DB)
         return
 
-    def send_notification(self, op, data):
+    def send_entries_notification(self, op, data):
         opdata = [op,data]
         msg = json.dumps(opdata,separators=(',',':'))
-        self.db.publish('APPL_DB','FLUSHNATREQUEST', msg)
+        self.db.publish('APPL_DB','FLUSHNATENTRIES', msg)
         return
+
+    def send_statistics_notification(self, op, data):
+        opdata = [op,data]
+        msg = json.dumps(opdata,separators=(',',':'))
+        self.db.publish('APPL_DB','FLUSHNATSTATISTICS', msg)
+        return
+
 
 def main():
     parser = argparse.ArgumentParser(description='Clear the nat information',
@@ -49,11 +56,11 @@ def main():
     try:
         nat = NatClear()
         if clear_translations:
-            nat.send_notification("ENTRIES", "ALL")
+            nat.send_entries_notification("ENTRIES", "ALL")
             print ""
             print("Dynamic NAT entries are cleared.")
         elif clear_statistics:
-            nat.send_notification("STATISTICS", "ALL")
+            nat.send_statistics_notification("STATISTICS", "ALL")
             print ""
             print("NAT statistics are cleared.")
     except Exception as e:

--- a/scripts/natshow
+++ b/scripts/natshow
@@ -132,6 +132,8 @@ class NatShow(object):
                 continue
 
             ip_protocol = "all"
+            source = "---"
+            destination = "---"
             translated_dst = "---"
             translated_src = "---"
 
@@ -249,7 +251,7 @@ class NatShow(object):
                     napt_keys = re.split(':', napt_entry)
                     napt_values = self.appl_db.get_all(self.appl_db.APPL_DB,'NAPT_TABLE:{}'.format(napt_entry))
 
-                    ip_protocol = napt_keys[0]
+                    ip_protocol = napt_keys[0].lower()
                     source = "---"
                     destination = "---"
 
@@ -278,6 +280,8 @@ class NatShow(object):
                     nat_twice_values = self.appl_db.get_all(self.appl_db.APPL_DB,'NAT_TWICE_TABLE:{}'.format(nat_twice_entry))
 
                     ip_protocol = "all"
+                    source = "---"
+                    destination = "---"
 
                     source = nat_twice_keys[0]
                     destination = nat_twice_keys[1]
@@ -301,7 +305,9 @@ class NatShow(object):
                     napt_twice_keys = re.split(':', napt_twice_entry)
                     napt_twice_values = self.appl_db.get_all(self.appl_db.APPL_DB,'NAPT_TWICE_TABLE:{}'.format(napt_twice_entry))
 
-                    ip_protocol = napt_twice_keys[0]
+                    ip_protocol = napt_twice_keys[0].lower()
+                    source = "---"
+                    destination = "---"
 
                     source = napt_twice_keys[1] + ':' + napt_twice_keys[2]
                     destination = napt_twice_keys[3] + ':' + napt_twice_keys[4]


### PR DESCRIPTION
Separated the notifications for 2 clear commands, as "sonic-clear nat translations" notifications to be handled now at NatMgr and like earlier "sonic-clear nat statistics" notification to be handled at NatOrch.

Depends on:
https://github.com/Azure/sonic-swss/pull/1274
https://github.com/Azure/sonic-buildimage/pull/4596

 Signed-off-by: Akhilesh Samineni <akhilesh.samineni@broadcom.com>
