### PR TITLE
Stop/Start restapi server upon config reload

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -509,6 +509,7 @@ def _abort_if_false(ctx, param, value):
 def _stop_services():
     # on Mellanox platform pmon is stopped by syncd
     services_to_stop = [
+        'restapi',
         'swss',
         'lldp',
         'pmon',
@@ -539,7 +540,8 @@ def _reset_failed_services():
         'syncd',
         'teamd',
         'nat',
-        'sflow'
+        'sflow',
+        'restapi'
     ]
     execute_systemctl(services_to_reset, SYSTEMCTL_ACTION_RESET_FAILED)
 
@@ -559,6 +561,7 @@ def _restart_services():
         'hostcfgd',
         'nat',
         'sflow',
+        'restapi'
     ]
 
     if asic_type == 'mellanox' and 'pmon' in services_to_restart:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Restart restapi container when performing config reload
**- How I did it**
By adding restapi as the first container to be stopped and the last container to be restarted.
**- How to verify it**
By doing config reload
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

