### PR TITLE
support show interface commands for multi ASIC platforms

### DIFF
--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -1,16 +1,24 @@
 #! /usr/bin/python
 
-import swsssdk
+import argparse
+import os
+from os import ttyname
 import sys
 import re
 import types
+from pprint import pprint
+
 from tabulate import tabulate
 from natsort import natsorted
-from swsssdk import ConfigDBConnector
-from pprint import pprint
-from utilities_common.intf_filter import parse_interface_in_filter
 
-import os
+import swsssdk
+from swsssdk import ConfigDBConnector
+from utilities_common.constants import PORT_CHANNEL_OBJ
+from utilities_common.constants import PORT_OBJ
+from utilities_common.multi_asic import MultiAsic
+from utilities_common.multi_asic import multi_asic_args
+from utilities_common.multi_asic import run_on_all_asics
+from utilities_common.intf_filter import parse_interface_in_filter
 
 # mock the redis for unit test purposes #
 try:
@@ -347,7 +355,12 @@ header_stat_sub_intf = ['Sub port interface', 'Speed', 'MTU', 'Vlan', 'Admin', '
 
 class IntfStatus(object):
 
-    def display_intf_status(self, intf_name, appl_db_keys, front_panel_ports_list, portchannel_speed_dict, appl_db_sub_intf_keys, sub_intf_list, sub_intf_only):
+    def display_intf_status(self):
+        self.get_intf_status()
+        sorted_table = natsorted(self.table)
+        print tabulate(sorted_table, header_stat if not self.sub_intf_only else header_stat_sub_intf, tablefmt="simple", stralign='right')
+    
+    def generate_intf_status(self):
         """
             Generate interface-status output
         """
@@ -356,91 +369,88 @@ class IntfStatus(object):
         table = []
         key = []
 
-        intf_fs = parse_interface_in_filter(intf_name)
-
+        intf_fs = parse_interface_in_filter(self.intf_name)
         #
         # Iterate through all the keys and append port's associated state to
         # the result table.
         #
-        if not sub_intf_only:
-            for i in appl_db_keys:
+        if not self.sub_intf_only:
+            for i in self.appl_db_keys:
                 key = re.split(':', i, maxsplit=1)[-1].strip()
-                if key in front_panel_ports_list:
-                    if intf_name is None or key in intf_fs:
+                if key in self.front_panel_ports_list:
+                    if self.multi_asic.skip_display(PORT_OBJ, key):
+                        continue
+
+                    if self.intf_name is None or key in intf_fs:
                         table.append((key,
-                                appl_db_port_status_get(self.appl_db, key, PORT_LANES_STATUS),
-                                appl_db_port_status_get(self.appl_db, key, PORT_SPEED),
-                                appl_db_port_status_get(self.appl_db, key, PORT_MTU_STATUS),
-                                appl_db_port_status_get(self.appl_db, key, PORT_FEC),
-                                appl_db_port_status_get(self.appl_db, key, PORT_ALIAS),
+                                appl_db_port_status_get(self.db, key, PORT_LANES_STATUS),
+                                appl_db_port_status_get(self.db, key, PORT_SPEED),
+                                appl_db_port_status_get(self.db, key, PORT_MTU_STATUS),
+                                appl_db_port_status_get(self.db, key, PORT_FEC),
+                                appl_db_port_status_get(self.db, key, PORT_ALIAS),
                                 config_db_vlan_port_keys_get(self.combined_int_to_vlan_po_dict, self.front_panel_ports_list, key),
-                                appl_db_port_status_get(self.appl_db, key, PORT_OPER_STATUS),
-                                appl_db_port_status_get(self.appl_db, key, PORT_ADMIN_STATUS),
-                                state_db_port_optics_get(self.state_db, key, PORT_OPTICS_TYPE),
-                                appl_db_port_status_get(self.appl_db, key, PORT_PFC_ASYM_STATUS)))
+                                appl_db_port_status_get(self.db, key, PORT_OPER_STATUS),
+                                appl_db_port_status_get(self.db, key, PORT_ADMIN_STATUS),
+                                state_db_port_optics_get(self.db, key, PORT_OPTICS_TYPE),
+                                appl_db_port_status_get(self.db, key, PORT_PFC_ASYM_STATUS)))
 
