### PR TITLE
[sonic-utilities-tests/config_mgmt_test.py]: Unit Tests for config_mg…

### DIFF
--- a/sonic-utilities-tests/config_mgmt_test.py
+++ b/sonic-utilities-tests/config_mgmt_test.py
@@ -1,0 +1,475 @@
+import imp
+import os
+import mock_tables.dbconnector
+# import file under test i.e. config_mgmt.py
+imp.load_source('config_mgmt', \
+    os.path.join(os.path.dirname(__file__), '..', 'config', 'config_mgmt.py'))
+import config_mgmt
+
+from unittest import TestCase
+from mock import MagicMock, call
+from json import dump
+
+class TestConfigMgmt(TestCase):
+
+    def setUp(self):
+        config_mgmt.YANG_DIR = "../../sonic-yang-models/yang-models/"
+        config_mgmt.CONFIG_DB_JSON_FILE = "startConfigDb.json"
+        config_mgmt.DEFAULT_CONFIG_DB_JSON_FILE = "portBreakOutConfigDb.json"
+        return
+
+    def test_config_validation(self):
+        iConfig = dict(configDbJson)
+        self.writeJson(iConfig, config_mgmt.CONFIG_DB_JSON_FILE)
+        cm = config_mgmt.ConfigMgmt(source=config_mgmt.CONFIG_DB_JSON_FILE)
+        assert cm.validateConfigData() == True
+        return
+
+    def test_table_without_yang(self):
+        iConfig = dict(configDbJson)
+        unknown = {"unknown_table": {"ukey": "uvalue"}}
+        self.updateConfig(iConfig, unknown)
+        self.writeJson(iConfig, config_mgmt.CONFIG_DB_JSON_FILE)
+        cm = config_mgmt.ConfigMgmt(source=config_mgmt.CONFIG_DB_JSON_FILE)
+        #assert "unknown_table" in cm.tablesWithoutYang()
+        return
+
+    def test_search_keys(self):
+        iConfig = dict(configDbJson)
+        self.writeJson(iConfig, config_mgmt.CONFIG_DB_JSON_FILE)
+        cmdpb = config_mgmt.ConfigMgmtDPB(source=config_mgmt.CONFIG_DB_JSON_FILE)
+        out = cmdpb.configWithKeys(portBreakOutConfigDbJson, \
+            ["Ethernet8","Ethernet9"])
+        assert "VLAN" not in out.keys()
+        assert "INTERFACE" not in out.keys()
+        for k in out['ACL_TABLE'].keys():
+            # only ports must be chosen
+            len(out['ACL_TABLE'][k]) == 1
+        out = cmdpb.configWithKeys(portBreakOutConfigDbJson, \
+            ["Ethernet10","Ethernet11"])
+        assert "INTERFACE" in out.keys()
+        for k in out['ACL_TABLE'].keys():
+            # only ports must be chosen
+            len(out['ACL_TABLE'][k]) == 1
+        return
+
+    def test_break_out(self):
+        # prepare default config
+        self.writeJson(portBreakOutConfigDbJson, \
+            config_mgmt.DEFAULT_CONFIG_DB_JSON_FILE)
+        # prepare config dj json to start with
+        iConfig = dict(configDbJson)
+        #Ethernet8: start from 4x25G-->2x50G with -f -l
+        self.dpb_port8_4x25G_2x50G_f_l(iConfig)
+        #Ethernet8: move from 2x50G-->1x100G without force, list deps
+        self.dpb_port8_2x50G_1x100G(iConfig)
+        # Ethernet8: move from 2x50G-->1x100G with force, where deps exists
+        self.dpb_port8_2x50G_1x100G_f(iConfig)
+        # Ethernet8: move from 1x100G-->4x25G without force, no deps
+        self.dpb_port8_1x100G_4x25G(iConfig)
+        # Ethernet8: move from 4x25G-->1x100G with force, no deps
+        self.dpb_port8_4x25G_1x100G_f(iConfig)
+        # Ethernet8: move from 1x100G-->1x50G(2)+2x25G(2) with -f -l,
+        self.dpb_port8_1x100G_1x50G_2x25G_f_l(iConfig)
+        # Ethernet4: breakout from 4x25G to 2x50G with -f -l
+        self.dpb_port4_4x25G_2x50G_f_l(iConfig)
+        return
+
+    def tearDown(self):
+        try:
+            os.remove(config_mgmt.CONFIG_DB_JSON_FILE)
+            os.remove(config_mgmt.DEFAULT_CONFIG_DB_JSON_FILE)
+        except Exception as e:
+            pass
+        return
+
+    ########### HELPER FUNCS #####################################
+    def writeJson(self, d, file):
+        with open(file, 'w') as f:
+            dump(d, f, indent=4)
+        return
+    # config_mgmt.ConfigMgmtDPB class instance with mocked functions. Not using
+    # pytest fixture, because it is used in non test funcs.
+    def config_mgmt_dpb(self, iConfig):
+        # create object
+        self.writeJson(iConfig, config_mgmt.CONFIG_DB_JSON_FILE)
+        cmdpb = config_mgmt.ConfigMgmtDPB(source=config_mgmt.CONFIG_DB_JSON_FILE)
+        # mock funcs
+        cmdpb.writeConfigDB = MagicMock(return_value=True)
+        cmdpb._verifyAsicDB = MagicMock(return_value=True)
+        return cmdpb
+
+    # Generate port to deleted, added and lanes and speed setting based on
+    # current and new mode.
+    def generate_args(self, portIdx, laneIdx, curMode, newMode):
+        # default params
+        pre = "Ethernet"
+        laneMap = {"4x25G": [1,1,1,1], "2x50G": [2,2], "1x100G":[4], \
+            "1x50G(2)+2x25G(2)":[2,1,1], "2x25G(2)+1x50G(2)":[1,1,2]}
+        laneSpeed = 25000
+        # generate dPorts
+        l = list(laneMap[curMode]); l.insert(0, 0); id = portIdx; dPorts = list()
+        for i in l[:-1]:
+            id = id + i
+            portName = portName = "{}{}".format(pre, id)
+            dPorts.append(portName)
+        # generate aPorts
+        l = list(laneMap[newMode]); l.insert(0, 0); id = portIdx; aPorts = list()
+        for i in l[:-1]:
+            id = id + i
+            portName = portName = "{}{}".format(pre, id)
+            aPorts.append(portName)
+        # generate pJson
+        l = laneMap[newMode]; pJson = {"PORT": {}}; li = laneIdx; pi = 0
+        for i in l:
+            speed = laneSpeed*i
+            lanes = [str(li+j) for j in range(i)]; lanes = ','.join(lanes)
+            pJson['PORT'][aPorts[pi]] = {"speed": str(speed), "lanes": str(lanes)}
+            li = li+i; pi = pi + 1
+        return dPorts, aPorts ,pJson
+
+    # update the config to emulate continous breakingout a single port
+    def updateConfig(self, conf, uconf):
+        try:
+            for it in uconf.keys():
+                # if conf has the key
+                if conf.get(it):
+                    # if marked for deletion
+                    if uconf[it] == None:
+                        del conf[it]
+                    else:
+                        if isinstance(conf[it], list) and isinstance(uconf[it], list):
+                            conf[it] = list(uconf[it])
+                        elif isinstance(conf[it], dict) and isinstance(uconf[it], dict):
+                            self.updateConfig(conf[it], uconf[it])
+                        else:
+                            conf[it] = uconf[it]
+                    del uconf[it]
+            # update new keys in conf
+            conf.update(uconf)
+        except Exception as e:
+            print("update Config failed")
+            print(e)
+            raise e
+        return
+
+    # Usual result check in many test is: Make sure dConfig and aConfig is
+    # pushed in order to configDb
+    def checkResult(self, cmdpb, dConfig, aConfig):
+        calls = [call(dConfig), call(aConfig)]
+        assert cmdpb.writeConfigDB.call_count == 2
+        cmdpb.writeConfigDB.assert_has_calls(calls, any_order=False)
+        return
+
+    # After breakout, update the config to emulate continous breakingout a
+    # single port
+    def postUpdateConfig(self, iConfig, dConfig, aConfig):
+        # update the iConfig with change
+        self.updateConfig(iConfig, dConfig)
+        self.updateConfig(iConfig, aConfig)
+        return
+
+    def dpb_port8_1x100G_1x50G_2x25G_f_l(self, iConfig):
+        cmdpb = self.config_mgmt_dpb(iConfig)
+        # create ARGS
+        dPorts, aPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
+            curMode='1x100G', newMode='1x50G(2)+2x25G(2)')
+        deps, ret = cmdpb.breakOutPort(delPorts=dPorts, addPorts= aPorts, portJson=pJson,
+            force=True, loadDefConfig=True)
+        # Expected Result dConfig and aConfig is pushed in order
+        dConfig = {u'PORT': {u'Ethernet8': None}}
+        aConfig = {u'ACL_TABLE': {u'NO-NSW-PACL-V4': {u'ports': ['Ethernet0', \
+        'Ethernet4', 'Ethernet8', 'Ethernet10']}, u'NO-NSW-PACL-TEST': {u'ports': \
+        ['Ethernet11']}}, u'INTERFACE': {u'Ethernet11|2a04:1111:40:a709::1/126': \
+        {u'scope': u'global', u'family': u'IPv6'}, u'Ethernet11': {}}, \
+        u'VLAN_MEMBER': {u'Vlan100|Ethernet8': {u'tagging_mode': u'untagged'}, \
+        u'Vlan100|Ethernet11': {u'tagging_mode': u'untagged'}}, u'PORT': \
+        {'Ethernet8': {'speed': '50000', 'lanes': '73,74'}, 'Ethernet10': \
+        {'speed': '25000', 'lanes': '75'}, 'Ethernet11': {'speed': '25000', 'lanes': '76'}}}
+        self.checkResult(cmdpb, dConfig, aConfig)
+        self.postUpdateConfig(iConfig, dConfig, aConfig)
+        return
+
+    def dpb_port8_4x25G_1x100G_f(self, iConfig):
+        cmdpb = self.config_mgmt_dpb(iConfig)
+        # create ARGS
+        dPorts, aPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
+            curMode='4x25G', newMode='1x100G')
+        deps, ret = cmdpb.breakOutPort(delPorts=dPorts, addPorts= aPorts, portJson=pJson,
+            force=False, loadDefConfig=False)
+        # Expected Result dConfig and aConfig is pushed in order
+        dConfig = {u'PORT': {u'Ethernet8': None, u'Ethernet9': None, \
+            u'Ethernet10': None, u'Ethernet11': None}}
+        aConfig = pJson
+        self.checkResult(cmdpb, dConfig, aConfig)
+        self.postUpdateConfig(iConfig, dConfig, aConfig)
+        return
+
+    def dpb_port8_1x100G_4x25G(self, iConfig):
+        cmdpb = self.config_mgmt_dpb(iConfig)
+        dPorts, aPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
+            curMode='1x100G', newMode='4x25G')
+        deps, ret = cmdpb.breakOutPort(delPorts=dPorts, addPorts= aPorts, portJson=pJson,
+            force=False, loadDefConfig=False)
+        # Expected Result dConfig and aConfig is pushed in order
+        dConfig = {u'PORT': {u'Ethernet8': None}}
+        aConfig = pJson
+        self.checkResult(cmdpb, dConfig, aConfig)
+        self.postUpdateConfig(iConfig, dConfig, aConfig)
+        return
+
+    def dpb_port8_2x50G_1x100G_f(self, iConfig):
+        cmdpb = self.config_mgmt_dpb(iConfig)
+        # create ARGS
+        dPorts, aPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
+            curMode='2x50G', newMode='1x100G')
+        deps, ret = cmdpb.breakOutPort(delPorts=dPorts, addPorts= aPorts, portJson=pJson,
+            force=True, loadDefConfig=False)
+        # Expected Result dConfig and aConfig is pushed in order
+        dConfig = {u'ACL_TABLE': {u'NO-NSW-PACL-V4': {u'ports': ['Ethernet0', 'Ethernet4']}}, \
+        u'VLAN_MEMBER': {u'Vlan100|Ethernet8': None}, u'PORT': {u'Ethernet8': None, \
+        u'Ethernet10': None}}
+        aConfig = pJson
+        self.checkResult(cmdpb, dConfig, aConfig)
+        self.postUpdateConfig(iConfig, dConfig, aConfig)
+
+    def dpb_port8_2x50G_1x100G(self, iConfig):
+        cmdpb = self.config_mgmt_dpb(iConfig)
+        # create ARGS
+        dPorts, aPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
+            curMode='2x50G', newMode='1x100G')
+        deps, ret = cmdpb.breakOutPort(delPorts=dPorts, addPorts= aPorts, portJson=pJson,
+            force=False, loadDefConfig=False)
+        # Expected Result
+        assert ret == False and len(deps) == 3
+        assert cmdpb.writeConfigDB.call_count == 0
+        return
+
+    def dpb_port8_4x25G_2x50G_f_l(self, iConfig):
+        cmdpb = self.config_mgmt_dpb(iConfig)
+        # create ARGS
+        dPorts, aPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
+            curMode='4x25G', newMode='2x50G')
+        cmdpb.breakOutPort(delPorts=dPorts, addPorts= aPorts, portJson=pJson,
+            force=True, loadDefConfig=True)
+        # Expected Result dConfig and aConfig is pushed in order
+        dConfig = {u'ACL_TABLE': {u'NO-NSW-PACL-V4': \
+        {u'ports': ['Ethernet0', 'Ethernet4']}, u'NO-NSW-PACL-TEST': {u'ports': None}}, \
+        u'INTERFACE': None, u'VLAN_MEMBER': {u'Vlan100|Ethernet8': None, \
+        u'Vlan100|Ethernet11': None}, u'PORT': {u'Ethernet8': None, \
+        u'Ethernet9': None, u'Ethernet10': None, u'Ethernet11': None}}
+        aConfig = {u'ACL_TABLE': {u'NO-NSW-PACL-V4': \
+        {u'ports': ['Ethernet0', 'Ethernet4', 'Ethernet8', 'Ethernet10']}}, \
+        u'VLAN_MEMBER': {u'Vlan100|Ethernet8': {u'tagging_mode': u'untagged'}}, \
+        u'PORT': {'Ethernet8': {'speed': '50000', 'lanes': '73,74'}, \
+        'Ethernet10': {'speed': '50000', 'lanes': '75,76'}}}
+        assert cmdpb.writeConfigDB.call_count == 2
+        self.checkResult(cmdpb, dConfig, aConfig)
+        self.postUpdateConfig(iConfig, dConfig, aConfig)
+        return
+
+    def dpb_port4_4x25G_2x50G_f_l(self, iConfig):
+        cmdpb = self.config_mgmt_dpb(iConfig)
+        # create ARGS
+        dPorts, aPorts, pJson = self.generate_args(portIdx=4, laneIdx=69, \
+            curMode='4x25G', newMode='2x50G')
+        cmdpb.breakOutPort(delPorts=dPorts, addPorts= aPorts, portJson=pJson,
+            force=True, loadDefConfig=True)
+        # Expected Result dConfig and aConfig is pushed in order
+        dConfig = {u'ACL_TABLE': {u'NO-NSW-PACL-V4': \
+        {u'ports': ['Ethernet0', 'Ethernet8', 'Ethernet10']}}, u'PORT': \
+        {u'Ethernet4': None, u'Ethernet5': None, u'Ethernet6': None, \
+        u'Ethernet7': None}}
+        aConfig = {u'ACL_TABLE': {u'NO-NSW-PACL-V4': \
+        {u'ports': ['Ethernet0', 'Ethernet8', 'Ethernet10', 'Ethernet4']}}, \
+        u'PORT': {'Ethernet4': {'speed': '50000', 'lanes': '69,70'}, \
+        'Ethernet6': {'speed': '50000', 'lanes': '71,72'}}}
+        self.checkResult(cmdpb, dConfig, aConfig)
+        self.postUpdateConfig(iConfig, dConfig, aConfig)
+        return
+
+###########GLOBAL Configs#####################################
+configDbJson =  {
+    "ACL_TABLE": {
+        "NO-NSW-PACL-TEST": {
+            "policy_desc": "NO-NSW-PACL-TEST",
+            "type": "L3",
+            "stage": "INGRESS",
+            "ports": [
+                "Ethernet9",
+                "Ethernet11",
+                ]
+        },
+        "NO-NSW-PACL-V4": {
+            "policy_desc": "NO-NSW-PACL-V4",
+            "type": "L3",
+            "stage": "INGRESS",
+            "ports": [
+                "Ethernet0",
+                "Ethernet4",
+                "Ethernet8",
+                "Ethernet10"
+                ]
+        }
+    },
+    "VLAN": {
+        "Vlan100": {
+            "admin_status": "up",
+            "description": "server_vlan",
+            "dhcp_servers": [
+                "10.186.72.116"
+            ]
+        },
+    },
+    "VLAN_MEMBER": {
+        "Vlan100|Ethernet0": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan100|Ethernet2": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan100|Ethernet8": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan100|Ethernet11": {
+            "tagging_mode": "untagged"
+        },
+    },
+    "INTERFACE": {
+        "Ethernet10": {},
+        "Ethernet10|2a04:0000:40:a709::1/126": {
+            "scope": "global",
+            "family": "IPv6"
+        }
+    },
+    "PORT": {
+        "Ethernet0": {
+            "alias": "Eth1/1",
+            "lanes": "65",
+            "description": "",
+            "speed": "25000",
+            "admin_status": "up"
+        },
+        "Ethernet1": {
+            "alias": "Eth1/2",
+            "lanes": "66",
+            "description": "",
+            "speed": "25000",
+            "admin_status": "up"
+        },
+        "Ethernet2": {
+            "alias": "Eth1/3",
+            "lanes": "67",
+            "description": "",
+            "speed": "25000",
+            "admin_status": "up"
+        },
+        "Ethernet3": {
+            "alias": "Eth1/4",
+            "lanes": "68",
+            "description": "",
+            "speed": "25000",
+            "admin_status": "up"
+        },
+        "Ethernet4": {
+            "alias": "Eth2/1",
+            "lanes": "69",
+            "description": "",
+            "speed": "25000",
+            "admin_status": "up"
+        },
+        "Ethernet5": {
+            "alias": "Eth2/2",
+            "lanes": "70",
+            "description": "",
+            "speed": "25000",
+            "admin_status": "up"
+        },
+        "Ethernet6": {
+            "alias": "Eth2/3",
+            "lanes": "71",
+            "description": "",
+            "speed": "25000",
+            "admin_status": "up"
+        },
+        "Ethernet7": {
+            "alias": "Eth2/4",
+            "lanes": "72",
+            "description": "",
+            "speed": "25000",
+            "admin_status": "up"
+        },
+        "Ethernet8": {
+            "alias": "Eth3/1",
+            "lanes": "73",
+            "description": "",
+            "speed": "25000",
+            "admin_status": "up"
+        },
+        "Ethernet9": {
+            "alias": "Eth3/2",
+            "lanes": "74",
+            "description": "",
+            "speed": "25000",
+            "admin_status": "up"
+        },
+        "Ethernet10": {
+            "alias": "Eth3/3",
+            "lanes": "75",
+            "description": "",
+            "speed": "25000",
+            "admin_status": "up"
+        },
+        "Ethernet11": {
+            "alias": "Eth3/4",
+            "lanes": "76",
+            "description": "",
+            "speed": "25000",
+            "admin_status": "up"
+        }
+    }
+}
+
+portBreakOutConfigDbJson = {
+    "ACL_TABLE": {
+        "NO-NSW-PACL-TEST": {
+            "ports": [
+                "Ethernet9",
+                "Ethernet11",
+                ]
+        },
+        "NO-NSW-PACL-V4": {
+            "policy_desc": "NO-NSW-PACL-V4",
+            "ports": [
+                "Ethernet0",
+                "Ethernet4",
+                "Ethernet8",
+                "Ethernet10"
+                ]
+        }
+    },
+    "VLAN": {
+        "Vlan100": {
+            "admin_status": "up",
+            "description": "server_vlan",
+            "dhcp_servers": [
+                "10.186.72.116"
+            ]
+        }
+    },
+    "VLAN_MEMBER": {
+        "Vlan100|Ethernet8": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan100|Ethernet11": {
+            "tagging_mode": "untagged"
+       }
+    },
+    "INTERFACE": {
+        "Ethernet11": {},
+        "Ethernet11|2a04:1111:40:a709::1/126": {
+            "scope": "global",
+            "family": "IPv6"
+        }
+    }
+}


