### PR TITLE
[warm-reboot]: added pre-check for ISSU file

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -168,26 +168,39 @@ function recover_issu_bank_file_instruction()
 function check_issu_bank_file()
 {
     ISSU_BANK_FILE=/host/warmboot/issu_bank.txt
-    MLNX_ISSU_BANK_BROKEN=102
+    MLNX_ISSU_BANK_BROKEN_BEFORE_PRE_SHUTDOWN=102
+    MLNX_ISSU_BANK_BROKEN_AFTER_PRE_SHUTDOWN=103
 
     if [[ ! -s "$ISSU_BANK_FILE" ]]; then
         error "(${ISSU_BANK_FILE}) does NOT exist or empty ..."
         recover_issu_bank_file_instruction
-        exit "${MLNX_ISSU_BANK_BROKEN}"
+	if [[ "$1" = true ]]; then
+            exit "${MLNX_ISSU_BANK_BROKEN_BEFORE_PRE_SHUTDOWN}"
+	else
+            exit "${MLNX_ISSU_BANK_BROKEN_AFTER_PRE_SHUTDOWN}"
+	fi
     fi
 
     issu_file_chars_count=`stat -c %s ${ISSU_BANK_FILE}`;
     if [[ $issu_file_chars_count != 1 ]]; then
         error "(${ISSU_BANK_FILE}) characters count is NOT valid ..."
         recover_issu_bank_file_instruction
-        exit "${MLNX_ISSU_BANK_BROKEN}"
+	if [[ "$1" = true ]]; then
+            exit "${MLNX_ISSU_BANK_BROKEN_BEFORE_PRE_SHUTDOWN}"
+	else
+            exit "${MLNX_ISSU_BANK_BROKEN_AFTER_PRE_SHUTDOWN}"
+	fi
     fi
 
     issu_file_content=`awk '{print $0}' ${ISSU_BANK_FILE}`
     if [[ "$issu_file_content" != "0" && "$issu_file_content" != "1" ]]; then
         error "(${ISSU_BANK_FILE}) has invalid content ..."
         recover_issu_bank_file_instruction
-        exit "${MLNX_ISSU_BANK_BROKEN}"
+	if [[ "$1" = true ]]; then
+            exit "${MLNX_ISSU_BANK_BROKEN_BEFORE_PRE_SHUTDOWN}"
+	else
+            exit "${MLNX_ISSU_BANK_BROKEN_AFTER_PRE_SHUTDOWN}"
+	fi
     fi
 }
 
@@ -519,8 +532,10 @@ systemctl stop swss
 if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; then
     initialize_pre_shutdown
 
+    BEFORE_PRE_SHUTDOWN=true
+
     if [[ "x$sonic_asic_type" == x"mellanox" ]]; then
-        check_issu_bank_file
+        check_issu_bank_file "$BEFORE_PRE_SHUTDOWN"
     fi
 
     request_pre_shutdown
@@ -528,7 +543,7 @@ if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; t
     wait_for_pre_shutdown_complete_or_fail
 
     if [[ "x$sonic_asic_type" == x"mellanox" ]]; then