-            for po, value in portchannel_speed_dict.iteritems():
+            for po, value in self.portchannel_speed_dict.iteritems():
                 if po:
-                    if intf_name is None or po in intf_fs:
+                    if self.multi_asic.skip_display(PORT_CHANNEL_OBJ, po):
+                        continue
+                    if self.intf_name is None or po in intf_fs:
                         table.append((po,
-                                appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_LANES_STATUS, self.portchannel_speed_dict),
-                                appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_SPEED, self.portchannel_speed_dict),
-                                appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_MTU_STATUS, self.portchannel_speed_dict),
-                                appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_FEC, self.portchannel_speed_dict),
-                                appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_ALIAS, self.portchannel_speed_dict),
-                                appl_db_portchannel_status_get(self.appl_db, self.config_db, po, "vlan", self.portchannel_speed_dict),
-                                appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_OPER_STATUS, self.portchannel_speed_dict),
-                                appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_ADMIN_STATUS, self.portchannel_speed_dict),
-                                appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_OPTICS_TYPE, self.portchannel_speed_dict),
-                                appl_db_portchannel_status_get(self.appl_db, self.config_db, po, PORT_PFC_ASYM_STATUS, self.portchannel_speed_dict)))
+                                appl_db_portchannel_status_get(self.db, self.config_db, po, PORT_LANES_STATUS, self.portchannel_speed_dict),
+                                appl_db_portchannel_status_get(self.db, self.config_db, po, PORT_SPEED, self.portchannel_speed_dict),
+                                appl_db_portchannel_status_get(self.db, self.config_db, po, PORT_MTU_STATUS, self.portchannel_speed_dict),
+                                appl_db_portchannel_status_get(self.db, self.config_db, po, PORT_FEC, self.portchannel_speed_dict),
+                                appl_db_portchannel_status_get(self.db, self.config_db, po, PORT_ALIAS, self.portchannel_speed_dict),
+                                appl_db_portchannel_status_get(self.db, self.config_db, po, "vlan", self.portchannel_speed_dict),
+                                appl_db_portchannel_status_get(self.db, self.config_db, po, PORT_OPER_STATUS, self.portchannel_speed_dict),
+                                appl_db_portchannel_status_get(self.db, self.config_db, po, PORT_ADMIN_STATUS, self.portchannel_speed_dict),
+                                appl_db_portchannel_status_get(self.db, self.config_db, po, PORT_OPTICS_TYPE, self.portchannel_speed_dict),
+                                appl_db_portchannel_status_get(self.db, self.config_db, po, PORT_PFC_ASYM_STATUS, self.portchannel_speed_dict)))
         else:
-            for key in appl_db_sub_intf_keys:
+            for key in self.appl_db_sub_intf_keys:
                 sub_intf = re.split(':', key, maxsplit=1)[-1].strip()
-                if sub_intf in sub_intf_list:
+                if sub_intf in self.sub_intf_list:
                     table.append((sub_intf,
-                                appl_db_sub_intf_status_get(self.appl_db, self.config_db, self.front_panel_ports_list, self.portchannel_speed_dict, sub_intf, PORT_SPEED),
-                                appl_db_sub_intf_status_get(self.appl_db, self.config_db, self.front_panel_ports_list, self.portchannel_speed_dict, sub_intf, PORT_MTU_STATUS),
-                                appl_db_sub_intf_status_get(self.appl_db, self.config_db, self.front_panel_ports_list, self.portchannel_speed_dict, sub_intf, "vlan"),
-                                appl_db_sub_intf_status_get(self.appl_db, self.config_db, self.front_panel_ports_list, self.portchannel_speed_dict, sub_intf, PORT_ADMIN_STATUS),
-                                appl_db_sub_intf_status_get(self.appl_db, self.config_db, self.front_panel_ports_list, self.portchannel_speed_dict, sub_intf, PORT_OPTICS_TYPE)))
+                                appl_db_sub_intf_status_get(self.db, self.config_db, self.front_panel_ports_list, self.portchannel_speed_dict, sub_intf, PORT_SPEED),
+                                appl_db_sub_intf_status_get(self.db, self.config_db, self.front_panel_ports_list, self.portchannel_speed_dict, sub_intf, PORT_MTU_STATUS),
+                                appl_db_sub_intf_status_get(self.db, self.config_db, self.front_panel_ports_list, self.portchannel_speed_dict, sub_intf, "vlan"),
+                                appl_db_sub_intf_status_get(self.db, self.config_db, self.front_panel_ports_list, self.portchannel_speed_dict, sub_intf, PORT_ADMIN_STATUS),
+                                appl_db_sub_intf_status_get(self.db, self.config_db, self.front_panel_ports_list, self.portchannel_speed_dict, sub_intf, PORT_OPTICS_TYPE)))
+        return table
 
