### PR TITLE
[config] Add 'interface transceiver' subgroup with 'lpmode' and 'reset' subcommands

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1966,7 +1966,7 @@ def transceiver(ctx):
 @click.argument('state', metavar='(enable|disable)', type=click.Choice(['enable', 'disable']))
 @click.pass_context
 def lpmode(ctx, interface_name, state):
-    """Enable/disable low-power mode for transceiver"""
+    """Enable/disable low-power mode for SFP transceiver module"""
     if get_interface_naming_mode() == "alias":
         interface_name = interface_alias_to_name(interface_name)
         if interface_name is None:
@@ -1986,7 +1986,7 @@ def lpmode(ctx, interface_name, state):
 @click.argument('interface_name', metavar='<interface_name>', required=True)
 @click.pass_context
 def reset(ctx, interface_name):
-    """Reset transceiver"""
+    """Reset SFP transceiver module"""
     if get_interface_naming_mode() == "alias":
         interface_name = interface_alias_to_name(interface_name)
         if interface_name is None:

--- a/config/main.py
+++ b/config/main.py
@@ -1963,7 +1963,7 @@ def transceiver(ctx):
 
 @transceiver.command()
 @click.argument('interface_name', metavar='<interface_name>', required=True)
-@click.argument('state', type=click.Choice(['enable', 'disable']))
+@click.argument('state', metavar='(enable|disable)', type=click.Choice(['enable', 'disable']))
 @click.pass_context
 def lpmode(ctx, interface_name, state):
     """Enable/disable low-power mode for transceiver"""

--- a/config/main.py
+++ b/config/main.py
@@ -1948,6 +1948,57 @@ def remove(ctx, interface_name, ip_addr):
         ctx.fail("'ip_addr' is not valid.")
 
 #
+# 'transceiver' subgroup ('config interface transceiver ...')
+#
+
+@interface.group(cls=AbbreviationGroup)
+@click.pass_context
+def transceiver(ctx):
+    """SFP transceiver configuration"""
+    pass
+
+#
+# 'lpmode' subcommand ('config interface transceiver lpmode ...')
+#
+
+@transceiver.command()
+@click.argument('interface_name', metavar='<interface_name>', required=True)
+@click.argument('state', type=click.Choice(['enable', 'disable']))
+@click.pass_context
+def lpmode(ctx, interface_name, state):
+    """Enable/disable low-power mode for transceiver"""
+    if get_interface_naming_mode() == "alias":
+        interface_name = interface_alias_to_name(interface_name)
+        if interface_name is None:
+            ctx.fail("'interface_name' is None!")
+
+    if interface_name_is_valid(interface_name) is False:
+        ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
+
+    cmd = "sudo sfputil lpmode {} {}".format("on" if state == "enable" else "off", interface_name)
+    run_command(cmd)
+
+#
+# 'reset' subcommand ('config interface reset ...')
+#
+
+@transceiver.command()
+@click.argument('interface_name', metavar='<interface_name>', required=True)
+@click.pass_context
+def reset(ctx, interface_name):
+    """Reset transceiver"""
+    if get_interface_naming_mode() == "alias":
+        interface_name = interface_alias_to_name(interface_name)
+        if interface_name is None:
+            ctx.fail("'interface_name' is None!")
+
+    if interface_name_is_valid(interface_name) is False:
+        ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
+
+    cmd = "sudo sfputil reset {}".format(interface_name)
+    run_command(cmd)
+
+#
 # 'vrf' subgroup ('config interface vrf ...')
 #
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -2501,7 +2501,7 @@ This sub-section explains the following list of configuration on the interfaces.
 
 From 201904 release onwards, the “config interface” command syntax is changed and the format is as follows:
 
-- config interface  interface_subcommand <interface_name>
+- config interface interface_subcommand <interface_name>
 i.e Interface name comes after the subcommand
 - Ex: config interface startup Ethernet63
 
@@ -2667,6 +2667,7 @@ This command is used to administratively shut down either the Physical interface
   *Versions <= 201811*
   ```
   config interface <interface_name> shutdown (for 201811- version)
+  ```
 
 - Example:
 
@@ -2694,6 +2695,7 @@ This command is used for administratively bringing up the Physical interface or 
   *Versions <= 201811*
   ```
   config interface <interface_name> startup (for 201811- version)
+  ```
 
 - Example:
 
@@ -2732,6 +2734,44 @@ Dynamic breakout feature is yet to be supported in SONiC and hence uses cannot c
 - Example (Versions <= 201811):
   ```
   admin@sonic:~$ sudo config interface Ethernet63 speed 40000
+
+  ```
+
+**config interface transceiver lpmode**
+
+This command is used to enable or disable low-power mode for an SFP transceiver
+
+- Usage:
+
+  ```
+  config interface transceiver lpmode <interface_name> (enable | disable)
+  ```
+
+- Examples:
+
+  ```
+  user@sonic~$ sudo config interface transceiver lpmode Ethernet0 enable
+  Enabling low-power mode for port Ethernet0...  OK
+
+  user@sonic~$ sudo config interface transceiver lpmode Ethernet0 disable
+  Disabling low-power mode for port Ethernet0...  OK
+  ```
+
+**config interface transceiver reset**
+
+This command is used to reset an SFP transceiver
+
+- Usage:
+
+  ```
+  config interface transceiver reset <interface_name>
+  ```
+
+- Examples:
+
+  ```
+  user@sonic~$ sudo config interface transceiver reset Ethernet0
+  Resetting port Ethernet0...  OK
   ```
 
 **config interface mtu <interface_name> (Versions >= 201904)**


### PR DESCRIPTION
Add 'transceiver' subgroup with 'lpmode' and 'reset' subcommands to 'config interface' group, wrapping sfputil commands.

New command examples:

```
user@sonic~$ sudo config interface transceiver --help
Usage: config interface transceiver [OPTIONS] COMMAND [ARGS]...

  SFP transceiver configuration

Options:
  -?, -h, --help  Show this message and exit.

Commands:
  lpmode  Enable/disable low-power mode for transceiver
  reset   Reset transceiver

user@sonic~$ sudo config interface transceiver lpmode --help          
Usage: config interface transceiver lpmode [OPTIONS] <interface_name>
                                           (enable|disable)

  Enable/disable low-power mode for SFP transceiver module

Options:
  -?, -h, --help  Show this message and exit.

user@sonic~$ sudo config interface transceiver lpmode Ethernet0 enable
Enabling low-power mode for port Ethernet0...  OK

user@sonic~$ sudo config interface transceiver lpmode Ethernet0 disable
Disabling low-power mode for port Ethernet0...  OK

user@sonic~$ sudo config interface transceiver reset --help
Usage: config interface transceiver reset [OPTIONS] <interface_name>

  Reset SFP transceiver module

Options:
  -?, -h, --help  Show this message and exit.

user@sonic~$ sudo config interface transceiver reset Ethernet0
Resetting port Ethernet0...  OK
```