### PR TITLE
Remove dependency on click-default-group package

### DIFF
--- a/clear/bgp_frr_v6.py
+++ b/clear/bgp_frr_v6.py
@@ -14,32 +14,22 @@ def bgp():
     """Clear IPv6 BGP (Border Gateway Protocol) information"""
     pass
 
-
-# Default 'bgp' command (called if no subcommands or their aliases were passed)
-@bgp.command(default=True)
-def default():
-    """Clear all BGP peers"""
-    command = 'sudo vtysh -c "clear bgp ipv6 *"'
-    run_command(command)
-
-
 @bgp.group()
 def neighbor():
     """Clear specific BGP peers"""
     pass
 
-
-@neighbor.command(default=True)
+# 'all' subcommand
+@neighbor.command('all')
 @click.argument('ipaddress', required=False)
-def default(ipaddress):
+def neigh_all(ipaddress):
     """Clear all BGP peers"""
 
     if ipaddress is not None:
-        command = 'sudo vtysh -c "clear bgp ipv6 {} "'.format(ipaddress)
+        command = 'sudo vtysh -c "clear bgp ipv6 {}"'.format(ipaddress)
     else:
         command = 'sudo vtysh -c "clear bgp ipv6 *"'
     run_command(command)
-
 
 # 'in' subcommand
 @neighbor.command('in')
@@ -72,19 +62,6 @@ def soft():
     """Soft reconfig BGP's inbound/outbound updates"""
     pass
 
-
-@soft.command(default=True)
-@click.argument('ipaddress', required=False)
-def default(ipaddress):
-    """Clear BGP neighbors soft configuration"""
-
-    if ipaddress is not None:
-        command = 'sudo vtysh -c "clear bgp ipv6 {} soft "'.format(ipaddress)
-    else:
-        command = 'sudo vtysh -c "clear bgp ipv6 * soft"'
-    run_command(command)
-
-
 # 'soft in' subcommand
 @soft.command('in')
 @click.argument('ipaddress', required=False)
@@ -97,6 +74,18 @@ def soft_in(ipaddress):
         command = 'sudo vtysh -c "clear bgp ipv6 * soft in"'
     run_command(command)
 
+
+# 'soft all' subcommand
+@neighbor.command('all')
+@click.argument('ipaddress', required=False)
+def soft_all(ipaddress):
+    """Clear BGP neighbors soft configuration"""
+
+    if ipaddress is not None:
+        command = 'sudo vtysh -c "clear bgp ipv6 {} soft"'.format(ipaddress)
+    else:
+        command = 'sudo vtysh -c "clear bgp ipv6 * soft"'
+    run_command(command)
 
 # 'soft out' subcommand
 @soft.command('out')

--- a/clear/bgp_quagga_v4.py
+++ b/clear/bgp_quagga_v4.py
@@ -15,27 +15,19 @@ def bgp():
     pass
 
 
-# Default 'bgp' command (called if no subcommands or their aliases were passed)
-@bgp.command(default=True)
-def default():
-    """Clear all BGP peers"""
-    command = 'sudo vtysh -c "clear ip bgp *"'
-    run_command(command)
-
-
 @bgp.group()
 def neighbor():
     """Clear specific BGP peers"""
     pass
 
 
-@neighbor.command(default=True)
+@neighbor.command('all')
 @click.argument('ipaddress', required=False)
-def default(ipaddress):
+def neigh_all(ipaddress):
     """Clear all BGP peers"""
 
     if ipaddress is not None:
-        command = 'sudo vtysh -c "clear ip bgp {} "'.format(ipaddress)
+        command = 'sudo vtysh -c "clear ip bgp {}"'.format(ipaddress)
     else:
         command = 'sudo vtysh -c "clear ip bgp *"'
     run_command(command)
@@ -73,13 +65,13 @@ def soft():
     pass
 
 
-@soft.command(default=True)
+@soft.command('all')
 @click.argument('ipaddress', required=False)
