### PR TITLE
Revert the change to kdump reboot

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Reboot immediately if we run the kdump capture kernel
+VMCORE_FILE=/proc/vmcore
+if [ -e $VMCORE_FILE -a -s $VMCORE_FILE ]; then
+   echo "We have a /proc/vmcore, then we just kdump'ed"
+   /sbin/reboot
+fi
+
 REBOOT_USER=$(logname)
 REBOOT_TIME=$(date)
 PLATFORM=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
@@ -17,18 +24,6 @@ function debug()
     fi
     logger "$@"
 }
-
-# Reboot immediately if we run the kdump capture kernel
-VMCORE_FILE=/proc/vmcore
-if [ -e $VMCORE_FILE -a -s $VMCORE_FILE ]; then
-   debug "We have a /proc/vmcore, then we just kdump'ed"
-   if [ -x ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT} ]; then
-       VERBOSE=yes debug "Rebooting with platform ${PLATFORM} specific tool ..."
-       exec ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT}
-   else
-       /sbin/reboot
-   fi
-fi
 
 function stop_sonic_services()
 {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
This is to revert the change to the reboot command in https://github.com/Azure/sonic-utilities/commit/710540047dea0bc54aaf3e8bdea0e5d041912abd. 

Platform reboot is not supported by the kdump kernel, as the platform drivers are not loaded. With the existing code, there are some error messages printed, but the device is still rebooted by CPU. The change here helps to avoid the error messages.

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

