### PR TITLE
[show]: add transceiver info 

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -879,7 +879,7 @@ This command displays information for all the interfaces for the transceiver req
 
 - Example (Display information stored on the EEPROM of SFP transceiver connected to Ethernet0 horizontally):
   ```
-  root@sonic:/home/admin# show interfaces transceiver info Ethernet0
+  admin@sonic:~$ show interfaces transceiver info Ethernet0
   Interface    Type               Number of lanes  Vendor Name    Model Name          Serial Number    Nominal bit rate[100Mbs]
   -----------  ---------------  -----------------  -------------  ----------------  ---------------  --------------------------
   Ethernet0    QSFP28 or later                  4  ColorChip ltd  C100QSFPCWDM400B         18130506                         255
@@ -888,7 +888,7 @@ This command displays information for all the interfaces for the transceiver req
 
 - Example (Display DOM information stored on the EEPROM of SFP transceiver connected to Ethernet0 horizontally):
   ```
-  root@sonic:/home/admin# show interfaces transceiver info --dom Ethernet0
+  admin@sonic:~$ show interfaces transceiver info --dom Ethernet0
   Interface    Lane Number    Temp[C]                         Voltage[V]                       Current[mA]                    Tx Power[dBm]                    Rx Power[dBm]
   -----------  -------------  ------------------------------  -------------------------------  -----------------------------  -------------------------------  --------------------------------
   Ethernet0    Lane 1         37.371 [low=0.000, high=75.000]  3.276 [low=3.134, high=3.465]  44.954 [low=28.392, high=49.000]  -1.018 [low=-9.5001, high=2.400]  -1.018 [low=-9.5001, high=2.400]

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -821,7 +821,7 @@ This command displays information for all the interfaces for the transceiver req
 
 - Usage:
   ```
-  show interfaces transceiver (eeprom [-d|--dom] | lpmode | presence) [<interface_name>]
+  show interfaces transceiver (eeprom [-d|--dom] | info [-d|--dom] | lpmode | presence) [<interface_name>]
   ```
 
 - Example (Decode and display information stored on the EEPROM of SFP transceiver connected to Ethernet0):
@@ -874,6 +874,27 @@ This command displays information for all the interfaces for the transceiver req
   Port         Presence
   -----------  ----------
   Ethernet100  Present
