### PR TITLE
[filter-fdb] Fix For Vlan Defined With No CIDR

### DIFF
--- a/scripts/filter_fdb_entries.py
+++ b/scripts/filter_fdb_entries.py
@@ -31,6 +31,8 @@ def get_vlan_cidr_map(filename):
     vlan_cidr = defaultdict()
     if "VLAN_INTERFACE" in config_db_entries.keys() and "VLAN" in config_db_entries.keys():
         for vlan_key in config_db_entries["VLAN_INTERFACE"].keys():
+            if '|' not in vlan_key:
+                continue
             vlan, cidr = tuple(vlan_key.split('|'))
             if vlan in config_db_entries["VLAN"]:
                 vlan_cidr[vlan] = ip_interface(cidr).network

--- a/sonic-utilities-tests/filter_fdb_input/test_vectors.py
+++ b/sonic-utilities-tests/filter_fdb_input/test_vectors.py
@@ -198,6 +198,7 @@ filterFdbEntriesTestVector = [
                 "Vlan1000": {}
             },
             "VLAN_INTERFACE": {
+                "Vlan1000": {}, 
                 "Vlan1000|192.168.128.1/21": {}
             }, 
         },


### PR DESCRIPTION
VLAN_INTERFACE section in Config_db may contain entries with now CIDR.
This fix skip those entries.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

Fixes #4933

**- What I did**
Fix for VLAN_INTERFACE with no CIDR

**- How I did it**
Skipped over entries in VLAN_INTERFACE section that do not have CIDR

**- How to verify it**
***- Without This Fix***
```
taahme@024d65787c01:/sonic/sonic-utilities$ sudo pytest sonic-utilities-tests/filter_fdb_entries_test.py  -vvvv
=================================================================================================================================================== test session starts ===================================================================================================================================================
platform linux2 -- Python 2.7.13, pytest-3.0.6, py-1.4.32, pluggy-0.4.0 -- /usr/bin/python
cachedir: sonic-utilities-tests/.cache
rootdir: /sonic/sonic-utilities/sonic-utilities-tests, inifile: pytest.ini
plugins: cov-2.4.0
collected 10 items 

sonic-utilities-tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData0] PASSED
sonic-utilities-tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData1] PASSED
sonic-utilities-tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData2] PASSED
sonic-utilities-tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData3] PASSED
sonic-utilities-tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData4] PASSED
sonic-utilities-tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData5] FAILED
sonic-utilities-tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData6] PASSED
sonic-utilities-tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData7] PASSED
sonic-utilities-tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData8] PASSED
sonic-utilities-tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData9] PASSED

======================================================================================================================================================== FAILURES =========================================================================================================================================================
```
***- With This Fix***
```
taahme@024d65787c01:/sonic/sonic-utilities$ sudo pytest sonic-utilities-tests/filter_fdb_entries_test.py  -vvvv
=================================================================================================================================================== test session starts ===================================================================================================================================================
platform linux2 -- Python 2.7.13, pytest-3.0.6, py-1.4.32, pluggy-0.4.0 -- /usr/bin/python
cachedir: sonic-utilities-tests/.cache
rootdir: /sonic/sonic-utilities/sonic-utilities-tests, inifile: pytest.ini
plugins: cov-2.4.0
collected 10 items 

sonic-utilities-tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData0] PASSED
sonic-utilities-tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData1] PASSED
sonic-utilities-tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData2] PASSED
sonic-utilities-tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData3] PASSED
sonic-utilities-tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData4] PASSED
sonic-utilities-tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData5] PASSED
sonic-utilities-tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData6] PASSED
sonic-utilities-tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData7] PASSED
sonic-utilities-tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData8] PASSED
sonic-utilities-tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData9] PASSED

================================================================================================================================================ 10 passed in 0.34 seconds ================================================================================================================================================
```
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