### PR DESCRIPTION
…mt.py library.

Signed-off-by: Praveen Chaudhary pchaudhary@linkedin.com

This is a dummy PR just for better description. Committed in [https://github.com/Azure/sonic-utilities/pull/765/commits/77e3734c66339f5b92be560c10f4d8a291ccb7e7]
#### Depend on https://github.com/Azure/sonic-utilities/pull/765. 
#### Depend on https://github.com/Azure/sonic-buildimage/pull/4798.
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Write Unit tests for Config_mgmt library introduced in PR #765.

**- How I did it**
Key Decisions:
-- Config_mgmt interaction with Redis DB:
These tests will be executed at build time, the entire interaction with Redis DB is mocked using:
    import mock_tables.dbconnector
This mocks below classes used in config_mgmt
from swsssdk import ConfigDBConnector, SonicV2Connector, port_util

-- Mock sonic_yang or not:
Most of the functions in config_mgmt calls APIs from sonic_yang_mgmt (https://github.com/Azure/sonic-buildimage/tree/master/src/sonic-yang-mgmt) library. It is important to catch any compatibility issues during build time rather than run time. So it is decided not to mock sonic_yang but use real instance. Due to this sonic_utilities will have a build time dependency on sonic_yang_mgmt.

-- Unit Test each function or the functions exposed to caller:
	1.	To unit test each function, we need to mock sonic_yang, which is against the previous decision.  
	2.	Also calling the functions which are exposed to the caller is sufficient to unit test all functions. Because functions like breakOutPort internally call every function in the library, and the expected result is not produced if internal functions are not working properly. 
	3.	In the real scenario, the caller will use this library for config validation and to break out the port in a continuous manner. To emulate a real scenario it is decided to exercise only the functions exposed to the caller. 

Check Result:
-- How to check expected result for breakout Command:
	1.	A successful call to breakOutPort API results in a call to writeConfigDB API twice. 
One time with config to be deleted and second time with config to be added. Both calls are necessary and should be done in order. This is tested by mocking writeConfigDB API as below:
```
cmdpb = config_mgmt.ConfigMgmtDPB(source=config_mgmt.CONFIG_DB_JSON_FILE)
cmdpb.writeConfigDB = MagicMock(return_value=True)
```
Then we can check result as below:
```
calls = [call(dConfig), call(aConfig)]
        assert cmdpb.writeConfigDB.call_count == 2
        cmdpb.writeConfigDB.assert_has_calls(calls, any_order=False)
```
Note: it is important to check that both calls are done, rather than just checking final config.


Tests: 
-- Create the configMgmt Class object and validate config.

-- Have a table without yang model in config, Check if this table is returned by tablesWithoutYang()

-- Test configWithKeys() to search ports in the config.

-- Important Test case, Test below sequence for port breakout:
```
        #Ethernet8: start from 4x25G-->2x50G with -f -l

        #Ethernet8: move from 2x50G-->1x100G without force, list deps

        # Ethernet8: move from 2x50G-->1x100G with force, where deps exists

        # Ethernet8: move from 1x100G-->4x25G without force, no deps

        # Ethernet8: move from 4x25G-->1x100G with force, no deps

        # Ethernet8: move from 1x100G-->1x50G(2)+2x25G(2) with -f -l,

        # Ethernet4: breakout from 4x25G to 2x50G with -f -l
```
Note: this is important to do this sequence in one test case, because it is good to test with continuous  change in Config. Also this way, a new configuration for each test is not needed.
 
Expected Result:
All automated tests should pass.

Each breakout test is checked for expected result  as below:
Have a hard coded value of expected dConfig and aConfig, where
dConfig: Config to be deleted.
aConfig: Config to be deleted.

    And check if writeConfigDB is called using the above configurations.
Example: 
```
dConfig = {u'PORT': {u'Ethernet8': None}}

aConfig = {u'ACL_TABLE': {u'NO-NSW-PACL-V4': {u'ports': ['Ethernet0', \
        'Ethernet4', 'Ethernet8', 'Ethernet10']}, u'NO-NSW-PACL-TEST': {u'ports': \
        ['Ethernet11']}}, u'INTERFACE': {u'Ethernet11|2a04:1111:40:a709::1/126': \
        {u'scope': u'global', u'family': u'IPv6'}, u'Ethernet11': {}}, \
        u'VLAN_MEMBER': {u'Vlan100|Ethernet8': {u'tagging_mode': u'untagged'}, \
        u'Vlan100|Ethernet11': {u'tagging_mode': u'untagged'}}, u'PORT': \
        {'Ethernet8': {'speed': '50000', 'lanes': '73,74'}, 'Ethernet10': \
        {'speed': '25000', 'lanes': '75'}, 'Ethernet11': {'speed': '25000', 'lanes': '76'}}}
        
self.checkResult(cmdpb, dConfig, aConfig)
```
Actual Result:
```
============================================================ test session starts ============================================================
platform linux2 -- Python 2.7.13, pytest-3.0.6, py-1.4.32, pluggy-0.4.0
rootdir: /sonic/src/sonic-utilities/sonic-utilities-tests, inifile: pytest.ini
plugins: cov-2.4.0
collected 4 items

config_mgmt_test.py ....

========================================================= 4 passed in 0.67 seconds ==========================================================
```

**- How to verify it**
Actual Result:
```
============================================================ test session starts ============================================================
platform linux2 -- Python 2.7.13, pytest-3.0.6, py-1.4.32, pluggy-0.4.0
rootdir: /sonic/src/sonic-utilities/sonic-utilities-tests, inifile: pytest.ini
plugins: cov-2.4.0
collected 4 items

config_mgmt_test.py ....

========================================================= 4 passed in 0.67 seconds ==========================================================
```
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

