### PR TITLE
Multi-asic changes for config bgp commands and utilities.

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -167,9 +167,8 @@ def validate_namespace(namespace):
     else:
         return False
 
-"""In case of Multi-Asic platform, Each ASIC will have a host name and we call it internal hosts.
-   So we loop through the databases in different namespaces and get the hostname
-"""
+# In case of Multi-Asic platform, Each ASIC will have a host name and we call it internal hosts.
+# So we loop through the databases in different namespaces and get the hostname
 def get_all_internal_hosts():
     internal_hosts = []
     num_asics = _get_num_asic()
@@ -1676,14 +1675,14 @@ def all(verbose):
     log_info("'bgp shutdown all' executing...")
     namespaces = [DEFAULT_NAMESPACE]
     int_hosts = []
-    if is_multi_asic:
+    if is_multi_asic():
         ns_list = get_all_namespaces()
         namespaces = ns_list['front_ns']
         int_hosts = get_all_internal_hosts()
 
-    """Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
-       namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
-    """
+    # Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
+    # namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
+
     for namespace in namespaces:
         config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
         config_db.connect()
@@ -1702,13 +1701,13 @@ def neighbor(ipaddr_or_hostname, verbose):
     log_info("'bgp shutdown neighbor {}' executing...".format(ipaddr_or_hostname))
     namespaces = [DEFAULT_NAMESPACE]
     found_neighbor = False
-    if is_multi_asic:
+    if is_multi_asic():
         ns_list = get_all_namespaces()
         namespaces = ns_list['front_ns'] + ns_list['back_ns']
 
-    """Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
-       namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
-    """
+    # Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
+    # namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
+
     for namespace in namespaces:
         config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
         config_db.connect()
@@ -1734,14 +1733,14 @@ def all(verbose):
     namespaces = [DEFAULT_NAMESPACE]
     int_hosts = []
 
-    if is_multi_asic:
+    if is_multi_asic():
         ns_list = get_all_namespaces()
         namespaces = ns_list['front_ns']
         int_hosts = get_all_internal_hosts()
 
-    """Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
-       namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
-    """
+    # Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
+    # namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
+
     for namespace in namespaces:
         config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
         config_db.connect()
@@ -1761,13 +1760,13 @@ def neighbor(ipaddr_or_hostname, verbose):
     namespaces = [DEFAULT_NAMESPACE]
     found_neighbor = False
 
-    if is_multi_asic:
+    if is_multi_asic():
         ns_list = get_all_namespaces()
         namespaces = ns_list['front_ns'] + ns_list['back_ns']
 
-    """Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
-       namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
-    """
+    # Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
+    # namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
+
     for namespace in namespaces:
         config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
         config_db.connect()
@@ -1795,13 +1794,13 @@ def remove_neighbor(neighbor_ip_or_hostname):
     namespaces = [DEFAULT_NAMESPACE]
     removed_neighbor = False
 
-    if is_multi_asic:
+    if is_multi_asic():
         ns_list = get_all_namespaces()
         namespaces = ns_list['front_ns'] + ns_list['back_ns']
 
-    """Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
-       namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
-    """
+    # Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
+    # namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
+
     for namespace in namespaces:
         config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
         config_db.connect()


### PR DESCRIPTION
**- What I did**

Changes to config bgp commands for Multi-ASIC devices.

**- How I did it**

The changes done here are based on the namespace support added in SonicDBConfig/ConfigDBConnector/SonicV2Connector classes in the PR  **Azure/sonic-py-swsssdk#63**
> To connect to DB in a particular namespace pass the parameter namespace=namespaceName
> To connect to the DB in the local context ( where ever we are ) don't pass any namespace input, it would be defaulted to '' (empty string ). This is the default option, so that the changes made here are backward compatible with single ASIC platforms.

**The following are the changes introduced in this PR**

(a) added a new parameter of **config_db** to the bgp neighbor helper API's. This approach is better, as now we have to do this once **config_db = ConfigDBConnector()** in the CLI handler and the config_db instance is passed down as argument to the API. 

(b) Modified the API _get_all_neighbor_ipaddresses() to accept an additional parameter **ignore_hosts** if there are any hosts to be ignored when forming the ip_addr neighbor list.

(c) config bgp commands : In multi-ASIC devices we have both internal BGP sessions between the bgp dockers running in different namespaces and EBGP sessions with external neighbors.
   > config bgp startup/shutdown all : performs "action" only on the external BGP neighbors.
   > config bgp startup/shutdown/remove neighbor : performs "action" on any internal/external BGP neighbor based on user input. User has to be careful of not giving the neighbor address of IBGP sessions.

**- How to verify it**
Verified on a multi-ASIC devices, by running the Config commands.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**