### PR TITLE
 Fix the None Type Exception when Interface Table does not exist (cold boot) as part of db migration

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -115,8 +115,12 @@ class DBMigrator():
         if self.appDB is None:
             return
 
-        if_db = []
         data = self.appDB.keys(self.appDB.APPL_DB, "INTF_TABLE:*")
+
+        if data is None:
+            return
+
+        if_db = []
         for key in data:
             if_name = key.split(":")[1]
             if if_name == "lo":

--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -141,7 +141,7 @@ class SFPShow(object):
         ident = '        '
         seperator = ": "
         for key in sorted_key_table:
-            if dom_info_dict is not None and dom_info_dict[key] != 'N/A':
+            if dom_info_dict is not None and key in dom_info_dict and dom_info_dict[key] != 'N/A':
                 current_val = (ident + ident +
                         dom_value_map[key])
                 current_val = (current_val + seperator.rjust(len(seperator) +


### PR DESCRIPTION
 Fix the None Type Exception when Interface Table does not exist (cold boot) as part of db migration
Because of this exception database service does not come up.

After fix all docker and services cam up fine.
