### PR TITLE
[sonic-installer] Create Envvars File for Incoming Image

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ setup(
     ],
     data_files=[
         ('/etc/bash_completion.d', glob.glob('data/etc/bash_completion.d/*')),
-        ('/usr/share/sonic/templates/sonic-environment.j2', 'sonic_installer/templates/sonic-environment.j2'),
+        ('/usr/share/sonic/templates', ['sonic_installer/templates/sonic-environment.j2']),
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,7 @@ setup(
     ],
     data_files=[
         ('/etc/bash_completion.d', glob.glob('data/etc/bash_completion.d/*')),
+        ('/usr/share/sonic/templates/sonic-environment.j2', 'sonic_installer/templates/sonic-environment.j2'),
     ],
     entry_points={
         'console_scripts': [

--- a/sonic_installer/common.py
+++ b/sonic_installer/common.py
@@ -23,3 +23,19 @@ def run_command(command):
 
     if proc.returncode != 0:
         sys.exit(proc.returncode)
+
+# Run bash command, print output to stdout and return output on success
+def run_command_output(command):
+    click.echo(click.style("Command: ", fg='cyan') + click.style(command, fg='green'))
+
+    proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
+    (out, _) = proc.communicate()
+
+    click.echo(out)
+
+    if proc.returncode != 0:
+        click.echo(click.style("FAILED!", fg='red'))
+        sys.exit(proc.returncode)
+
+    return out
+

--- a/sonic_installer/common.py
+++ b/sonic_installer/common.py
@@ -24,18 +24,14 @@ def run_command(command):
     if proc.returncode != 0:
         sys.exit(proc.returncode)
 
-# Run bash command, print output to stdout and return output on success
-def run_command_output(command):
-    click.echo(click.style("Command: ", fg='cyan') + click.style(command, fg='green'))
+# Run bash command and return output, raise if it fails
+def run_command_or_raise(argv):
+    click.echo(click.style("Command: ", fg='cyan') + click.style(' '.join(argv), fg='green'))
 
-    proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
-    (out, _) = proc.communicate()
-
-    click.echo(out)
+    proc = subprocess.Popen(argv, stdout=subprocess.PIPE)
+    out, _ = proc.communicate()
 
     if proc.returncode != 0:
-        click.echo(click.style("FAILED!", fg='red'))
-        sys.exit(proc.returncode)
+        raise Exception("Failed to run command '{0}'".format(argv))
 
-    return out
-
+    return out.rstrip("\n")

--- a/sonic_installer/common.py
+++ b/sonic_installer/common.py
@@ -8,6 +8,8 @@ import sys
 
 import click
 
+from .exception import SonicRuntimeException
+
 HOST_PATH = '/host'
 IMAGE_PREFIX = 'SONiC-OS-'
 IMAGE_DIR_PREFIX = 'image-'
@@ -32,6 +34,6 @@ def run_command_or_raise(argv):
     out, _ = proc.communicate()
 
     if proc.returncode != 0:
-        raise Exception("Failed to run command '{0}'".format(argv))
+        raise SonicRuntimeException("Failed to run command '{0}'".format(argv))
 
     return out.rstrip("\n")

--- a/sonic_installer/exception.py
+++ b/sonic_installer/exception.py
@@ -1,0 +1,8 @@
+"""
+Module sonic_installer exceptions
+"""
+
+class SonicRuntimeException(Exception):
+    """SONiC Runtime Excpetion class used to report SONiC related errors
+    """
+    pass

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -208,6 +208,39 @@ def print_deprecation_warning(deprecated_cmd_or_subcmd, new_cmd_or_subcmd):
                 fg="red", err=True)
     click.secho("Please use '{}' instead".format(new_cmd_or_subcmd), fg="red", err=True)
 
+def run_cmd_or_abort(click, argv):
+    cmd_process = subprocess.Popen(argv, stdout=subprocess.PIPE)
+    stdout, stderr = cmd_process.communicate()
+    if not stdout or cmd_process.returncode:
+        click.echo("Failed to run command '{0}'".format(argv))
+        raise click.Abort()
+
+    return stdout
+
+def update_sonic_environment(click, binary_image_version):
+    sonic_env_template_file = "/usr/share/sonic/templates/sonic-environment.j2"
+    if os.path.exists(sonic_env_template_file):
+        sonic_version = re.sub("SONiC-OS-", '', binary_image_version)
+        sonic_env = run_cmd_or_abort(
+            click,
+            [
+                "sonic-cfggen",
+                "-d",
+                "-y",
+                "/etc/sonic/sonic_version.yml",
+                "-a",
+                "{{\"build_version\":\"{0}\"}}".format(sonic_version),
+                "-t",
+                sonic_env_template_file
+            ]
+        )
+        sonic_image_dir = "image-" + sonic_version
+        env_dir = "/host/" + sonic_image_dir + "/sonic-config"
+        os.mkdir(env_dir, 0o755)
+        env_file = env_dir + "/sonic-environment"
+        with open(env_file, "w+") as ef:
+            print >>ef, sonic_env
+        os.chmod(env_file, 0o644)
 
 # Main entrypoint
 @click.group(cls=AliasedGroup)
@@ -273,6 +306,8 @@ def install(url, force, skip_migration=False):
             click.echo("Skipping configuration migration as requested in the command option.")
         else:
             run_command('config-setup backup')
+
+        update_sonic_environment(click, binary_image_version)
 
     # Finally, sync filesystem
     run_command("sync;sync;sync")

--- a/sonic_installer/templates/sonic-environment.j2
+++ b/sonic_installer/templates/sonic-environment.j2
@@ -1,0 +1,5 @@
+SONIC_VERSION={{ build_version }}
+PLATFORM={{ DEVICE_METADATA.localhost.platform }}
+HWSKU={{ DEVICE_METADATA.localhost.hwsku }}
+DEVICE_TYPE={{ DEVICE_METADATA.localhost.type }}
+ASIC_TYPE={{ asic_type }}


### PR DESCRIPTION
Create environment files for SONiC immutable attribute. The file
will reside in the incoming image dir under sonic-config dir.
Incoming image will then move the file to /etc/sonic. The file
will be used to avoid calls into cfggen for those attributes.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

**- What I did**
Added support to generate envvar file

**- How I did it**
Extended sonic_installer with ability to generate envvar file

**- How to verify it**
1. For existing image:
update main.py in /usr/lib/python2.7/dist-packages/sonic_installer/main.py with new code
run sonic_installer install -y <image>

2. SONiC Image (ongoing)
build sonic image with new change in order to verify packaging.


**- Previous command output (if the output of a command-line utility has changed)**
N/A
**- New command output (if the output of a command-line utility has changed)**
N/A
