### PR TITLE
[sonic-installer] Hyphens instead of underscores in command and subcommands

### DIFF
--- a/data/etc/bash_completion.d/sonic-installer
+++ b/data/etc/bash_completion.d/sonic-installer
@@ -1,0 +1,8 @@
+_sonic_installer_completion() {
+    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
+                   COMP_CWORD=$COMP_CWORD \
+                   _SONIC_INSTALLER_COMPLETE=complete $1 ) )
+    return 0
+}
+
+complete -F _sonic_installer_completion -o default sonic-installer;

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -4645,7 +4645,7 @@ Supported options:
 2. -f|--force - install FW regardless the current version
 3. -i|--image - update FW using current/next SONiC image
 
-Note: the default option is --image=current (current/next values are taken from `sonic_installer list`)
+Note: the default option is --image=current (current/next values are taken from `sonic-installer list`)
 
 ### Platform Component Firmware vendor specific behaviour
 
@@ -6604,7 +6604,7 @@ Go Back To [Beginning of the document](#) or [Beginning of this section](#waterm
 
 ## Software Installation and Management
 
-SONiC software can be installed in two methods, viz, "using sonic_installer tool", "ONIE Installer".
+SONiC software can be installed in two methods, viz, "using sonic-installer tool", "ONIE Installer".
 
 
 ### SONiC Installer
@@ -6612,18 +6612,18 @@ This is a command line tool available as part of the SONiC software; If the devi
 This tool has facility to install an alternate image, list the available images and to set the next reboot image.
 This command requires elevated (root) privileges to run.
 
-**sonic_installer list**
+**sonic-installer list**
 
 This command displays information about currently installed images. It displays a list of installed images, currently running image and image set to be loaded in next reboot.
 
 - Usage:
   ```
-  sonic_installer list
+  sonic-installer list
   ```
 
 - Example:
    ```
-  admin@sonic:~$ sudo sonic_installer list
+  admin@sonic:~$ sudo sonic-installer list
   Current: SONiC-OS-HEAD.XXXX
   Next: SONiC-OS-HEAD.XXXX
   Available:
@@ -6633,18 +6633,18 @@ This command displays information about currently installed images. It displays 
 
 TIP: This output can be obtained without evelated privileges by running the `show boot` command. See [here](#show-system-status) for details.
 
-**sonic_installer install**
+**sonic-installer install**
 
 This command is used to install a new image on the alternate image partition.  This command takes a path to an installable SONiC image or URL and installs the image.
 
 - Usage:
   ```
-  sonic_installer install <image_file_path>
+  sonic-installer install <image_file_path>
   ```
 
 - Example:
   ```
-  admin@sonic:~$ sudo sonic_installer install https://sonic-jenkins.westus.cloudapp.azure.com/job/xxxx/job/buildimage-xxxx-all/xxx/artifact/target/sonic-xxxx.bin
+  admin@sonic:~$ sudo sonic-installer install https://sonic-jenkins.westus.cloudapp.azure.com/job/xxxx/job/buildimage-xxxx-all/xxx/artifact/target/sonic-xxxx.bin
   New image will be installed, continue? [y/N]: y
   Downloading image...
   ...100%, 480 MB, 3357 KB/s, 146 seconds passed
@@ -6676,46 +6676,46 @@ This command is used to install a new image on the alternate image partition.  T
   Done
   ```
 
-**sonic_installer set_default**
+**sonic-installer set_default**
 
 This command is be used to change the image which can be loaded by default in all the subsequent reboots.
 
 - Usage:
   ```
-  sonic_installer set_default <image_name>
+  sonic-installer set_default <image_name>
   ```
 
 - Example:
   ```
-  admin@sonic:~$ sudo sonic_installer set_default SONiC-OS-HEAD.XXXX
+  admin@sonic:~$ sudo sonic-installer set_default SONiC-OS-HEAD.XXXX
   ```
 
-**sonic_installer set_next_boot**
+**sonic-installer set_next_boot**
 
 This command is used to change the image that can be loaded in the *next* reboot only. Note that it will fallback to current image in all other subsequent reboots after the next reboot.
 
 - Usage:
   ```
-  sonic_installer set_next_boot <image_name>
+  sonic-installer set_next_boot <image_name>
   ```
 
 - Example:
   ```
-  admin@sonic:~$ sudo sonic_installer set_next_boot SONiC-OS-HEAD.XXXX
+  admin@sonic:~$ sudo sonic-installer set_next_boot SONiC-OS-HEAD.XXXX
   ```
 
-**sonic_installer remove**
+**sonic-installer remove**
 
 This command is used to remove the unused SONiC image from the disk. Note that it's *not* allowed to remove currently running image.
 
 - Usage:
   ```
-  sonic_installer remove [-y|--yes] <image_name>
+  sonic-installer remove [-y|--yes] <image_name>
   ```
 
 - Example:
   ```
-  admin@sonic:~$ sudo sonic_installer remove SONiC-OS-HEAD.YYYY
+  admin@sonic:~$ sudo sonic-installer remove SONiC-OS-HEAD.YYYY
   Image will be removed, continue? [y/N]: y
   Updating GRUB...
   Done
@@ -6726,18 +6726,18 @@ This command is used to remove the unused SONiC image from the disk. Note that i
   Image removed
   ```
 
-**sonic_installer cleanup**
+**sonic-installer cleanup**
 
 This command removes all unused images from the device, leaving only the currently active image and the image which will be booted into next (if different) installed. If there are no images which can be removed, the command will output `No image(s) to remove`
 
 - Usage:
   ```
-  sonic_installer cleanup [-y|--yes]
+  sonic-installer cleanup [-y|--yes]
   ```
 
 - Example:
   ```
-  admin@sonic:~$ sudo sonic_installer cleanup
+  admin@sonic:~$ sudo sonic-installer cleanup
   Remove images which are not current and next, continue? [y/N]: y
   No image(s) to remove
   ```

--- a/fwutil/lib.py
+++ b/fwutil/lib.py
@@ -221,13 +221,13 @@ class SquashFs(object):
         self.overlay_mountpoint = self.OVERLAY_MOUNTPOINT_TEMPLATE.format(image_stem)
 
     def get_current_image(self):
-        cmd = "sonic_installer list | grep 'Current: ' | cut -f2 -d' '"
+        cmd = "sonic-installer list | grep 'Current: ' | cut -f2 -d' '"
         output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
 
         return output.rstrip(NEWLINE)
 
     def get_next_image(self):
-        cmd = "sonic_installer list | grep 'Next: ' | cut -f2 -d' '"
+        cmd = "sonic-installer list | grep 'Next: ' | cut -f2 -d' '"
         output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
 
         return output.rstrip(NEWLINE)

--- a/scripts/asic_config_check
+++ b/scripts/asic_config_check
@@ -73,8 +73,8 @@ function ConfirmASICConfigChecksumsMatch()
 # Main starts here
 debug "Checking that ASIC configuration has not changed"
 
-CURR_SONIC_IMAGE="$(sonic_installer list | grep "Current: " | cut -f2 -d' ')"
-DST_SONIC_IMAGE="$(sonic_installer list | grep "Next: " | cut -f2 -d' ')"
+CURR_SONIC_IMAGE="$(sonic-installer list | grep "Current: " | cut -f2 -d' ')"
+DST_SONIC_IMAGE="$(sonic-installer list | grep "Next: " | cut -f2 -d' ')"
 if [[ "${CURR_SONIC_IMAGE}" == "${DST_SONIC_IMAGE}" ]]; then
     debug "ASIC config unchanged, current and destination SONiC version are the same"
     exit "${ASIC_CONFIG_UNCHANGED}"

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -273,7 +273,7 @@ function teardown_control_plane_assistant()
 function setup_reboot_variables()
 {
     # Kernel and initrd image
-    NEXT_SONIC_IMAGE=$(sonic_installer list | grep "Next: " | cut -d ' ' -f 2)
+    NEXT_SONIC_IMAGE=$(sonic-installer list | grep "Next: " | cut -d ' ' -f 2)
     IMAGE_PATH="/host/image-${NEXT_SONIC_IMAGE#SONiC-OS-}"
     if grep -q aboot_platform= /host/machine.conf; then
         KERNEL_IMAGE="$(ls $IMAGE_PATH/boot/vmlinuz-*)"

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -63,7 +63,7 @@ function show_help_and_exit()
 
 function setup_reboot_variables()
 {
-    NEXT_SONIC_IMAGE=$(sonic_installer list | grep "Next: " | cut -d ' ' -f 2)
+    NEXT_SONIC_IMAGE=$(sonic-installer list | grep "Next: " | cut -d ' ' -f 2)
     IMAGE_PATH="/host/image-${NEXT_SONIC_IMAGE#SONiC-OS-}"
 }
 

--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -77,7 +77,7 @@ def run_command(cmd, use_shell=False):
 
 ## Search which SONiC image is the Current image
 def get_current_image():
-    (rc, img, err_str) = run_command("sonic_installer list | grep 'Current: ' | cut -d '-' -f 3-", use_shell=True);
+    (rc, img, err_str) = run_command("sonic-installer list | grep 'Current: ' | cut -d '-' -f 3-", use_shell=True);
     if type(img) == list and len(img) == 1:
         return img[0]
     print_err("Unable to locate current SONiC image")
@@ -85,7 +85,7 @@ def get_current_image():
 
 ## Search which SONiC image is the Next image
 def get_next_image():
-    (rc, img, err_str) = run_command("sonic_installer list | grep 'Next: ' | cut -d '-' -f 3-", use_shell=True);
+    (rc, img, err_str) = run_command("sonic-installer list | grep 'Next: ' | cut -d '-' -f 3-", use_shell=True);
     if type(img) == list and len(img) == 1:
         return img[0]
     print_err("Unable to locate current SONiC image")

--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,8 @@ setup(
             'pddf_ledutil = pddf_ledutil.main:cli',
             'show = show.main:cli',
             'sonic-clear = clear.main:cli',
-            'sonic_installer = sonic_installer.main:cli',
+            'sonic-installer = sonic_installer.main:sonic_installer',
+            'sonic_installer = sonic_installer.main:sonic_installer',
             'undebug = undebug.main:cli',
             'watchdogutil = watchdogutil.main:watchdogutil',
         ]

--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ setup(
             'show = show.main:cli',
             'sonic-clear = clear.main:cli',
             'sonic-installer = sonic_installer.main:sonic_installer',
-            'sonic_installer = sonic_installer.main:sonic_installer',
+            'sonic_installer = sonic_installer.main:sonic_installer',  # Deprecated
             'undebug = undebug.main:cli',
             'watchdogutil = watchdogutil.main:watchdogutil',
         ]

--- a/show/main.py
+++ b/show/main.py
@@ -2722,7 +2722,7 @@ def ecn():
 @cli.command('boot')
 def boot():
     """Show boot configuration"""
-    cmd = "sudo sonic_installer list"
+    cmd = "sudo sonic-installer list"
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
     click.echo(proc.stdout.read())
 

--- a/sonic_installer/aliases.ini
+++ b/sonic_installer/aliases.ini
@@ -1,0 +1,6 @@
+[aliases]
+set_default=set-default
+set_next_boot=set-next-boot
+binary_version=binary-version
+upgrade_docker=upgrade-docker
+rollback_docker=rollback-docker

--- a/sonic_installer/common.py
+++ b/sonic_installer/common.py
@@ -1,5 +1,5 @@
 """
-Module holding common functions and constants used by sonic_installer and its
+Module holding common functions and constants used by sonic-installer and its
 subpackages.
 """
 

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -185,6 +185,11 @@ def sonic_installer():
     if os.geteuid() != 0:
         exit("Root privileges required for this operation")
 
+    # Warn the user if they are calling the deprecated version of the command (with an underscore instead of a hyphen)
+    if os.path.basename(sys.argv[0]) == "sonic_installer":
+        click.secho("Warning: 'sonic_installer' is deprecated and will be removed in the future", fg="red", err=True)
+        click.secho("Please use 'sonic-installer' instead", fg="red", err=True)
+
 
 # Install image
 @sonic_installer.command('install')

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -210,7 +210,7 @@ def sonic_installer():
 
     # Warn the user if they are calling the deprecated version of the command (with an underscore instead of a hyphen)
     if os.path.basename(sys.argv[0]) == "sonic_installer":
-        click.secho("Warning: 'sonic_installer' is deprecated and will be removed in the future", fg="red", err=True)
+        click.secho("Warning: 'sonic_installer' command is deprecated and will be removed in the future", fg="red", err=True)
         click.secho("Please use 'sonic-installer' instead", fg="red", err=True)
 
 
@@ -293,6 +293,11 @@ def list_command():
 @click.argument('image')
 def set_default(image):
     """ Choose image to boot from by default """
+    # Warn the user if they are calling the deprecated version of the subcommand (with an underscore instead of a hyphen)
+    if "set_default" in sys.argv:
+        click.secho("Warning: 'set_default' subcommand is deprecated and will be removed in the future", fg="red", err=True)
+        click.secho("Please use 'set-default' instead", fg="red", err=True)
+
     bootloader = get_bootloader()
     if image not in bootloader.get_installed_images():
         click.echo('Error: Image does not exist')
@@ -305,6 +310,11 @@ def set_default(image):
 @click.argument('image')
 def set_next_boot(image):
     """ Choose image for next reboot (one time action) """
+    # Warn the user if they are calling the deprecated version of the subcommand (with underscores instead of hyphens)
+    if "set_next_boot" in sys.argv:
+        click.secho("Warning: 'set_next_boot' subcommand is deprecated and will be removed in the future", fg="red", err=True)
+        click.secho("Please use 'set-next-boot' instead", fg="red", err=True)
+
     bootloader = get_bootloader()
     if image not in bootloader.get_installed_images():
         click.echo('Error: Image does not exist')
@@ -337,6 +347,11 @@ def remove(image):
 @click.argument('binary_image_path')
 def binary_version(binary_image_path):
     """ Get version from local binary image file """
+    # Warn the user if they are calling the deprecated version of the subcommand (with an underscore instead of a hyphen)
+    if "binary_version" in sys.argv:
+        click.secho("Warning: 'binary_version' subcommand is deprecated and will be removed in the future", fg="red", err=True)
+        click.secho("Please use 'binary-version' instead", fg="red", err=True)
+
     bootloader = get_bootloader()
     version = bootloader.get_binary_image_version(binary_image_path)
     if not version:
@@ -380,6 +395,10 @@ def cleanup():
 @click.argument('url')
 def upgrade_docker(container_name, url, cleanup_image, skip_check, tag, warm):
     """ Upgrade docker image from local binary or URL"""
+    # Warn the user if they are calling the deprecated version of the subcommand (with an underscore instead of a hyphen)
+    if "upgrade_docker" in sys.argv:
+        click.secho("Warning: 'upgrade_docker' subcommand is deprecated and will be removed in the future", fg="red", err=True)
+        click.secho("Please use 'upgrade-docker' instead", fg="red", err=True)
 
     image_name = get_container_image_name(container_name)
     image_latest = image_name + ":latest"
@@ -540,6 +559,11 @@ def upgrade_docker(container_name, url, cleanup_image, skip_check, tag, warm):
                 type=click.Choice(["swss", "snmp", "lldp", "bgp", "pmon", "dhcp_relay", "telemetry", "teamd", "radv", "amon", "sflow"]))
 def rollback_docker(container_name):
     """ Rollback docker image to previous version"""
+    # Warn the user if they are calling the deprecated version of the subcommand (with an underscore instead of a hyphen)
+    if "rollback_docker" in sys.argv:
+        click.secho("Warning: 'rollback_docker' subcommand is deprecated and will be removed in the future", fg="red", err=True)
+        click.secho("Please use 'rollback-docker' instead", fg="red", err=True)
+
     image_name = get_container_image_name(container_name)
     # All images id under the image name
     image_id_all = get_container_image_id_all(image_name)

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -12,9 +12,32 @@ from swsssdk import SonicV2Connector
 from .bootloader import get_bootloader
 from .common import run_command
 
+try:
+    import ConfigParser as configparser
+except ImportError:
+    import configparser
+
 
 # Global Config object
 _config = None
+
+
+# This is from the aliases example:
+# https://github.com/pallets/click/blob/57c6f09611fc47ca80db0bd010f05998b3c0aa95/examples/aliases/aliases.py
+class Config(object):
+    """Object to hold CLI config"""
+
+    def __init__(self):
+        self.path = os.getcwd()
+        self.aliases = {}
+
+    def read_config(self, filename):
+        parser = configparser.RawConfigParser()
+        parser.read([filename])
+        try:
+            self.aliases.update(parser.items('aliases'))
+        except configparser.NoSectionError:
+            pass
 
 
 class AliasedGroup(click.Group):

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -202,6 +202,13 @@ def hdel_warm_restart_table(db_name, table_name, warm_app_name, key):
     return client.hdel(_hash, key)
 
 
+def print_deprecation_warning(deprecated_cmd_or_subcmd, new_cmd_or_subcmd):
+    click.secho("Warning: '{}' {}command is deprecated and will be removed in the future"
+                .format(deprecated_cmd_or_subcmd, "" if deprecated_cmd_or_subcmd == "sonic_installer" else "sub"),
+                fg="red", err=True)
+    click.secho("Please use '{}' instead".format(new_cmd_or_subcmd), fg="red", err=True)
+
+
 # Main entrypoint
 @click.group(cls=AliasedGroup)
 def sonic_installer():
@@ -211,8 +218,7 @@ def sonic_installer():
 
     # Warn the user if they are calling the deprecated version of the command (with an underscore instead of a hyphen)
     if os.path.basename(sys.argv[0]) == "sonic_installer":
-        click.secho("Warning: 'sonic_installer' command is deprecated and will be removed in the future", fg="red", err=True)
-        click.secho("Please use 'sonic-installer' instead", fg="red", err=True)
+        print_deprecation_warning("sonic_installer", "sonic-installer")
 
 
 # Install image
@@ -296,8 +302,7 @@ def set_default(image):
     """ Choose image to boot from by default """
     # Warn the user if they are calling the deprecated version of the subcommand (with an underscore instead of a hyphen)
     if "set_default" in sys.argv:
-        click.secho("Warning: 'set_default' subcommand is deprecated and will be removed in the future", fg="red", err=True)
-        click.secho("Please use 'set-default' instead", fg="red", err=True)
+        print_deprecation_warning("set_default", "set-default")
 
     bootloader = get_bootloader()
     if image not in bootloader.get_installed_images():
@@ -313,8 +318,7 @@ def set_next_boot(image):
     """ Choose image for next reboot (one time action) """
     # Warn the user if they are calling the deprecated version of the subcommand (with underscores instead of hyphens)
     if "set_next_boot" in sys.argv:
-        click.secho("Warning: 'set_next_boot' subcommand is deprecated and will be removed in the future", fg="red", err=True)
-        click.secho("Please use 'set-next-boot' instead", fg="red", err=True)
+        print_deprecation_warning("set_next_boot", "set-next-boot")
 
     bootloader = get_bootloader()
     if image not in bootloader.get_installed_images():
@@ -350,8 +354,7 @@ def binary_version(binary_image_path):
     """ Get version from local binary image file """
     # Warn the user if they are calling the deprecated version of the subcommand (with an underscore instead of a hyphen)
     if "binary_version" in sys.argv:
-        click.secho("Warning: 'binary_version' subcommand is deprecated and will be removed in the future", fg="red", err=True)
-        click.secho("Please use 'binary-version' instead", fg="red", err=True)
+        print_deprecation_warning("binary_version", "binary-version")
 
     bootloader = get_bootloader()
     version = bootloader.get_binary_image_version(binary_image_path)
@@ -414,8 +417,7 @@ def upgrade_docker(container_name, url, cleanup_image, skip_check, tag, warm):
     """ Upgrade docker image from local binary or URL"""
     # Warn the user if they are calling the deprecated version of the subcommand (with an underscore instead of a hyphen)
     if "upgrade_docker" in sys.argv:
-        click.secho("Warning: 'upgrade_docker' subcommand is deprecated and will be removed in the future", fg="red", err=True)
-        click.secho("Please use 'upgrade-docker' instead", fg="red", err=True)
+        print_deprecation_warning("upgrade_docker", "upgrade-docker")
 
     image_name = get_container_image_name(container_name)
     image_latest = image_name + ":latest"
@@ -578,8 +580,7 @@ def rollback_docker(container_name):
     """ Rollback docker image to previous version"""
     # Warn the user if they are calling the deprecated version of the subcommand (with an underscore instead of a hyphen)
     if "rollback_docker" in sys.argv:
-        click.secho("Warning: 'rollback_docker' subcommand is deprecated and will be removed in the future", fg="red", err=True)
-        click.secho("Please use 'rollback-docker' instead", fg="red", err=True)
+        print_deprecation_warning("rollback_docker", "rollback-docker")
 
     image_name = get_container_image_name(container_name)
     # All images id under the image name

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -2,12 +2,13 @@
 
 import configparser
 import os
-import sys
-import time
-import click
-import urllib
-import syslog
 import subprocess
+import sys
+import syslog
+import time
+import urllib
+
+import click
 from swsssdk import SonicV2Connector
 
 from .bootloader import get_bootloader

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -1,6 +1,10 @@
 #! /usr/bin/python -u
 
-import configparser
+try:
+    import ConfigParser as configparser
+except ImportError:
+    import configparser
+
 import os
 import subprocess
 import sys

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -391,7 +391,7 @@ DOCKER_CONTAINER_LIST = [
     "pmon",
     "radv",
     "restapi",
-    "sflow"
+    "sflow",
     "snmp",
     "swss",
     "syncd",

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -379,6 +379,22 @@ def cleanup():
         click.echo("No image(s) to remove")
 
 
+DOCKER_CONTAINER_LIST = [
+    "bgp",
+    "dhcp_relay",
+    "lldp",
+    "nat",
+    "pmon",
+    "radv",
+    "restapi",
+    "sflow"
+    "snmp",
+    "swss",
+    "syncd",
+    "teamd",
+    "telemetry"
+]
+
 # Upgrade docker image
 @sonic_installer.command('upgrade-docker')
 @click.option('-y', '--yes', is_flag=True, callback=abort_if_false,
@@ -388,7 +404,7 @@ def cleanup():
 @click.option('--tag', type=str, help="Tag for the new docker image")
 @click.option('--warm', is_flag=True, help="Perform warm upgrade")
 @click.argument('container_name', metavar='<container_name>', required=True,
-                type=click.Choice(["swss", "snmp", "lldp", "bgp", "pmon", "dhcp_relay", "telemetry", "teamd", "radv", "amon", "sflow"]))
+                type=click.Choice(DOCKER_CONTAINER_LIST))
 @click.argument('url')
 def upgrade_docker(container_name, url, cleanup_image, skip_check, tag, warm):
     """ Upgrade docker image from local binary or URL"""
@@ -553,7 +569,7 @@ def upgrade_docker(container_name, url, cleanup_image, skip_check, tag, warm):
 @click.option('-y', '--yes', is_flag=True, callback=abort_if_false,
               expose_value=False, prompt='Docker image will be rolled back, continue?')
 @click.argument('container_name', metavar='<container_name>', required=True,
-                type=click.Choice(["swss", "snmp", "lldp", "bgp", "pmon", "dhcp_relay", "telemetry", "teamd", "radv", "amon", "sflow"]))
+                type=click.Choice(DOCKER_CONTAINER_LIST))
 def rollback_docker(container_name):
     """ Rollback docker image to previous version"""
     # Warn the user if they are calling the deprecated version of the subcommand (with an underscore instead of a hyphen)

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -1,5 +1,6 @@
 #! /usr/bin/python -u
 
+import configparser
 import os
 import sys
 import time
@@ -11,11 +12,6 @@ from swsssdk import SonicV2Connector
 
 from .bootloader import get_bootloader
 from .common import run_command
-
-try:
-    import ConfigParser as configparser
-except ImportError:
-    import configparser
 
 
 # Global Config object


### PR DESCRIPTION
Replace underscores with hyphens in all sonic-installer subcommands as well as the root command itself.

- Install two entry points for sonic-installer: `sonic-installer` and `sonic_installer`. This allows for backward compatibility and time for users to transition from using the underscore versions to the hyphenated versions.

- Replace underscores with hyphens in the following subcommands:
    ```
    set-default
    set-next-boot
    binary-version
    upgrade-docker
    rollback-docker
    ```

    - Also add aliases from the underscore versions of these subcommnds to the new hyphenated subcommands to allow for backward compatibility and time for users to transition from using the underscore versions to the hyphenated versions.

- Print deprecation warnings to stderr if issued command line contains any deprecated versions with underscores

- Bonus: Addition of the AliasedGroup base class also adds support for abbreviated subcommands

- Fixed some style issues which did not align with PEP8 standards

- Eliminate duplicate code by adding DOCKER_CONTAINER_LIST; Remove unknown 'amon' container from the list

This is work towards resolving issue https://github.com/Azure/sonic-utilities/issues/982. We can set a deprecation date for the underscore versions of the commands, and when that date arrives, we can simply delete all aliases and deprecation warnings.