### PR TITLE
[show/config]: combine feature and container feature cli

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -692,12 +692,12 @@ def _get_disabled_services_list():
                 log_warning("Feature is None")
                 continue
 
-            status = feature_table[feature_name]['status']
-            if not status:
-                log_warning("Status of feature '{}' is None".format(feature_name))
+            state = feature_table[feature_name]['state']
+            if not state:
+                log_warning("Enable state of feature '{}' is None".format(feature_name))
                 continue
 
-            if status == "disabled":
+            if state == "disabled":
                 disabled_services_list.append(feature_name)
     else:
         log_warning("Unable to retreive FEATURE table")
@@ -3780,40 +3780,41 @@ def feature():
 #
 # 'feature' command ('config feature state ...')
 #
-@feature.command('state')
+@feature.command('state', short_help="Enable/disable a feature")
 @click.argument('name', metavar='<feature-name>', required=True)
-@click.argument('state', metavar='<feature-state>', required=True, type=click.Choice(["enabled", "disabled"]))
+@click.argument('state', metavar='<state>', required=True, type=click.Choice(["enabled", "disabled"]))
 def feature_state(name, state):
-    """ Configure status of feature"""
+    """Enable/disable a feature"""
     config_db = ConfigDBConnector()
     config_db.connect()
-    status_data = config_db.get_entry('FEATURE', name)
+    state_data = config_db.get_entry('FEATURE', name)
 
-    if not status_data:
+    if not state_data:
         click.echo(" Feature '{}' doesn't exist".format(name))
         return
 
-    config_db.mod_entry('FEATURE', name, {'status': state})
+    config_db.mod_entry('FEATURE', name, {'state': state})
 
 #
 # 'autorestart' subcommand ('config feature autorestart ...')
 #
-@feature.command(name='autorestart', short_help="Configure the autosrestart status for a feature")
+@feature.command(name='autorestart', short_help="Enable/disable autosrestart of a feature")
 @click.argument('name', metavar='<feature-name>', required=True)
-@click.argument('autorestart_status', metavar='<feature-status>', required=True, type=click.Choice(["enabled", "disabled"]))
-def feature_autorestart(name, autorestart_status):
+@click.argument('autorestart', metavar='<autorestart>', required=True, type=click.Choice(["enabled", "disabled"]))
+def feature_autorestart(name, autorestart):
+    """Enable/disable autorestart of a feature"""
     config_db = ConfigDBConnector()
     config_db.connect()
-    container_feature_table = config_db.get_table('FEATURE')
-    if not container_feature_table:
+    feature_table = config_db.get_table('FEATURE')
+    if not feature_table:
         click.echo("Unable to retrieve feature table from Config DB.")
         return
 
-    if not container_feature_table.has_key(name):
+    if not feature_table.has_key(name):
         click.echo("Unable to retrieve feature '{}'".format(name))
         return
 
-    config_db.mod_entry('FEATURE', name, {'auto_restart': autorestart_status})
+    config_db.mod_entry('FEATURE', name, {'auto_restart': autorestart})
 
 if __name__ == '__main__':
     config()

