### PR TITLE
[Multi NPU] Time Improvements to the config reload/load_minigraph commands 

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -155,9 +155,9 @@ def execute_systemctl(list_of_services, action):
         threads = []
         # Use this event object to co-ordinate if any threads raised exception
         e = threading.Event()
-        kwargs = {'multi_inst_list' : multi_inst_service_list, 'action' : action}
+        kwargs = {'multi_inst_list': multi_inst_service_list, 'action': action}
         for inst in range(num_asic):
-            t = threading.Thread(target=execute_asic_instance, args=(inst,e), kwargs=kwargs)
+            t = threading.Thread(target=execute_asic_instance, args=(inst, e), kwargs=kwargs)
             threads.append(t)
             t.start()
 

--- a/config/main.py
+++ b/config/main.py
@@ -117,7 +117,7 @@ except KeyError, TypeError:
 #
 
 # Execute action per NPU instance for multi instance services.
-def execute_asic_instance(inst, event, service, action):
+def execute_systemctl_per_asic_instance(inst, event, service, action):
     try:
         click.echo("Executing {} of service {}@{}...".format(action, service, inst))
         run_command("systemctl {} {}@{}.service".format(action, service, inst))
@@ -153,7 +153,7 @@ def execute_systemctl(list_of_services, action):
 
                 kwargs = {'service': service, 'action': action}
                 for inst in range(num_asic):
-                    t = threading.Thread(target=execute_asic_instance, args=(inst, e), kwargs=kwargs)
+                    t = threading.Thread(target=execute_systemctl_per_asic_instance, args=(inst, e), kwargs=kwargs)
                     threads.append(t)
                     t.start()
 

--- a/config/main.py
+++ b/config/main.py
@@ -117,14 +117,15 @@ except KeyError, TypeError:
 #
 
 # Execute action per NPU instance for multi instance services.
-def execute_asic_instance(inst, multi_inst_list, action):
+def execute_asic_instance(inst, event, multi_inst_list, action):
     for service in multi_inst_list:
         try:
             click.echo("Executing {} of service {}@{}...".format(action, service, inst))
             run_command("systemctl {} {}@{}.service".format(action, service, inst))
         except SystemExit as e:
             log_error("Failed to execute {} of service {}@{} with error {}".format(action, service, inst, e))
-            raise
+            # Set the event object if there is a failure and exception was raised.
+            event.set()
 
 # Execute action on list of systemd services
 def execute_systemctl(list_of_services, action):
@@ -152,15 +153,21 @@ def execute_systemctl(list_of_services, action):
     # With Multi NPU, Start a thread per instance to do the "action" on multi instance services.
     if sonic_device_util.is_multi_npu():
         threads = []
+        # Use this event object to co-ordinate if any threads raised exception
+        e = threading.Event()
         kwargs = {'multi_inst_list' : multi_inst_service_list, 'action' : action}
         for inst in range(num_asic):
-            t = threading.Thread(target=execute_asic_instance, args=(inst,), kwargs=kwargs)
+            t = threading.Thread(target=execute_asic_instance, args=(inst,e), kwargs=kwargs)
             threads.append(t)
             t.start()
 
         # Wait for all the threads to finish.
         for inst in range(num_asic):
             threads[inst].join()