-def default(ipaddress):
+def soft_all(ipaddress):
     """Clear BGP neighbors soft configuration"""
 
     if ipaddress is not None:
-        command = 'sudo vtysh -c "clear ip bgp {} soft "'.format(ipaddress)
+        command = 'sudo vtysh -c "clear ip bgp {} soft"'.format(ipaddress)
     else:
         command = 'sudo vtysh -c "clear ip bgp * soft"'
     run_command(command)

--- a/clear/bgp_quagga_v6.py
+++ b/clear/bgp_quagga_v6.py
@@ -14,28 +14,18 @@ def bgp():
     """Clear IPv6 BGP (Border Gateway Protocol) information"""
     pass
 
-
-# Default 'bgp' command (called if no subcommands or their aliases were passed)
-@bgp.command(default=True)
-def default():
-    """Clear all BGP peers"""
-    command = 'sudo vtysh -c "clear ipv6 bgp *"'
-    run_command(command)
-
-
 @bgp.group()
 def neighbor():
     """Clear specific BGP peers"""
     pass
 
-
-@neighbor.command(default=True)
+@neighbor.command('all')
 @click.argument('ipaddress', required=False)
-def default(ipaddress):
+def neigh_all(ipaddress):
     """Clear all BGP peers"""
 
     if ipaddress is not None:
-        command = 'sudo vtysh -c "clear ipv6 bgp {} "'.format(ipaddress)
+        command = 'sudo vtysh -c "clear ipv6 bgp {}"'.format(ipaddress)
     else:
         command = 'sudo vtysh -c "clear ipv6 bgp *"'
     run_command(command)
@@ -73,13 +63,13 @@ def soft():
     pass
 
 
-@soft.command(default=True)
+@soft.command('all')
 @click.argument('ipaddress', required=False)
-def default(ipaddress):
+def soft_all(ipaddress):
     """Clear BGP neighbors soft configuration"""
 
     if ipaddress is not None:
-        command = 'sudo vtysh -c "clear ipv6 bgp {} soft "'.format(ipaddress)
+        command = 'sudo vtysh -c "clear ipv6 bgp {} soft"'.format(ipaddress)
     else:
         command = 'sudo vtysh -c "clear ipv6 bgp * soft"'
     run_command(command)

--- a/clear/main.py
+++ b/clear/main.py
@@ -3,7 +3,6 @@
 import click
 import os
 import subprocess
-from click_default_group import DefaultGroup
 
 try:
     # noinspection PyPep8Naming
@@ -35,12 +34,10 @@ class Config(object):
 _config = None
 
 
-# This aliased group has been modified from click examples to inherit from DefaultGroup instead of click.Group.
-# DefaultFroup is a superclass of click.Group which calls a default subcommand instead of showing
-# a help message if no subcommand is passed
-class AliasedGroup(DefaultGroup):
-    """This subclass of a DefaultGroup supports looking up aliases in a config
-    file and with a bit of magic.
+
+class AliasedGroup(click.Group):
+    """This subclass of click.Group supports abbreviations and
+       looking up aliases in a config file with a bit of magic.
     """
 
     def get_command(self, ctx, cmd_name):
@@ -71,12 +68,9 @@ class AliasedGroup(DefaultGroup):
         matches = [x for x in self.list_commands(ctx)
                    if x.lower().startswith(cmd_name.lower())]
         if not matches:
-            # No command name matched. Issue Default command.
-            ctx.arg0 = cmd_name
-            cmd_name = self.default_cmd_name
-            return DefaultGroup.get_command(self, ctx, cmd_name)
+            return None
         elif len(matches) == 1:
-            return DefaultGroup.get_command(self, ctx, matches[0])
+            return click.Group.get_command(self, ctx, matches[0])
         ctx.fail('Too many matches: %s' % ', '.join(sorted(matches)))
 
 
@@ -384,7 +378,7 @@ def line(linenum):
 # 'nat' group ("clear nat ...")
 #
 
-@cli.group(cls=AliasedGroup, default_if_no_args=False)
+@cli.group(cls=AliasedGroup)
 def nat():
     """Clear the nat info"""
     pass

--- a/config/main.py
+++ b/config/main.py
@@ -14,7 +14,6 @@ import sonic_device_util
 import ipaddress
 from swsssdk import ConfigDBConnector, SonicV2Connector, SonicDBConfig
 from minigraph import parse_device_desc_xml
-from click_default_group import DefaultGroup
 
 import aaa
 import mlnx
@@ -62,12 +61,8 @@ def log_error(msg):
     syslog.closelog()
 
 
-# This aliased group has been modified from click examples to inherit from DefaultGroup instead of click.Group.
-# DefaultGroup is a superclass of click.Group which calls a default subcommand instead of showing
-# a help message if no subcommand is passed
-class AbbreviationGroup(DefaultGroup):
-    """This subclass of a DefaultGroup supports looking up aliases in a config
-    file and with a bit of magic.
+class AbbreviationGroup(click.Group):
+    """This subclass of click.Group supports abbreviated subgroup/subcommand names
     """
 
     def get_command(self, ctx, cmd_name):
