### PR TITLE
[show] Add missing verbose option to "show line"

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -2650,7 +2650,8 @@ def reboot_cause():
 # 'line' command ("show line")
 #
 @cli.command('line')
-def line():
+@click.option('--verbose', is_flag=True, help="Enable verbose output")
+def line(verbose):
     """Show all /dev/ttyUSB lines and their info"""
     cmd = "consutil show"
     run_command(cmd, display_cmd=verbose)


### PR DESCRIPTION
 Fixing "show line" by adding the missing decorator that supports
"--verbose" option.

Signed-off-by: lolyu <lolv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
```
# sudo show line
```
**- Previous command output (if the output of a command-line utility has changed)**
```
$ sudo show line
Traceback (most recent call last):
  File "/usr/bin/show", line 12, in <module>
    sys.exit(cli())
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/show/main.py", line 2638, in line
    run_command(cmd, display_cmd=verbose)
NameError: global name 'verbose' is not defined
```
**- New command output (if the output of a command-line utility has changed)**

```
$ sudo show line
Command resulted in error: ls: cannot access '/dev/ttyUSB*': No such file or directory
```