### PR TITLE
Add watchdogutil to control the hw watchdog

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         'sonic-utilities-tests',
         'undebug',
         'utilities_common',
+        'watchdogutil',
     ],
     package_data={
         'show': ['aliases.ini'],
@@ -135,6 +136,7 @@ setup(
             'sonic-clear = clear.main:cli',
             'sonic_installer = sonic_installer.main:cli',
             'undebug = undebug.main:cli',
+            'watchdogutil = watchdogutil.main:cli',
         ]
     },
     # NOTE: sonic-utilities also depends on other packages that are either only

--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ setup(
             'sonic-clear = clear.main:cli',
             'sonic_installer = sonic_installer.main:cli',
             'undebug = undebug.main:cli',
-            'watchdogutil = watchdogutil.main:cli',
+            'watchdogutil = watchdogutil.main:watchdogutil',
         ]
     },
     # NOTE: sonic-utilities also depends on other packages that are either only

--- a/watchdogutil/main.py
+++ b/watchdogutil/main.py
@@ -8,11 +8,8 @@
 try:
     import sys
     import os
-    import subprocess
     import click
-    import imp
     import syslog
-    from tabulate import tabulate
     import sonic_platform
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))

--- a/watchdogutil/main.py
+++ b/watchdogutil/main.py
@@ -75,6 +75,10 @@ def load_platform_watchdog():
 
     return 0
 
+def get_watchdog_status()
+    status = platform_watchdog.is_armed()
+    remaining_time = platform_watchdog.get_remaining_time()
+    return status, remaining_time
 
 # ==================== CLI commands and groups ====================
 
@@ -99,17 +103,11 @@ def version():
     """Display version info"""
     click.echo("watchdogutil version {0}".format(VERSION))
 
-# 'is_armed' subcommand
+# 'status' subcommand
 @watchdogutil.command()
-def is_armed():
-    """Check if watchdog is armed"""
-    click.echo(str(platform_watchdog.is_armed()))
-
-# 'get_remaining_time' subcommand
-@watchdogutil.command()
-def get_remaining_time():
-    """Check the remaining watchdog time"""
-    click.echo(str(platform_watchdog.get_remaining_time()))
+def status():
+    """Check the watchdog status with remaining_time if it's armed"""
+    click.echo(str(get_watchdog_status()))
 
 # 'disarm' subcommand
 @watchdogutil.command()

--- a/watchdogutil/main.py
+++ b/watchdogutil/main.py
@@ -75,7 +75,7 @@ def load_platform_watchdog():
 
     return 0
 
-def get_watchdog_status()
+def get_watchdog_status():
     status = platform_watchdog.is_armed()
     remaining_time = platform_watchdog.get_remaining_time()
     return status, remaining_time

--- a/watchdogutil/main.py
+++ b/watchdogutil/main.py
@@ -131,7 +131,7 @@ def arm(seconds):
     if result < 0:
         click.echo("Failed to arm Watchdog for {} seconds".format(seconds))
     else:
-        click.echo("Watchdog armed for {} seconds".format(results))
+        click.echo("Watchdog armed for {} seconds".format(result))
 
 if __name__ == '__main__':
     cli()

--- a/watchdogutil/main.py
+++ b/watchdogutil/main.py
@@ -75,10 +75,6 @@ def load_platform_watchdog():
 
     return 0
 
-def get_watchdog_status():
-    status = platform_watchdog.is_armed()
-    remaining_time = platform_watchdog.get_remaining_time()
-    return status, remaining_time
 
 # ==================== CLI commands and groups ====================
 
@@ -107,20 +103,34 @@ def version():
 @watchdogutil.command()
 def status():
     """Check the watchdog status with remaining_time if it's armed"""
-    click.echo(str(get_watchdog_status()))
+    status = platform_watchdog.is_armed()
+    remaining_time = platform_watchdog.get_remaining_time()
+    if status is True:
+        click.echo("Watchdog armed with remaining {} seconds".format(remaining_time))
+    else:
+        click.echo("Watchdog unarmed")
+
 
 # 'disarm' subcommand
 @watchdogutil.command()
 def disarm():
     """Disarm HW watchdog"""