@@ -92,18 +87,15 @@ class AbbreviationGroup(DefaultGroup):
                     shortest = x
 
         if not matches:
-            # No command name matched. Issue Default command.
-            ctx.arg0 = cmd_name
-            cmd_name = self.default_cmd_name
-            return DefaultGroup.get_command(self, ctx, cmd_name)
+            return None
         elif len(matches) == 1:
-            return DefaultGroup.get_command(self, ctx, matches[0])
+            return click.Group.get_command(self, ctx, matches[0])
         else:
             for x in matches:
                 if not x.startswith(shortest):
                     break
             else:
-                return DefaultGroup.get_command(self, ctx, shortest)
+                return click.Group.get_command(self, ctx, shortest)
 
             ctx.fail('Too many matches: %s' % ', '.join(sorted(matches)))
 

--- a/connect/main.py
+++ b/connect/main.py
@@ -3,7 +3,6 @@
 import click
 import os
 import pexpect
-from click_default_group import DefaultGroup
 
 try:
     # noinspection PyPep8Naming
@@ -35,12 +34,9 @@ class Config(object):
 _config = None
 
 
-# This aliased group has been modified from click examples to inherit from DefaultGroup instead of click.Group.
-# DefaultGroup is a superclass of click.Group which calls a default subcommand instead of showing
-# a help message if no subcommand is passed
-class AliasedGroup(DefaultGroup):
-    """This subclass of a DefaultGroup supports looking up aliases in a config
-    file and with a bit of magic.
+class AliasedGroup(click.Group):
+    """This subclass of click.Group supports abbreviations and
+       looking up aliases in a config file with a bit of magic.
     """
 
     def get_command(self, ctx, cmd_name):
@@ -71,12 +67,9 @@ class AliasedGroup(DefaultGroup):
         matches = [x for x in self.list_commands(ctx)
                    if x.lower().startswith(cmd_name.lower())]
         if not matches:
-            # No command name matched. Issue Default command.
-            ctx.arg0 = cmd_name
-            cmd_name = self.default_cmd_name
-            return DefaultGroup.get_command(self, ctx, cmd_name)
+            return None
         elif len(matches) == 1:
-            return DefaultGroup.get_command(self, ctx, matches[0])
+            return click.Group.get_command(self, ctx, matches[0])
         ctx.fail('Too many matches: %s' % ', '.join(sorted(matches)))
 
 def run_command(command, display_cmd=False):

--- a/debug/main.py
+++ b/debug/main.py
@@ -3,7 +3,6 @@
 
 import click
 import subprocess
-from click_default_group import DefaultGroup
 
 def run_command(command, pager=False):
     click.echo(click.style("Command: ", fg='cyan') + click.style(command, fg='green'))
@@ -192,17 +191,13 @@ else:
     #
     # 'bgp' group for quagga ###
     #
-    @cli.group(cls=DefaultGroup, default_if_no_args=True)
-    #@cli.group()
-    def bgp():
-        """debug bgp on """
-        pass
-
-    @bgp.command(default=True)
-    def default():
-        """debug bgp"""
-        command = 'sudo vtysh -c "debug bgp"'
-        run_command(command)
+    @cli.group(invoke_without_command=True)
+    @click.pass_context
+    def bgp(ctx):
+        """debug bgp on"""
+        if ctx.invoked_subcommand is None:
+            command = 'sudo vtysh -c "debug bgp"'
+            run_command(command)
 
     @bgp.command()
     def events():

--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,6 @@ setup(
     # - swsssdk
     # - tabulate
     install_requires=[
-        'click-default-group',
         'click',
         'natsort'
     ],

--- a/show/main.py
+++ b/show/main.py
@@ -11,7 +11,6 @@ import ipaddress
 from pkg_resources import parse_version
 
 import click
-from click_default_group import DefaultGroup
 from natsort import natsorted
 from tabulate import tabulate
 
@@ -119,12 +118,9 @@ class InterfaceAliasConverter(object):
 _config = None
 
 
-# This aliased group has been modified from click examples to inherit from DefaultGroup instead of click.Group.
-# DefaultGroup is a superclass of click.Group which calls a default subcommand instead of showing
-# a help message if no subcommand is passed
-class AliasedGroup(DefaultGroup):
-    """This subclass of a DefaultGroup supports looking up aliases in a config
-    file and with a bit of magic.
+class AliasedGroup(click.Group):
+    """This subclass of click.Group supports abbreviations and
+       looking up aliases in a config file with a bit of magic.
     """
 
     def get_command(self, ctx, cmd_name):
