### PR TITLE
[sonic-installer] Update group name for 'verify-next-image' subcommand

### DIFF
--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -607,7 +607,7 @@ def rollback_docker(container_name):
     click.echo('Done')
 
 # verify the next image
-@cli.command('verify-next-image')
+@sonic_installer.command('verify-next-image')
 def verify_next_image():
     """ Verify the next image for reboot"""
     bootloader = get_bootloader()


### PR DESCRIPTION
Root group name was changed from `cli` to `sonic_installer` in https://github.com/Azure/sonic-utilities/pull/983. However, `verify-next-image` subcommand was being added in an already-open PR https://github.com/Azure/sonic-utilities/pull/979/ at the time. It did not get updated before merge. This aligns it with the new group name.