### PR TITLE
[config/config_mgmt.py]: Fix typo and enable test for tablesWithOutYang()

### DIFF
--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -83,7 +83,7 @@ class ConfigMgmt():
     def __del__(self):
         pass
 
-    def tablesWithoutYang(self):
+    def tablesWithOutYang(self):
         '''
         Return tables loaded in config for which YANG model does not exist.
 

--- a/sonic-utilities-tests/config_mgmt_test.py
+++ b/sonic-utilities-tests/config_mgmt_test.py
@@ -32,7 +32,7 @@ class TestConfigMgmt(TestCase):
         self.updateConfig(curConfig, unknown)
         self.writeJson(curConfig, config_mgmt.CONFIG_DB_JSON_FILE)
         cm = config_mgmt.ConfigMgmt(source=config_mgmt.CONFIG_DB_JSON_FILE)
-        #assert "unknown_table" in cm.tablesWithoutYang()
+        assert "unknown_table" in cm.tablesWithOutYang()
         return
 
     def test_search_keys(self):


### PR DESCRIPTION
…ng().

Signed-off-by: Praveen Chaudhary pchaudhary@linkedin.com

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Fix typo and enable test for tablesWithOutYang()

**- How I did it**
Fix typo and enable test for tablesWithOutYang()

**- How to verify it**
After enabling built time test. I Build the PKG.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