@@ -155,12 +151,9 @@ class AliasedGroup(DefaultGroup):
         matches = [x for x in self.list_commands(ctx)
                    if x.lower().startswith(cmd_name.lower())]
         if not matches:
-            # No command name matched. Issue Default command.
-            ctx.arg0 = cmd_name
-            cmd_name = self.default_cmd_name
-            return DefaultGroup.get_command(self, ctx, cmd_name)
+            return None
         elif len(matches) == 1:
-            return DefaultGroup.get_command(self, ctx, matches[0])
+            return click.Group.get_command(self, ctx, matches[0])
         ctx.fail('Too many matches: %s' % ', '.join(sorted(matches)))
 
 
@@ -685,7 +678,7 @@ def mgmt_vrf(ctx,routes):
 # 'management_interface' group ("show management_interface ...")
 #
 
-@cli.group(name='management_interface', cls=AliasedGroup, default_if_no_args=False)
+@cli.group(name='management_interface', cls=AliasedGroup)
 def management_interface():
     """Show management interface parameters"""
     pass
@@ -751,7 +744,7 @@ def snmptrap (ctx):
 # 'interfaces' group ("show interfaces ...")
 #
 
-@cli.group(cls=AliasedGroup, default_if_no_args=False)
+@cli.group(cls=AliasedGroup)
 def interfaces():
     """Show details of the network interfaces"""
     pass
@@ -796,7 +789,7 @@ def alias(interfacename):
 #
 # 'neighbor' group ###
 #
-@interfaces.group(cls=AliasedGroup, default_if_no_args=False)
+@interfaces.group(cls=AliasedGroup)
 def neighbor():
     """Show neighbor related information"""
     pass
@@ -853,7 +846,7 @@ def expected(interfacename):
 
     click.echo(tabulate(body, header))
 
-@interfaces.group(cls=AliasedGroup, default_if_no_args=False)
+@interfaces.group(cls=AliasedGroup)
 def transceiver():
     """Show SFP Transceiver information"""
     pass
