### PR TITLE
Add support for port mirroring CLIs

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -730,16 +730,17 @@ class AclLoader(object):
 
             if val.get("type") == "SPAN":
                 span_data.append([key, val.get("status", ""), val.get("dst_port", ""),
-                         val.get("src_port", ""), val.get("direction", "").lower(),val.get("queue", ""), val.get("policer", "")])
+                                    val.get("src_port", ""), val.get("direction", "").lower(),
+                                    val.get("queue", ""), val.get("policer", "")])
             else:
                 erspan_data.append([key, val.get("status", ""), val.get("src_ip", ""),
-                         val.get("dst_ip", ""), val.get("gre_type", ""), val.get("dscp", ""),
-                         val.get("ttl", ""), val.get("queue", ""), val.get("policer", ""),
-                         val.get("monitor_port", ""), val.get("src_port", ""), val.get("direction", "").lower()])
+                                    val.get("dst_ip", ""), val.get("gre_type", ""), val.get("dscp", ""),
+                                    val.get("ttl", ""), val.get("queue", ""), val.get("policer", ""),
+                                    val.get("monitor_port", ""), val.get("src_port", ""), val.get("direction", "").lower()])
 
-        print 'ERSPAN Sessions'
+        print("ERSPAN Sessions")
         print(tabulate.tabulate(erspan_data, headers=erspan_header, tablefmt="simple", missingval=""))
-        print '\nSPAN Sessions'
+        print("\nSPAN Sessions")
         print(tabulate.tabulate(span_data, headers=span_header, tablefmt="simple", missingval=""))
 
     def show_policer(self, policer_name):

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -730,13 +730,13 @@ class AclLoader(object):
 
             if val.get("type") == "SPAN":
                 span_data.append([key, val.get("status", ""), val.get("dst_port", ""),
-                                    val.get("src_port", ""), val.get("direction", "").lower(),
-                                    val.get("queue", ""), val.get("policer", "")])
+                                       val.get("src_port", ""), val.get("direction", "").lower(),
+                                       val.get("queue", ""), val.get("policer", "")])
             else:
                 erspan_data.append([key, val.get("status", ""), val.get("src_ip", ""),
-                                    val.get("dst_ip", ""), val.get("gre_type", ""), val.get("dscp", ""),
-                                    val.get("ttl", ""), val.get("queue", ""), val.get("policer", ""),
-                                    val.get("monitor_port", ""), val.get("src_port", ""), val.get("direction", "").lower()])
+                                         val.get("dst_ip", ""), val.get("gre_type", ""), val.get("dscp", ""),
+                                         val.get("ttl", ""), val.get("queue", ""), val.get("policer", ""),
+                                         val.get("monitor_port", ""), val.get("src_port", ""), val.get("direction", "").lower()])
 
         print("ERSPAN Sessions")
         print(tabulate.tabulate(erspan_data, headers=erspan_header, tablefmt="simple", missingval=""))

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -718,21 +718,29 @@ class AclLoader(object):
         :param session_name: Optional. Mirror session name. Filter sessions by specified name.
         :return:
         """
-        header = ("Name", "Status", "SRC IP", "DST IP", "GRE", "DSCP", "TTL", "Queue", "Policer", "Monitor Port")
+        erspan_header = ("Name", "Status", "SRC IP", "DST IP", "GRE", "DSCP", "TTL", "Queue",
+                            "Policer", "Monitor Port", "SRC Port", "Direction")
+        span_header = ("Name", "Status", "DST Port", "SRC Port", "Direction", "Queue", "Policer")
 
-        data = []
+        erspan_data = []
+        span_data = []
         for key, val in self.get_sessions_db_info().iteritems():
             if session_name and key != session_name:
                 continue
-            # For multi-mpu platform status and monitor port will be dict()
-            # of 'asic-x':value
-            data.append([key, val["status"], val["src_ip"], val["dst_ip"],
-                         val.get("gre_type", ""), val.get("dscp", ""),
+
+            if val.get("type") == "SPAN":
+                span_data.append([key, val.get("status", ""), val.get("dst_port", ""),
+                         val.get("src_port", ""), val.get("direction", "").lower(),val.get("queue", ""), val.get("policer", "")])
+            else:
+                erspan_data.append([key, val.get("status", ""), val.get("src_ip", ""),
+                         val.get("dst_ip", ""), val.get("gre_type", ""), val.get("dscp", ""),
                          val.get("ttl", ""), val.get("queue", ""), val.get("policer", ""),
-                         val.get("monitor_port", "")])
+                         val.get("monitor_port", ""), val.get("src_port", ""), val.get("direction", "").lower()])
 
-        print(tabulate.tabulate(data, headers=header, tablefmt="simple", missingval=""))
-
+        print 'ERSPAN Sessions'
+        print(tabulate.tabulate(erspan_data, headers=erspan_header, tablefmt="simple", missingval=""))
+        print '\nSPAN Sessions'
+        print(tabulate.tabulate(span_data, headers=span_header, tablefmt="simple", missingval=""))
 
     def show_policer(self, policer_name):
         """

