### PR TITLE
Show Vnet alias to name mapping

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -2990,6 +2990,38 @@ def brief():
     click.echo(tabulate(tablelize(vnet_keys, vnet_data), header))
 
 @vnet.command()
+@click.argument('vnet_alias', required=False)
+def alias(vnet_alias):
+    """Show vnet alias to name information"""
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    header = ['Alias', 'Name']
+
+    # Fetching data from config_db for VNET
+    vnet_data = config_db.get_table('VNET')
+    vnet_keys = natsorted(vnet_data.keys())
+
+    def tablelize(vnet_keys, vnet_data, vnet_alias):
+        table = []
+        for k in vnet_keys:
+            r = []
+            if vnet_alias is not None:
+                if vnet_data[k].get('guid') == vnet_alias:
+                    r.append(vnet_data[k].get('guid'))
+                    r.append(k)
+                    table.append(r)
+                    return table
+                else:
+                    continue
+
+            r.append(vnet_data[k].get('guid'))
+            r.append(k)
+            table.append(r)
+        return table
+
+    click.echo(tabulate(tablelize(vnet_keys, vnet_data, vnet_alias), header))
+
+@vnet.command()
 def interfaces():
     """Show vnet interfaces information"""
     config_db = ConfigDBConnector()


### PR DESCRIPTION
**- What I did**
Mapping for `alias `to vnet `name`

**- How I did it**

**- How to verify it**
Run show command

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

```
admin@str-sn-01:~$ show vnet alias 
Alias        Name
-----------  ------
vnet-guid-1  Vnet1
vnet-guid-2  Vnet2

admin@str-sn-01:~$ show vnet alias vnet-guid-2
Alias        Name
-----------  ------
vnet-guid-2  Vnet2
```

