### PR TITLE
[fwutil]: Fix firmware update command

### DIFF
--- a/fwutil/main.py
+++ b/fwutil/main.py
@@ -227,8 +227,6 @@ def update(ctx, yes, force, image):
         squashfs = None
 
         try:
-            cup = ComponentUpdateProvider()
-
             if image == IMAGE_NEXT:
                 squashfs = SquashFs()
 
@@ -237,6 +235,9 @@ def update(ctx, yes, force, image):
                     cup = ComponentUpdateProvider(fs_path)
                 else:
                     log_helper.print_warning("Next boot is set to current: fallback to defaults")
+                    cup = ComponentUpdateProvider()
+            else:
+                cup = ComponentUpdateProvider()
 
             click.echo(cup.get_status(force))
 


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->
This PR contains a fix for `fwutil update --image=next` command: do not fail when current image contains invalid `platform_component.json`

**- What I did**
* Fixed firmware update command

**- How I did it**
* Changed `ComponentUpdateProvider` init order

**- How to verify it**
1. fwutil update --image=current
2. fwutil update --image=next

**- Previous command output (if the output of a command-line utility has changed)**
```
root@sonic:/home/admin# fwutil update --image=next
Error: Chassis component names mismatch: keys=['CPLD1', 'CPLD2', 'CPLD', 'CPLD3']. Aborting...
Aborted!
```

**- New command output (if the output of a command-line utility has changed)**
```
root@sonic:/home/admin# fwutil update --image=next
Chassis                  Module    Component    Firmware    Version                  Status      Info
-----------------------  --------  -----------  ----------  -----------------------  ----------  ------
x86_64-mlnx_msn3700c-r0  N/A       BIOS         N/A         0ACLH004_02.02.007_9600  up-to-date  N/A
                                   CPLD1        N/A         CPLD000120_REV0223       up-to-date  N/A
                                   CPLD2        N/A         CPLD000162_REV0800       up-to-date  N/A
                                   CPLD3        N/A         CPLD000106_REV0100       up-to-date  N/A
New firmware will be installed, continue? [y/N]: y

Summary:

Chassis                  Module    Component    Status
-----------------------  --------  -----------  ----------
x86_64-mlnx_msn3700c-r0  N/A       BIOS         up-to-date
                                   CPLD1        up-to-date
                                   CPLD2        up-to-date
                                   CPLD3        up-to-date
```