### PR TITLE
[PFCWD] Fix issue with "pfcwd show stats" command during SONiC init

### DIFF
--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -40,7 +40,7 @@ def cli():
 
 def get_all_queues(db):
     queue_names = db.get_all(db.COUNTERS_DB, 'COUNTERS_QUEUE_NAME_MAP')
-    return natsorted(queue_names.keys())
+    return natsorted(queue_names.keys() if queue_names else {})
 
 def get_all_ports(db):
     all_port_names = db.get_all(db.COUNTERS_DB, 'COUNTERS_PORT_NAME_MAP')


### PR DESCRIPTION
* Traceback was returned if DB is not yet initialized

Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Fixed issue with ```pfcwd show stats``` command during SONiC init.
Traceback was returned if DB was not yet initialized which is incorrect. Correct behavior would to rather return empty line if something is not yet ready to be pulled and displayed.

**- How I did it**
Returned empty dictionary instead of ```None``` if data are still not present in DB. It is because in source code data expected to be as dictionary type but if there is no expected attributes in DB ```None``` was returned. Wich is incorrect and caused following exception: ```'NoneType' object has no attribute 'keys'```

**- How to verify it**
Perform any type of reboot or config reload and once switch bootted but not fully initialized execute command ```pfcwd show stats```. No exception or errors should be observed, just empty table.

**- Previous command output (if the output of a command-line utility has changed)**
```
root@sonic:/home/admin# pfcwd show stats
Traceback (most recent call last):
  File "/usr/bin/pfcwd", line 12, in <module>
    sys.exit(cli())
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/pfcwd/main.py", line 83, in stats
    queues = get_all_queues(db)
  File "/usr/lib/python2.7/dist-packages/pfcwd/main.py", line 44, in get_all_queues
    return natsorted(queue_names.keys())
AttributeError: 'NoneType' object has no attribute 'keys'
root@sonic:/home/admin#
```

**- New command output (if the output of a command-line utility has changed)**
```
root@sonic:/home/admin# pfcwd show stats
  QUEUE    STATUS    STORM DETECTED/RESTORED    TX OK/DROP    RX OK/DROP    TX LAST OK/DROP    RX LAST OK/DROP
-------  --------  -------------------------  ------------  ------------  -----------------  -----------------
root@sonic:/home/admin#
```
