### PR TITLE
[show] Fix abbreviations for 'show ip bgp ...' commands

### DIFF
--- a/show/bgp_frr_v4.py
+++ b/show/bgp_frr_v4.py
@@ -1,5 +1,5 @@
 import click
-from show.main import ip, run_command, get_bgp_summary_extended
+from show.main import AliasedGroup, ip, run_command, get_bgp_summary_extended
 
 
 ###############################################################################
@@ -9,7 +9,7 @@ from show.main import ip, run_command, get_bgp_summary_extended
 ###############################################################################
 
 
-@ip.group()
+@ip.group(cls=AliasedGroup)
 def bgp():
     """Show IPv4 BGP (Border Gateway Protocol) information"""
     pass

--- a/show/bgp_frr_v6.py
+++ b/show/bgp_frr_v6.py
@@ -1,5 +1,5 @@
 import click
-from show.main import ipv6, run_command, get_bgp_summary_extended
+from show.main import AliasedGroup, ipv6, run_command, get_bgp_summary_extended
 
 
 ###############################################################################
@@ -9,7 +9,7 @@ from show.main import ipv6, run_command, get_bgp_summary_extended
 ###############################################################################
 
 
-@ipv6.group()
+@ipv6.group(cls=AliasedGroup)
 def bgp():
     """Show IPv6 BGP (Border Gateway Protocol) information"""
     pass

--- a/show/bgp_quagga_v4.py
+++ b/show/bgp_quagga_v4.py
@@ -1,5 +1,5 @@
 import click
-from show.main import ip, run_command, get_bgp_summary_extended
+from show.main import AliasedGroup, ip, run_command, get_bgp_summary_extended
 
 
 ###############################################################################
@@ -9,7 +9,7 @@ from show.main import ip, run_command, get_bgp_summary_extended
 ###############################################################################
 
 
-@ip.group()
+@ip.group(cls=AliasedGroup)
 def bgp():
     """Show IPv4 BGP (Border Gateway Protocol) information"""
     pass

--- a/show/bgp_quagga_v6.py
+++ b/show/bgp_quagga_v6.py
@@ -1,5 +1,5 @@
 import click
-from show.main import ipv6, run_command, get_bgp_summary_extended
+from show.main import AliasedGroup, ipv6, run_command, get_bgp_summary_extended
 
 
 ###############################################################################
@@ -9,7 +9,7 @@ from show.main import ipv6, run_command, get_bgp_summary_extended
 ###############################################################################
 
 
-@ipv6.group()
+@ipv6.group(cls=AliasedGroup)
 def bgp():
     """Show IPv6 BGP (Border Gateway Protocol) information"""
     pass


### PR DESCRIPTION
Currently, the `AliasedGroup` class in show/main.py handles finding a subcommand to run based on an abbreviation. Thus, we need to import in the bgp files and use it as the base class for the 'bgp' groups in order to allow abbreviations to work for the subcommands in these groups.