-    click.echo(str(platform_watchdog.disarm()))
+    result = platform_watchdog.disarm()
+    if result is True:
+        click.echo("Watchdog disarmed successfully")
+    else:
+        click.echo("Failed to disarm Watchdog")
 
 # 'arm' subcommand
 @watchdogutil.command()
 @click.option('-s', '--seconds', default=180, type=int, help="the default timeout of HW watchdog")
 def arm(seconds):
     """Arm HW watchdog"""
-    click.echo(str(platform_watchdog.arm(seconds)))
+    result = int(platform_watchdog.arm(seconds))
+    if result == seconds:
+        click.echo("Watchdog armed for {} seconds".format(seconds))
+    else:
+        click.echo("Failed to arm Watchdog for {} seconds".format(seconds))
 
 if __name__ == '__main__':
     cli()

--- a/watchdogutil/main.py
+++ b/watchdogutil/main.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+#
+# main.py
+#
+# Command-line utility for interacting with HW Watchdog in SONiC
+#
+
+try:
+    import sys
+    import os
+    import subprocess
+    import click
+    import imp
+    import syslog
+    from tabulate import tabulate
+    import sonic_platform
+except ImportError as e:
+    raise ImportError("%s - required module not found" % str(e))
+
+VERSION = '2.0'
+
+SYSLOG_IDENTIFIER = "watchdogutil"
+
+WATCHDOG_LOAD_ERROR = -1
+CHASSIS_LOAD_ERROR = -2
+
+# Global platform-specific watchdog class instance
+platform_watchdog = None
+
+
+# ========================== Syslog wrappers ==========================
+
+
+def log_info(msg, also_print_to_console=False):
+    syslog.openlog(SYSLOG_IDENTIFIER)
+    syslog.syslog(syslog.LOG_INFO, msg)
+    syslog.closelog()
+
+    if also_print_to_console:
+        click.echo(msg)
+
+
+def log_warning(msg, also_print_to_console=False):
+    syslog.openlog(SYSLOG_IDENTIFIER)
+    syslog.syslog(syslog.LOG_WARNING, msg)
+    syslog.closelog()
+
+    if also_print_to_console:
+        click.echo(msg)
+
+
+def log_error(msg, also_print_to_console=False):
+    syslog.openlog(SYSLOG_IDENTIFIER)
+    syslog.syslog(syslog.LOG_ERR, msg)
+    syslog.closelog()
+
+    if also_print_to_console:
+        click.echo(msg)
+
+
+# ==================== Methods for initialization ====================
+
+# Loads platform specific watchdog module from source
+def load_platform_watchdog():
+    global platform_watchdog
+
+    platform = sonic_platform.platform.Platform()
+
+    chassis = platform.get_chassis()
+    if not chassis:
+        log_error("Failed to get chassis")
+        return CHASSIS_LOAD_ERROR
+
+    platform_watchdog = chassis.get_watchdog()
+    if not platform_watchdog:
+        log_error("Failed to get watchdog module")
+        return WATCHDOG_LOAD_ERROR
+
+    return 0
+
+
+# ==================== CLI commands and groups ====================
+
+
+# This is our main entrypoint - the main 'watchdogutil' command
+@click.group()
+def cli():
+    """watchdogutil - Command line utility for providing HW watchdog interface"""
+
+    if os.geteuid() != 0:
+        click.echo("Root privileges are required for this operation")
+        sys.exit(1)
+
+    # Load platform-specific watchdog class
+    err = load_platform_watchdog()
+    if err != 0:
+        sys.exit(2)
+
+# 'version' subcommand
+@cli.command()
+def version():
+    """Display version info"""
+    click.echo("watchdogutil version {0}".format(VERSION))
+
+# 'disarm' subcommand
+@cli.command()
+def disarm():
+    """Disarm HW watchdog"""
+    click.echo(str(platform_watchdog.disarm()))
+
+# 'arm' subcommand
+@cli.command()
+@click.option('-s', '--seconds', default=180, type=int, help="the default timeout of HW watchdog")
+def arm(seconds):
+    """Arm HW watchdog"""
+    click.echo(str(platform_watchdog.arm(seconds)))
+
+if __name__ == '__main__':
+    cli()

--- a/watchdogutil/main.py
+++ b/watchdogutil/main.py
@@ -106,9 +106,10 @@ def status():
     status = platform_watchdog.is_armed()
     remaining_time = platform_watchdog.get_remaining_time()
     if status is True:
