### PR TITLE
Save the PCIE device status to STATE DB

### DIFF
--- a/pcieutil/main.py
+++ b/pcieutil/main.py
@@ -181,8 +181,10 @@ def pcie_check():
             log_warning("PCIe Device: " +  item["name"] + " Not Found")
             err+=1
     if err:
+        os.system('redis-cli -n 6 SET "PCIE_STATE|system" "0"')
         print "PCIe Device Checking All Test ----------->>> FAILED"
     else:
+        os.system('redis-cli -n 6 SET "PCIE_STATE|system" "1"')
         print "PCIe Device Checking All Test ----------->>> PASSED"
         
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Add the pcie device status to STATE_DB
**- How I did it**
Update the state_db during PcieUtil.get_pcie_check()
**- How to verify it**
sudo pcieutil pcie-check
and then read the state db to see if it's updated properly.
ex) 
user@server:~$redis-cli -n 6 GET "PCIE_STATE|system"
"1"
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