@@ -994,7 +987,7 @@ def portchannel(verbose):
 # 'subinterfaces' group ("show subinterfaces ...")
 #
 
-@cli.group(cls=AliasedGroup, default_if_no_args=False)
+@cli.group(cls=AliasedGroup)
 def subinterfaces():
     """Show details of the sub port interfaces"""
     pass
@@ -1025,7 +1018,7 @@ def status(subinterfacename, verbose):
 # 'pfc' group ("show pfc ...")
 #
 
-@cli.group(cls=AliasedGroup, default_if_no_args=False)
+@cli.group(cls=AliasedGroup)
 def pfc():
     """Show details of the priority-flow-control (pfc) """
     pass
@@ -1067,7 +1060,7 @@ def asymmetric(interface):
     run_command(cmd)
 
 # 'pfcwd' subcommand ("show pfcwd...")
-@cli.group(cls=AliasedGroup, default_if_no_args=False)
+@cli.group(cls=AliasedGroup)
 def pfcwd():
     """Show details of the pfc watchdog """
     pass
@@ -1103,7 +1096,7 @@ def naming_mode(verbose):
 # 'watermark' group ("show watermark telemetry interval")
 #
 
-@cli.group(cls=AliasedGroup, default_if_no_args=False)
+@cli.group(cls=AliasedGroup)
 def watermark():
     """Show details of watermark """
     pass
@@ -1124,7 +1117,7 @@ def show_tm_interval():
 # 'queue' group ("show queue ...")
 #
 
-@cli.group(cls=AliasedGroup, default_if_no_args=False)
+@cli.group(cls=AliasedGroup)
 def queue():
     """Show details of the queues """
     pass
@@ -1198,7 +1191,7 @@ def pwm_q_multi():
 # 'priority-group' group ("show priority-group ...")
 #
 
-@cli.group(name='priority-group', cls=AliasedGroup, default_if_no_args=False)
+@cli.group(name='priority-group', cls=AliasedGroup)
 def priority_group():
     """Show details of the PGs """
 
@@ -1241,7 +1234,7 @@ def pwm_pg_shared():
 # 'buffer_pool' group ("show buffer_pool ...")
 #
 
-@cli.group(name='buffer_pool', cls=AliasedGroup, default_if_no_args=False)
+@cli.group(name='buffer_pool', cls=AliasedGroup)
 def buffer_pool():
     """Show details of the buffer pools"""
 
@@ -1299,7 +1292,7 @@ def route_map(route_map_name, verbose):
 #
 
 # This group houses IP (i.e., IPv4) commands and subgroups
-@cli.group(cls=AliasedGroup, default_if_no_args=False)
+@cli.group(cls=AliasedGroup)
 def ip():
     """Show IP (IPv4) commands"""
     pass
@@ -1482,7 +1475,7 @@ def protocol(verbose):
 #
 
 # This group houses IPv6-related commands and subgroups
-@cli.group(cls=AliasedGroup, default_if_no_args=False)
+@cli.group(cls=AliasedGroup)
 def ipv6():
     """Show IPv6 commands"""
     pass
@@ -1600,7 +1593,7 @@ elif routing_stack == "frr":
 # 'lldp' group ("show lldp ...")
 #
 
-@cli.group(cls=AliasedGroup, default_if_no_args=False)
+@cli.group(cls=AliasedGroup)
 def lldp():
     """LLDP (Link Layer Discovery Protocol) information"""
     pass
@@ -1654,7 +1647,7 @@ def get_hw_info_dict():
     hw_info_dict['asic_type'] = asic_type
     return hw_info_dict
 
-@cli.group(cls=AliasedGroup, default_if_no_args=False)
+@cli.group(cls=AliasedGroup)
 def platform():
     """Show platform-specific hardware info"""
     pass
@@ -1803,7 +1796,7 @@ def environment(verbose):
 # 'processes' group ("show processes ...")
 #
 
