### PR TITLE
handled the priority of ACL rules to be case insensitive

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -762,7 +762,11 @@ class AclLoader(object):
         header = ("Table", "Rule", "Priority", "Action", "Match")
 
         def pop_priority(val):
-            priority  = val.pop("PRIORITY")
+            priority = "N/A"
+            for key in dict(val):
+                if (key.upper() == "PRIORITY"):
+                    priority  = val.pop(key)
+                    return priority
             return priority
 
         def pop_action(val):

--- a/scripts/aclshow
+++ b/scripts/aclshow
@@ -169,8 +169,13 @@ class AclStat(object):
                     self.get_counter_value(rule_key, 'packets') == 'N/A'):
                 continue
             rule = self.acl_rules[rule_key]
+            rule_priority = -1
+            if "PRIORITY" in rule:
+                rule_priority = rule['PRIORITY']
+            elif "priority" in rule:
+                rule_priority = rule['priority']
             line = [rule_key[1], rule_key[0],
-                    rule['PRIORITY'],
+                    rule_priority,
                     self.get_counter_value(rule_key, 'packets'),
                     self.get_counter_value(rule_key, 'bytes')]
             aclstat.append(line)

--- a/scripts/aclshow
+++ b/scripts/aclshow
@@ -170,10 +170,9 @@ class AclStat(object):
                 continue
             rule = self.acl_rules[rule_key]
             rule_priority = -1
