### PR TITLE
Intf table migration for APP_DB entries during warmboot

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -5,6 +5,7 @@ import sys
 import argparse
 import syslog
 from swsssdk import ConfigDBConnector, SonicDBConfig
+from swsssdk import SonicV2Connector
 import sonic_device_util
 import os
 import subprocess
@@ -55,6 +56,10 @@ class DBMigrator():
             self.configDB = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace, **db_kwargs)
         self.configDB.db_connect('CONFIG_DB')
 
+        self.appDB = SonicV2Connector(host='127.0.0.1')
+        if self.appDB is not None:
+            self.appDB.connect(self.appDB.APPL_DB)
+
     def migrate_pfc_wd_table(self):
         '''
         Migrate all data entries from table PFC_WD_TABLE to PFC_WD
@@ -101,6 +106,41 @@ class DBMigrator():
                 log_info('Migrating interface table for ' + key[0])
                 self.configDB.set_entry(table, key[0], data[key])
                 if_db.append(key[0])
+
+    def migrate_intf_table(self):
+        '''
+        Migrate all data from existing INTF table in APP DB during warmboot with IP Prefix
+        to have an additional ONE entry without IP Prefix. For. e.g, for an entry
+        "Vlan1000:192.168.0.1/21": {}", this function shall add an entry without
+        IP prefix as ""Vlan1000": {}". This also migrates 'lo' to 'Loopback0' interface
+        '''
+
+        if self.appDB is None:
+            return
+
+        if_db = []
+        data = self.appDB.keys(self.appDB.APPL_DB, "INTF_TABLE:*")
+        for key in data:
+            if_name = key.split(":")[1]
+            if if_name == "lo":
+                self.appDB.delete(self.appDB.APPL_DB, key)
+                key = key.replace(if_name, "Loopback0")
+                log_info('Migrating lo entry to ' + key)
+                self.appDB.set(self.appDB.APPL_DB, key, 'NULL', 'NULL')
+
+            if '/' not in key:
+                if_db.append(key.split(":")[1])
+                continue
+
+        data = self.appDB.keys(self.appDB.APPL_DB, "INTF_TABLE:*")
+        for key in data:
+            if_name = key.split(":")[1]
+            if if_name in if_db:
+                continue
+            log_info('Migrating intf table for ' + if_name)
+            table = "INTF_TABLE:" + if_name
+            self.appDB.set(self.appDB.APPL_DB, table, 'NULL', 'NULL')
+            if_db.append(if_name)
 
     def mlnx_migrate_buffer_pool_size(self):
         """
@@ -216,6 +256,7 @@ class DBMigrator():
         #       upgrade will take care of the subsequent migrations.
         self.migrate_pfc_wd_table()
         self.migrate_interface_table()
+        self.migrate_intf_table()
         self.set_version('version_1_0_2')
         return 'version_1_0_2'
 
@@ -226,6 +267,7 @@ class DBMigrator():
         log_info('Handling version_1_0_1')
 
         self.migrate_interface_table()
+        self.migrate_intf_table()
         self.set_version('version_1_0_2')
         return 'version_1_0_2'
 


### PR DESCRIPTION
**- What I did**

Fix issue during warmboot from 201811 to 201911. (Issue - https://github.com/Azure/sonic-buildimage/issues/4589)

1. Migrate INTF table to have a default non-prefix entry 

`"INTF_TABLE:Vlan1000:192.168.0.1/21"`
to
```
"INTF_TABLE:Vlan1000"
"INTF_TABLE:Vlan1000:192.168.0.1/21"
```

2. Migrate 'lo' intf to 'Loopback0' interface 

`"INTF_TABLE:lo:10.1.0.32/32"`
to
`"INTF_TABLE:Loopback0:10.1.0.32/32"`

**- How I did it**

**- How to verify it**
```
Jul  7 03:31:29.383159 str-acs-1 INFO db_migrator: Migrating lo entry to INTF_TABLE:Loopback0:FC00:1::32/128
Jul  7 03:31:29.383693 str-acs-1 INFO db_migrator: Migrating lo entry to INTF_TABLE:Loopback0:10.1.0.32/32
Jul  7 03:31:29.385589 str-acs-1 INFO db_migrator: Migrating intf table for PortChannel0003
Jul  7 03:31:29.386098 str-acs-1 INFO db_migrator: Migrating intf table for Loopback0
Jul  7 03:31:29.386466 str-acs-1 INFO db_migrator: Migrating intf table for PortChannel0001
Jul  7 03:31:29.386825 str-acs-1 INFO db_migrator: Migrating intf table for Vlan1000
Jul  7 03:31:29.387188 str-acs-1 INFO db_migrator: Migrating intf table for PortChannel0002
Jul  7 03:31:29.387556 str-acs-1 INFO db_migrator: Migrating intf table for PortChannel0004
```

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