-        check_issu_bank_file
+        check_issu_bank_file "!$BEFORE_PRE_SHUTDOWN"
     fi
 
     # Warm reboot: dump state to host disk

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -158,52 +158,32 @@ function request_pre_shutdown()
 
 function recover_issu_bank_file_instruction()
 {
-    error "To recover (${ISSU_BANK_FILE}) file, do the following:"
-    error "$ docker exec -it syncd sx_api_dbg_generate_dump.py"
-    error "$ docker exec -it syncd cat /tmp/sdkdump | grep 'ISSU Bank'"
-    error "Command above will print the VALUE of ISSU BANK - 0 or 1, use this VALUE in the next command"
-    error "$ printf VALUE > /host/warmboot/issu_bank.txt"
+    debug "To recover (${ISSU_BANK_FILE}) file, do the following:"
+    debug "$ docker exec -it syncd sx_api_dbg_generate_dump.py"
+    debug "$ docker exec -it syncd cat /tmp/sdkdump | grep 'ISSU Bank'"
+    debug "Command above will print the VALUE of ISSU BANK - 0 or 1, use this VALUE in the next command"
+    debug "$ printf VALUE > /host/warmboot/issu_bank.txt"
 }
 
 function check_issu_bank_file()
 {
     ISSU_BANK_FILE=/host/warmboot/issu_bank.txt
-    MLNX_ISSU_BANK_BROKEN_BEFORE_PRE_SHUTDOWN=102
-    MLNX_ISSU_BANK_BROKEN_AFTER_PRE_SHUTDOWN=103
 
     if [[ ! -s "$ISSU_BANK_FILE" ]]; then
         error "(${ISSU_BANK_FILE}) does NOT exist or empty ..."
         recover_issu_bank_file_instruction
-    if [[ "$1" = true ]]; then
-        exit "${MLNX_ISSU_BANK_BROKEN_BEFORE_PRE_SHUTDOWN}"
-    else
-        exit "${MLNX_ISSU_BANK_BROKEN_AFTER_PRE_SHUTDOWN}"
-    fi
+        return
     fi
 
     issu_file_chars_count=`stat -c %s ${ISSU_BANK_FILE}`;
-    if [[ $issu_file_chars_count != 1 ]]; then
-        error "(${ISSU_BANK_FILE}) characters count is NOT valid ..."
-        recover_issu_bank_file_instruction
-    if [[ "$1" = true ]]; then
-        exit "${MLNX_ISSU_BANK_BROKEN_BEFORE_PRE_SHUTDOWN}"
-    else
-        exit "${MLNX_ISSU_BANK_BROKEN_AFTER_PRE_SHUTDOWN}"
-    fi
-    fi
-
     issu_file_content=`awk '{print $0}' ${ISSU_BANK_FILE}`
-    if [[ "$issu_file_content" != "0" && "$issu_file_content" != "1" ]]; then
-        error "(${ISSU_BANK_FILE}) has invalid content ..."
+
+    if [[ $issu_file_chars_count != 1 ]] ||
+        [[ "$issu_file_content" != "0" && "$issu_file_content" != "1" ]]; then
+        error "(${ISSU_BANK_FILE}) is broken ..."
         recover_issu_bank_file_instruction
-    if [[ "$1" = true ]]; then
-        exit "${MLNX_ISSU_BANK_BROKEN_BEFORE_PRE_SHUTDOWN}"
-    else
-        exit "${MLNX_ISSU_BANK_BROKEN_AFTER_PRE_SHUTDOWN}"
-    fi
     fi
 }
