### PR TITLE
[Vnet] Fix NameError for 'swsssdk' and align output

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -3050,8 +3050,11 @@ def neighbors():
                 for ip, mac in nbrs_data[intf]:
                     r = ["", ip, mac, intf]
                     table.append(r)
-    click.echo(tabulate(table, header))
-    click.echo("\n")
+        click.echo(tabulate(table, header))
+        click.echo("\n")
+
+    if not bool(vnet_intfs):
+        click.echo(tabulate(table, header))
 
 @vnet.group()
 def routes():

--- a/show/main.py
+++ b/show/main.py
@@ -3026,7 +3026,7 @@ def neighbors():
             else:
                 vnet_intfs[vnet_name] = [k]
 
-    appl_db = swsssdk.SonicV2Connector()
+    appl_db = SonicV2Connector()
     appl_db.connect(appl_db.APPL_DB)
 
     # Fetching data from appl_db for neighbors
@@ -3050,8 +3050,8 @@ def neighbors():
                 for ip, mac in nbrs_data[intf]:
                     r = ["", ip, mac, intf]
                     table.append(r)
-        click.echo(tabulate(table, header))
-        click.echo("\n")
+    click.echo(tabulate(table, header))
+    click.echo("\n")
 
 @vnet.group()
 def routes():
@@ -3061,7 +3061,7 @@ def routes():
 @routes.command()
 def all():
     """Show all vnet routes"""
-    appl_db = swsssdk.SonicV2Connector()
+    appl_db = SonicV2Connector()
     appl_db.connect(appl_db.APPL_DB)
 
     header = ['vnet name', 'prefix', 'nexthop', 'interface']
@@ -3104,7 +3104,7 @@ def all():
 @routes.command()
 def tunnel():
     """Show vnet tunnel routes"""
-    appl_db = swsssdk.SonicV2Connector()
+    appl_db = SonicV2Connector()
     appl_db.connect(appl_db.APPL_DB)
 
     header = ['vnet name', 'prefix', 'endpoint', 'mac address', 'vni']


### PR DESCRIPTION
**- What I did**
1. Fix  NameError:
```
admin@str-sn-01:~$ show vnet routes tunnel
    appl_db = swsssdk.SonicV2Connector()
NameError: global name 'swsssdk' is not defined
```
2. Fix empty output for neighbors 
```
admin@str-sn-01:~$ show vnet neighbors 
admin@str-sn-01:~$ 
```
**- How I did it**
Code Fix - `SonicV2Connector `is already imported from `swsssdk `in the file

**- How to verify it**
Rerun commands

**- Previous command output (if the output of a command-line utility has changed)**
```
admin@str-sn-01:~$ show vnet neighbors 
admin@str-sn-01:~$ 
```
**- New command output (if the output of a command-line utility has changed)**
```
admin@str-sn-01:~$ show vnet neighbors 
<vnet_name>    neighbor    mac_address    interfaces
-------------  ----------  -------------  ------------

admin@str-sn-01:~$
```