-        click.echo("Watchdog armed with remaining {} seconds".format(remaining_time))
+        click.echo("Status : Armed")
+        click.echo("Time remaining : {} seconds".format(remaining_time))
     else:
-        click.echo("Watchdog unarmed")
+        click.echo("Status : Unarmed")
 
 
 # 'disarm' subcommand

--- a/watchdogutil/main.py
+++ b/watchdogutil/main.py
@@ -106,10 +106,10 @@ def status():
     status = platform_watchdog.is_armed()
     remaining_time = platform_watchdog.get_remaining_time()
     if status is True:
-        click.echo("Status : Armed")
-        click.echo("Time remaining : {} seconds".format(remaining_time))
+        click.echo("Status: Armed")
+        click.echo("Time remaining: {} seconds".format(remaining_time))
     else:
-        click.echo("Status : Unarmed")
+        click.echo("Status: Unarmed")
 
 
 # 'disarm' subcommand

--- a/watchdogutil/main.py
+++ b/watchdogutil/main.py
@@ -128,10 +128,10 @@ def disarm():
 def arm(seconds):
     """Arm HW watchdog"""
     result = int(platform_watchdog.arm(seconds))
-    if result == seconds:
-        click.echo("Watchdog armed for {} seconds".format(seconds))
-    else:
+    if result < 0:
         click.echo("Failed to arm Watchdog for {} seconds".format(seconds))
+    else:
+        click.echo("Watchdog armed for {} seconds".format(results))
 
 if __name__ == '__main__':
     cli()

--- a/watchdogutil/main.py
+++ b/watchdogutil/main.py
@@ -81,7 +81,7 @@ def load_platform_watchdog():
 
 # This is our main entrypoint - the main 'watchdogutil' command
 @click.group()
-def cli():
+def watchdogutil():
     """watchdogutil - Command line utility for providing HW watchdog interface"""
 
     if os.geteuid() != 0:
@@ -94,19 +94,31 @@ def cli():
         sys.exit(2)
 
 # 'version' subcommand
-@cli.command()
+@watchdogutil.command()
 def version():
     """Display version info"""
     click.echo("watchdogutil version {0}".format(VERSION))
 
+# 'is_armed' subcommand
+@watchdogutil.command()
+def is_armed():
+    """Check if watchdog is armed"""
+    click.echo(str(platform_watchdog.is_armed()))
+
+# 'get_remaining_time' subcommand
+@watchdogutil.command()
+def get_remaining_time():
+    """Check the remaining watchdog time"""
+    click.echo(str(platform_watchdog.get_remaining_time()))
+
 # 'disarm' subcommand
-@cli.command()
+@watchdogutil.command()
 def disarm():
     """Disarm HW watchdog"""
     click.echo(str(platform_watchdog.disarm()))
 
 # 'arm' subcommand
-@cli.command()
+@watchdogutil.command()
 @click.option('-s', '--seconds', default=180, type=int, help="the default timeout of HW watchdog")
 def arm(seconds):
     """Arm HW watchdog"""

--- a/watchdogutil/main.py
+++ b/watchdogutil/main.py
@@ -14,7 +14,7 @@ try:
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
 
-VERSION = '1.0'
+VERSION = "1.0"
 
 SYSLOG_IDENTIFIER = "watchdogutil"
 
@@ -134,4 +134,4 @@ def arm(seconds):
         click.echo("Watchdog armed for {} seconds".format(result))
 
 if __name__ == '__main__':
-    cli()
+    watchdogutil()

--- a/watchdogutil/main.py
+++ b/watchdogutil/main.py
@@ -14,7 +14,7 @@ try:
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
 
-VERSION = '2.0'
+VERSION = '1.0'
 
 SYSLOG_IDENTIFIER = "watchdogutil"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Add a command line utility to control the hw watchdog arm/disarm
**- How I did it**
Add watchdogutil
**- How to verify it**
Check the syslog 
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**
```
user@server:~$ sudo watchdogutil status
Status : Unarmed
user@server:~$ sudo watchdogutil arm
Watchdog armed for 180 seconds
user@server:~$ sudo watchdogutil disarm
Watchdog disarmed successfully
```