### PR TITLE
[show] Add support for QSFP-DD cables on 'show' command

### DIFF
--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -38,7 +38,8 @@ qsfp_data_map = {'model': 'Vendor PN',
                  'nominal_bit_rate': 'Nominal Bit Rate(100Mbs)',
                  'specification_compliance': 'Specification compliance',
                  'encoding': 'Encoding',
-                 'connector': 'Connector'
+                 'connector': 'Connector',
+                 'application_advertisement': 'Application Advertisement'
                  }
 
 sfp_dom_channel_monitor_map = {'rx1power': 'RXPower',
@@ -261,11 +262,14 @@ class SFPShow(object):
             elif key1 == 'cable_length':
                 pass
             elif key1 == 'specification_compliance':
-                spefic_compliance_dict = eval(sfp_info_dict['specification_compliance'])
-                sorted_compliance_key_table = natsorted(spefic_compliance_dict)
-                out_put = out_put + ident + qsfp_data_map['specification_compliance'] + ': ' + '\n'
-                for compliance_key in sorted_compliance_key_table:
-                    out_put = out_put + ident + ident + compliance_key + ': ' + spefic_compliance_dict[compliance_key] + '\n'
+                if sfp_info_dict['type'] == "QSFP-DD Double Density 8X Pluggable Transceiver":
+                    out_put = out_put + ident + qsfp_data_map[key1] + ': ' + sfp_info_dict[key1] + '\n'
+                else:
+                    out_put = out_put + ident + qsfp_data_map['specification_compliance'] + ': ' + '\n'
+                    spefic_compliance_dict = eval(sfp_info_dict['specification_compliance'])
+                    sorted_compliance_key_table = natsorted(spefic_compliance_dict)
+                    for compliance_key in sorted_compliance_key_table:
+                        out_put = out_put + ident + ident + compliance_key + ': ' + spefic_compliance_dict[compliance_key] + '\n'
             else:
                 out_put = out_put + ident + qsfp_data_map[key1] + ': ' + sfp_info_dict[key1] + '\n'
 

--- a/sonic-utilities-tests/mock_tables/state_db.json
+++ b/sonic-utilities-tests/mock_tables/state_db.json
@@ -14,7 +14,8 @@
         "cable_type": "Length Cable Assembly(m)",
         "cable_length": "3",
         "specification_compliance": "{'10/40G Ethernet Compliance Code': '40G Active Cable (XLPPI)'}",
-        "nominal_bit_rate": "255"
+        "nominal_bit_rate": "255",
+        "application_advertisement": "N/A"
     },
     "TRANSCEIVER_DOM_SENSOR|Ethernet0": {
         "temperature": "30.9258",

--- a/sonic-utilities-tests/sfp_test.py
+++ b/sonic-utilities-tests/sfp_test.py
@@ -1,6 +1,7 @@
 import sys
 import os
 from click.testing import CliRunner
+import mock_tables.dbconnector
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
@@ -36,6 +37,7 @@ Ethernet200  Not present
         runner = CliRunner()
         result = runner.invoke(show.cli.commands["interfaces"].commands["transceiver"].commands["eeprom"], ["Ethernet0 -d"])
         expected = """Ethernet0: SFP EEPROM detected
+        Application Advertisement: N/A
         Connector: No separable connector
         Encoding: 64B66B
         Extended Identifier: Power Class 3(2.5W max), CDR present in Rx Tx
@@ -89,6 +91,7 @@ Ethernet200  Not present
         runner = CliRunner()
         result = runner.invoke(show.cli.commands["interfaces"].commands["transceiver"].commands["eeprom"], ["Ethernet0"])
         expected = """Ethernet0: SFP EEPROM detected
+        Application Advertisement: N/A
         Connector: No separable connector
         Encoding: 64B66B
         Extended Identifier: Power Class 3(2.5W max), CDR present in Rx Tx


### PR DESCRIPTION
**- What I did**
Add support for QSFP-DD cables on 'sfpshow' script
Adapt sfp_test to new eeprom output.

**- How I did it**
Added a new label "application_advertisement" to print from DB.
Exclude "specification compliance" print from QSFP-DD cables.

**- How to verify it**
Check for Transceiver DB data with QSFP-DD cable.
Check 'show interfaces transceiver eeprom Ethernet#' output.
Run unit test sfp_test.

**- Previous command output (if the output of a command-line utility has changed)**
**- New command output (if the output of a command-line utility has changed)**