### PR TITLE
201911 fixes #4716 show ipv6 interface neighbor_ip N/A issue

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1504,12 +1504,14 @@ def interfaces():
 
         if netifaces.AF_INET6 in ipaddresses:
             ifaddresses = []
+            neighbor_name = 'N/A'
+            neighbor_ip = 'N/A'
             for ipaddr in ipaddresses[netifaces.AF_INET6]:
-                neighbor_name = 'N/A'
-                neighbor_ip = 'N/A'
                 local_ip = str(ipaddr['addr'])
                 netmask = ipaddr['netmask'].split('/', 1)[-1]
                 ifaddresses.append(["", local_ip + "/" + str(netmask)])
+                if neighbor_ip != 'N/A' and neighbor_name != 'N/A':
+                    continue
                 try:
                     neighbor_name = bgp_peer[local_ip][0]
                     neighbor_ip = bgp_peer[local_ip][1]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- Why I did it**
When exec 'show ipv6 interfaces', the neighbor_ip will always be 'N/A' which will confuse the consumers. After checking we found that this is a show issue. As we know, there will be one local linked IPV6 address for every valid interface. In show/main.py, the interface's ipv6 neighbor ip will always be written by this local linked IPV6's neighbor_ip address which is 'N/A'. And i think this part code of 'show ipv6 interface' was copied from 'show ip interface' before, right? Yea, some change is necessary!
**- What I did**
This is bug fixing.
**- How I did it**
Code change.
**- How to verify it**
upgrate config_db.config attached in Azure/sonic-buildimage#4716 and show ipv6 interfaces

