### PR TITLE
[show lldp]: Fix 'input device is not a TTY' error

### DIFF
--- a/scripts/lldpshow
+++ b/scripts/lldpshow
@@ -74,7 +74,7 @@ class Lldpshow(object):
             lldp_interface_list = lldp_port if lldp_port is not None else self.lldp_interface[lldp_instace_num]
             # In detail mode we will pass interface list (only front ports) and get O/P as plain text 
             # and in table format we will get xml output
-            lldp_cmd = 'sudo docker exec -it lldp{} lldpctl '.format(self.lldp_instance[lldp_instace_num]) + ('-f xml' if not lldp_detail_info else lldp_interface_list)
+            lldp_cmd = 'sudo docker exec -i lldp{} lldpctl '.format(self.lldp_instance[lldp_instace_num]) + ('-f xml' if not lldp_detail_info else lldp_interface_list)
             p = subprocess.Popen(lldp_cmd, stdout=subprocess.PIPE, shell=True)
             (output, err) = p.communicate()
             ## Wait for end of command. Get return returncode ##


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

Fix "the input device is not a TTY" error reported by 'show lldp' commands when executed via pytest scripts in sonic-mgmt.

resolves Azure/sonic-buildimage#5019

**- How I did it**

Removed the usage of '-t' docker exec option to not allocate a TTY, while invoking 'lldpctl'.

**- How to verify it**

Execute 'TestShowLLDP' test cases in test_iface_namingmode.py script in sonic-mgmt.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

