### PR TITLE
[show interface transceiver] Ensure key exists in dom_info_dict before accessing

### DIFF
--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -141,7 +141,7 @@ class SFPShow(object):
         ident = '        '
         seperator = ": "
         for key in sorted_key_table:
-            if dom_info_dict is not None and dom_info_dict[key] != 'N/A':
+            if dom_info_dict is not None and key in dom_info_dict and dom_info_dict[key] != 'N/A':
                 current_val = (ident + ident +
                         dom_value_map[key])
                 current_val = (current_val + seperator.rjust(len(seperator) +


### PR DESCRIPTION
**- What I did**
Executing show interface transceiver eeprom command with -d (-d, --dom Also display Digital Optical Monitoring (DOM) data) result error of key not present in dom dictionary.

Error O/P:

show interface transceiver eeprom -d Ethernet124
Traceback (most recent call last):
  File "/usr/bin/sfpshow", line 358, in <module>
    cli()
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/bin/sfpshow", line 348, in eeprom
    sfp.display_eeprom(port, dump_dom)
  File "/usr/bin/sfpshow", line 293, in display_eeprom
    out_put = self.convert_interface_sfp_info_to_cli_output_string(self.sdb, interfacename, dump_dom)
  File "/usr/bin/sfpshow", line 282, in convert_interface_sfp_info_to_cli_output_string
    dom_output = self.convert_dom_to_output_string(sfp_type, dom_info_dict)
  File "/usr/bin/sfpshow", line 186, in convert_dom_to_output_string
    channel_threshold_align)
  File "/usr/bin/sfpshow", line 146, in format_dict_value_to_string
    if dom_info_dict is not None and dom_info_dict[key] != 'N/A':

Fix the above error

**- How I did it**
Make sure key is present in dom_info_dict and then only parse
else skip.
**- How to verify it**
Command is executed fine after fix.
show interface transceiver eeprom -d Ethernet124
Ethernet124: SFP EEPROM detected
        .......
        ChannelMonitorValues:
                RX1Power: -infdBm
                RX2Power: -infdBm
                RX3Power: -infdBm
                RX4Power: -infdBm
                TX1Bias: 0.0000mA
                TX2Bias: 0.0000mA
                TX3Bias: 0.0000mA
                TX4Bias: 0.0000mA
        ChannelThresholdValues:
        ModuleMonitorValues:
                Temperature: 1.5039C
                Vcc: 0.0000Volts
        ModuleThresholdValues: