### PR TITLE
importing json needed for DPB CLI

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -10,6 +10,7 @@ import syslog
 import time
 import netifaces
 import threading
+import json
 
 import sonic_device_util
 import ipaddress


### PR DESCRIPTION
Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>

**- What I did**
Importing **json** module needed for loading json file in DPB.
somehow, missed in #766 PR. [3910 PR](https://github.com/Azure/sonic-buildimage/pull/3910) in sonic-buildimage is failing for it.

**- How I did it**
Imported built-in module.

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