-        # Sorting and tabulating the result table.
-        sorted_table = natsorted(table)
-        print tabulate(sorted_table, header_stat if not sub_intf_only else header_stat_sub_intf, tablefmt="simple", stralign='right')
-
-
-    def __init__(self, intf_name):
+    def __init__(self, intf_name, namespace_option, display_option):
         """
         Class constructor method
         :param self: 
         :param intf_name: string of interface
         :return: 
         """
-        self.appl_db = db_connect_appl()
-        self.state_db = db_connect_state()
-        self.config_db = db_connect_configdb()
-        if self.appl_db is None:
-            return
-        if self.state_db is None: 
-            return
-        if self.config_db is None:
-            return
-
-        sub_intf_only = False
-        sub_intf_name = intf_name
+        self.db = None
+        self.config_db = None
+        self.sub_intf_only = False
+        self.intf_name = intf_name
+        self.sub_intf_name = intf_name
+        self.table = []
+        self.multi_asic = MultiAsic(display_option, namespace_option)
         if intf_name is not None:
             if intf_name == SUB_PORT:
-                intf_name = None
-                sub_intf_name = None
-                sub_intf_only = True
+                self.intf_name = None
+                self.sub_intf_name = None
+                self.sub_intf_only = True
             else:
                 sub_intf_sep_idx = intf_name.find(VLAN_SUB_INTERFACE_SEPARATOR)
                 if sub_intf_sep_idx != -1:
-                    sub_intf_only = True
-                    intf_name = intf_name[:sub_intf_sep_idx]
+                    self.sub_intf_only = True
+                    self.intf_name = intf_name[:sub_intf_sep_idx]
 
+    @run_on_all_asics
+    def get_intf_status(self):
         self.front_panel_ports_list = get_frontpanel_port_list(self.config_db)
-        appl_db_keys = appl_db_keys_get(self.appl_db, self.front_panel_ports_list, None)
+        self.appl_db_keys = appl_db_keys_get(self.db, self.front_panel_ports_list, None)
         self.int_to_vlan_dict = get_interface_vlan_dict(self.config_db)
         self.get_raw_po_int_configdb_info = get_raw_portchannel_info(self.config_db)
         self.portchannel_list = get_portchannel_list(self.get_raw_po_int_configdb_info)
@@ -448,16 +458,13 @@ class IntfStatus(object):
         self.po_int_dict = create_po_int_dict(self.po_int_tuple_list)
         self.int_po_dict = create_int_to_portchannel_dict(self.po_int_tuple_list)
         self.combined_int_to_vlan_po_dict = merge_dicts(self.int_to_vlan_dict, self.int_po_dict)
-        self.portchannel_speed_dict = po_speed_dict(self.po_int_dict, self.appl_db)
+        self.portchannel_speed_dict = po_speed_dict(self.po_int_dict, self.db)
         self.portchannel_keys = self.portchannel_speed_dict.keys()
 
         self.sub_intf_list = get_sub_port_intf_list(self.config_db)
-        appl_db_sub_intf_keys = appl_db_sub_intf_keys_get(self.appl_db, self.sub_intf_list, sub_intf_name)
-        if appl_db_keys is None:
-            return
-        self.display_intf_status(intf_name, appl_db_keys, self.front_panel_ports_list, self.portchannel_speed_dict, appl_db_sub_intf_keys, self.sub_intf_list, sub_intf_only)
-
-
+        self.appl_db_sub_intf_keys = appl_db_sub_intf_keys_get(self.db, self.sub_intf_list, self.sub_intf_name)
+        if self.appl_db_keys:
+            self.table += self.generate_intf_status()
 
 # ========================== interface-description logic ==========================
 
@@ -467,7 +474,15 @@ header_desc = ['Interface', 'Oper', 'Admin', 'Alias', 'Description']
 
 class IntfDescription(object):
 
