### PR TITLE
[sfpshow][mock_state_db] Tweak key names of some transceiver info fields

### DIFF
--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -24,16 +24,21 @@ try:
 except KeyError:
     pass 
 
-qsfp_data_map = {'modelname': 'Vendor PN', 'vendor_oui': 'Vendor OUI',
+qsfp_data_map = {'model': 'Vendor PN',
+                 'vendor_oui': 'Vendor OUI',
                  'vendor_date': 'Vendor Date Code(YYYY-MM-DD Lot)',
-                 'manufacturename': 'Vendor Name',
-                 'hardwarerev': 'Vendor Rev', 'serialnum': 'Vendor SN',
-                 'type': 'Identifier', 'ext_identifier': 'Extended Identifier',
+                 'manufacturer': 'Vendor Name',
+                 'hardware_rev': 'Vendor Rev',
+                 'serial': 'Vendor SN',
+                 'type': 'Identifier',
+                 'ext_identifier': 'Extended Identifier',
                  'ext_rateselect_compliance': 'Extended RateSelect Compliance',
-                 'cable_length': 'cable_length', 'cable_type': 'Length',
+                 'cable_length': 'cable_length',
+                 'cable_type': 'Length',
                  'nominal_bit_rate': 'Nominal Bit Rate(100Mbs)',
-                 'specification_compliance':'Specification compliance',
-                 'encoding': 'Encoding', 'Connector': 'Connector' 
+                 'specification_compliance': 'Specification compliance',
+                 'encoding': 'Encoding',
+                 'connector': 'Connector'
                  }
 
 sfp_dom_channel_monitor_map = {'rx1power': 'RXPower',

--- a/sonic-utilities-tests/mock_tables/state_db.json
+++ b/sonic-utilities-tests/mock_tables/state_db.json
@@ -1,13 +1,13 @@
 {
     "TRANSCEIVER_INFO|Ethernet0": {
         "type": "QSFP28 or later",
-        "hardwarerev": "AC",
-        "serialnum": "MT1706FT02064",
-        "manufacturename": "Mellanox",
-        "modelname": "MFA1A00-C003",
+        "hardware_rev": "AC",
+        "serial": "MT1706FT02064",
+        "manufacturer": "Mellanox",
+        "model": "MFA1A00-C003",
         "vendor_oui": "00-02-c9",
         "vendor_date": "2017-01-13 ",
-        "Connector": "No separable connector",
+        "connector": "No separable connector",
         "encoding": "64B66B",
         "ext_identifier": "Power Class 3(2.5W max), CDR present in Rx Tx",
         "ext_rateselect_compliance": "QSFP+ Rate Select Version 1",


### PR DESCRIPTION
Change the following key names:

- hardwarerev -> hardware_rev
- serialnum -> serial
- manufacturename -> manufacturer
- modelname -> model
- Connector -> connector

Depends on:
- https://github.com/Azure/sonic-platform-common/pull/97
- https://github.com/Azure/sonic-platform-daemons/pull/62