--- a/config/main.py
+++ b/config/main.py
@@ -883,6 +883,17 @@ def validate_mirror_session_config(config_db, session_name, dst_port, src_port, 
 @click.group(cls=AbbreviationGroup, context_settings=CONTEXT_SETTINGS)
 def config():
     """SONiC command line - 'config' command"""
+    #
+    # Load asic_type for further use
+    #
+    try:
+        version_info = sonic_device_util.get_sonic_version_info()
+        asic_type = version_info['asic_type']
+    except KeyError, TypeError:
+        raise click.Abort()
+
+    if asic_type == 'mellanox':
+        platform.add_command(mlnx.mlnx)
 
     # Load the global config file database_global.json once.
     SonicDBConfig.load_sonic_global_db_config()
@@ -892,6 +903,10 @@ def config():
 
     SonicDBConfig.load_sonic_global_db_config()
 
+    global config_db
+
+    config_db = ConfigDBConnector()
+    config_db.connect()
 
 config.add_command(aaa.aaa)
 config.add_command(aaa.tacacs)
@@ -3803,19 +3818,4 @@ def feature_autorestart(name, autorestart):
     config_db.mod_entry('FEATURE', name, {'auto_restart': autorestart})
 
 if __name__ == '__main__':
-    #
-    # Load asic_type for further use
-    #
-    try:
-        version_info = sonic_device_util.get_sonic_version_info()
-        asic_type = version_info['asic_type']
-    except KeyError, TypeError:
-        raise click.Abort()
-
-    if asic_type == 'mellanox':
-        platform.add_command(mlnx.mlnx)
-
-    config_db = ConfigDBConnector()
-    config_db.connect()
-
     config()

--- a/config/main.py
+++ b/config/main.py
@@ -886,6 +886,8 @@ def config():
     #
     # Load asic_type for further use
     #
+    global asic_type
+
     try:
         version_info = sonic_device_util.get_sonic_version_info()
         asic_type = version_info['asic_type']

--- a/config/main.py
+++ b/config/main.py
@@ -552,7 +552,7 @@ def _is_neighbor_ipaddress(config_db, ipaddress):
 
 def _get_all_neighbor_ipaddresses(config_db, ignore_local_hosts=False):
     """Returns list of strings containing IP addresses of all BGP neighbors
-       if the flag ignore_local_hosts is set to True, additional check to see if 
+       if the flag ignore_local_hosts is set to True, additional check to see if
        if the BGP neighbor AS number is same as local BGP AS number, if so ignore that neigbor.
     """
     addrs = []
@@ -1007,7 +1007,7 @@ def load(filename, yes):
         # if any of the config files in linux host OR namespace is not present, return
         if not os.path.isfile(file):
             click.echo("The config_db file {} doesn't exist".format(file))
-            return 
+            return
 
         if namespace is None:
             command = "{} -j {} --write-to-db".format(SONIC_CFGGEN_PATH, file)
@@ -1225,7 +1225,7 @@ def load_minigraph(no_service_restart):
 
     if os.path.isfile('/etc/sonic/acl.json'):
         run_command("acl-loader update full /etc/sonic/acl.json", display_cmd=True)
-    
+
     # Write latest db version string into db
     db_migrator='/usr/bin/db_migrator.py'
     if os.path.isfile(db_migrator) and os.access(db_migrator, os.X_OK):
@@ -1235,7 +1235,7 @@ def load_minigraph(no_service_restart):
             else:
                 cfggen_namespace_option = " -n {}".format(namespace)
             run_command(db_migrator + ' -o set_version' + cfggen_namespace_option)
-     
+
     # We first run "systemctl reset-failed" to remove the "failed"
     # status from all services before we attempt to restart them
     if not no_service_restart:
@@ -1891,7 +1891,7 @@ def add_snmp_agent_address(ctx, agentip, port, vrf):
     #Construct SNMP_AGENT_ADDRESS_CONFIG table key in the format ip|<port>|<vrf>
     key = agentip+'|'
     if port:
-        key = key+port   
+        key = key+port
     key = key+'|'
     if vrf:
         key = key+vrf
@@ -1912,7 +1912,7 @@ def del_snmp_agent_address(ctx, agentip, port, vrf):
 
     key = agentip+'|'
     if port:
-        key = key+port   
+        key = key+port
     key = key+'|'
     if vrf:
         key = key+vrf
@@ -2174,7 +2174,7 @@ def all(verbose):
         config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
         config_db.connect()
         bgp_neighbor_ip_list = _get_all_neighbor_ipaddresses(config_db, ignore_local_hosts)
-        for ipaddress in bgp_neighbor_ip_list: 
+        for ipaddress in bgp_neighbor_ip_list:
             _change_bgp_session_status_by_addr(config_db, ipaddress, 'up', verbose)
 
 # 'neighbor' subcommand
@@ -2463,7 +2463,7 @@ def breakout(ctx, interface_name, mode, verbose, force_remove_dependencies, load
         sys.exit(0)
 
 def _get_all_mgmtinterface_keys():
-    """Returns list of strings containing mgmt interface keys 
+    """Returns list of strings containing mgmt interface keys
     """
     config_db = ConfigDBConnector()
     config_db.connect()
@@ -3191,9 +3191,9 @@ def priority(ctx, interface_name, priority, status):
         interface_name = interface_alias_to_name(interface_name)
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
-    
+
     run_command("pfc config priority {0} {1} {2}".format(status, interface_name, priority))
-    
+
 #
 # 'platform' group ('config platform ...')
 #
@@ -3292,10 +3292,10 @@ def naming_mode_alias():
 def is_loopback_name_valid(loopback_name):
     """Loopback name validation
     """
-    
+
     if loopback_name[:CFG_LOOPBACK_PREFIX_LEN] != CFG_LOOPBACK_PREFIX :
         return False
-    if (loopback_name[CFG_LOOPBACK_PREFIX_LEN:].isdigit() is False or 
+    if (loopback_name[CFG_LOOPBACK_PREFIX_LEN:].isdigit() is False or
           int(loopback_name[CFG_LOOPBACK_PREFIX_LEN:]) > CFG_LOOPBACK_ID_MAX_VAL) :
         return False
     if len(loopback_name) > CFG_LOOPBACK_NAME_TOTAL_LEN_MAX:
@@ -3462,7 +3462,7 @@ def add_ntp_server(ctx, ntp_ip_address):
     if ntp_ip_address in ntp_servers:
         click.echo("NTP server {} is already configured".format(ntp_ip_address))
         return
-    else: 
+    else:
         db.set_entry('NTP_SERVER', ntp_ip_address, {'NULL': 'NULL'})
         click.echo("NTP server {} added to configuration".format(ntp_ip_address))
         try:
@@ -3483,7 +3483,7 @@ def del_ntp_server(ctx, ntp_ip_address):
     if ntp_ip_address in ntp_servers:
         db.set_entry('NTP_SERVER', '{}'.format(ntp_ip_address), None)
         click.echo("NTP server {} removed from configuration".format(ntp_ip_address))
-    else: 
+    else:
         ctx.fail("NTP server {} is not configured.".format(ntp_ip_address))
     try:
         click.echo("Restarting ntp-config service...")
@@ -3770,12 +3770,20 @@ def delete(ctx):
     config_db.set_entry('SFLOW', 'global', sflow_tbl['global'])
 
 #
-# 'feature' command ('config feature name state')
-# 
-@config.command('feature')
+# 'feature' group ('config feature ...')
+#
+@config.group(cls=AbbreviationGroup, name='feature', invoke_without_command=False)
+def feature():
+    """Modify configuration of features"""
+    pass
+
+#
+# 'feature' command ('config feature state ...')
+#
+@feature.command('state')
 @click.argument('name', metavar='<feature-name>', required=True)
 @click.argument('state', metavar='<feature-state>', required=True, type=click.Choice(["enabled", "disabled"]))
-def feature_status(name, state):
+def feature_state(name, state):
     """ Configure status of feature"""
     config_db = ConfigDBConnector()
     config_db.connect()
@@ -3788,40 +3796,24 @@ def feature_status(name, state):
     config_db.mod_entry('FEATURE', name, {'status': state})
 
 #
-# 'container' group ('config container ...')
+# 'autorestart' subcommand ('config feature autorestart ...')
 #
-@config.group(cls=AbbreviationGroup, name='container', invoke_without_command=False)
-def container():
-    """Modify configuration of containers"""
-    pass
-
-#
-# 'feature' group ('config container feature ...')
-#
-@container.group(cls=AbbreviationGroup, name='feature', invoke_without_command=False)
-def feature():
-    """Modify configuration of container features"""
-    pass
-
-#
-# 'autorestart' subcommand ('config container feature autorestart ...')
-#
-@feature.command(name='autorestart', short_help="Configure the status of autorestart feature for specific container")
-@click.argument('container_name', metavar='<container_name>', required=True)
-@click.argument('autorestart_status', metavar='<autorestart_status>', required=True, type=click.Choice(["enabled", "disabled"]))
-def autorestart(container_name, autorestart_status):
+@feature.command(name='autorestart', short_help="Configure the autosrestart status for a feature")
+@click.argument('name', metavar='<feature-name>', required=True)
+@click.argument('autorestart_status', metavar='<feature-status>', required=True, type=click.Choice(["enabled", "disabled"]))
+def feature_autorestart(name, autorestart_status):
     config_db = ConfigDBConnector()
     config_db.connect()
-    container_feature_table = config_db.get_table('CONTAINER_FEATURE')
+    container_feature_table = config_db.get_table('FEATURE')
     if not container_feature_table:
-        click.echo("Unable to retrieve container feature table from Config DB.")
+        click.echo("Unable to retrieve feature table from Config DB.")
         return
 
-    if not container_feature_table.has_key(container_name):
-        click.echo("Unable to retrieve features for container '{}'".format(container_name))
+    if not container_feature_table.has_key(name):
+        click.echo("Unable to retrieve feature '{}'".format(name))
         return
 
-    config_db.mod_entry('CONTAINER_FEATURE', container_name, {'auto_restart': autorestart_status})
+    config_db.mod_entry('FEATURE', name, {'auto_restart': autorestart_status})
 
 if __name__ == '__main__':
     config()

--- a/config/main.py
+++ b/config/main.py
@@ -3778,7 +3778,7 @@ def feature():
     pass
 
 #
-# 'feature' command ('config feature state ...')
+# 'state' command ('config feature state ...')
 #
 @feature.command('state', short_help="Enable/disable a feature")
 @click.argument('name', metavar='<feature-name>', required=True)
@@ -3796,7 +3796,7 @@ def feature_state(name, state):
     config_db.mod_entry('FEATURE', name, {'state': state})
 
 #
-# 'autorestart' subcommand ('config feature autorestart ...')
+# 'autorestart' command ('config feature autorestart ...')
 #
 @feature.command(name='autorestart', short_help="Enable/disable autosrestart of a feature")
 @click.argument('name', metavar='<feature-name>', required=True)

--- a/show/main.py
+++ b/show/main.py
@@ -559,7 +559,10 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help', '-?'])
 @click.group(cls=AliasedGroup, context_settings=CONTEXT_SETTINGS)
 def cli():
     """SONiC command line - 'show' command"""
-    pass
+    global config_db
+
+    config_db = ConfigDBConnector()
+    config_db.connect()
 
 #
 # 'vrf' command ("show vrf")
@@ -3421,7 +3424,4 @@ def tunnel():
     click.echo(tabulate(table, header))
 
 if __name__ == '__main__':
-    config_db = ConfigDBConnector()
-    config_db.connect()
-
     cli()

--- a/show/main.py
+++ b/show/main.py
@@ -1179,8 +1179,8 @@ def priority(interface):
     cmd = 'pfc show priority'
     if interface is not None and get_interface_mode() == "alias":
         interface = iface_alias_converter.alias_to_name(interface)
-                
-    if interface is not None:    
+
+    if interface is not None:
         cmd += ' {0}'.format(interface)
 
     run_command(cmd)
@@ -1192,8 +1192,8 @@ def asymmetric(interface):
     cmd = 'pfc show asymmetric'
     if interface is not None and get_interface_mode() == "alias":
         interface = iface_alias_converter.alias_to_name(interface)
-                
-    if interface is not None:    
+
+    if interface is not None:
         cmd += ' {0}'.format(interface)
 
     run_command(cmd)
@@ -1727,7 +1727,7 @@ if routing_stack == "quagga":
     from .bgp_quagga_v6 import bgp
     ipv6.add_command(bgp)
 elif routing_stack == "frr":
-    from .bgp_frr_v4 import bgp 
+    from .bgp_frr_v4 import bgp
     ip.add_command(bgp)
     from .bgp_frr_v6 import bgp
     ipv6.add_command(bgp)
@@ -2173,7 +2173,7 @@ def ntp(ctx, verbose):
     ntpstat_cmd = "ntpstat"
     ntpcmd = "ntpq -p -n"
     if is_mgmt_vrf_enabled(ctx) is True:
-        #ManagementVRF is enabled. Call ntpq using "ip vrf exec" or cgexec based on linux version 
+        #ManagementVRF is enabled. Call ntpq using "ip vrf exec" or cgexec based on linux version
         os_info =  os.uname()
         release = os_info[2].split('-')
         if parse_version(release[0]) > parse_version("4.9.0"):
@@ -2971,7 +2971,7 @@ def pool(verbose):
 
 # Define GEARBOX commands only if GEARBOX is configured
 app_db = SonicV2Connector(host='127.0.0.1')
-app_db.connect(app_db.APPL_DB) 
+app_db.connect(app_db.APPL_DB)
 if app_db.keys(app_db.APPL_DB, '_GEARBOX_TABLE:phy:*'):
 
     @cli.group(cls=AliasedGroup)
@@ -3051,53 +3051,46 @@ def ztp(status, verbose):
     run_command(cmd, display_cmd=verbose)
 
 #
-# show features
+# 'feature' group (show feature ...)
 #
-@cli.command('features')
-def features():
-    """Show status of optional features"""
+@cli.group(name='feature', invoke_without_command=False)
+def feature():
+    """Show feature status"""
+    pass
+
+#
+# 'status' subcommand (show feature status)
+#
+@feature.command('status', short_help="Show feature status")
+@click.argument('feature_name', required=False)
+def autorestart(feature_name):
     config_db = ConfigDBConnector()
     config_db.connect()
-    header = ['Feature', 'Status']
+    header = ['Feature', 'Status', 'AutoRestart']
     body = []
-    status_data = config_db.get_table('FEATURE')
-    for key in status_data.keys():
-        body.append([key, status_data[key]['status']])
+    feature_table = config_db.get_table('FEATURE')
+    for key in feature_table.keys():
+        body.append([key, feature_table[key]['status']])
+        body.append([key, feature_table[key]['auto_restart']])
     click.echo(tabulate(body, header))
 
 #
-# 'container' group (show container ...)
+# 'autorestart' subcommand (show feature autorestart)
 #
-@cli.group(name='container', invoke_without_command=False)
-def container():
-    """Show container"""
-    pass
-
-#
-# 'feature' group (show container feature ...)
-#
-@container.group(name='feature', invoke_without_command=False)
-def feature():
-    """Show container feature"""
-    pass
-
-#
-# 'autorestart' subcommand (show container feature autorestart)
-#
-@feature.command('autorestart', short_help="Show whether the auto-restart feature for container(s) is enabled or disabled")
-@click.argument('container_name', required=False)
-def autorestart(container_name):
+@feature.command('autorestart', short_help="Show auto-restart status for a feature")
+@click.argument('feature_name', required=False)
+def autorestart(feature_name):
     config_db = ConfigDBConnector()
     config_db.connect()
-    header = ['Container Name', 'Status']
+    header = ['Feature', 'AutoRestart']
     body = []
-    container_feature_table = config_db.get_table('CONTAINER_FEATURE')
-    if container_name:
-        if container_feature_table and container_feature_table.has_key(container_name):
-            body.append([container_name, container_feature_table[container_name]['auto_restart']])
+    feature_table = config_db.get_table('FEATURE')
+    if feature_name:
+        if feature_table and feature_table.has_key(feature):
+            body.append([feature_name, feature_table[feature_name]['auto_restart']])
     else:
-        for name in container_feature_table.keys():
-            body.append([name, container_feature_table[name]['auto_restart']])
+        for name in feature_table.keys():
+            body.append([name, feature_table[name]['auto_restart']])
     click.echo(tabulate(body, header))
 
 #

--- a/show/main.py
+++ b/show/main.py
@@ -3059,25 +3059,25 @@ def feature():
     pass
 
 #
-# 'status' subcommand (show feature status)
+# 'state' subcommand (show feature state)
 #
-@feature.command('status', short_help="Show feature status")
+@feature.command('state', short_help="Show feature state")
 @click.argument('feature_name', required=False)
 def autorestart(feature_name):
     config_db = ConfigDBConnector()
     config_db.connect()
-    header = ['Feature', 'Status', 'AutoRestart']
+    header = ['Feature', 'State', 'AutoRestart']
     body = []
     feature_table = config_db.get_table('FEATURE')
     for key in feature_table.keys():
-        body.append([key, feature_table[key]['status']])
+        body.append([key, feature_table[key]['State']])
         body.append([key, feature_table[key]['auto_restart']])
     click.echo(tabulate(body, header))
 
 #
 # 'autorestart' subcommand (show feature autorestart)
 #
-@feature.command('autorestart', short_help="Show auto-restart status for a feature")
+@feature.command('autorestart', short_help="Show auto-restart state for a feature")
 @click.argument('feature_name', required=False)
 def autorestart(feature_name):
     config_db = ConfigDBConnector()

--- a/show/main.py
+++ b/show/main.py
@@ -3421,7 +3421,6 @@ def tunnel():
     click.echo(tabulate(table, header))
 
 if __name__ == '__main__':
-
     config_db = ConfigDBConnector()
     config_db.connect()
 

--- a/sonic-utilities-tests/feature_test.py
+++ b/sonic-utilities-tests/feature_test.py
@@ -1,5 +1,6 @@
-import sys
 import os
+import sys
+
 import mock
 from click.testing import CliRunner
 from swsssdk import ConfigDBConnector

--- a/sonic-utilities-tests/feature_test.py
+++ b/sonic-utilities-tests/feature_test.py
@@ -1,0 +1,168 @@
+import sys
+import os
+import mock
+import pytest
+import traceback
+from click.testing import CliRunner
+from swsssdk import ConfigDBConnector
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(test_path)
+sys.path.insert(0, modules_path)
+
+import mock_tables.dbconnector
+import show.main as show
+import config.main as config
+
+config.asic_type = mock.MagicMock(return_value = "broadcom")
+config._get_device_type = mock.MagicMock(return_value = "ToRRouter")
+
+config_db = ConfigDBConnector()
+config_db.connect()
+
+show.config_db = config_db
+config.config_db = config_db
+
+show_feature_status_output="""\
+Feature     State     AutoRestart
+----------  --------  -------------
+bgp         enabled   enabled
+database    enabled   disabled
+dhcp_relay  enabled   enabled
+lldp        enabled   enabled
+nat         enabled   enabled
+pmon        enabled   enabled
+radv        enabled   enabled
+restapi     disabled  enabled
+sflow       disabled  enabled
+snmp        enabled   enabled
+swss        enabled   enabled
+syncd       enabled   enabled
+teamd       enabled   enabled
+telemetry   enabled   enabled
+"""
+
+show_feature_bgp_status_output="""\
+Feature    State    AutoRestart
+---------  -------  -------------
+bgp        enabled  enabled
+"""
+
+show_feature_bgp_disabled_status_output="""\
+Feature    State     AutoRestart
+---------  --------  -------------
+bgp        disabled  enabled
+"""
+
+show_feature_autorestart_output="""\
+Feature     AutoRestart
+----------  -------------
+bgp         enabled
+database    disabled
+dhcp_relay  enabled
+lldp        enabled
+nat         enabled
+pmon        enabled
+radv        enabled
+restapi     enabled
+sflow       enabled
+snmp        enabled
+swss        enabled
+syncd       enabled
+teamd       enabled
+telemetry   enabled
+"""
+
+show_feature_bgp_autorestart_output="""\
+Feature    AutoRestart
+---------  -------------
+bgp        enabled
+"""
+
+
+show_feature_bgp_disabled_autorestart_output="""\
+Feature    AutoRestart
+---------  -------------
+bgp        disabled
+"""
+
+class TestFeature(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+
+    def test_show_feature_status(self):
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["feature"].commands["status"], [])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_feature_status_output
+
+    def test_show_bgp_feature_status(self):
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["feature"].commands["status"], ["bgp"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_feature_bgp_status_output
+
+    def test_show_unknown_feature_status(self):
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["feature"].commands["status"], ["foo"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 1
+
+    def test_show_feature_autorestart(self):
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["feature"].commands["autorestart"], [])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_feature_autorestart_output
+
+    def test_show_bgp_autorestart_status(self):
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["feature"].commands["autorestart"], ["bgp"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_feature_bgp_autorestart_output
+
+    def test_show_unknown_autorestart_status(self):
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["feature"].commands["autorestart"], ["foo"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 1
+
+    def test_config_bgp_feature_state(self):
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["feature"].commands["state"], ["bgp", "disabled"])
+        print(result.exit_code)
+        print(result.output)
+        result = runner.invoke(show.cli.commands["feature"].commands["status"], ["bgp"])
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_feature_bgp_disabled_status_output
+
+    def test_config_bgp_autorestart(self):
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["feature"].commands["autorestart"], ["bgp", "disabled"])
+        print(result.exit_code)
+        print(result.output)
+        result = runner.invoke(show.cli.commands["feature"].commands["autorestart"], ["bgp"])
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_feature_bgp_disabled_autorestart_output
+
+    def test_config_unknown_feature(self):
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["feature"].commands['state'], ["foo", "enabled"])
+        print(result.output)
+        assert result.exit_code == 1
+
+    @classmethod
+    def teardown_class(cls):
+        print("TEARDOWN")

--- a/sonic-utilities-tests/feature_test.py
+++ b/sonic-utilities-tests/feature_test.py
@@ -1,8 +1,6 @@
 import sys
 import os
 import mock
-import pytest
-import traceback
 from click.testing import CliRunner
 from swsssdk import ConfigDBConnector
 
@@ -10,7 +8,6 @@ test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 sys.path.insert(0, modules_path)
 
-import mock_tables.dbconnector
 import show.main as show
 import config.main as config
 

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -151,76 +151,74 @@
     "DEBUG_COUNTER_DROP_REASON|DEBUG_1|ACL_ANY": {},
     "DEBUG_COUNTER_DROP_REASON|DEBUG_2|IP_HEADER_ERROR": {},
     "DEBUG_COUNTER_DROP_REASON|DEBUG_2|NO_L3_HEADER": {},
-    "FEATURE": {
-        "bgp": {
-            "status": "enabled",
-            "auto_restart": "enabled",
-            "high_mem_alert": "disabled"
-        },
-        "database": {
-            "status": "enabled",
-            "auto_restart": "disabled",
-            "high_mem_alert": "disabled"
-        },
-        "dhcp_relay": {
-            "status": "enabled",
-            "auto_restart": "enabled",
-            "high_mem_alert": "disabled"
-        },
-        "lldp": {
-            "status": "enabled",
-            "auto_restart": "enabled",
-            "high_mem_alert": "disabled"
-        },
-        "nat": {
-            "status": "enabled",
-            "auto_restart": "enabled",
-            "high_mem_alert": "disabled"
-        },
-        "pmon": {
-            "status": "enabled",
-            "auto_restart": "enabled",
-            "high_mem_alert": "disabled"
-        },
-        "radv": {
-            "status": "enabled",
-            "auto_restart": "enabled",
-            "high_mem_alert": "disabled"
-        },
-        "restapi": {
-            "status": "disabled",
-            "auto_restart": "enabled",
-            "high_mem_alert": "disabled"
-        },
-        "sflow": {
-            "status": "disabled",
-            "auto_restart": "enabled",
-            "high_mem_alert": "disabled"
-        },
-        "snmp": {
-            "status": "enabled",
-            "auto_restart": "enabled",
-            "high_mem_alert": "disabled"
-        },
-        "swss": {
-            "status": "enabled",
-            "auto_restart": "enabled",
-            "high_mem_alert": "disabled"
-        },
-        "syncd": {
-            "status": "enabled",
-            "auto_restart": "enabled",
-            "high_mem_alert": "disabled"
-        },
-        "teamd": {
-            "status": "enabled",
-            "auto_restart": "enabled",
-            "high_mem_alert": "disabled"
-        },
-        "telemetry": {
-            "status": "enabled",
-            "auto_restart": "enabled",
-            "high_mem_alert": "disabled"
-        }
+    "FEATURE|bgp": {
+        "state": "enabled",
+        "auto_restart": "enabled",
+        "high_mem_alert": "disabled"
+    },
+    "FEATURE|database": {
+        "state": "enabled",
+        "auto_restart": "disabled",
+        "high_mem_alert": "disabled"
+    },
+    "FEATURE|dhcp_relay": {
+        "state": "enabled",
+        "auto_restart": "enabled",
+        "high_mem_alert": "disabled"
+    },
+    "FEATURE|lldp": {
+        "state": "enabled",
+        "auto_restart": "enabled",
+        "high_mem_alert": "disabled"
+    },
+    "FEATURE|nat": {
+        "state": "enabled",
+        "auto_restart": "enabled",
+        "high_mem_alert": "disabled"
+    },
+    "FEATURE|pmon": {
+        "state": "enabled",
+        "auto_restart": "enabled",
+        "high_mem_alert": "disabled"
+    },
+    "FEATURE|radv": {
+        "state": "enabled",
+        "auto_restart": "enabled",
+        "high_mem_alert": "disabled"
+    },
+    "FEATURE|restapi": {
+        "state": "disabled",
+        "auto_restart": "enabled",
+        "high_mem_alert": "disabled"
+    },
+    "FEATURE|sflow": {
+        "state": "disabled",
+        "auto_restart": "enabled",
+        "high_mem_alert": "disabled"
+    },
+    "FEATURE|snmp": {
+        "state": "enabled",
+        "auto_restart": "enabled",
+        "high_mem_alert": "disabled"
+    },
+    "FEATURE|swss": {
+        "state": "enabled",
+        "auto_restart": "enabled",
+        "high_mem_alert": "disabled"
+    },
+    "FEATURE|syncd": {
+        "state": "enabled",
+        "auto_restart": "enabled",
+        "high_mem_alert": "disabled"
+    },
+    "FEATURE|teamd": {
+        "state": "enabled",
+        "auto_restart": "enabled",
+        "high_mem_alert": "disabled"
+    },
+    "FEATURE|telemetry": {
+        "state": "enabled",
+        "auto_restart": "enabled",
+        "high_mem_alert": "disabled"
     }
 }

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -150,5 +150,77 @@
     "DEBUG_COUNTER_DROP_REASON|DEBUG_0|IP_HEADER_ERROR": {},
     "DEBUG_COUNTER_DROP_REASON|DEBUG_1|ACL_ANY": {},
     "DEBUG_COUNTER_DROP_REASON|DEBUG_2|IP_HEADER_ERROR": {},
-    "DEBUG_COUNTER_DROP_REASON|DEBUG_2|NO_L3_HEADER": {}
+    "DEBUG_COUNTER_DROP_REASON|DEBUG_2|NO_L3_HEADER": {},
+    "FEATURE": {
+        "bgp": {
+            "status": "enabled",
+            "auto_restart": "enabled",
+            "high_mem_alert": "disabled"
+        },
+        "database": {
+            "status": "enabled",
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+        "dhcp_relay": {
+            "status": "enabled",
+            "auto_restart": "enabled",
+            "high_mem_alert": "disabled"
+        },
+        "lldp": {
+            "status": "enabled",
+            "auto_restart": "enabled",
+            "high_mem_alert": "disabled"
+        },
+        "nat": {
+            "status": "enabled",
+            "auto_restart": "enabled",
+            "high_mem_alert": "disabled"
+        },
+        "pmon": {
+            "status": "enabled",
+            "auto_restart": "enabled",
+            "high_mem_alert": "disabled"
+        },
+        "radv": {
+            "status": "enabled",
+            "auto_restart": "enabled",
+            "high_mem_alert": "disabled"
+        },
+        "restapi": {
+            "status": "disabled",
+            "auto_restart": "enabled",
+            "high_mem_alert": "disabled"
+        },
+        "sflow": {
+            "status": "disabled",
+            "auto_restart": "enabled",
+            "high_mem_alert": "disabled"
+        },
+        "snmp": {
+            "status": "enabled",
+            "auto_restart": "enabled",
+            "high_mem_alert": "disabled"
+        },
+        "swss": {
+            "status": "enabled",
+            "auto_restart": "enabled",
+            "high_mem_alert": "disabled"
+        },
+        "syncd": {
+            "status": "enabled",
+            "auto_restart": "enabled",
+            "high_mem_alert": "disabled"
+        },
+        "teamd": {
+            "status": "enabled",
+            "auto_restart": "enabled",
+            "high_mem_alert": "disabled"
+        },
+        "telemetry": {
+            "status": "enabled",
+            "auto_restart": "enabled",
+            "high_mem_alert": "disabled"
+        }
+    }
 }


### PR DESCRIPTION
Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
merge container feature cli into feature cli
add unit tests

```
02:24:22  ============================= test session starts ==============================
02:24:22  platform linux2 -- Python 2.7.16, pytest-3.10.1, py-1.7.0, pluggy-0.8.0
02:24:22  rootdir: /sonic/sonic-utilities, inifile: pytest.ini
02:24:22  plugins: cov-2.6.0
02:24:24  collected 75 items
02:24:24  
02:24:24  sonic-utilities-tests/acl_loader_test.py ....                            [  5%]
02:24:24  sonic-utilities-tests/aclshow_test.py ...........                        [ 20%]
02:24:25  sonic-utilities-tests/config_mgmt_test.py ....                           [ 25%]
02:24:26  sonic-utilities-tests/drops_group_test.py .......                        [ 34%]
02:24:26  sonic-utilities-tests/feature_test.py .........                          [ 46%]
02:24:27  sonic-utilities-tests/filter_fdb_entries_test.py ..........              [ 60%]
02:24:27  sonic-utilities-tests/gearbox_test.py ..                                 [ 62%]
02:24:36  sonic-utilities-tests/intfstat_test.py ........                          [ 73%]
02:24:39  sonic-utilities-tests/intfutil_test.py ........                          [ 84%]
02:24:39  sonic-utilities-tests/port2alias_test.py ....                            [ 89%]
02:24:40  sonic-utilities-tests/psu_test.py ...                                    [ 93%]
02:24:41  sonic-utilities-tests/sfp_test.py ...                                    [ 97%]
02:24:41  sonic-utilities-tests/show_breakout_test.py ..                           [100%]
```

config command:
```
admin@vlab-01:~$ sudo config feature
Usage: config feature [OPTIONS] COMMAND [ARGS]...

  Modify configuration of features

Options:
  -?, -h, --help  Show this message and exit.

Commands:
  autorestart  Configure autorestart status for a feature
  state        Configure status of feature
```

show command:
```
admin@vlab-01:~$ show feature
Usage: show feature [OPTIONS] COMMAND [ARGS]...

  Show feature status

Options:
  -?, -h, --help  Show this message and exit.

Commands:
  autorestart  Show auto-restart status for a feature
  status       Show feature status
```

output:

```
admin@vlab-01:~$ show feature status
Feature     State     AutoRestart
----------  --------  -------------
bgp         enabled   enabled
database    enabled   disabled
dhcp_relay  enabled   enabled
lldp        enabled   enabled
nat         enabled   enabled
pmon        enabled   enabled
radv        enabled   enabled
restapi     disabled  enabled
sflow       disabled  enabled
snmp        enabled   enabled
swss        enabled   enabled
syncd       enabled   enabled
teamd       enabled   enabled
telemetry   enabled   enabled
admin@vlab-01:~$ show feature autorestart
Feature     AutoRestart
----------  -------------
bgp         enabled
database    disabled
dhcp_relay  enabled
lldp        enabled
nat         enabled
pmon        enabled
radv        enabled
restapi     enabled
sflow       enabled
snmp        enabled
swss        enabled
syncd       enabled
teamd       enabled
telemetry   enabled
```
**- How I did it**
There will be other changes needed and unit added.

This is just to get some feedback about the cli.

**- How to verify it**
validate in virtual switch.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

