### PR TITLE
Changes to commands  config reload/load-minigraph

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -694,8 +694,9 @@ def load(filename, yes):
 @config.command()
 @click.option('-y', '--yes', is_flag=True)
 @click.option('-l', '--load-sysinfo', is_flag=True, help='load system default information (mac, portmap etc) first.')
+@click.option('-n', '--no_service_restart', default=False, is_flag=True, help='Do not restart docker services')
 @click.argument('filename', required=False)
-def reload(filename, yes, load_sysinfo):
+def reload(filename, yes, load_sysinfo, no_service_restart):
     """Clear current configuration and import a previous saved config DB dump file.
        <filename> : Names of configuration file(s) to load, separated by comma with no spaces in between
     """
@@ -735,8 +736,9 @@ def reload(filename, yes, load_sysinfo):
             cfg_hwsku = cfg_hwsku.strip()
 
     #Stop services before config push
-    log_info("'reload' stopping services...")
-    _stop_services()
+    if not no_service_restart:
+        log_info("'reload' stopping services...")
+        _stop_services()
 
     """ In Single AISC platforms we have single DB service. In multi-ASIC platforms we have a global DB
         service running in the host + DB services running in each ASIC namespace created per ASIC.
@@ -808,9 +810,10 @@ def reload(filename, yes, load_sysinfo):
 
     # We first run "systemctl reset-failed" to remove the "failed"
     # status from all services before we attempt to restart them
-    _reset_failed_services()
-    log_info("'reload' restarting services...")
-    _restart_services()
+    if not no_service_restart:
+        _reset_failed_services()
+        log_info("'reload' restarting services...")
+        _restart_services()
 
 @config.command("load_mgmt_config")
 @click.option('-y', '--yes', is_flag=True, callback=_abort_if_false,
@@ -840,7 +843,8 @@ def load_mgmt_config(filename):
 @config.command("load_minigraph")
 @click.option('-y', '--yes', is_flag=True, callback=_abort_if_false,
                 expose_value=False, prompt='Reload config from minigraph?')
-def load_minigraph():
+@click.option('-n', '--no_service_restart', default=False, is_flag=True, help='Do not restart docker services')
+def load_minigraph(no_service_restart):
     """Reconfigure based on minigraph."""
     log_info("'load_minigraph' executing...")
 
@@ -855,8 +859,9 @@ def load_minigraph():
         device_type = device_type.strip()
 
     #Stop services before config push
-    log_info("'load_minigraph' stopping services...")
-    _stop_services()
+    if not no_service_restart:
+        log_info("'load_minigraph' stopping services...")
+        _stop_services()
 
     # For Single Asic platform the namespace list has the empty string
     # for mulit Asic platform the empty string to generate the config
@@ -901,10 +906,11 @@ def load_minigraph():
 
     # We first run "systemctl reset-failed" to remove the "failed"
     # status from all services before we attempt to restart them
-    _reset_failed_services()
-    #FIXME: After config DB daemon is implemented, we'll no longer need to restart every service.
-    log_info("'load_minigraph' restarting services...")
-    _restart_services()
+    if not no_service_restart:
+        _reset_failed_services()
+        #FIXME: After config DB daemon is implemented, we'll no longer need to restart every service.
+        log_info("'load_minigraph' restarting services...")
+        _restart_services()
     click.echo("Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`.")
 
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -3269,9 +3269,13 @@ NOTE: Management interface IP address and default route (or specific route) may 
 When user specifies the optional argument "-y" or "--yes", this command forces the loading without prompting the user for confirmation.
 If the argument is not specified, it prompts the user to confirm whether user really wants to load this configuration file.
 
+When user specifies the optional argument "-n" or "--no-service-restart", this command loads the configuration without restarting various services
+running on the device. One of the use case for this option is during boot time when config-setup service loads minigraph configuration and there is no services
+running on the device.
+
 - Usage:
   ```
-  config load_minigraph [-y|--yes]
+  config load_minigraph [-y|--yes] [-n|--no-service-restart]
   ```
 
 - Example:
@@ -3304,9 +3308,13 @@ NOTE: Management interface IP address and default route (or specific route) may 
 When user specifies the optional argument "-y" or "--yes", this command forces the loading without prompting the user for confirmation.
 If the argument is not specified, it prompts the user to confirm whether user really wants to load this configuration file.
 
+When user specifies the optional argument "-n" or "--no-service-restart", this command clear and loads the configuration without restarting various services
+running on the device. One of the use case for this option is during boot time when config-setup service loads exisitng old configuration and there is no services
+running on the device.
+
 - Usage:
   ```
-  config reload [-y|--yes] [-l|--load-sysinfo] [<filename>]
+  config reload [-y|--yes] [-l|--load-sysinfo] [<filename>] [-n|--no-service-restart]
   ```
 
 - Example:

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -3269,8 +3269,8 @@ NOTE: Management interface IP address and default route (or specific route) may 
 When user specifies the optional argument "-y" or "--yes", this command forces the loading without prompting the user for confirmation.
 If the argument is not specified, it prompts the user to confirm whether user really wants to load this configuration file.
 
-When user specifies the optional argument "-n" or "--no-service-restart", this command loads the configuration without restarting various services
-running on the device. One of the use case for this option is during boot time when config-setup service loads minigraph configuration and there is no services
+When user specifies the optional argument "-n" or "--no-service-restart", this command loads the configuration without restarting dependent services
+running on the device. One use case for this option is during boot time when config-setup service loads minigraph configuration and there is no services
 running on the device.
 
 - Usage:
@@ -3308,8 +3308,8 @@ NOTE: Management interface IP address and default route (or specific route) may 
 When user specifies the optional argument "-y" or "--yes", this command forces the loading without prompting the user for confirmation.
 If the argument is not specified, it prompts the user to confirm whether user really wants to load this configuration file.
 
-When user specifies the optional argument "-n" or "--no-service-restart", this command clear and loads the configuration without restarting various services
-running on the device. One of the use case for this option is during boot time when config-setup service loads exisitng old configuration and there is no services
+When user specifies the optional argument "-n" or "--no-service-restart", this command clear and loads the configuration without restarting dependent services
+running on the device. One use case for this option is during boot time when config-setup service loads existing old configuration and there is no services
 running on the device.
 
 - Usage:


### PR DESCRIPTION
**- What I did**
Changes to make commands config reload/load-minigraph
to have option of not stop/start docker services. This is not needed
when this commands are called from config-setup shell script. PR: https://github.com/Azure/sonic-buildimage/pull/4609 used this change.
**- How I did it**
Added new option -n (--no-service-restart) with default as False
so that existing command behavior remains same.
**- How to verify it**
Verified Manually and as well when invoke with config-setup