-@cli.group(cls=AliasedGroup, default_if_no_args=False)
+@cli.group(cls=AliasedGroup)
 def processes():
     """Display process information"""
     pass
@@ -1866,7 +1859,7 @@ def techsupport(since, verbose):
 # 'runningconfiguration' group ("show runningconfiguration")
 #
 
-@cli.group(cls=AliasedGroup, default_if_no_args=False)
+@cli.group(cls=AliasedGroup)
 def runningconfiguration():
     """Show current running configuration information"""
     pass
@@ -1980,7 +1973,7 @@ def syslog(verbose):
 # 'startupconfiguration' group ("show startupconfiguration ...")
 #
 
-@cli.group(cls=AliasedGroup, default_if_no_args=False)
+@cli.group(cls=AliasedGroup)
 def startupconfiguration():
     """Show startup configuration information"""
     pass
@@ -2052,7 +2045,7 @@ def system_memory(verbose):
     cmd = "free -m"
     run_command(cmd, display_cmd=verbose)
 
-@cli.group(cls=AliasedGroup, default_if_no_args=False)
+@cli.group(cls=AliasedGroup)
 def vlan():
     """Show VLAN information"""
     pass
@@ -2060,7 +2053,7 @@ def vlan():
 #
 # 'kdump command ("show kdump ...")
 #
-@cli.group(cls=AliasedGroup, default_if_no_args=True, )
+@cli.group(cls=AliasedGroup)
 def kdump():
     """Show kdump configuration, status and information """
     pass
@@ -2456,7 +2449,7 @@ def show_sflow_global(config_db):
 # 'acl' group ###
 #
 
-@cli.group(cls=AliasedGroup, default_if_no_args=False)
+@cli.group(cls=AliasedGroup)
 def acl():
     """Show ACL related information"""
     pass
@@ -2498,7 +2491,7 @@ def table(table_name, verbose):
 # 'dropcounters' group ###
 #
 
-@cli.group(cls=AliasedGroup, default_if_no_args=False)
+@cli.group(cls=AliasedGroup)
 def dropcounters():
     """Show drop counter related information"""
     pass
@@ -2609,7 +2602,7 @@ def line():
     return
 
 
-@cli.group(name='warm_restart', cls=AliasedGroup, default_if_no_args=False)
+@cli.group(name='warm_restart', cls=AliasedGroup)
 def warm_restart():
     """Show warm restart configuration and state"""
     pass
@@ -2735,7 +2728,7 @@ def config(redis_unix_socket_path):
 # 'nat' group ("show nat ...")
 #
 
-@cli.group(cls=AliasedGroup, default_if_no_args=False)
+@cli.group(cls=AliasedGroup)
 def nat():
     """Show details of the nat """
     pass
@@ -2906,7 +2899,7 @@ def autorestart(container_name):
 #
 # 'vnet' command ("show vnet")
 #
-@cli.group(cls=AliasedGroup, default_if_no_args=False)
+@cli.group(cls=AliasedGroup)
 def vnet():
     """Show vnet related information"""
     pass
@@ -3128,7 +3121,7 @@ def tunnel():
 #
 # 'vxlan' command ("show vxlan")
 #
-@cli.group(cls=AliasedGroup, default_if_no_args=False)
+@cli.group(cls=AliasedGroup)
 def vxlan():
     """Show vxlan related information"""
     pass

--- a/show/main.py
+++ b/show/main.py
@@ -2076,7 +2076,7 @@ def enabled():
     else:
         click.echo("kdump is disabled")
 
-@kdump.command('status', default=True)
+@kdump.command('status')
 def status():
     """Show kdump status"""
     run_command("sonic-kdump-config --status")

--- a/undebug/main.py
+++ b/undebug/main.py
@@ -3,7 +3,6 @@
 
 import click
 import subprocess
-from click_default_group import DefaultGroup
 
 def run_command(command, pager=False):
     click.echo(click.style("Command: ", fg='cyan') + click.style(command, fg='green'))
