### PR TITLE
Append default mask field if user has not provided one

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2045,7 +2045,12 @@ def add(ctx, interface_name, ip_addr, gw):
             ctx.fail("'interface_name' is None!")
 
     try:
-        ipaddress.ip_network(unicode(ip_addr), strict=False)
+        net = ipaddress.ip_network(unicode(ip_addr), strict=False)
+        if '/' not in ip_addr:
+            if net.version == 4:
+                ip_addr = "%s/32" % ip_addr
+            else:
+                ip_addr = "%s/128" % ip_addr
 
         if interface_name == 'eth0':
 
@@ -2102,7 +2107,12 @@ def remove(ctx, interface_name, ip_addr):
             ctx.fail("'interface_name' is None!")
 
     try:
-        ipaddress.ip_network(unicode(ip_addr), strict=False)
+        net = ipaddress.ip_network(unicode(ip_addr), strict=False)
+        if '/' not in ip_addr:
+            if net.version == 4:
+                ip_addr = "%s/32" % ip_addr
+            else:
+                ip_addr = "%s/128" % ip_addr
 
         if interface_name == 'eth0':
             config_db.set_entry("MGMT_INTERFACE", (interface_name, ip_addr), None)

--- a/config/main.py
+++ b/config/main.py
@@ -2047,10 +2047,7 @@ def add(ctx, interface_name, ip_addr, gw):
     try:
         net = ipaddress.ip_network(unicode(ip_addr), strict=False)
         if '/' not in ip_addr:
-            if net.version == 4:
-                ip_addr = "%s/32" % ip_addr
-            else:
-                ip_addr = "%s/128" % ip_addr
+            ip_addr = str(net)
 
         if interface_name == 'eth0':
 
@@ -2109,10 +2106,7 @@ def remove(ctx, interface_name, ip_addr):
     try:
         net = ipaddress.ip_network(unicode(ip_addr), strict=False)
         if '/' not in ip_addr:
-            if net.version == 4:
-                ip_addr = "%s/32" % ip_addr
-            else:
-                ip_addr = "%s/128" % ip_addr
+            ip_addr = str(net)
 
         if interface_name == 'eth0':
             config_db.set_entry("MGMT_INTERFACE", (interface_name, ip_addr), None)


### PR DESCRIPTION
**- What I did**
If user configures IP (v4 or v6) address without a mask, append the default `/32` or `/128` mask

**- How I did it**

**- How to verify it**
Redis command

```
config interface ip add Vlan1000 2001::1
config interface ip add Vlan1000 1.1.1.3
127.0.0.1:6379[4]> KEYS *VLAN_INTERFACE*
1) "VLAN_INTERFACE|Vlan1000|2001::1/128"
2) "VLAN_INTERFACE|Vlan1000|1.1.1.3/32"
```


**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

