### PR TITLE
Support load_minigraph command for multi NPU platform

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -957,7 +957,7 @@ def load_minigraph():
             run_command(db_migrator + ' -o set_version' + cfggen_namespace_option)
 
     if os.path.isfile('/etc/sonic/acl.json'):
-            run_command("acl-loader update full /etc/sonic/acl.json", display_cmd=True)
+        run_command("acl-loader update full /etc/sonic/acl.json", display_cmd=True)
 
     # We first run "systemctl reset-failed" to remove the "failed"
     # status from all services before we attempt to restart them

--- a/config/main.py
+++ b/config/main.py
@@ -36,6 +36,7 @@ SYSTEMCTL_ACTION_STOP="stop"
 SYSTEMCTL_ACTION_RESTART="restart"
 SYSTEMCTL_ACTION_RESET_FAILED="reset-failed"
 
+DEFAULT_NAMESPACE = ''
 # ========================== Syslog wrappers ==========================
 
 def log_debug(msg):
@@ -920,12 +921,13 @@ def load_minigraph():
     # For Single Asic platform the namespace list has the empty string
     # for mulit Asic platform the empty string to generate the config
     # for host
-    namespace_list = ['']
-    if sonic_device_util.get_num_npus() > 1:
+    namespace_list = [DEFAULT_NAMESPACE]
+    num_npus = sonic_device_util.get_num_npus()
+    if num_npus > 1:
         namespace_list += sonic_device_util.get_namespaces()
 
     for namespace in namespace_list:
-        if namespace is '':
+        if namespace is DEFAULT_NAMESPACE:
             config_db = ConfigDBConnector()
             cfggen_namespace_option = " "
             ns_cmd_prefix = " "
@@ -942,11 +944,20 @@ def load_minigraph():
             command = "{} -H -m --write-to-db {} ".format(SONIC_CFGGEN_PATH,cfggen_namespace_option)
         run_command(command, display_cmd=True)
         client.set(config_db.INIT_INDICATOR, 1)
-        if device_type != 'MgmtToRRouter':
-            run_command('{} pfcwd start_default'.format(ns_cmd_prefix), display_cmd=True)
-        if os.path.isfile('/etc/sonic/acl.json'):
+
+        # These commands are not run for host on multi asic platform
+        if num_npus == 1 or namespace is not DEFAULT_NAMESPACE:
+            if device_type != 'MgmtToRRouter':
+                run_command('{} pfcwd start_default'.format(ns_cmd_prefix), display_cmd=True)
+            run_command("{} config qos reload".format(ns_cmd_prefix), display_cmd=True)
+
+        # Write latest db version string into db
+        db_migrator='/usr/bin/db_migrator.py'
+        if os.path.isfile(db_migrator) and os.access(db_migrator, os.X_OK):
+            run_command(db_migrator + ' -o set_version' + cfggen_namespace_option)
+
+    if os.path.isfile('/etc/sonic/acl.json'):
             run_command("acl-loader update full /etc/sonic/acl.json", display_cmd=True)
-        run_command("{} config qos reload".format(ns_cmd_prefix), display_cmd=True)
 
     # We first run "systemctl reset-failed" to remove the "failed"
     # status from all services before we attempt to restart them

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -358,6 +358,10 @@ main() {
         /proc/zoneinfo \
         || abort "${ERROR_PROCFS_SAVE_FAILED}" "Proc saving operation failed. Aborting for safety."
 
+    save_cmd "systemd-analyze blame" "systemd.analyze.blame"
+    save_cmd "systemd-analyze dump" "systemd.analyze.dump"
+    save_cmd "systemd-analyze plot" "systemd.analyze.plot.svg"
+    
     save_platform "syseeprom" "platform"
     save_platform "psustatus" "platform"
     save_platform "ssdhealth" "platform"


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Modify the load_minigraph command handler to support multi NPU platforms
 This PR needs the changes from[#4222](https://github.com/Azure/sonic-buildimage/pull/4222) for the minigraph parsing changes

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**
No command output is changed
**- New command output (if the output of a command-line utility has changed)**
No command output is changed