-    def display_intf_description(self, appl_db_keys, front_panel_ports_list):
+    def display_intf_description(self):
+        
+        self.get_intf_description()
+
+        # Sorting and tabulating the result table.
+        sorted_table = natsorted(self.table)
+        print tabulate(sorted_table, header_desc, tablefmt="simple", stralign='right')
+
+    def generate_intf_description(self):
         """
             Generate interface-description output
         """
@@ -480,58 +495,53 @@ class IntfDescription(object):
         # Iterate through all the keys and append port's associated state to
         # the result table.
         #
-        for i in appl_db_keys:
+        for i in self.appl_db_keys:
             key = re.split(':', i, maxsplit=1)[-1].strip()
-            if key in front_panel_ports_list:
+            if key in self.front_panel_ports_list:
+                if self.multi_asic.skip_display(PORT_OBJ, key):
+                        continue
                 table.append((key,
-                              appl_db_port_status_get(self.appl_db, key, PORT_OPER_STATUS),
-                              appl_db_port_status_get(self.appl_db, key, PORT_ADMIN_STATUS),
-                              appl_db_port_status_get(self.appl_db, key, PORT_ALIAS),
-                              appl_db_port_status_get(self.appl_db, key, PORT_DESCRIPTION)))
+                              appl_db_port_status_get(self.db, key, PORT_OPER_STATUS),
+                              appl_db_port_status_get(self.db, key, PORT_ADMIN_STATUS),
+                              appl_db_port_status_get(self.db, key, PORT_ALIAS),
+                              appl_db_port_status_get(self.db, key, PORT_DESCRIPTION)))
+        return table
 
-        # Sorting and tabulating the result table.
-        sorted_table = natsorted(table)
-        print tabulate(sorted_table, header_desc, tablefmt="simple", stralign='right')
+    def __init__(self, intf_name, namespace_option, display_option):
 
-    def __init__(self, intf_name):
-
-        self.config_db = db_connect_configdb()
-        self.appl_db = db_connect_appl()
-        if self.appl_db is None:
-            return
-        if self.config_db is None:
-            return
+        self.db = None
+        self.config_db = None
+        self.table = []
+        self.multi_asic = MultiAsic(display_option, namespace_option)
 
         if intf_name is not None and intf_name == SUB_PORT:
-            intf_name = None
+            self.intf_name = None
+        else:
+            self.intf_name = intf_name
 
+    @run_on_all_asics
+    def get_intf_description(self):
         self.front_panel_ports_list = get_frontpanel_port_list(self.config_db)
-        appl_db_keys = appl_db_keys_get(self.appl_db, self.front_panel_ports_list, intf_name)
-        if appl_db_keys is None:
-            return
+        self.appl_db_keys = appl_db_keys_get(self.db, self.front_panel_ports_list, self.intf_name)
+        if self.appl_db_keys:
+            self.table += self.generate_intf_description()
 
