### PR TITLE
[config] Fix indentation level in _get_disabled_services_list()

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -515,8 +515,8 @@ def _get_disabled_services_list():
                 log_warning("Status of feature '{}' is None".format(feature_name))
                 continue
 
-        if status == "disabled":
-            disabled_services_list.append(feature_name)
+            if status == "disabled":
+                disabled_services_list.append(feature_name)
     else:
         log_warning("Unable to retreive FEATURE table")
 


### PR DESCRIPTION
If FEATURE table did not exist,` config load/reload/reload_minigraph` commands would crash similar to the following:

```
Executing reset-failed of service nat...
Executing reset-failed of service sflow...
Traceback (most recent call last):
  File "/usr/bin/config", line 12, in <module>
    sys.exit(config())
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/config/main.py", line 862, in reload
    _restart_services()
  File "/usr/lib/python2.7/dist-packages/config/main.py", line 585, in _restart_services
    disable_services = _get_disabled_services_list()
  File "/usr/lib/python2.7/dist-packages/config/main.py", line 518, in _get_disabled_services_list
    if status == "disabled":
UnboundLocalError: local variable 'status' referenced before assignment
```