+  ```
+
+
+- Example (Display information stored on the EEPROM of SFP transceiver connected to Ethernet0 horizontally):
+  ```
+  root@sonic:/home/admin# show interfaces transceiver info Ethernet0
+  Interface    Type               Number of lanes  Vendor Name    Model Name          Serial Number    Nominal bit rate[100Mbs]
+  -----------  ---------------  -----------------  -------------  ----------------  ---------------  --------------------------
+  Ethernet0    QSFP28 or later                  4  ColorChip ltd  C100QSFPCWDM400B         18130506                         255
+  ```
+
+
+- Example (Display DOM information stored on the EEPROM of SFP transceiver connected to Ethernet0 horizontally):
+  ```
+  root@sonic:/home/admin# show interfaces transceiver info --dom Ethernet0
+  Interface    Lane Number    Temp[C]                         Voltage[V]                       Current[mA]                    Tx Power[dBm]                    Rx Power[dBm]
+  -----------  -------------  ------------------------------  -------------------------------  -----------------------------  -------------------------------  --------------------------------
+  Ethernet0    Lane 1         37.371 [low=0.000, high=75.000]  3.276 [low=3.134, high=3.465]  44.954 [low=28.392, high=49.000]  -1.018 [low=-9.5001, high=2.400]  -1.018 [low=-9.5001, high=2.400]
+               Lane 2         37.371 [low=0.000, high=75.000]  3.276 [low=3.134, high=3.465]  38.386 [low=28.392, high=49.000]  -1.385 [low=-9.5001, high=2.400]  -1.385 [low=-9.5001, high=2.400]
+               Lane 3         37.371 [low=0.000, high=75.000]  3.276 [low=3.134, high=3.465]  35.166 [low=28.392, high=49.000]  -0.391 [low=-9.5001, high=2.400]  -0.391 [low=-9.5001, high=2.400]
+               Lane 4         37.371 [low=0.000, high=75.000]  3.276 [low=3.134, high=3.465]  36.156 [low=28.392, high=49.000]  -1.720 [low=-9.5001, high=2.400]  -1.720 [low=-9.5001, high=2.400]
   ```
 Go Back To [Beginning of the document](#) or [Beginning of this section](#basic-show-commands)
 

--- a/scripts/transceivershow
+++ b/scripts/transceivershow
@@ -28,6 +28,17 @@ PORT_VOLTAGE = "voltage"
 PORT_CUR = "tx{}bias"
 PORT_TX_PWR = "tx{}power"
 PORT_RX_PWR = "rx{}power"
+
+TEMP_TH_HIGH_WARNING = 'temphighalarm'
+TEMP_TH_LOW_WARNING = 'templowwarning'
+VOLT_TH_HIGH_WARNING = 'vcchighwarning'
+VOLT_TH_LOW_WARNING = 'vcclowwarning'
+RX_TH_HIGH_WARNING = 'rxpowerhighwarning'
+RX_TH_LOW_WARNING = 'rxpowerlowwarning'
+TX_TH_HIGH_WARNING = 'txpowerhighwarning'
+TX_TH_LOW_WARNING = 'txpowerlowwarning'
+BIAS_HIGH_WARNING = 'txbiashighwarning'
+BIAS_TH_LOW_WARNING = 'txbiaslowwarning'
 NULL_VAL = "N/A"
 
 
@@ -112,14 +123,27 @@ def state_db_port_dom_get(state_db, port_name, key):
 
     return NULL_VAL if port_dom is None else port_dom
 
+
 def get_num_of_len(appl_db, port_name):
     port_lens = appl_db_port_status_get(appl_db, port_name, PORT_LANES_STATUS)
     return len(port_lens.split(","))
 
+
+def ret_float(value):
+    ret_val = value
+    try:
+        float_val = float(value)
+        ret_val = "%.3f" % round(float_val, 3)
+    except ValueError:
+        pass
+    return ret_val
+
+
 # ========================== transceiver-status logic ==========================
 
 
-header_info = ['Interface', 'Type', 'Number of lanes', 'Vendor Name', 'Model Name', 'Serial Number', 'Nominal bit rate[100Mbs]']
+header_info = ['Interface', 'Type', 'Number of lanes', 'Vendor Name',
+               'Model Name', 'Serial Number', 'Nominal bit rate[100Mbs]']
 
 
 class TransceiverInfo(object):
@@ -185,13 +209,14 @@ header_dom = ['Interface', 'Lane Number', 'Temp[C]', 'Voltage[V]',
 
 class TransceiverDOM(object):
 
-    def __init__(self, port_name):
+    def __init__(self, port_name, threshold):
         """
         Class constructor method
         :param self: 
         :param port_name: string of transceiver
         :return: 
         """
+        self.display_th = threshold
         self.appl_db = db_connect_appl()
         self.state_db = db_connect_state()
         self.config_db = db_connect_configdb()
@@ -206,6 +231,9 @@ class TransceiverDOM(object):
             return
         self.display_transceiver_dom(appl_db_keys, self.front_panel_ports_list)
 
+    def display_data_with_threshold(self, value, low_th, high_th):
+        return ret_float(value) if not self.display_th else '{} [low={}, high={}]'.format(ret_float(value), ret_float(low_th), ret_float(high_th))
+
     def display_transceiver_dom(self, appl_db_keys, front_panel_ports_list):
         """
             Generate transceiver dom output
@@ -216,6 +244,26 @@ class TransceiverDOM(object):
         for i in sorted_appl_db_keys:
             key = re.split(':', i, maxsplit=1)[-1].strip()
             num_of_lane = get_num_of_len(self.appl_db, key)
+            temp_low = state_db_port_dom_get(
+                self.state_db, key, TEMP_TH_LOW_WARNING)
+            temp_high = state_db_port_dom_get(
+                self.state_db, key, TEMP_TH_HIGH_WARNING)
+            curr_low = state_db_port_dom_get(
+                self.state_db, key, BIAS_TH_LOW_WARNING)
+            curr_high = state_db_port_dom_get(
+                self.state_db, key, BIAS_HIGH_WARNING)
+            volt_low = state_db_port_dom_get(
+                self.state_db, key, VOLT_TH_LOW_WARNING)
+            volt_high = state_db_port_dom_get(
+                self.state_db, key, VOLT_TH_HIGH_WARNING)
+            tx_low = state_db_port_dom_get(
+                self.state_db, key, TX_TH_LOW_WARNING)
+            tx_high = state_db_port_dom_get(
+                self.state_db, key, TX_TH_HIGH_WARNING)
+            rx_low = state_db_port_dom_get(
+                self.state_db, key, RX_TH_LOW_WARNING)
+            rx_high = state_db_port_dom_get(
+                self.state_db, key, RX_TH_HIGH_WARNING)
             port_temp = state_db_port_dom_get(self.state_db, key, PORT_TEMP)
             port_voltage = state_db_port_dom_get(
                 self.state_db, key, PORT_VOLTAGE)
@@ -223,14 +271,16 @@ class TransceiverDOM(object):
                 for lane in range(1, num_of_lane+1):
                     port = key if lane == 1 else ""
                     table.append((port, "Lane {}".format(lane),
-                                  port_temp,
-                                  port_voltage,
-                                  state_db_port_dom_get(
-                                      self.state_db, key, PORT_CUR.format(lane)),
-                                  state_db_port_dom_get(
-                                      self.state_db, key, PORT_TX_PWR.format(lane)),
-                                  state_db_port_dom_get(
-                                      self.state_db, key, PORT_RX_PWR.format(lane))
+                                  self.display_data_with_threshold(
+                                      port_temp, temp_low, temp_high),
+                                  self.display_data_with_threshold(
+                                      port_voltage, volt_low, volt_high),
+                                  self.display_data_with_threshold(state_db_port_dom_get(
+                                      self.state_db, key, PORT_CUR.format(lane)), curr_low, curr_high),
+                                  self.display_data_with_threshold(state_db_port_dom_get(
+                                      self.state_db, key, PORT_TX_PWR.format(lane)), tx_low, tx_high),
+                                  self.display_data_with_threshold(state_db_port_dom_get(
+                                      self.state_db, key, PORT_RX_PWR.format(lane)), rx_low, rx_high),
                                   ))
 
         print tabulate(table, header_dom, tablefmt="simple", stralign='left')
@@ -244,8 +294,9 @@ def cli():
 # 'dom' subcommand
 @cli.command()
 @click.option('-p', '--port', metavar='<port_name>', help="Display Digital Optical Monitoring (DOM) data of <port_name> only")
-def dom(port):
-    TransceiverDOM(port)
+@click.option('-t', '--threshold', is_flag=True, help="Display threshold value")
+def dom(port, threshold):
+    TransceiverDOM(port, threshold)
 
 
 # 'info' subcommand

--- a/scripts/transceivershow
+++ b/scripts/transceivershow
@@ -1,6 +1,5 @@
 #! /usr/bin/python
 
-import os
 import re
 import click
 import swsssdk

--- a/scripts/transceivershow
+++ b/scripts/transceivershow
@@ -1,0 +1,260 @@
+#! /usr/bin/python
+
+import os
+import re
+import click
+import swsssdk
+from natsort import natsorted
+from tabulate import tabulate
+
+
+# ========================== Common transceiver-utils logic ==========================
+
+
+PORT_STATUS_TABLE_PREFIX = "PORT_TABLE:"
+PORT_TRANSCEIVER_TABLE_PREFIX = "TRANSCEIVER_INFO|"
+PORT_TRANSCEIVER_DOM_PREFIX = "TRANSCEIVER_DOM_SENSOR|"
+PORT_LANES_STATUS = "lanes"
+
+PORT_SERIAL = "serialnum"
+PORT_VENDOR = "manufacturename"
+PORT_LEN = "cable_length"
+PORT_PN = "modelname"
+PORT_NBR = "nominal_bit_rate"
+PORT_COM = "specification_compliance"
+PORT_OPTICS_TYPE = "type"
+
+PORT_TEMP = "temperature"
+PORT_VOLTAGE = "voltage"
+PORT_CUR = "tx{}bias"
+PORT_TX_PWR = "tx{}power"
+PORT_RX_PWR = "rx{}power"
+NULL_VAL = "N/A"
+
+
+def db_connect_configdb():
+    """
+    Connect to configdb
+    """
+    config_db = swsssdk.ConfigDBConnector()
+    if config_db is None:
+        return None
+    config_db.connect()
+    return config_db
+
+
+def get_frontpanel_port_list(config_db):
+    ports_dict = config_db.get_table('PORT')
+    front_panel_ports_list = []
+    for port in ports_dict.iterkeys():
+        front_panel_ports_list.append(port)
+    return front_panel_ports_list
+
+
+def db_connect_appl():
+    appl_db = swsssdk.SonicV2Connector(host='127.0.0.1')
+    if appl_db is None:
+        return None
+    appl_db.connect(appl_db.APPL_DB)
+    return appl_db
+
+
+def appl_db_keys_get(appl_db, front_panel_ports_list, port_name):
+    """
+    Get APPL_DB Keys
+    """
+    if port_name is None:
+        appl_db_keys = appl_db.keys(appl_db.APPL_DB, "PORT_TABLE:*")
+    elif port_name in front_panel_ports_list:
+        appl_db_keys = appl_db.keys(
+            appl_db.APPL_DB, "PORT_TABLE:%s" % port_name)
+    else:
+        return None
+    return appl_db_keys
+
+
+def appl_db_port_status_get(appl_db, port_name, status_type):
+    """
+    Get the port status
+    """
+    full_table_id = PORT_STATUS_TABLE_PREFIX + port_name
+    status = appl_db.get(appl_db.APPL_DB, full_table_id, status_type)
+    return NULL_VAL if status is None else status
+
+
+def db_connect_state():
+    """
+    Connect to REDIS STATE DB and get optics info
+    """
+    state_db = swsssdk.SonicV2Connector(host='127.0.0.1')
+    if state_db is None:
+        return None
+    state_db.connect(state_db.STATE_DB, False)   # Make one attempt only
+    return state_db
+
+
+def state_db_port_info_get(state_db, port_name, key):
+    """
+    Get optic info of port
+    """
+    full_table_id = PORT_TRANSCEIVER_TABLE_PREFIX + port_name
+    port_info = state_db.get(state_db.STATE_DB, full_table_id, key)
+    return NULL_VAL if port_info is None else port_info
+
+
+def state_db_port_dom_get(state_db, port_name, key):
+    """
+    Get dom info of port
+    """
+    full_table_id = PORT_TRANSCEIVER_DOM_PREFIX + port_name
+    port_dom = state_db.get(state_db.STATE_DB, full_table_id, key)
+    if port_dom and "-inf" in port_dom:
+        port_dom = NULL_VAL
+
+    return NULL_VAL if port_dom is None else port_dom
+
+def get_num_of_len(appl_db, port_name):
+    port_lens = appl_db_port_status_get(appl_db, port_name, PORT_LANES_STATUS)
+    return len(port_lens.split(","))
+
+# ========================== transceiver-status logic ==========================
+
+
+header_info = ['Interface', 'Type', 'Number of lanes', 'Vendor Name', 'Model Name', 'Serial Number', 'Nominal bit rate[100Mbs]']
+
+
+class TransceiverInfo(object):
+
+    def __init__(self, port_name):
+        """
+        Class constructor method
+        :param self: 
+        :param port_name: string of transceiver
+        :return: 
+        """
+        self.appl_db = db_connect_appl()
+        self.state_db = db_connect_state()
+        self.config_db = db_connect_configdb()
+        if self.appl_db is None:
+            return
+        if self.state_db is None:
+            return
+        if self.config_db is None:
+            return
+
+        self.front_panel_ports_list = get_frontpanel_port_list(self.config_db)
+        appl_db_keys = appl_db_keys_get(
+            self.appl_db, self.front_panel_ports_list, port_name)
+
+        if appl_db_keys is None:
+            return
+        self.display_transceiver_info(
+            appl_db_keys, self.front_panel_ports_list)
+
+    def display_transceiver_info(self, appl_db_keys, front_panel_ports_list):
+        """
+            Generate transceiver info output
+        """
+        sorted_appl_db_keys = natsorted(appl_db_keys)
+        table = []
+
+        for i in sorted_appl_db_keys:
+            key = re.split(':', i, maxsplit=1)[-1].strip()
+            if key in front_panel_ports_list:
+                table.append((key,
+                              state_db_port_info_get(
+                                  self.state_db, key, PORT_OPTICS_TYPE),
+                              get_num_of_len(self.appl_db, key),
+                              state_db_port_info_get(
+                                  self.state_db, key, PORT_VENDOR),
+                              state_db_port_info_get(
+                                  self.state_db, key, PORT_PN),
+                              state_db_port_info_get(
+                                  self.state_db, key, PORT_SERIAL),
+                              state_db_port_info_get(
+                                  self.state_db, key, PORT_NBR)
+                              ))
+
+        print tabulate(table, header_info, tablefmt="simple", stralign='left')
+
+# ========================== transceiver  ==========================
+
+
+header_dom = ['Interface', 'Lane Number', 'Temp[C]', 'Voltage[V]',
+              'Current[mA]', 'Tx Power[dBm]', 'Rx Power[dBm]']
+
+
+class TransceiverDOM(object):
+
+    def __init__(self, port_name):
+        """
+        Class constructor method
+        :param self: 
+        :param port_name: string of transceiver
+        :return: 
+        """
+        self.appl_db = db_connect_appl()
+        self.state_db = db_connect_state()
+        self.config_db = db_connect_configdb()
+        if not self.appl_db or not self.state_db or not self.config_db:
+            return
+
+        self.front_panel_ports_list = get_frontpanel_port_list(self.config_db)
+        appl_db_keys = appl_db_keys_get(
+            self.appl_db, self.front_panel_ports_list, port_name)
+
+        if not appl_db_keys:
+            return
+        self.display_transceiver_dom(appl_db_keys, self.front_panel_ports_list)
+
+    def display_transceiver_dom(self, appl_db_keys, front_panel_ports_list):
+        """
+            Generate transceiver dom output
+        """
+        table = []
+        sorted_appl_db_keys = natsorted(appl_db_keys)
+
+        for i in sorted_appl_db_keys:
+            key = re.split(':', i, maxsplit=1)[-1].strip()
+            num_of_lane = get_num_of_len(self.appl_db, key)
+            port_temp = state_db_port_dom_get(self.state_db, key, PORT_TEMP)
+            port_voltage = state_db_port_dom_get(
+                self.state_db, key, PORT_VOLTAGE)
+            if key in front_panel_ports_list:
+                for lane in range(1, num_of_lane+1):
+                    port = key if lane == 1 else ""
+                    table.append((port, "Lane {}".format(lane),
+                                  port_temp,
+                                  port_voltage,
+                                  state_db_port_dom_get(
+                                      self.state_db, key, PORT_CUR.format(lane)),
+                                  state_db_port_dom_get(
+                                      self.state_db, key, PORT_TX_PWR.format(lane)),
+                                  state_db_port_dom_get(
+                                      self.state_db, key, PORT_RX_PWR.format(lane))
+                                  ))
+
+        print tabulate(table, header_dom, tablefmt="simple", stralign='left')
+
+
+@click.group()
+def cli():
+    """Command line utility for display transceivers information"""
+    pass
+
+# 'dom' subcommand
+@cli.command()
+@click.option('-p', '--port', metavar='<port_name>', help="Display Digital Optical Monitoring (DOM) data of <port_name> only")
+def dom(port):
+    TransceiverDOM(port)
+
+
+# 'info' subcommand
+@cli.command()
+@click.option('-p', '--port', metavar='<port_name>', help="Display tranceiver information of <port_name> only")
+def info(port):
+    TransceiverInfo(port)
+
+
+if __name__ == "__main__":
+    cli()

--- a/show/main.py
+++ b/show/main.py
@@ -908,6 +908,23 @@ def presence(interfacename, verbose):
 
     run_command(cmd, display_cmd=verbose)
 
+@transceiver.command()
+@click.argument('interfacename', required=False)
+@click.option('-d', '--dom', 'dump_dom', is_flag=True, help="Show interface transceiver (DOM) data")
+@click.option('--verbose', is_flag=True, help="Enable verbose output")
+def info(interfacename, dump_dom, verbose):
+    """Show interface transceiver information"""
+
+    cmd = "transceivershow info" if not dump_dom else "transceivershow dom"
+
+    if interfacename is not None:
+        if get_interface_mode() == "alias":
+            interfacename = iface_alias_converter.alias_to_name(interfacename)
+
+        cmd += " -p {}".format(interfacename)
+
+    run_command(cmd, display_cmd=verbose)
+
 
 @interfaces.command()
 @click.argument('interfacename', required=False)

--- a/show/main.py
+++ b/show/main.py
@@ -910,12 +910,12 @@ def presence(interfacename, verbose):
 
 @transceiver.command()
 @click.argument('interfacename', required=False)
-@click.option('-d', '--dom', 'dump_dom', is_flag=True, help="Show interface transceiver (DOM) data")
+@click.option('-d', '--dom', 'dump_dom', is_flag=True, help="Show interface transceiver (DOM) info")
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def info(interfacename, dump_dom, verbose):
     """Show interface transceiver information"""
 
-    cmd = "transceivershow info" if not dump_dom else "transceivershow dom"
+    cmd = "transceivershow info" if not dump_dom else "transceivershow dom -t"
 
     if interfacename is not None:
         if get_interface_mode() == "alias":


### PR DESCRIPTION
**- What I did**
- Add transceiver info display to show command

**- How I did it**
- Implement `transceivershow` script
- Add transceivershow to show command

**- How to verify it**
- Run command `show interfaces transceiver info `
- [transceiver_info_test.log](https://github.com/Azure/sonic-utilities/files/4791798/transceiver_info_test.log)



**- Previous command output (if the output of a command-line utility has changed)**
```
admin@sonic:~$ show interfaces transceiver 
Usage: show interfaces transceiver [OPTIONS] COMMAND [ARGS]...

  Show SFP Transceiver information