-
 
 function wait_for_pre_shutdown_complete_or_fail()
 {
@@ -532,10 +512,8 @@ systemctl stop swss
 if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; then
     initialize_pre_shutdown
 
-    BEFORE_PRE_SHUTDOWN=true
-
     if [[ "x$sonic_asic_type" == x"mellanox" ]]; then
-        check_issu_bank_file "$BEFORE_PRE_SHUTDOWN"
+        check_issu_bank_file
     fi
 
     request_pre_shutdown
@@ -543,7 +521,7 @@ if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; t
     wait_for_pre_shutdown_complete_or_fail
 
     if [[ "x$sonic_asic_type" == x"mellanox" ]]; then
-        check_issu_bank_file "!$BEFORE_PRE_SHUTDOWN"
+        check_issu_bank_file
     fi
 
     # Warm reboot: dump state to host disk

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -174,33 +174,33 @@ function check_issu_bank_file()
     if [[ ! -s "$ISSU_BANK_FILE" ]]; then
         error "(${ISSU_BANK_FILE}) does NOT exist or empty ..."
         recover_issu_bank_file_instruction
-	if [[ "$1" = true ]]; then
-            exit "${MLNX_ISSU_BANK_BROKEN_BEFORE_PRE_SHUTDOWN}"
-	else
-            exit "${MLNX_ISSU_BANK_BROKEN_AFTER_PRE_SHUTDOWN}"
-	fi
+    if [[ "$1" = true ]]; then
+        exit "${MLNX_ISSU_BANK_BROKEN_BEFORE_PRE_SHUTDOWN}"
+    else
+        exit "${MLNX_ISSU_BANK_BROKEN_AFTER_PRE_SHUTDOWN}"
+    fi
     fi
 
     issu_file_chars_count=`stat -c %s ${ISSU_BANK_FILE}`;
     if [[ $issu_file_chars_count != 1 ]]; then
         error "(${ISSU_BANK_FILE}) characters count is NOT valid ..."
         recover_issu_bank_file_instruction
-	if [[ "$1" = true ]]; then
-            exit "${MLNX_ISSU_BANK_BROKEN_BEFORE_PRE_SHUTDOWN}"
-	else
-            exit "${MLNX_ISSU_BANK_BROKEN_AFTER_PRE_SHUTDOWN}"
-	fi
+    if [[ "$1" = true ]]; then
+        exit "${MLNX_ISSU_BANK_BROKEN_BEFORE_PRE_SHUTDOWN}"
+    else
+        exit "${MLNX_ISSU_BANK_BROKEN_AFTER_PRE_SHUTDOWN}"
+    fi
     fi
 
     issu_file_content=`awk '{print $0}' ${ISSU_BANK_FILE}`
     if [[ "$issu_file_content" != "0" && "$issu_file_content" != "1" ]]; then
         error "(${ISSU_BANK_FILE}) has invalid content ..."
         recover_issu_bank_file_instruction
-	if [[ "$1" = true ]]; then
-            exit "${MLNX_ISSU_BANK_BROKEN_BEFORE_PRE_SHUTDOWN}"
-	else
-            exit "${MLNX_ISSU_BANK_BROKEN_AFTER_PRE_SHUTDOWN}"
-	fi
+    if [[ "$1" = true ]]; then
+        exit "${MLNX_ISSU_BANK_BROKEN_BEFORE_PRE_SHUTDOWN}"
+    else
+        exit "${MLNX_ISSU_BANK_BROKEN_AFTER_PRE_SHUTDOWN}"
+    fi
     fi
 }
 

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -168,10 +168,14 @@ function recover_issu_bank_file_instruction()
 function check_issu_bank_file()
 {
     ISSU_BANK_FILE=/host/warmboot/issu_bank.txt
+    MLNX_ISSU_BANK_BROKEN=102
 
     if [[ ! -s "$ISSU_BANK_FILE" ]]; then
         error "(${ISSU_BANK_FILE}) does NOT exist or empty ..."
         recover_issu_bank_file_instruction
+        if [[ "$1" = true ]]; then
+            exit "${MLNX_ISSU_BANK_BROKEN}"
+        fi
         return
     fi
 
@@ -182,6 +186,9 @@ function check_issu_bank_file()
         [[ "$issu_file_content" != "0" && "$issu_file_content" != "1" ]]; then
         error "(${ISSU_BANK_FILE}) is broken ..."
         recover_issu_bank_file_instruction
+        if [[ "$1" = true ]]; then
+            exit "${MLNX_ISSU_BANK_BROKEN}"
+        fi
     fi
 }
 
@@ -512,8 +519,10 @@ systemctl stop swss
 if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; then
     initialize_pre_shutdown
 
+    BEFORE_PRE_SHUTDOWN=true
+
     if [[ "x$sonic_asic_type" == x"mellanox" ]]; then
-        check_issu_bank_file
+        check_issu_bank_file "$BEFORE_PRE_SHUTDOWN"
     fi
 
     request_pre_shutdown

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -176,7 +176,7 @@ function check_issu_bank_file()
         exit "${MLNX_ISSU_BANK_BROKEN}"
     fi
 
-    issu_file_chars_count=`wc -m ${ISSU_BANK_FILE} | awk '{print $1}'`;
+    issu_file_chars_count=`stat -c %s ${ISSU_BANK_FILE}`;
     if [[ $issu_file_chars_count != 1 ]]; then
         error "(${ISSU_BANK_FILE}) characters count is NOT valid ..."
         recover_issu_bank_file_instruction
@@ -525,11 +525,11 @@ if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; t
 
     request_pre_shutdown
 
+    wait_for_pre_shutdown_complete_or_fail
+
     if [[ "x$sonic_asic_type" == x"mellanox" ]]; then
         check_issu_bank_file
     fi