-            if "PRIORITY" in rule:
-                rule_priority = rule['PRIORITY']
-            elif "priority" in rule:
-                rule_priority = rule['priority']
+            for key,val in rule.items():
+                if key.upper() == "PRIORITY":
+                    rule_priority = val
             line = [rule_key[1], rule_key[0],
                     rule_priority,
                     self.get_counter_value(rule_key, 'packets'),

--- a/sonic-utilities-tests/aclshow_test.py
+++ b/sonic-utilities-tests/aclshow_test.py
@@ -24,6 +24,7 @@ RULE_3        DATAACL         9997              301            300
 RULE_4        DATAACL         9996              401            400
 RULE_7        DATAACL         9993              701            700
 RULE_9        DATAACL         9991              901            900
+RULE_10       DATAACL         9989             1001           1000
 DEFAULT_RULE  DATAACL            1                2              1
 RULE_6        EVERFLOW        9994              601            600
 """
@@ -39,6 +40,7 @@ RULE_4        DATAACL         9996              401            400
 RULE_05       DATAACL         9995                0              0
 RULE_7        DATAACL         9993              701            700
 RULE_9        DATAACL         9991              901            900
+RULE_10       DATAACL         9989             1001           1000
 DEFAULT_RULE  DATAACL            1                2              1
 RULE_6        EVERFLOW        9994              601            600
 RULE_08       EVERFLOW        9992                0              0
@@ -49,6 +51,13 @@ rule1_dataacl_output = '' + \
 """RULE NAME    TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
 -----------  ------------  ------  ---------------  -------------
 RULE_1       DATAACL         9999              101            100
+"""
+
+# Expected output for aclshow -r RULE_1 -t DATAACL
+rule10_dataacl_output = '' + \
+"""RULE NAME    TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
+-----------  ------------  ------  ---------------  -------------
+RULE_10      DATAACL         9989             1001           1000
 """
 
 # Expected output for aclshow -a -r RULE_05
@@ -68,7 +77,7 @@ rule0_output = '' + \
 rule4_rule6_verbose_output = '' + \
 """Reading ACL info...
 Total number of ACL Tables: 5
-Total number of ACL Rules: 10
+Total number of ACL Rules: 11
 
 RULE NAME    TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
 -----------  ------------  ------  ---------------  -------------
@@ -93,6 +102,7 @@ RULE_3        DATAACL         9997              301            300
 RULE_4        DATAACL         9996              401            400
 RULE_7        DATAACL         9993              701            700
 RULE_9        DATAACL         9991              901            900
+RULE_10       DATAACL         9989             1001           1000
 DEFAULT_RULE  DATAACL            1                2              1
 """
 
@@ -111,6 +121,7 @@ RULE_4        DATAACL         9996                0              0
 RULE_05       DATAACL         9995                0              0
 RULE_7        DATAACL         9993                0              0
 RULE_9        DATAACL         9991                0              0
+RULE_10       DATAACL         9989                0              0
 DEFAULT_RULE  DATAACL            1                0              0
 RULE_6        EVERFLOW        9994                0              0
 RULE_08       EVERFLOW        9992                0              0
@@ -184,10 +195,10 @@ def test_rule0():
     test = Aclshow(all = None, clear = None, rules = 'RULE_0', tables = None, verbose = None)
     assert test.result.getvalue() == rule0_output
 
-# aclshow -r RULE_4 -t DATAACL
-def test_rule4_lowercase_priority():
-    test = Aclshow(all = None, clear = None, rules = 'RULE_4', tables = 'DATAACL', verbose = None)
-    assert test.result.getvalue() == rule4_dataacl_output
+# aclshow -r RULE_10 -t DATAACL
+def test_rule10_lowercase_priority():
+    test = Aclshow(all = None, clear = None, rules = 'RULE_10', tables = 'DATAACL', verbose = None)
+    assert test.result.getvalue() == rule10_dataacl_output
 
 # aclshow -r RULE_4,RULE_6 -vv
 def test_rule4_rule6_verbose():

--- a/sonic-utilities-tests/aclshow_test.py
+++ b/sonic-utilities-tests/aclshow_test.py
@@ -184,6 +184,11 @@ def test_rule0():
     test = Aclshow(all = None, clear = None, rules = 'RULE_0', tables = None, verbose = None)
     assert test.result.getvalue() == rule0_output
 
+# aclshow -r RULE_4 -t DATAACL
+def test_rule4_lowercase_priority():
+    test = Aclshow(all = None, clear = None, rules = 'RULE_4', tables = 'DATAACL', verbose = None)
+    assert test.result.getvalue() == rule4_dataacl_output
+
 # aclshow -r RULE_4,RULE_6 -vv
 def test_rule4_rule6_verbose():
     test = Aclshow(all = None, clear = None, rules = 'RULE_4,RULE_6', tables = None, verbose = True)

--- a/sonic-utilities-tests/mock_tables/config_db.json
+++ b/sonic-utilities-tests/mock_tables/config_db.json
@@ -67,7 +67,7 @@
     "ACL_RULE|DATAACL|RULE_4": {
             "L4_SRC_PORT": "4661",
             "PACKET_ACTION": "FORWARD",
-            "priority": "9996"
+            "PRIORITY": "9996"
     },
     "ACL_RULE|DATAACL|RULE_05": {
             "IP_PROTOCOL": "126",
@@ -93,6 +93,11 @@
             "L4_DST_PORT": "4661",
             "PACKET_ACTION": "FORWARD",
             "PRIORITY": "9991"
+    },
+    "ACL_RULE|DATAACL|RULE_10": {
+            "PACKET_ACTION": "DROP",
+            "priority": "9989",
+            "SRC_IP": "10.0.0.3/32"
     },
      "ACL_TABLE|DATAACL": {
             "policy_desc": "DATAACL",

--- a/sonic-utilities-tests/mock_tables/config_db.json
+++ b/sonic-utilities-tests/mock_tables/config_db.json
@@ -67,7 +67,7 @@
     "ACL_RULE|DATAACL|RULE_4": {
             "L4_SRC_PORT": "4661",
             "PACKET_ACTION": "FORWARD",
-            "PRIORITY": "9996"
+            "priority": "9996"
     },
     "ACL_RULE|DATAACL|RULE_05": {
             "IP_PROTOCOL": "126",

--- a/sonic-utilities-tests/mock_tables/counters_db.json
+++ b/sonic-utilities-tests/mock_tables/counters_db.json
@@ -115,6 +115,10 @@
             "Bytes": "900",
             "Packets": "901"
     },
+    "COUNTERS:DATAACL:RULE_10": {
+            "Bytes": "1000",
+            "Packets": "1001"
+    },
     "COUNTERS:oid:0x1000000000002": {
         "SAI_PORT_STAT_IF_IN_ERRORS": "10",
         "SAI_PORT_STAT_IF_IN_DISCARDS": "100",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

- What I did
I made the priority of ACL rule props in the ACL commands to be case insensitive.

- How I did it
Instead of checking the ACL ruleprops dictionary for "PRIORITY" based key, I made it the actual key to be searched for.

- How to verify it
I verified the fix by testing on my switch using different case sensitive options of keyword "Priority".


**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

