### PR TITLE
Update all references to new 'sonic-installer' file name

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -315,9 +315,9 @@ function reboot_pre_check()
         exit ${EXIT_FILE_SYSTEM_FULL}
     fi
 
-    # Verify the next image by sonic_installer
+    # Verify the next image by sonic-installer
     INSTALLER_VERIFY_RC=0
-    sonic_installer verify-next-image > /dev/null || INSTALLER_VERIFY_RC=$?
+    sonic-installer verify-next-image > /dev/null || INSTALLER_VERIFY_RC=$?
     if [[ INSTALLER_VERIFY_RC -ne 0 ]]; then
         error "Failed to verify next image. Exit code: $INSTALLER_VERIFY_RC"
         exit ${EXIT_SONIC_INSTALLER_VERIFY_REBOOT}

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -80,8 +80,8 @@ function reboot_pre_check()
     fi
     rm ${filename}
 
-    # Verify the next image by sonic_installer
-    local message=$(sonic_installer verify-next-image 2>&1)
+    # Verify the next image by sonic-installer
+    local message=$(sonic-installer verify-next-image 2>&1)
     if [ $? -ne 0 ]; then
         VERBOSE=yes debug "Failed to verify next image: ${message}"
         exit ${EXIT_SONIC_INSTALLER_VERIFY_REBOOT}

--- a/sonic_installer/exception.py
+++ b/sonic_installer/exception.py
@@ -1,5 +1,5 @@
 """
-Module sonic_installer exceptions
+Module sonic-installer exceptions
 """
 
 class SonicRuntimeException(Exception):


### PR DESCRIPTION
**- Why I did it**
`sonic_installer` has been renamed `sonic-installer`

**- How I did it**
Update the file name everywhere it is used

**- How to verify it**

Test the affected applications. They should work and no longer output the sonic_installer deprecation warning.
