### PR TITLE
[master]fix #4716 show ipv6 interfaces neighbor_ip is N/A issue

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1546,6 +1546,7 @@ def interfaces():
 
         if netifaces.AF_INET6 in ipaddresses:
             ifaddresses = []
+            neighbor_info = []
             for ipaddr in ipaddresses[netifaces.AF_INET6]:
                 neighbor_name = 'N/A'
                 neighbor_ip = 'N/A'
@@ -1557,6 +1558,7 @@ def interfaces():
                     neighbor_ip = bgp_peer[local_ip][1]
                 except Exception:
                     pass
+                neighbor_info.append([neighbor_name, neighbor_ip])
 
             if len(ifaddresses) > 0:
                 admin = get_if_admin_state(iface)
@@ -1567,9 +1569,11 @@ def interfaces():
                 master = get_if_master(iface)
                 if get_interface_mode() == "alias":
                     iface = iface_alias_converter.name_to_alias(iface)
-                data.append([iface, master, ifaddresses[0][1], admin + "/" + oper, neighbor_name, neighbor_ip])
-            for ifaddr in ifaddresses[1:]:
-                data.append(["", "", ifaddr[1], ""])
+                data.append([iface, master, ifaddresses[0][1], admin + "/" + oper, neighbor_info[0][0], neighbor_info[0][1]])
+                neighbor_info.pop(0)
+                for ifaddr in ifaddresses[1:]:
+                    data.append(["", "", ifaddr[1], admin + "/" + oper, neighbor_info[0][0], neighbor_info[0][1]])
+                    neighbor_info.pop(0)
 
     print tabulate(data, header, tablefmt="simple", stralign='left', missingval="")
 


### PR DESCRIPTION
 - Why I did it

    When exec 'show ipv6 interfaces', the neighbor_ip will always be 'N/A' which will confuse the consumers. After checking we found that this is a show issue. As we know, there will be one local linked IPV6 address for every valid interface. In show/main.py, the interface's ipv6 neighbor ip will always be written by this local linked IPV6's neighbor_ip address which is 'N/A'. And i think this part code of 'show ipv6 interface' was copied from 'show ip interface' before, right? Yea, some change is necessary!
 
-  What I did

    This is bug fixing. Using a array to store neighbor info in case that the old one be written by the newer one.
   
- How I did it

    Code change.
 
- How to verify it
    Upgrate config_db.config attached in https://github.com/Azure/sonic-buildimage/issues/4716 and show ipv6 interfaces

- Previous command output (if the output of a command-line utility has changed)
```
root@switch2:/usr/lib/python2.7/dist-packages/show# show ipv6 interfaces
Interface     Master        IPv6 address/mask                          Admin/Oper    BGP Neighbor    Neighbor IP
------------  ------------  -----------------------------------------  ------------  --------------  -------------
Bridge                      fe80::fce5:f4ff:fed5:b262%Bridge/64        up/up         N/A             N/A
Ethernet0     PortChannel1  fe80::5a69:6cff:fefb:2230%Ethernet0/64     up/up         N/A             N/A
Ethernet52                  2001:50:5:1::5/64                          up/up         N/A             N/A
                            2001:50:5:1::4/64
                            2001:50:5:1::3/64
                            2001:50:5:1::2/64
                            fe80::5a69:6cff:fefb:2230%Ethernet52/64
Loopback0                   6::6/128                                   up/up         N/A             N/A
                            fe80::44cb:61ff:fe6b:4d41%Loopback0/64
PortChannel1  Bridge        fe80::5a69:6cff:fefb:2230%PortChannel1/64  up/up         N/A             N/A
Vlan3                       150::1/64                                  up/up         N/A             N/A
                            fe80::5a69:6cff:fefb:2230%Vlan3/64
eth0                        fe80::5a69:6cff:fefb:2230%eth0/64          up/up         N/A             N/A
lo                          ::1/128                                    up/up         N/A             N/A
root@switch2:/usr/lib/python2.7/dist-packages/show#

```

- New command output (if the output of a command-line utility has changed)
```
root@switch2:/home/admin# show ipv6 interfaces
Interface     Master        IPv6 address/mask                          Admin/Oper    BGP Neighbor    Neighbor IP
------------  ------------  -----------------------------------------  ------------  --------------  --------------
Bridge                      fe80::fce5:f4ff:fed5:b262%Bridge/64        up/up         N/A             N/A
Ethernet0     PortChannel1  fe80::5a69:6cff:fefb:2230%Ethernet0/64     up/up         N/A             N/A
Ethernet52                  2001:50:5:1::5/64                          up/up         LCv6            2001:50:5:1::9
                            2001:50:5:1::4/64                          up/up         LCv6            2001:50:5:1::8
                            2001:50:5:1::3/64                          up/up         LCv6            2001:50:5:1::7
                            2001:50:5:1::2/64                          up/up         LCv6            2001:50:5:1::1
                            fe80::5a69:6cff:fefb:2230%Ethernet52/64    up/up         N/A             N/A
Loopback0                   6::6/128                                   up/up         N/A             N/A
                            fe80::44cb:61ff:fe6b:4d41%Loopback0/64     up/up         N/A             N/A
PortChannel1  Bridge        fe80::5a69:6cff:fefb:2230%PortChannel1/64  up/up         N/A             N/A
Vlan3                       150::1/64                                  up/up         N/A             N/A
                            fe80::5a69:6cff:fefb:2230%Vlan3/64         up/up         N/A             N/A
eth0                        fe80::5a69:6cff:fefb:2230%eth0/64          up/up         N/A             N/A
lo                          ::1/128                                    up/up         N/A             N/A

```