@@ -192,57 +191,53 @@ else:
     #
     # 'bgp' group for quagga ###
     #
-    @cli.group(cls=DefaultGroup, default_if_no_args=True)
-    #@cli.group()
-    def bgp():
-        """debug bgp on """
-        pass
-
-    @bgp.command(default=True)
-    def default():
-        """debug bgp"""
-        command = 'sudo vtysh -c "no debug bgp"'
-        run_command(command)
+    @cli.group(invoke_without_command=True)
+    @click.pass_context
+    def bgp(ctx):
+        """debug bgp off"""
+        if ctx.invoked_subcommand is None:
+            command = 'sudo vtysh -c "no debug bgp"'
+            run_command(command)
 
     @bgp.command()
     def events():
-        """debug bgp events on"""
+        """debug bgp events off"""
         command = 'sudo vtysh -c "no debug bgp events"'
         run_command(command)
 
     @bgp.command()
     def updates():
-        """debug bgp updates on"""
+        """debug bgp updates off"""
         command = 'sudo vtysh -c "no debug bgp updates"'
         run_command(command)
 
     @bgp.command()
     def as4():
-        """debug bgp as4 actions on"""
+        """debug bgp as4 actions off"""
         command = 'sudo vtysh -c "no debug bgp as4"'
         run_command(command)
 
     @bgp.command()
     def filters():
-        """debug bgp filters on"""
+        """debug bgp filters off"""
         command = 'sudo vtysh -c "no debug bgp filters"'
         run_command(command)
 
     @bgp.command()
     def fsm():
-        """debug bgp finite state machine on"""
+        """debug bgp finite state machine off"""
         command = 'sudo vtysh -c "no debug bgp fsm"'
         run_command(command)
 
     @bgp.command()
     def keepalives():
-        """debug bgp keepalives on"""
+        """debug bgp keepalives off"""
         command = 'sudo vtysh -c "no debug bgp keepalives"'
         run_command(command)
 
     @bgp.command()
     def zebra():
-        """debug bgp zebra messages on"""
+        """debug bgp zebra messages off"""
         command = 'sudo vtysh -c "no debug bgp zebra"'
         run_command(command)
 


### PR DESCRIPTION
Inheriting `DefaultGroup` class from click-default-group package breaks autocomplete, so we remove dependence upon it.

Fixes https://github.com/Azure/sonic-utilities/issues/27

- In doing so, a couple commands changed:
    - Previously, `sonic-clear ip bgp` would, by default, clear all bgp data for all neighbors. This functionality was already being duplicated if someone ran `sonic-clear ip bgp neighbor` without specifying a peer IP address. Thus, I instead added an 'all' subcommand to `sonic-clear ip bgp neighbor` (and also added a matching 'all' subcommand to the 'soft' group `sonic-clear ip bgp soft`), restructuring the `sonic-clear ip bgp` commands as follows:
        - `sonic-clear ip bgp neighbor all [<ipaddress>]`
        - `sonic-clear ip bgp neighbor in [<ipaddress>]`
        - `sonic-clear ip bgp neighbor out [<ipaddress>]`
        - `sonic-clear ip bgp neighbor soft all [<ipaddress>]`
        - `sonic-clear ip bgp neighbor soft in [<ipaddress>]`
        - `sonic-clear ip bgp neighbor soft out [<ipaddress>]`

    - I think we could further consolidate these functions in the future by adding `soft` as an option (e.g., a `-s|--soft` flag?) to the first three `sonic-clear ip bgp neighbor` commands instead of making it its own subgroup of commands (opened issue https://github.com/Azure/sonic-utilities/issues/906).

    - I also think we should consider removing the `undebug` utility, and instead add an `on|off` parameter to all commands in the `debug` utility, thus consolidating further (opened issue https://github.com/Azure/sonic-utilities/issues/905).

- Also corrected some docstrings