### PR TITLE
[show] Fix for 'trunk' PortChannel reported as 'routed' port

### DIFF
--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -290,7 +290,7 @@ def po_speed_dict(po_int_dict, appl_db):
         po_speed_dict = {}
         return po_speed_dict
 
-def appl_db_portchannel_status_get(appl_db, config_db, po_name, status_type, portchannel_speed_dict):
+def appl_db_portchannel_status_get(appl_db, config_db, po_name, status_type, portchannel_speed_dict, combined_int_to_vlan_po_dict=None):
     """
     Get the port status
     """
@@ -301,7 +301,10 @@ def appl_db_portchannel_status_get(appl_db, config_db, po_name, status_type, por
         status = portchannel_speed_dict[po_name]
         return status
     if status_type == "vlan":
-        status = "routed"
+        if po_name in combined_int_to_vlan_po_dict.keys():
+            status = "trunk"
+        else:
+            status = "routed"
         return status
     if status_type == "mtu":
         status = config_db.get(config_db.CONFIG_DB, po_table_id, status_type)
@@ -388,7 +391,7 @@ class IntfStatus(object):
                                 appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_MTU_STATUS, self.portchannel_speed_dict),
                                 appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_FEC, self.portchannel_speed_dict),
                                 appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_ALIAS, self.portchannel_speed_dict),
-                                appl_db_portchannel_status_get(self.appl_db, self.config_db, po, "vlan", self.portchannel_speed_dict),
+                                appl_db_portchannel_status_get(self.appl_db, self.config_db, po, "vlan", self.portchannel_speed_dict, self.combined_int_to_vlan_po_dict),
                                 appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_OPER_STATUS, self.portchannel_speed_dict),
                                 appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_ADMIN_STATUS, self.portchannel_speed_dict),
                                 appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_OPTICS_TYPE, self.portchannel_speed_dict),

--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -301,7 +301,7 @@ def appl_db_portchannel_status_get(appl_db, config_db, po_name, status_type, por
         status = portchannel_speed_dict[po_name]
         return status
     if status_type == "vlan":
-        if po_name in combined_int_to_vlan_po_dict.keys():
+        if combined_int_to_vlan_po_dict and po_name in combined_int_to_vlan_po_dict.keys():
             status = "trunk"
         else:
             status = "routed"


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Changed the output of 'show interfaces status' field related to a PortChannel.
If the PortChannel is a member of a vlan group it will be printed as 'trunk' port instead of default 'routed'.

**- How I did it**
Check if the PortChannel is a member of a Vlan group and assign a proper tag for it.

**- How to verify it**
1) Add a PortChannel to a Vlan group.
2) Run 'show interfaces status' command.

**- Previous command output (if the output of a command-line utility has changed)**

PortChannel0005   N/A     100G     9100     N/A   N/A      routed    down       up       N/A         N/A

**- New command output (if the output of a command-line utility has changed)**

PortChannel0005   N/A     100G     9100     N/A   N/A      trunk    down       up       N/A         N/A