### PR TITLE
[tests]: fix drops_group_test failure on second run

### DIFF
--- a/tests/drops_group_test.py
+++ b/tests/drops_group_test.py
@@ -76,11 +76,14 @@ Ethernet8      N/A         0           0         0           0          0       
 sonic_drops_test               0
 """
 
+dropstat_path = "/tmp/dropstat"
+
 class TestDropCounters(object):
     @classmethod
     def setup_class(cls):
         print("SETUP")
-        shutil.rmtree("/tmp/dropstat")
+        if os.path.exists(dropstat_path):
+            shutil.rmtree(dropstat_path)
         os.environ["PATH"] += os.pathsep + scripts_path
         os.environ["UTILITIES_UNIT_TESTING"] = "1"
 

--- a/tests/drops_group_test.py
+++ b/tests/drops_group_test.py
@@ -1,5 +1,7 @@
-import sys
 import os
+import sys
+
+import shutil
 from click.testing import CliRunner
 
 test_path = os.path.dirname(os.path.abspath(__file__))
@@ -8,7 +10,6 @@ scripts_path = os.path.join(modules_path, "scripts")
 sys.path.insert(0, test_path)
 sys.path.insert(0, modules_path)
 
-import mock_tables.dbconnector
 import show.main as show
 import clear.main as clear
 
@@ -79,6 +80,7 @@ class TestDropCounters(object):
     @classmethod
     def setup_class(cls):
         print("SETUP")
+        shutil.rmtree("/tmp/dropstat")
         os.environ["PATH"] += os.pathsep + scripts_path
         os.environ["UTILITIES_UNIT_TESTING"] = "1"
 


### PR DESCRIPTION

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
a few tests in drops_group_test fails on second run.
The reason is that /tmp/dropstat is not cleaned, the first
run leave some state in the folder which cause the subsequent
run to fail.

The fix is the always clean up the folder.

**- How I did it**
The fix is the always clean up the folder.

**- How to verify it**
run python setup.py test multiple times.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

