### PR TITLE
Suppport to verify aboot swi image for secure boot

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -149,7 +149,8 @@ setup(
     # - tabulate
     install_requires=[
         'click',
-        'natsort'
+        'natsort',
+        'm2crypto'
     ],
     setup_requires= [
         'pytest-runner'

--- a/sonic_installer/bootloader/aboot.py
+++ b/sonic_installer/bootloader/aboot.py
@@ -124,11 +124,9 @@ class AbootBootloader(Bootloader):
     def verify_binary_image(self, image_path):
         try:
             subprocess.check_call(['/usr/bin/unzip', '-tq', image_path])
-            if not self._verify_secureboot_image(image_path):
-                return False
+            return self._verify_secureboot_image(image_path):
         except subprocess.CalledProcessError:
             return False
-        return True
 
     def _verify_secureboot_image(self, image_path):
         if isSecureboot():

--- a/sonic_installer/bootloader/aboot.py
+++ b/sonic_installer/bootloader/aboot.py
@@ -131,14 +131,8 @@ class AbootBootloader(Bootloader):
 
     def _verify_secureboot_image(self, image_path):
         if isSecureboot():
-            current_image_path = self.get_current_image()
-            current_swi_path = self._swi_image_path(current_image_path).replace('flash:', HOST_PATH + '/')
             cert = self.getCert(image_path)
-            current_cert = self.getCert(current_swi_path)
-            if not cert or not current_cert:
-                return False
-            # Verify the signing certificates are from the same issuer
-            return str(cert.get_issuer()) == str(current_cert.get_issuer())
+            return cert is not None
         return True
 
     @classmethod


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
The feature is to verify the aboot swi image, it makes sure the installing image should be signed when secure boot enabled.

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

