### PR TITLE
Support to verify reboot for secure boot

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -33,7 +33,6 @@ EXIT_SYNCD_SHUTDOWN=11
 EXIT_FAST_REBOOT_DUMP_FAILURE=12
 EXIT_FILTER_FDB_ENTRIES_FAILURE=13
 EXIT_NO_CONTROL_PLANE_ASSISTANT=20
-EXIT_SONIC_INSTALLER_VERIFY_REBOOT=21
 
 function error()
 {
@@ -307,11 +306,7 @@ function reboot_pre_check()
     fi
 
     # Verify the next image by sonic_installer
-    local message=$(sonic_installer verify_next_image 2>&1)
-    if [ $? -ne 0 ]; then
-        debug "Failed to verify next image: ${message}"
-        exit ${EXIT_SONIC_INSTALLER_VERIFY_REBOOT}
-    fi
+    sonic_installer verify-next-image
     
     # Make sure ASIC configuration has not changed between images
     ASIC_CONFIG_CHECK_SCRIPT="/usr/bin/asic_config_check"

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -307,9 +307,9 @@ function reboot_pre_check()
     fi
 
     # Verify the next image by sonic_installer
-    local message=$(sonic_installer verify-next-image 2>&1)
+    local message=$(sonic_installer verify_next_image 2>&1)
     if [ $? -ne 0 ]; then
-        debug "Failed to verify next image by running command: sonic_installer verify-next-image, result message: ${message}"
+        debug "Failed to verify next image by running command: sonic_installer verify_next_image, result message: ${message}"
         exit ${EXIT_SONIC_INSTALLER_VERIFY_REBOOT}
     fi
     

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -309,7 +309,7 @@ function reboot_pre_check()
     # Verify the next image by sonic_installer
     local message=$(sonic_installer verify_next_image 2>&1)
     if [ $? -ne 0 ]; then
-        debug "Failed to verify next image by running command: sonic_installer verify_next_image, result message: ${message}"
+        debug "Failed to verify next image: ${message}"
         exit ${EXIT_SONIC_INSTALLER_VERIFY_REBOOT}
     fi
     

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -32,6 +32,7 @@ EXIT_SYNCD_SHUTDOWN=11
 EXIT_FAST_REBOOT_DUMP_FAILURE=12
 EXIT_FILTER_FDB_ENTRIES_FAILURE=13
 EXIT_NO_CONTROL_PLANE_ASSISTANT=20
+EXIT_SONIC_INSTALLER_VERIFY_REBOOT=21
 
 function error()
 {
@@ -304,10 +305,11 @@ function reboot_pre_check()
         exit ${EXIT_FILE_SYSTEM_FULL}
     fi
 
-    # Make sure that the next image exists
-    if [[ ! -d ${IMAGE_PATH} ]]; then
-        debug "Next image ${NEXT_SONIC_IMAGE} doesn't exist ..."
-        exit ${EXIT_NEXT_IMAGE_NOT_EXISTS}
+    # Verify reboot by sonic_installer
+    local message=$(sonic_installer verify-reboot)
+    if [ $? -ne 0 ]; then
+        debug "Failed to verify next reboot by running command: sonic_installer verify-reboot, result message: ${message}"
+        exit ${EXIT_SONIC_INSTALLER_VERIFY_REBOOT}
     fi
     
     # Make sure ASIC configuration has not changed between images

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -33,6 +33,7 @@ EXIT_SYNCD_SHUTDOWN=11
 EXIT_FAST_REBOOT_DUMP_FAILURE=12
 EXIT_FILTER_FDB_ENTRIES_FAILURE=13
 EXIT_NO_CONTROL_PLANE_ASSISTANT=20
+EXIT_SONIC_INSTALLER_VERIFY_REBOOT=21
 
 function error()
 {
@@ -306,7 +307,12 @@ function reboot_pre_check()
     fi
 
     # Verify the next image by sonic_installer
-    sonic_installer verify-next-image
+    INSTALLER_VERIFY_RC=0
+    sonic_installer verify-next-image > /dev/null || INSTALLER_VERIFY_RC=$?
+    if [[ INSTALLER_VERIFY_RC -ne 0 ]]; then
+        error "Failed to verify next image. Exit code: $INSTALLER_VERIFY_RC"
+        exit ${EXIT_SONIC_INSTALLER_VERIFY_REBOOT}
+    fi
     
     # Make sure ASIC configuration has not changed between images
     ASIC_CONFIG_CHECK_SCRIPT="/usr/bin/asic_config_check"

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -306,10 +306,10 @@ function reboot_pre_check()
         exit ${EXIT_FILE_SYSTEM_FULL}
     fi
 
-    # Verify reboot by sonic_installer
-    local message=$(sonic_installer verify-reboot)
+    # Verify the next image by sonic_installer
+    local message=$(sonic_installer verify-next-image 2>&1)
     if [ $? -ne 0 ]; then
-        debug "Failed to verify next reboot by running command: sonic_installer verify-reboot, result message: ${message}"
+        debug "Failed to verify next image by running command: sonic_installer verify-next-image, result message: ${message}"
         exit ${EXIT_SONIC_INSTALLER_VERIFY_REBOOT}
     fi
     

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -81,7 +81,7 @@ function reboot_pre_check()
     rm ${filename}
 
     # Verify the next image by sonic_installer
-    local message=$(sonic_installer verify_next_image 2>&1)
+    local message=$(sonic_installer verify-next-image 2>&1)
     if [ $? -ne 0 ]; then
         VERBOSE=yes debug "Failed to verify next image: ${message}"
         exit ${EXIT_SONIC_INSTALLER_VERIFY_REBOOT}

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -80,10 +80,10 @@ function reboot_pre_check()
     fi
     rm ${filename}
 
-    # Verify reboot by sonic_installer
-    local message=$(sonic_installer verify-reboot)
+    # Verify the next image by sonic_installer
+    local message=$(sonic_installer verify-next-image 2>&1)
     if [ $? -ne 0 ]; then
-        VERBOSE=yes debug "Failed to verify next reboot by running command: sonic_installer verify-reboot, result message: ${message}"
+        VERBOSE=yes debug "Failed to verify the next image by running command: sonic_installer verify-next-image, result message: ${message}"
         exit ${EXIT_SONIC_INSTALLER_VERIFY_REBOOT}
     fi
 }

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -81,9 +81,9 @@ function reboot_pre_check()
     rm ${filename}
 
     # Verify the next image by sonic_installer
-    local message=$(sonic_installer verify-next-image 2>&1)
+    local message=$(sonic_installer verify_next_image 2>&1)
     if [ $? -ne 0 ]; then
-        VERBOSE=yes debug "Failed to verify the next image by running command: sonic_installer verify-next-image, result message: ${message}"
+        VERBOSE=yes debug "Failed to verify the next image by running command: sonic_installer verify_next_image, result message: ${message}"
         exit ${EXIT_SONIC_INSTALLER_VERIFY_REBOOT}
     fi
 }

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -16,6 +16,7 @@ PLAT_REBOOT="platform_reboot"
 REBOOT_CAUSE_FILE="/host/reboot-cause/reboot-cause.txt"
 VERBOSE=no
 EXIT_NEXT_IMAGE_NOT_EXISTS=4
+EXIT_SONIC_INSTALLER_VERIFY_REBOOT=21
 
 function debug()
 {
@@ -79,10 +80,11 @@ function reboot_pre_check()
     fi
     rm ${filename}
 
-    # Make sure that the next image exists
-    if [[ ! -d ${IMAGE_PATH} ]]; then
-        VERBOSE=yes debug "Next image ${NEXT_SONIC_IMAGE} doesn't exist ..."
-        exit ${EXIT_NEXT_IMAGE_NOT_EXISTS}
+    # Verify reboot by sonic_installer
+    local message=$(sonic_installer verify-reboot)
+    if [ $? -ne 0 ]; then
+        VERBOSE=yes debug "Failed to verify next reboot by running command: sonic_installer verify-reboot, result message: ${message}"
+        exit ${EXIT_SONIC_INSTALLER_VERIFY_REBOOT}
     fi
 }
 

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -83,7 +83,7 @@ function reboot_pre_check()
     # Verify the next image by sonic_installer
     local message=$(sonic_installer verify_next_image 2>&1)
     if [ $? -ne 0 ]; then
-        VERBOSE=yes debug "Failed to verify the next image by running command: sonic_installer verify_next_image, result message: ${message}"
+        VERBOSE=yes debug "Failed to verify next image: ${message}"
         exit ${EXIT_SONIC_INSTALLER_VERIFY_REBOOT}
     fi
 }