+
+            # Check if any of the threads have raised exception, if so exit the process.
+            if e.is_set():
+              sys.exit(1)
 
 def run_command(command, display_cmd=False, ignore_error=False):
     """Run bash command and print output to stdout

--- a/config/main.py
+++ b/config/main.py
@@ -135,8 +135,6 @@ def execute_systemctl(list_of_services, action):
         log_error("Failed to get generated services")
         return
 
-    # For Multi NPU, do the "action" on the global services which is single instance first.
-    multi_inst_service_list = []
     for service in list_of_services:
         if (service + '.service' in generated_services_list):
             try:


### PR DESCRIPTION
**- What I did**
config reload and config load_minigraph commands were taking ~ 5m in in the multi ASIC platforms.**Reduced the total time taken to ~ 1min by parallelizing with python threads.**

**- How I did it**
Started a python thread per NPU to stop/restart the services. 

Currently the threads are started at the same time for all the ASIC's irrespective of whether they are front-end OR back-end ASIC's. I found it ok as we finish the entire activity of config reload in 1 min and when we do config reload usually the device should not be in production and not carrying active traffic.

**- How to verify it**
Verified on a Single ASIC and multi AISC devices. Attaching sample output.

**MULTI ASIC**

**~$ time sudo config reload  -y**
Executing stop of service swss@1...
Executing stop of service swss@0...
Executing stop of service swss@2...
Executing stop of service swss@3...
Executing stop of service swss@4...
Executing stop of service swss@5...
Executing stop of service lldp...
Executing stop of service lldp@1...
Executing stop of service lldp@0...
Executing stop of service lldp@2...
Executing stop of service lldp@3...
Executing stop of service lldp@4...
Executing stop of service lldp@5...
Executing stop of service pmon...
Executing stop of service bgp@0...
Executing stop of service bgp@1...
Executing stop of service bgp@2...
Executing stop of service bgp@3...
Executing stop of service bgp@4...
Executing stop of service bgp@5...
Executing stop of service hostcfgd...
Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/init_cfg.json -j /etc/sonic/config_db.json --write-to-db
Running command: /usr/bin/db_migrator.py -o migrate
Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/init_cfg.json -j /etc/sonic/config_db0.json -n asic0 --write-to-db
Running command: /usr/bin/db_migrator.py -o migrate -n asic0
Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/init_cfg.json -j /etc/sonic/config_db1.json -n asic1 --write-to-db
Running command: /usr/bin/db_migrator.py -o migrate -n asic1
Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/init_cfg.json -j /etc/sonic/config_db2.json -n asic2 --write-to-db
Running command: /usr/bin/db_migrator.py -o migrate -n asic2
Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/init_cfg.json -j /etc/sonic/config_db3.json -n asic3 --write-to-db
Running command: /usr/bin/db_migrator.py -o migrate -n asic3
Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/init_cfg.json -j /etc/sonic/config_db4.json -n asic4 --write-to-db
Running command: /usr/bin/db_migrator.py -o migrate -n asic4
Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/init_cfg.json -j /etc/sonic/config_db5.json -n asic5 --write-to-db
Running command: /usr/bin/db_migrator.py -o migrate -n asic5
Executing reset-failed of service bgp@0...
Executing reset-failed of service bgp@1...
Executing reset-failed of service bgp@2...
Executing reset-failed of service bgp@3...
Executing reset-failed of service bgp@4...
Executing reset-failed of service bgp@5...
Executing reset-failed of service dhcp_relay...
Executing reset-failed of service hostcfgd...
Executing reset-failed of service hostname-config...
Executing reset-failed of service interfaces-config...
Executing reset-failed of service lldp...
Executing reset-failed of service lldp@0...
Executing reset-failed of service lldp@1...
Executing reset-failed of service lldp@2...
Executing reset-failed of service lldp@3...
Executing reset-failed of service lldp@4...
Executing reset-failed of service lldp@5...
Executing reset-failed of service ntp-config...
Executing reset-failed of service pmon...
Executing reset-failed of service radv...
Executing reset-failed of service rsyslog-config...
Executing reset-failed of service snmp...
Executing reset-failed of service swss@1...
Executing reset-failed of service swss@0...
Executing reset-failed of service swss@2...
Executing reset-failed of service swss@3...
Executing reset-failed of service swss@4...
Executing reset-failed of service swss@5...
Executing reset-failed of service syncd@0...
Executing reset-failed of service syncd@1...
Executing reset-failed of service syncd@2...
Executing reset-failed of service syncd@3...
Executing reset-failed of service syncd@4...
Executing reset-failed of service syncd@5...
Executing reset-failed of service teamd@0...
Executing reset-failed of service teamd@1...
Executing reset-failed of service teamd@2...
Executing reset-failed of service teamd@3...
Executing reset-failed of service teamd@4...
Executing reset-failed of service teamd@5...
Executing restart of service hostname-config...
Executing restart of service interfaces-config...
Executing restart of service ntp-config...
Executing restart of service rsyslog-config...
Executing restart of service swss@0...
Executing restart of service swss@1...
Executing restart of service swss@2...
Executing restart of service swss@3...
Executing restart of service swss@4...
Executing restart of service swss@5...
Executing restart of service bgp@0...
Executing restart of service bgp@1...
Executing restart of service bgp@2...
Executing restart of service bgp@3...
Executing restart of service bgp@4...
Executing restart of service bgp@5...
Executing restart of service pmon...
Executing restart of service lldp...
Executing restart of service lldp@0...
Executing restart of service lldp@1...
Executing restart of service lldp@2...
Executing restart of service lldp@3...
Executing restart of service lldp@4...
Executing restart of service lldp@5...
Executing restart of service hostcfgd...

**real	1m55.971s**
user	0m3.652s
sys	0m1.232s


**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