Options:
  -?, -h, --help  Show this message and exit.

Commands:
  eeprom    Show interface transceiver EEPROM information
  lpmode    Show interface transceiver low-power mode status
  presence  Show interface transceiver presence
```
**- New command output (if the output of a command-line utility has changed)**
```
admin@sonic:~$ show interfaces transceiver 
Usage: show interfaces transceiver [OPTIONS] COMMAND [ARGS]...

  Show SFP Transceiver information

Options:
  -?, -h, --help  Show this message and exit.

Commands:
  eeprom    Show interface transceiver EEPROM information
  info      Show interface transceiver information
  lpmode    Show interface transceiver low-power mode...
  presence  Show interface transceiver presence

admin@sonic:~$ show interfaces transceiver info Ethernet0
Interface    Type               Number of lanes  Vendor Name    Model Name          Serial Number    Nominal bit rate[100Mbs]
-----------  ---------------  -----------------  -------------  ----------------  ---------------  --------------------------
Ethernet0    QSFP28 or later                  4  ColorChip ltd  C100QSFPCWDM400B         18130506                         255

admin@sonic:~$ show interfaces transceiver info --dom Ethernet0
Interface    Lane Number    Temp[C]                         Voltage[V]                       Current[mA]                    Tx Power[dBm]                    Rx Power[dBm]
-----------  -------------  ------------------------------  -------------------------------  -----------------------------  -------------------------------  --------------------------------
Ethernet0    Lane 1         37.371 [low=0.000, high=75.000]  3.276 [low=3.134, high=3.465]  44.954 [low=28.392, high=49.000]  -1.018 [low=-9.5001, high=2.400]  -1.018 [low=-9.5001, high=2.400]
             Lane 2         37.371 [low=0.000, high=75.000]  3.276 [low=3.134, high=3.465]  38.386 [low=28.392, high=49.000]  -1.385 [low=-9.5001, high=2.400]  -1.385 [low=-9.5001, high=2.400]
             Lane 3         37.371 [low=0.000, high=75.000]  3.276 [low=3.134, high=3.465]  35.166 [low=28.392, high=49.000]  -0.391 [low=-9.5001, high=2.400]  -0.391 [low=-9.5001, high=2.400]
             Lane 4         37.371 [low=0.000, high=75.000]  3.276 [low=3.134, high=3.465]  36.156 [low=28.392, high=49.000]  -1.720 [low=-9.5001, high=2.400]  -1.720 [low=-9.5001, high=2.400]
```

**Signed-off-by**: Wirut Getbamrung [wgetbumr@celestica.com]