-        self.display_intf_description(appl_db_keys, self.front_panel_ports_list)
+def main():
+    parser = argparse.ArgumentParser(description='Display Interface information',
+                                     formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument('-c', '--command', type=str, help='get interface status or description', default=None)
+    parser.add_argument('-i', '--interface', type=str, help='interface information for specific port: Ethernet0', default=None)
+    parser = multi_asic_args(parser)
+    args = parser.parse_args()
 
-
-
-def main(args):
-    if len(args) == 0:
-        print "No valid arguments provided"
-        return
-
-    command = args[0]
-    if command != "status" and command != "description":
-        print "No valid command provided"
-        return
-
-    intf_name = args[1] if len(args) == 2 else None
-
-    if command == "status":
-        interface_stat = IntfStatus(intf_name)
-    elif command == "description":
-        interface_desc = IntfDescription(intf_name)
+    if args.command == "status":
+        interface_stat = IntfStatus(args.interface, args.namespace, args.display)
+        interface_stat.display_intf_status()
+    elif args.command == "description":
+        interface_desc = IntfDescription(args.interface, args.namespace, args.display)
+        interface_desc.display_intf_description()
 
     sys.exit(0)
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+     main()

--- a/show/main.py
+++ b/show/main.py
@@ -22,6 +22,8 @@ from portconfig import get_child_ports
 
 import mlnx
 
+from utilities_common.multi_asic import multi_asic_click_options
+
 # Global Variable
 PLATFORM_ROOT_PATH = "/usr/share/sonic/device"
 PLATFORM_JSON = 'platform.json'
@@ -1022,34 +1024,40 @@ def presence(interfacename, verbose):
 
 @interfaces.command()
 @click.argument('interfacename', required=False)
+@multi_asic_click_options
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
-def description(interfacename, verbose):
+def description(interfacename, namespace, display, verbose):
     """Show interface status, protocol and description"""
 
-    cmd = "intfutil description"
+    cmd = "intfutil -c description"
 
     if interfacename is not None:
         if get_interface_mode() == "alias":
             interfacename = iface_alias_converter.alias_to_name(interfacename)
 
         cmd += " {}".format(interfacename)
-
+    namespace_option = "" if namespace is None else " -n {}".format(namespace)
+    cmd += " {} -d {}".format(namespace_option, display)
+    
     run_command(cmd, display_cmd=verbose)
 
 
 @interfaces.command()
 @click.argument('interfacename', required=False)
+@multi_asic_click_options
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
-def status(interfacename, verbose):
+def status(interfacename, namespace, display, verbose):
     """Show Interface status information"""
 
-    cmd = "intfutil status"
+    cmd = "intfutil -c status"
 
     if interfacename is not None:
         if get_interface_mode() == "alias":
             interfacename = iface_alias_converter.alias_to_name(interfacename)
 
         cmd += " {}".format(interfacename)
+    namespace_option = "" if namespace is None else " -n {}".format(namespace)
+    cmd += " {} -d {}".format(namespace_option, display)
 
     run_command(cmd, display_cmd=verbose)
 


### PR DESCRIPTION

Support show interface commands for multi ASIC platforms

Depends on the following PRs
 - [sonic-buildimage/4973](https://github.com/Azure/sonic-buildimage/pull/4973)
 - [sonic-utilities/999](https://github.com/Azure/sonic-utilities/pull/999) 

Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Support the following commands for multi ASIC
  -  show interface status
  - show interface description

2 new options have added

- [-n, --namespace] to allow user to display the information for given namespaces
  If this option is not present the information from all the namespaces will be displayed

- [-d, --display] to allow user to display information related both internal and external interfaces
  If this option is not present only external interfaces/neighbors will be display

One single ASIC platform, this options **_ignored_**, so the behavior remains unchanged

**- How I did it**
   -  Add argparse intfutil script
   - Change the _IntfDescription_ and _IntfStatus_ classes to get the information from all namespaces.
   - Add changes to filter out the internal ports from display
  -  Add support for `-n` and `-d`  click options

**- How to verify it**
**Help menu**
```
root@sonic:/home/admin# show interface description -h
Usage: show interface description [OPTIONS] [INTERFACENAME]

  Show interface status, protocol and description

Options:
  -d, --display [all|frontend]    Show internal interfaces  [default:
                                  frontend]
  -n, --namespace [asic0|asic1|asic2|asic3|asic4|asic5]
                                  Namespace name or all
  --verbose                       Enable verbose output
  -?, -h, --help                  Show this message and exit.
```
```
root@sonic:/home/admin# show interface status -h
Usage: show interface status [OPTIONS] [INTERFACENAME]

  Show Interface status information

Options:
  -d, --display [all|frontend]    Show internal interfaces  [default:
                                  frontend]
  -n, --namespace [asic0|asic1|asic2|asic3|asic4|asic5]
                                  Namespace name or all
  --verbose                       Enable verbose output
  -?, -h, --help                  Show this message and exit.
```

**Handling for invalid namespaces** 
```
root@sonic:/home/admin# show interface description -n asic -d all
Usage: show interface description [OPTIONS] [INTERFACENAME]

Error: Invalid value for "--namespace" / "-n": invalid choice: asic. (choose from asic0, asic1, asic2, asic3, asic4, asic5)
```

Sample output
```
root@sonic:/home/admin# show interface description -n asic0
  Interface    Oper    Admin         Alias               Description
-----------  ------  -------  ------------  ------------------------
  Ethernet0      up       up   Ethernet1/1  ARISTA01T2:Ethernet3/1/1
  Ethernet4      up       up   Ethernet1/2  ARISTA01T2:Ethernet3/2/1
  Ethernet8    down     down   Ethernet1/3               Ethernet1/3
 Ethernet12    down     down   Ethernet1/4               Ethernet1/4
 Ethernet16      up       up   Ethernet1/5  ARISTA03T2:Ethernet3/1/1
 Ethernet20      up       up   Ethernet1/6  ARISTA03T2:Ethernet3/2/1
 Ethernet24    down     down   Ethernet1/7               Ethernet1/7
 Ethernet28    down     down   Ethernet1/8               Ethernet1/8
 Ethernet32    down     down   Ethernet1/9               Ethernet1/9
 Ethernet36    down     down  Ethernet1/10              Ethernet1/10
 Ethernet40    down     down  Ethernet1/11              Ethernet1/11
 Ethernet44    down     down  Ethernet1/12              Ethernet1/12
 Ethernet48    down     down  Ethernet1/13              Ethernet1/13
 Ethernet52    down     down  Ethernet1/14              Ethernet1/14
 Ethernet56    down     down  Ethernet1/15              Ethernet1/15
 Ethernet60    down     down  Ethernet1/16              Ethernet1/16
```

```
root@sonic:/home/admin# show interface description -n asic0 -d all
    Interface    Oper    Admin          Alias               Description
-------------  ------  -------  -------------  ------------------------
    Ethernet0      up       up    Ethernet1/1  ARISTA01T2:Ethernet3/1/1
    Ethernet4      up       up    Ethernet1/2  ARISTA01T2:Ethernet3/2/1
    Ethernet8    down     down    Ethernet1/3               Ethernet1/3
   Ethernet12    down     down    Ethernet1/4               Ethernet1/4
   Ethernet16      up       up    Ethernet1/5  ARISTA03T2:Ethernet3/1/1
   Ethernet20      up       up    Ethernet1/6  ARISTA03T2:Ethernet3/2/1
   Ethernet24    down     down    Ethernet1/7               Ethernet1/7
   Ethernet28    down     down    Ethernet1/8               Ethernet1/8
   Ethernet32    down     down    Ethernet1/9               Ethernet1/9
   Ethernet36    down     down   Ethernet1/10              Ethernet1/10
   Ethernet40    down     down   Ethernet1/11              Ethernet1/11
   Ethernet44    down     down   Ethernet1/12              Ethernet1/12
   Ethernet48    down     down   Ethernet1/13              Ethernet1/13
   Ethernet52    down     down   Ethernet1/14              Ethernet1/14
   Ethernet56    down     down   Ethernet1/15              Ethernet1/15
   Ethernet60    down     down   Ethernet1/16              Ethernet1/16
 Ethernet-BP0      up       up   Ethernet-BP0          ASIC4:Eth0-ASIC4
 Ethernet-BP4      up       up   Ethernet-BP4          ASIC4:Eth1-ASIC4
 Ethernet-BP8      up       up   Ethernet-BP8          ASIC4:Eth2-ASIC4
Ethernet-BP12      up       up  Ethernet-BP12          ASIC4:Eth3-ASIC4
Ethernet-BP16      up       up  Ethernet-BP16          ASIC4:Eth4-ASIC4
Ethernet-BP20      up       up  Ethernet-BP20          ASIC4:Eth5-ASIC4
Ethernet-BP24      up       up  Ethernet-BP24          ASIC4:Eth6-ASIC4
Ethernet-BP28      up       up  Ethernet-BP28          ASIC4:Eth7-ASIC4
Ethernet-BP32      up       up  Ethernet-BP32          ASIC5:Eth0-ASIC5
Ethernet-BP36      up       up  Ethernet-BP36          ASIC5:Eth1-ASIC5
Ethernet-BP40      up       up  Ethernet-BP40          ASIC5:Eth2-ASIC5
Ethernet-BP44      up       up  Ethernet-BP44          ASIC5:Eth3-ASIC5
Ethernet-BP48      up       up  Ethernet-BP48          ASIC5:Eth4-ASIC5
Ethernet-BP52      up       up  Ethernet-BP52          ASIC5:Eth5-ASIC5
Ethernet-BP56      up       up  Ethernet-BP56          ASIC5:Eth6-ASIC5
Ethernet-BP60      up       up  Ethernet-BP60          ASIC5:Eth7-ASIC5
```

**- Previous command output (if the output of a command-line utility has changed)**
NA
**- New command output (if the output of a command-line utility has changed)**
NA
