### PR TITLE
[acl-loader] Fix bugs in acl-loader

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -244,6 +244,9 @@ class AclLoader(object):
         :param table_name: Table name
         :return:
         """
+        if not self.is_table_valid(table_name):
+            warning("Table \"%s\" not found" % table_name)
+
         self.current_table = table_name
 
     def set_session_name(self, session_name):
@@ -412,7 +415,7 @@ class AclLoader(object):
     def convert_ip(self, table_name, rule_idx, rule):
         rule_props = {}
 
-        if rule.ip.config.protocol:
+        if rule.ip.config.protocol or rule.ip.config.protocol == 0:  # 0 is a valid protocol number
             if self.ip_protocol_map.has_key(rule.ip.config.protocol):
                 rule_props["IP_PROTOCOL"] = self.ip_protocol_map[rule.ip.config.protocol]
             else:


### PR DESCRIPTION
- Fix issue where protocol == 0 would be ignored
- Emit warning if --table_name not found in Config DB

Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did/How I did it**
I fixed a bug in acl-loader where rules with protocol=0 would have the protocol field ignored due to python's implicit boolean conversion. I fixed this by explicitly adding the `== 0` check to the ip protocol field.

I also fixed/added a warning when the provided `--table_name` can't be found in Config DB. Previously this case would fail silently, now the user will receive a warning to point them in the right direction.

**- How to verify it**
Run `acl-loader` with a non-existent `--table_name`:
```
admin@sonic:~$ sudo acl-loader update full test.json --table_name yeehaw
Warning: Table "yeehaw" not found
```

Run `acl-loader` with a rule that includes `"protocol": 0`:
```
admin@sonic:~$ sudo acl-loader update full test.json --session_name test
admin@sonic:~$ show acl rule
Table       Rule      Priority  Action                Match
----------  ------  ----------  --------------------  --------------
EVERFLOW    RULE_1        9999  MIRROR INGRESS: test  IP_PROTOCOL: 0
```

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

