### PR TITLE
[show] Fix for 'show mac' command during DB flush

### DIFF
--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -32,14 +32,18 @@ import sys
 from natsort import natsorted
 from swsssdk import SonicV2Connector, port_util
 from tabulate import tabulate
+from sonic_daemon_base.daemon_base import Logger
 
 class FdbShow(object):
 
     HEADER = ['No.', 'Vlan', 'MacAddress', 'Port', 'Type']
     FDB_COUNT = 0
+    DB_MISS_THRESHOLD = 10
 
     def __init__(self):
         super(FdbShow,self).__init__()
+        self.logger = Logger("FDB")
+        self.db_miss_counter = 0
         self.db = SonicV2Connector(host="127.0.0.1")
         self.if_name_map, \
         self.if_oid_map = port_util.get_interface_oid_map(self.db)
@@ -68,8 +72,14 @@ class FdbShow(object):
             fdb = json.loads(fdb_entry .split(":", 2)[-1])
             if not fdb:
                 continue
-
-            ent = self.db.get_all('ASIC_DB', s, blocking=True)
+            if self.db.exists('ASIC_DB',s):
+                try:
+                    ent = self.db.get_all('ASIC_DB', s, blocking=True)
+                except:
+                    if db_miss_counter < DB_MISS_THRESHOLD:
+                        db_miss_counter += 1
+                        self.logger.log_info("Entry {} flushed from DB".format(str(s)))
+                    continue
             br_port_id = ent[b"SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID"][oid_pfx:]
             ent_type = ent[b"SAI_FDB_ENTRY_ATTR_TYPE"]
             fdb_type = ['Dynamic','Static'][ent_type == "SAI_FDB_ENTRY_TYPE_STATIC"]


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
When running 'show mac' command while there are many MAC entries in the DB, an exception can occur if during the execution of the command the DB is being flushed.

**- How I did it**

There are two checks in the fix, the first is to check if the entry still valid and present in the DB, if not continue, if yes try to fetch it. the 'try except' wrap is to make sure that right after the first check the entry not flushed from the DB to make sure this issue won't happen again.
the first check is necessary because a needed blocking flag is set to 'True' on the function call to redis, if there are many DB fetch misses the execution of the command can take a lot of time which is not reasonable. 

**- How to verify it**

1) Inject ~10000 MAC entried into the FDB.
2) Wait until aging time of the FDB.
3) Issue 'show mac' command.

**- Previous command output (if the output of a command-line utility has changed)**

Key 'ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY:{"bvid":"oid:0x26000000000acb","mac":"00:11:00:00:00:01","switch_id":"oid:0x21000000000000"}' unavailable in database '1'

**- New command output (if the output of a command-line utility has changed)**

Normal 'show mac' command output.