--- a/config/main.py
+++ b/config/main.py
@@ -1156,13 +1156,13 @@ def add(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer, src_p
     add_erspan(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer, src_port, direction)
 
 def gather_session_info(session_info, policer, queue, src_port, direction):
-    if policer is not None:
+    if policer:
         session_info['policer'] = policer
 
-    if queue is not None:
+    if queue:
         session_info['queue'] = queue
 
-    if src_port is not None:
+    if src_port:
         if get_interface_naming_mode() == "alias":
             src_port_list = []
             for port in src_port.split(","):
@@ -1170,7 +1170,7 @@ def gather_session_info(session_info, policer, queue, src_port, direction):
             src_port=",".join(src_port_list)
 
         session_info['src_port'] = src_port
-        if direction is None:
+        if not direction:
             direction = "both"
         session_info['direction'] = direction.upper()
 
@@ -1185,7 +1185,7 @@ def add_erspan(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer
             "ttl": ttl
             }
 
-    if gre_type is not None:
+    if not gre_type:
         session_info['gre_type'] = gre_type
 
     session_info = gather_session_info(session_info, policer, queue, src_port, direction)

--- a/config/main.py
+++ b/config/main.py
@@ -1185,7 +1185,7 @@ def add_erspan(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer
             "ttl": ttl
             }
 
-    if not gre_type:
+    if gre_type:
         session_info['gre_type'] = gre_type
 
     session_info = gather_session_info(session_info, policer, queue, src_port, direction)

--- a/config/main.py
+++ b/config/main.py
@@ -658,7 +658,7 @@ def validate_mirror_session_config(config_db, session_name, dst_port, src_port, 
                 return False
 
     if direction:
-        if not any ( [direction == 'rx', direction == 'tx', direction == 'both'] ):
+        if direction not in ['rx', 'tx', 'both']:
             click.echo("Error: Direction {} is invalid".format(direction))
             return False
 

--- a/config/main.py
+++ b/config/main.py
@@ -1147,6 +1147,8 @@ def erspan(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer, sr
             src_port=",".join(src_port_list)
 
         session_info['src_port'] = src_port
+        if direction is None:
+            direction = "both"
 
     if direction is not None:
         session_info['direction'] = direction.upper()
@@ -1199,6 +1201,8 @@ def span(session_name, dst_port, src_port, direction, queue, policer):
 
     if src_port is not None:
         session_info['src_port'] = src_port
+        if direction is None:
+            direction = "both"
 
     if direction is not None:
         session_info['direction'] = direction.upper()

--- a/config/main.py
+++ b/config/main.py
@@ -570,33 +570,42 @@ def is_ipaddress(val):
         return False
     return True
 
-#
-# Check if an interface_name is in a vlan
-#
 def  interface_is_in_vlan(vlan_member_table, interface_name):
-
-    for k,v in vlan_member_table:
+    """ Check if an interface  is in a vlan """
+    for _,v in vlan_member_table.keys():
         if v == interface_name:
             return True
 
     return False
 
+def  interface_is_in_portchannel(portchannel_member_table, interface_name):
+    """ Check if an interface is part of portchannel """
+    for _,v in portchannel_member_table.keys():
+        if v == interface_name:
+            return True
 
-#
-# Check if port is already configured as mirror destination port
-#
+    return False
+
+def interface_is_router_port(interface_table, interface_name):
+    """ Check if an interface has router config """
+    for entry in interface_table.keys():
+        if (interface_name == entry[0]):
+            return True
+
+    return False
+
 def interface_is_mirror_dst_port(config_db, interface_name):
+    """ Check if port is already configured as mirror destination port """
     mirror_table = config_db.get_table('MIRROR_SESSION')
-    for k,v in mirror_table.items():
+    for _,v in mirror_table.items():
         if 'dst_port' in v and v['dst_port'] == interface_name:
             return True
 
     return False
-#
-# Check if port is already configured with mirror config
-#
+
 def interface_has_mirror_config(mirror_table, interface_name):
-    for k,v in mirror_table.items():
+    """ Check if port is already configured with mirror config """
+    for _,v in mirror_table.items():
         if 'src_port' in v and v['src_port'] == interface_name:
             return True
         if 'dst_port' in v and v['dst_port'] == interface_name:
@@ -608,12 +617,15 @@ def interface_has_mirror_config(mirror_table, interface_name):
 # Check if SPAN mirror-session config is valid.
 #
 def validate_mirror_session_config(config_db, session_name, dst_port, src_port, direction):
+    """ Check if SPAN mirror-session config is valid """
     if len(config_db.get_entry('MIRROR_SESSION', session_name)) != 0:
         click.echo("Error: {} already exists".format(session_name))
         return False
 
     vlan_member_table = config_db.get_table('VLAN_MEMBER')
     mirror_table = config_db.get_table('MIRROR_SESSION')
+    portchannel_member_table = config_db.get_table('PORTCHANNEL_MEMBER')
+    interface_table = config_db.get_table('INTERFACE')
 
     if dst_port is not None:
         if interface_name_is_valid(dst_port) is False:
@@ -626,6 +638,14 @@ def validate_mirror_session_config(config_db, session_name, dst_port, src_port, 
 
         if interface_has_mirror_config(mirror_table, dst_port):
             click.echo("Error: Destination Interface {} already has mirror config".format(dst_port))
+            return False
+
+        if interface_is_in_portchannel(portchannel_member_table, dst_port):
+            click.echo("Error: Destination Interface {} has portchannel config".format(dst_port))
+            return False
+
+        if interface_is_router_port(interface_table, dst_port):
+            click.echo("Error: Destination Interface {} is a L3 interface".format(dst_port))
             return False
 
     if src_port is not None:
@@ -1072,6 +1092,8 @@ def portchannel_member(ctx):
 def add_portchannel_member(ctx, portchannel_name, port_name):
     """Add member to port channel"""
     db = ctx.obj['db']
+    if interface_is_mirror_dst_port(db, port_name):
+        ctx.fail("{} is configured as mirror destination port".format(interface_name))
     db.set_entry('PORTCHANNEL_MEMBER', (portchannel_name, port_name),
             {'NULL': 'NULL'})
 
@@ -1097,17 +1119,31 @@ def mirror_session():
 # 'add' subgroup ('config mirror_session add ...')
 #
 
-@mirror_session.group(cls=AbbreviationGroup, name='add')
+@mirror_session.command('add')
+@click.argument('session_name', metavar='<session_name>', required=True)
+@click.argument('src_ip', metavar='<src_ip>', required=True)
+@click.argument('dst_ip', metavar='<dst_ip>', required=True)
+@click.argument('dscp', metavar='<dscp>', required=True)
+@click.argument('ttl', metavar='<ttl>', required=True)
+@click.argument('gre_type', metavar='[gre_type]', required=False)
+@click.argument('queue', metavar='[queue]', required=False)
+@click.option('--policer')
+def add(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer):
+    """ Add ERSPAN mirror session.(Legacy support) """
+    add_erspan(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer)
+
+@mirror_session.group(cls=AbbreviationGroup, name='erspan')
 @click.pass_context
-def add(ctx):
-    """Add mirror_session"""
+def erspan(ctx):
+    """ ERSPAN mirror_session """
     pass
+
 
 #
 # 'add' subcommand
 #
 
-@add.command('erspan')
+@erspan.command('add')
 @click.argument('session_name', metavar='<session_name>', required=True)
 @click.argument('src_ip', metavar='<src_ip>', required=True)
 @click.argument('dst_ip', metavar='<dst_ip>', required=True)
@@ -1118,23 +1154,13 @@ def add(ctx):
 @click.argument('src_port', metavar='[src_port]', required=False)
 @click.argument('direction', metavar='[direction]', required=False)
 @click.option('--policer')
-def erspan(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer, src_port, direction):
-    """
-    Add ERSPAN mirror session
-    """
-    session_info = {
-            "type" : "ERSPAN",
-            "src_ip": src_ip,
-            "dst_ip": dst_ip,
-            "dscp": dscp,
-            "ttl": ttl
-            }
+def add(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer, src_port, direction):
+    """ Add ERSPAN mirror session """
+    add_erspan(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer, src_port, direction)
 
+def mirror_common_init(session_info, policer, queue, src_port, direction):
     if policer is not None:
         session_info['policer'] = policer
-
-    if gre_type is not None:
-        session_info['gre_type'] = gre_type
 
     if queue is not None:
         session_info['queue'] = queue
@@ -1152,6 +1178,21 @@ def erspan(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer, sr
 
     if direction is not None:
         session_info['direction'] = direction.upper()
+    return session_info
+
+def add_erspan(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer, src_port=None, direction=None):
+    session_info = {
+            "type" : "ERSPAN",
+            "src_ip": src_ip,
+            "dst_ip": dst_ip,
+            "dscp": dscp,
+            "ttl": ttl
+            }
+
+    if gre_type is not None:
+        session_info['gre_type'] = gre_type
+
+    session_info = mirror_common_init(session_info, policer, queue, src_port, direction)
 
     """
     For multi-npu platforms we need to program all front asic namespaces
@@ -1172,46 +1213,36 @@ def erspan(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer, sr
                 return
             per_npu_configdb[front_asic_namespaces].set_entry("MIRROR_SESSION", session_name, session_info)
 
-@add.command('span')
+@mirror_session.group(cls=AbbreviationGroup, name='span')
+@click.pass_context
+def span(ctx):
+    """ SPAN mirror session """
+    pass
+
+@span.command('add')
 @click.argument('session_name', metavar='<session_name>', required=True)
 @click.argument('dst_port', metavar='<dst_port>', required=True)
 @click.argument('src_port', metavar='[src_port]', required=False)
 @click.argument('direction', metavar='[direction]', required=False)
 @click.argument('queue', metavar='[queue]', required=False)
 @click.option('--policer')
-def span(session_name, dst_port, src_port, direction, queue, policer):
-    """
-    Add port mirror session
-    """
+def add(session_name, dst_port, src_port, direction, queue, policer):
+    """ Add SPAN mirror session """
+    add_span(session_name, dst_port, src_port, direction, queue, policer)
+
+def add_span(session_name, dst_port, src_port, direction, queue, policer):
     if get_interface_naming_mode() == "alias":
         dst_port = interface_alias_to_name(dst_port)
         if dst_port is None:
             click.echo("Error: Destination Interface {} is invalid".format(dst_port))
             return
-        if src_port is not None:
-            src_port_list = []
-            for port in src_port.split(","):
-                src_port_list.append(interface_alias_to_name(port))
-            src_port=",".join(src_port_list)
 
     session_info = {
             "type" : "SPAN",
             "dst_port": dst_port,
             }
 
-    if src_port is not None:
-        session_info['src_port'] = src_port
-        if direction is None:
-            direction = "both"
-
-    if direction is not None:
-        session_info['direction'] = direction.upper()
-
-    if policer is not None:
-        session_info['policer'] = policer
-
-    if queue is not None:
-        session_info['queue'] = queue
+    session_info = mirror_common_init(session_info, policer, queue, src_port, direction)
 
     """
     For multi-npu platforms we need to program all front asic namespaces
@@ -1232,12 +1263,11 @@ def span(session_name, dst_port, src_port, direction, queue, policer):
                 return
             per_npu_configdb[front_asic_namespaces].set_entry("MIRROR_SESSION", session_name, session_info)
 
+
 @mirror_session.command()
 @click.argument('session_name', metavar='<session_name>', required=True)
 def remove(session_name):
-    """
-    Delete mirror session
-    """
+    """ Delete mirror session """
 
     """
     For multi-npu platforms we need to program all front asic namespaces
@@ -1253,6 +1283,7 @@ def remove(session_name):
             per_npu_configdb[front_asic_namespaces] = ConfigDBConnector(use_unix_socket_path=True, namespace=front_asic_namespaces)
             per_npu_configdb[front_asic_namespaces].connect()
             per_npu_configdb[front_asic_namespaces].set_entry("MIRROR_SESSION", session_name, None)
+
 #
 # 'pfcwd' group ('config pfcwd ...')
 #

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -3798,19 +3798,32 @@ While adding a new ERSPAN session, users need to configure the following fields 
 
 - Usage:
   ```
-  config mirror_session add erspan <session_name> <src_ip> <dst_ip> <dscp> <ttl> [gre_type] [queue] [policer <policer_name>] [source-port-list] [direction]
+  config mirror_session erspan add <session_name> <src_ip> <dst_ip> <dscp> <ttl> [gre_type] [queue] [policer <policer_name>] [source-port-list] [direction]
+  ```
+
+  The following command is also supported to be backward compatible.
+  This command will be deprecated in future releases.
+  ```
+  config mirror_session add <session_name> <src_ip> <dst_ip> <dscp> <ttl> [gre_type] [queue]
   ```
 
 - Example:
   ```
-  root@T1-2:~# config mirror_session add erspan mrr_abcd 1.2.3.4 20.21.22.23 8 100 0x6558 0
+  root@T1-2:~# config mirror_session add mrr_legacy 1.2.3.4 20.21.22.23 8 100 0x6558 0
+  root@T1-2:~# show mirror_session
+  Name         Status    SRC IP     DST IP       GRE     DSCP    TTL    Queue    Policer    Monitor Port    SRC Port    Direction
+  ---------    --------  --------   -----------  ------  ------  -----  -------  ---------  --------------  ----------  -----------
+  mrr_legacy   inactive  1.2.3.4    20.21.22.23  0x6558  8       100    0
+
+
+  root@T1-2:~# config mirror_session erspan add mrr_abcd 1.2.3.4 20.21.22.23 8 100 0x6558 0
   root@T1-2:~# show mirror_session
   Name       Status    SRC IP     DST IP       GRE     DSCP    TTL    Queue    Policer    Monitor Port    SRC Port    Direction
   ---------  --------  --------   -----------  ------  ------  -----  -------  ---------  --------------  ----------  -----------
   mrr_abcd   inactive  1.2.3.4    20.21.22.23  0x6558  8       100    0
   root@T1-2:~#
 
-  root@T1-2:~# config mirror_session add erspan mrr_port 1.2.3.4 20.21.22.23 8 100 0x6558 0 Ethernet0 both
+  root@T1-2:~# config mirror_session erspan add mrr_port 1.2.3.4 20.21.22.23 8 100 0x6558 0 Ethernet0
   root@T1-2:~# show mirror_session
   Name       Status    SRC IP     DST IP       GRE     DSCP    TTL    Queue    Policer    Monitor Port    SRC Port    Direction
   ---------  --------  --------   -----------  ------  ------  -----  -------  ---------  --------------  ----------  -----------
@@ -3827,17 +3840,18 @@ While adding a new SPAN session, users need to configure the following fields th
 
 - Usage:
   ```
-  config mirror_session add span <session_name> <dst_port> [source-port-list] [direction] [queue] [policer <policer_name>]
+  config mirror_session span add <session_name> <dst_port> [source-port-list] [direction] [queue] [policer <policer_name>]
   ```
 
 - Example:
   ```
-  root@T1-2:~# config mirror_session add span port0 Ethernet0 Ethernet4,PortChannel001,Ethernet8 both
+  root@T1-2:~# config mirror_session span add port0 Ethernet0 Ethernet4,PortChannel001,Ethernet8
   root@T1-2:~# show mirror_session
   Name    Status    DST Port    SRC Port                           Direction
   ------  --------  ----------  ---------------------------------  -----------
   port0   active    Ethernet0   Ethernet4,PortChannel10,Ethernet8  both
   root@T1-2:~#
+  ```
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#mirroring)
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -3794,7 +3794,7 @@ While adding a new ERSPAN session, users need to configure the following fields 
 6) optional - Queue in which packets shall be sent out of the device. Valid values 0 to 7 for most of the devices. Users need to know their device and the number of queues supported in that device.
 7) optional - Policer which will be used to control the rate at which frames are mirrored.
 8) optional - List of source ports which can have both Ethernet and LAG ports.
-9) optional - Direction - Mirror session direction when configured along with Source port.
+9) optional - Direction - Mirror session direction when configured along with Source port. (Supported rx/tx/both. default direction is both)
 
 - Usage:
   ```
@@ -3821,7 +3821,7 @@ While adding a new ERSPAN session, users need to configure the following fields 
 While adding a new SPAN session, users need to configure the following fields that are used while forwarding the mirrored packets.
 1) destination port,
 2) optional - List of source ports- List of source ports which can have both Ethernet and LAG ports.
-3) optional - Direction - Mirror session direction when configured along with Source port.
+3) optional - Direction - Mirror session direction when configured along with Source port. (Supported rx/tx/both. default direction is both)
 4) optional - Queue in which packets shall be sent out of the device. Valid values 0 to 7 for most of the devices. Users need to know their device and the number of queues supported in that device.
 5) optional - Policer which will be used to control the rate at which frames are mirrored.
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -3747,7 +3747,6 @@ This command deletes the SNMP Trap server IP address to which SNMP agent is expe
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#management-vrf)
 
-
 ## Mirroring
 
 ### Mirroring Show commands
@@ -3763,10 +3762,16 @@ This command displays all the mirror sessions that are configured.
 
 - Example:
   ```
-  admin@sonic:~$ show mirror session
-  Name       Status    SRC IP     DST IP    GRE    DSCP    TTL    Queue
-  ---------  --------  ---------  --------  -----  ------  -----  -------
+  admin@sonic:~$ show mirror_session
+  ERSPAN Sessions
+  Name       Status    SRC IP     DST IP    GRE    DSCP    TTL    Queue    Policer    Monitor Port    SRC Port    Direction
+  ------     --------  --------   --------  -----  ------  -----  -------  ---------  --------------  ----------  -----------
   everflow0  active    10.1.0.32  10.0.0.7
+
+  SPAN Sessions
+  Name    Status    DST Port    SRC Port       Direction
+  ------  --------  ----------  -------------  -----------
+  port0   active    Ethernet0   PortChannel10  rx
   ```
 
 ### Mirroring Config commands
@@ -3774,7 +3779,12 @@ This command displays all the mirror sessions that are configured.
 **config mirror_session**
 
 This command is used to add or remove mirroring sessions. Mirror session is identified by "session_name".
-While adding a new session, users need to configure the following fields that are used while forwarding the mirrored packets.
+This command supports configuring both SPAN/ERSPAN sessions.
+In SPAN user can configure mirroring of list of source ports/LAG to destination port in ingress/egress/both directions.
+In ERSPAN user can configure mirroring of list of source ports/LAG to a destination IP.
+Both SPAN/ERSPAN support ACL based mirroring and can be used in ACL configurations.
+
+While adding a new ERSPAN session, users need to configure the following fields that are used while forwarding the mirrored packets.
 
 1) source IP address,
 2) destination IP address,
@@ -3782,20 +3792,52 @@ While adding a new session, users need to configure the following fields that ar
 4) TTL value
 5) optional - GRE Type in case if user wants to send the packet via GRE tunnel. GRE type could be anything; it could also be left as empty; by default, it is 0x8949 for Mellanox; and 0x88be for the rest of the chips.
 6) optional - Queue in which packets shall be sent out of the device. Valid values 0 to 7 for most of the devices. Users need to know their device and the number of queues supported in that device.
+7) optional - Policer which will be used to control the rate at which frames are mirrored.
+8) optional - List of source ports which can have both Ethernet and LAG ports.
+9) optional - Direction - Mirror session direction when configured along with Source port.
 
 - Usage:
   ```
-  config mirror_session add <session_name> <src_ip> <dst_ip> <dscp> <ttl> [gre_type] [queue]
+  config mirror_session add erspan <session_name> <src_ip> <dst_ip> <dscp> <ttl> [gre_type] [queue] [policer <policer_name>] [source-port-list] [direction]
   ```
 
 - Example:
   ```
-  admin@sonic:~$ sudo config mirror_session add mrr_abcd 1.2.3.4 20.21.22.23 8 100 0x6558 0
-  admin@sonic:~$ show mirror_session
-  Name       Status    SRC IP       DST IP       GRE     DSCP    TTL    Queue
-  ---------  --------  -----------  -----------  ------  ------  -----  -------
-  mrr_abcd   inactive  1.2.3.4      20.21.22.23  0x6558  8       100    0
+  root@T1-2:~# config mirror_session add erspan mrr_abcd 1.2.3.4 20.21.22.23 8 100 0x6558 0
+  root@T1-2:~# show mirror_session
+  Name       Status    SRC IP     DST IP       GRE     DSCP    TTL    Queue    Policer    Monitor Port    SRC Port    Direction
+  ---------  --------  --------   -----------  ------  ------  -----  -------  ---------  --------------  ----------  -----------
+  mrr_abcd   inactive  1.2.3.4    20.21.22.23  0x6558  8       100    0
+  root@T1-2:~#
+
+  root@T1-2:~# config mirror_session add erspan mrr_port 1.2.3.4 20.21.22.23 8 100 0x6558 0 Ethernet0 both
+  root@T1-2:~# show mirror_session
+  Name       Status    SRC IP     DST IP       GRE     DSCP    TTL    Queue    Policer    Monitor Port    SRC Port    Direction
+  ---------  --------  --------   -----------  ------  ------  -----  -------  ---------  --------------  ----------  -----------
+  mrr_port   inactive  1.2.3.4    20.21.22.23  0x6558  8       100    0                                   Ethernet0   both
+  root@T1-2:~#
   ```
+
+While adding a new SPAN session, users need to configure the following fields that are used while forwarding the mirrored packets.
+1) destination port,
+2) optional - List of source ports- List of source ports which can have both Ethernet and LAG ports.
+3) optional - Direction - Mirror session direction when configured along with Source port.
+4) optional - Queue in which packets shall be sent out of the device. Valid values 0 to 7 for most of the devices. Users need to know their device and the number of queues supported in that device.
+5) optional - Policer which will be used to control the rate at which frames are mirrored.
+
+- Usage:
+  ```
+  config mirror_session add span <session_name> <dst_port> [source-port-list] [direction] [queue] [policer <policer_name>]
+  ```
+
+- Example:
+  ```
+  root@T1-2:~# config mirror_session add span port0 Ethernet0 Ethernet4,PortChannel001,Ethernet8 both
+  root@T1-2:~# show mirror_session
+  Name    Status    DST Port    SRC Port                           Direction
+  ------  --------  ----------  ---------------------------------  -----------
+  port0   active    Ethernet0   Ethernet4,PortChannel10,Ethernet8  both
+  root@T1-2:~#
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#mirroring)
 


### PR DESCRIPTION
Signed-off-by: Rupesh Kumar <rupesh-k.kumar@broadcom.com>

**- What I did**

Port mirroring CLI implementation 
HLD @ https://github.com/Azure/SONiC/pull/58

**- How I did it**
Enhance existing mirror_session command to support port mirroring.

**- How to verify it**
Create ERSPAN/SPAN mirror session and verify show mirror_session.

**- Previous command output (if the output of a command-line utility has changed)**

config mirror_session add everflow0 10.1.1.1 12.1.1.1 10 10
root@sonic:/home/admin# show mirror_session
Name       Status    SRC IP    DST IP      GRE    DSCP    TTL  Queue    Policer    Monitor Port    SRC Port    Direction
---------  --------  --------  --------  -----  ------  -----  -------  ---------  --------------  ----------  -----------
everflow0  active  10.1.1.1  12.1.1.1             10     10

**- New command output (if the output of a command-line utility has changed)**

config mirror_session add span sess1 Ethernet44 Ethernet40 rx

root@sonic:/home/admin# show mirror_session
ERSPAN Sessions
Name       Status    SRC IP    DST IP      GRE    DSCP    TTL  Queue    Policer    Monitor Port    SRC Port    Direction
---------  --------  --------  --------  -----  ------  -----  -------  ---------  --------------  ----------  -----------
everflow0  active  10.1.1.1  12.1.1.1      0      10     10

SPAN Sessions
Name    Status    DST Port    SRC Port    Direction    Queue    Policer
------  --------  ----------  ----------  -----------  -------  ---------
sess1    active     Ethernet44  Ethernet40  rx       