-
-    wait_for_pre_shutdown_complete_or_fail
 
     # Warm reboot: dump state to host disk
     if [[ "$REBOOT_TYPE" = "fastfast-reboot" ]]; then

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -156,6 +156,42 @@ function request_pre_shutdown()
     }
 }
 
+function recover_issu_bank_file_instruction()
+{
+    error "To recover (${ISSU_BANK_FILE}) file, do the following:"
+    error "$ docker exec -it syncd sx_api_dbg_generate_dump.py"
+    error "$ docker exec -it syncd cat /tmp/sdkdump | grep 'ISSU Bank'"
+    error "Command above will print the VALUE of ISSU BANK - 0 or 1, use this VALUE in the next command"
+    error "$ printf VALUE > /host/warmboot/issu_bank.txt"
+}
+
+function check_issu_bank_file()
+{
+    ISSU_BANK_FILE=/host/warmboot/issu_bank.txt
+    MLNX_ISSU_BANK_BROKEN=102
+
+    if [[ ! -s "$ISSU_BANK_FILE" ]]; then
+        error "(${ISSU_BANK_FILE}) does NOT exist or empty ..."
+        recover_issu_bank_file_instruction
+        exit "${MLNX_ISSU_BANK_BROKEN}"
+    fi
+
+    issu_file_chars_count=`wc -m ${ISSU_BANK_FILE} | awk '{print $1}'`;
+    if [[ $issu_file_chars_count != 1 ]]; then
+        error "(${ISSU_BANK_FILE}) characters count is NOT valid ..."
+        recover_issu_bank_file_instruction
+        exit "${MLNX_ISSU_BANK_BROKEN}"
+    fi
+
+    issu_file_content=`awk '{print $0}' ${ISSU_BANK_FILE}`
+    if [[ "$issu_file_content" != "0" && "$issu_file_content" != "1" ]]; then
+        error "(${ISSU_BANK_FILE}) has invalid content ..."
+        recover_issu_bank_file_instruction
+        exit "${MLNX_ISSU_BANK_BROKEN}"
+    fi
+}
+
+
 function wait_for_pre_shutdown_complete_or_fail()
 {
     debug "Waiting for pre-shutdown ..."
@@ -483,7 +519,15 @@ systemctl stop swss
 if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; then
     initialize_pre_shutdown
 
+    if [[ "x$sonic_asic_type" == x"mellanox" ]]; then
+        check_issu_bank_file
+    fi
+
     request_pre_shutdown
+
+    if [[ "x$sonic_asic_type" == x"mellanox" ]]; then
+        check_issu_bank_file
+    fi
 
     wait_for_pre_shutdown_complete_or_fail
 


### PR DESCRIPTION
Signed-off-by: Vadym Hlushko <vadymh@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Added pre-check for file /host/warmboot/issu_bank.txt in warm-reboot script.
Added instruction on how to recover issu_bank.txt.

**- How I did it**
Modify the 'fast-reboot' script

**- How to verify it**
Need to somehow corrupt /host/warmboot/issu_bank.txt (list below) and then run the warm-reboot command.

1. Remove issu_bank.txt
2. Clear issu_bank.txt
3. Change characters count in issu_bank.txt
4. Write invalid content into issu_bank.txt

**- Previous command output (if the output of a command-line utility has changed)**
`root@arc-switch1041:~# warm-reboot`
`Warning: Stopping telemetry.service, but it can still be activated by:`
`  telemetry.timer`

**- New command output (if the output of a command-line utility has changed)**
`root@arc-switch1041:~# warm-reboot`
`(/host/warmboot/issu_bank.txt) does NOT exist or empty ...`
`To recover (/host/warmboot/issu_bank.txt) file, do the following:`
`$ docker exec -it syncd sx_api_dbg_generate_dump.py`
`$ docker exec -it syncd cat /tmp/sdkdump | grep 'ISSU Bank'`
`Command above will print the VALUE of ISSU BANK - 0 or 1, use this VALUE in the next command`
`$ printf VALUE > /host/warmboot/issu_bank.txt`