### PR TITLE
[crm] Use swsssdk API instead of redis-cli for getting keys from redis DB

### DIFF
--- a/crm/main.py
+++ b/crm/main.py
@@ -3,7 +3,6 @@
 import click
 import swsssdk
 from tabulate import tabulate
-from subprocess import Popen, PIPE
 
 class Crm:
     def __init__(self):
@@ -123,15 +122,9 @@ class Crm:
         header = ("Table ID", "Resource Name", "Used Count", "Available Count")
 
         # Retrieve all ACL table keys from CRM:ACL_TABLE_STATS
-        # TODO
-        # Volodymyr is working on refactoring codes to access redis database via redis-py or swsssdk
-        # we should avoid using 'keys' operation via redis-cli or sonic-db-cli
-        # there would be an issue when KEY in database contains space or '\n'
-        # for loop on the non-tty 'keys' output will take the space or `\n` as seperator when parsing the element
-        proc = Popen("docker exec -i database redis-cli --raw -n 2 KEYS *CRM:ACL_TABLE_STATS*", stdout=PIPE, stderr=PIPE, shell=True)
-        out, err = proc.communicate()
+        crm_acl_keys = countersdb.keys(countersdb.COUNTERS_DB, 'CRM:ACL_TABLE_STATS*')
 
-        for key in out.splitlines() or [None]:
+        for key in crm_acl_keys or [None]:
             data = []
 
             if key:


### PR DESCRIPTION
…s DB

Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Refactored CRM code to access redis DB due to issue described below. 
Using ```keys``` operation via ```redis-cli``` or ```sonic-db-cli``` should be avoided, because there would be an issue when ```KEY``` in database contains space or '\n'. For loop on the non-tty 'keys' output will take the space or '\n' as seperator when parsing the element. 

**- How I did it**
Changed CRM code to use ```swsssdk``` API  instead of ```redis-cli``` for getting keys from redis DB. 

**- How to verify it**
Run ```crm show resources all``` command and verify output is as expected. 

**- Previous command output (if the output of a command-line utility has changed)**
N/A

**- New command output (if the output of a command-line utility has changed)**
N/A