--- a/sonic_installer/bootloader/aboot.py
+++ b/sonic_installer/bootloader/aboot.py
@@ -130,8 +130,8 @@ class AbootBootloader(Bootloader):
         except subprocess.CalledProcessError:
             return False
 
-    def verify-next-image(self):
-        if not super(AbootBootloader, self).verify-next-image():
+    def verify_next_image(self):
+        if not super(AbootBootloader, self).verify_next_image():
             return False
         image = self.get_next_image()
         image_path = os.path.join(self.get_image_path(image), DEFAULT_SWI_IMAGE)

--- a/sonic_installer/bootloader/aboot.py
+++ b/sonic_installer/bootloader/aboot.py
@@ -129,6 +129,13 @@ class AbootBootloader(Bootloader):
         except subprocess.CalledProcessError:
             return False
 
+    def verify_reboot(self):
+        if not super(AbootBootloader, self).verify_reboot():
+            return False
+        image = self.get_next_image()
+        image_path = self.get_image_path(image) + '/sonic.swi'
+        return self._verify_secureboot_image(image_path)
+
     def _verify_secureboot_image(self, image_path):
         if isSecureboot():
             cert = self.getCert(image_path)

--- a/sonic_installer/bootloader/aboot.py
+++ b/sonic_installer/bootloader/aboot.py
@@ -23,6 +23,7 @@ from ..common import (
 from .bootloader import Bootloader
 
 _secureboot = None
+DEFAULT_SWI_IMAGE = 'sonic.swi'
 
 # For the signature format, see: https://github.com/aristanetworks/swi-tools/tree/master/switools
 SWI_SIG_FILE_NAME = 'swi-signature'
@@ -110,9 +111,9 @@ class AbootBootloader(Bootloader):
             self._boot_config_set(SWI=image_path, SWI_DEFAULT=image_path)
             click.echo("Set next and default boot to current image %s" % current)
 
-        image_dir = image.replace(IMAGE_PREFIX, IMAGE_DIR_PREFIX)
+        image_path = self.get_image_path(image)
         click.echo('Removing image root filesystem...')
-        subprocess.call(['rm','-rf', os.path.join(HOST_PATH, image_dir)])
+        subprocess.call(['rm','-rf', image_path])
         click.echo('Image removed')
 
     def get_binary_image_version(self, image_path):
@@ -129,11 +130,11 @@ class AbootBootloader(Bootloader):
         except subprocess.CalledProcessError:
             return False
 
-    def verify_reboot(self):
-        if not super(AbootBootloader, self).verify_reboot():
+    def verify-next-image(self):
+        if not super(AbootBootloader, self).verify-next-image():
             return False
         image = self.get_next_image()
-        image_path = self.get_image_path(image) + '/sonic.swi'
+        image_path = os.path.join(self.get_image_path(image), DEFAULT_SWI_IMAGE)
         return self._verify_secureboot_image(image_path)
 
     def _verify_secureboot_image(self, image_path):

--- a/sonic_installer/bootloader/bootloader.py
+++ b/sonic_installer/bootloader/bootloader.py
@@ -2,7 +2,6 @@
 Abstract Bootloader class
 """
 
-import sys
 from os import path
 
 from ..common import (

--- a/sonic_installer/bootloader/bootloader.py
+++ b/sonic_installer/bootloader/bootloader.py
@@ -56,10 +56,7 @@ class Bootloader(object):
         """verify the next image for reboot"""
         image = self.get_next_image()
         image_path = self.get_image_path(image)
-        if not path.exists(image_path):
-            sys.stdout.write('Next image {0} doesn\'t exist ...\n'.format(image))
-            return False
-        return True
+        return path.exists(image_path)
 
     @classmethod
     def detect(cls):

--- a/sonic_installer/bootloader/bootloader.py
+++ b/sonic_installer/bootloader/bootloader.py
@@ -57,7 +57,7 @@ class Bootloader(object):
         image = self.get_next_image()
         image_path = self.get_image_path(image)
         if not path.exists(image_path):
-            sys.stderr.write('Next image {0} doesn\'t exist ...\n'.format(image))
+            sys.stdout.write('Next image {0} doesn\'t exist ...\n'.format(image))
             return False
         return True
 

--- a/sonic_installer/bootloader/bootloader.py
+++ b/sonic_installer/bootloader/bootloader.py
@@ -52,7 +52,7 @@ class Bootloader(object):
         """verify that the image is supported by the bootloader"""
         raise NotImplementedError
 
-    def verify-next-image(self):
+    def verify_next_image(self):
         """verify the next image for reboot"""
         image = self.get_next_image()
         image_path = self.get_image_path(image)

--- a/sonic_installer/bootloader/bootloader.py
+++ b/sonic_installer/bootloader/bootloader.py
@@ -61,8 +61,6 @@ class Bootloader(object):
             return False
         return True
 
-    def get_image_path
-
     @classmethod
     def detect(cls):
         """returns True if the bootloader is in use"""

--- a/sonic_installer/bootloader/bootloader.py
+++ b/sonic_installer/bootloader/bootloader.py
@@ -52,8 +52,8 @@ class Bootloader(object):
         """verify that the image is supported by the bootloader"""
         raise NotImplementedError
 
-    def verify_reboot(self):
-        """verify the image for reboot"""
+    def verify-next-image(self):
+        """verify the next image for reboot"""
         image = self.get_next_image()
         image_path = self.get_image_path(image)
         if not path.exists(image_path):
@@ -69,6 +69,6 @@ class Bootloader(object):
     @classmethod
     def get_image_path(cls, image):
         """returns the image path"""
-        prefix = HOST_PATH + '/' + IMAGE_DIR_PREFIX
+        prefix = path.join(Host_PATH, IMAGE_DIR_PREFIX)
         return image.replace(IMAGE_PREFIX, prefix)
 

--- a/sonic_installer/bootloader/bootloader.py
+++ b/sonic_installer/bootloader/bootloader.py
@@ -69,6 +69,6 @@ class Bootloader(object):
     @classmethod
     def get_image_path(cls, image):
         """returns the image path"""
-        prefix = Host_PATH + '/' + IMAGE_DIR_PREFIX
+        prefix = HOST_PATH + '/' + IMAGE_DIR_PREFIX
         return image.replace(IMAGE_PREFIX, prefix)
 

--- a/sonic_installer/bootloader/bootloader.py
+++ b/sonic_installer/bootloader/bootloader.py
@@ -2,6 +2,15 @@
 Abstract Bootloader class
 """
 
+import sys
+from os import path
+
+from ..common import (
+   HOST_PATH,
+   IMAGE_DIR_PREFIX,
+   IMAGE_PREFIX,
+)
+
 class Bootloader(object):
 
     NAME = None
@@ -43,8 +52,25 @@ class Bootloader(object):
         """verify that the image is supported by the bootloader"""
         raise NotImplementedError
 
+    def verify_reboot(self):
+        """verify the image for reboot"""
+        image = self.get_next_image()
+        image_path = self.get_image_path(image)
+        if not path.exists(image_path):
+            sys.stderr.write('Next image {0} doesn\'t exist ...\n'.format(image))
+            return False
+        return True
+
+    def get_image_path
+
     @classmethod
     def detect(cls):
         """returns True if the bootloader is in use"""
         return False
+
+    @classmethod
+    def get_image_path(cls, image):
+        """returns the image path"""
+        prefix = Host_PATH + '/' + IMAGE_DIR_PREFIX
+        return image.replace(IMAGE_PREFIX, prefix)
 

--- a/sonic_installer/bootloader/bootloader.py
+++ b/sonic_installer/bootloader/bootloader.py
@@ -69,6 +69,6 @@ class Bootloader(object):
     @classmethod
     def get_image_path(cls, image):
         """returns the image path"""
-        prefix = path.join(Host_PATH, IMAGE_DIR_PREFIX)
+        prefix = path.join(HOST_PATH, IMAGE_DIR_PREFIX)
         return image.replace(IMAGE_PREFIX, prefix)
 

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -477,11 +477,11 @@ def rollback_docker(container_name):
     click.echo('Done')
 
 # verify the next image
-@cli.command('verify-next-image')
+@cli.command('verify_next_image')
 def verify_reboot():
     """ Verify the next image for reboot"""
     bootloader = get_bootloader()
-    if not bootloader.verify-next-image():
+    if not bootloader.verify_next_image():
         click.echo('Failed')
         sys.exit(1)
     click.echo('Done')

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -477,8 +477,8 @@ def rollback_docker(container_name):
     click.echo('Done')
 
 # verify the next image
-@cli.command('verify_next_image')
-def verify_reboot():
+@cli.command('verify-next-image')
+def verify_next_image():
     """ Verify the next image for reboot"""
     bootloader = get_bootloader()
     if not bootloader.verify_next_image():

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -476,12 +476,12 @@ def rollback_docker(container_name):
 
     click.echo('Done')
 
-# verify reboot
-@cli.command('verify_reboot')
+# verify the next image
+@cli.command('verify-next-image')
 def verify_reboot():
-    """ Verify the image for reboot"""
+    """ Verify the next image for reboot"""
     bootloader = get_bootloader()
-    if not bootloader.verify_reboot():
+    if not bootloader.verify-next-image():
         click.echo('Failed')
         sys.exit(1)
     click.echo('Done')

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -476,5 +476,15 @@ def rollback_docker(container_name):
 
     click.echo('Done')
 
+# verify reboot
+@cli.command('verify_reboot')
+def verify_reboot():
+    """ Verify the image for reboot"""
+    bootloader = get_bootloader()
+    if not bootloader.verify_reboot():
+        click.echo('Failed')
+        sys.exit(1)
+    click.echo('Done')
+
 if __name__ == '__main__':
     cli()

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -482,9 +482,9 @@ def verify_next_image():
     """ Verify the next image for reboot"""
     bootloader = get_bootloader()
     if not bootloader.verify_next_image():
-        click.echo('Failed')
+        click.echo('Image verification failed')
         sys.exit(1)
-    click.echo('Done')
+    click.echo('Image successfully verified')
 
 if __name__ == '__main__':
     cli()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Add a command "sonic_installer verify_reboot" to verify the image before reboot.
The command will be called when reboot/fast-reboot/warm-reboot.

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

