### PR TITLE
Change fast-reboot script to use swss and radv service script

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -503,8 +503,7 @@ systemctl stop nat
 debug "Stopped nat ..."
 
 # Kill radv before stopping BGP service to prevent annoucing our departure.
-debug "Stopping radv ..."
-docker kill radv &>/dev/null || [ $? == 1 ]
+debug "Stopping radv service..."
 systemctl stop radv
 
 # Kill bgpd to start the bgp graceful restart procedure
@@ -536,11 +535,7 @@ if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
     debug "Stopped teamd ..."
 fi
 
-# Kill swss Docker container
-# We call `docker kill swss` to ensure the container stops as quickly as possible,
-# then immediately call `systemctl stop swss` to prevent the service from
-# restarting the container automatically.
-docker kill swss &> /dev/null || debug "Docker swss is not running ($?) ..."
+debug "Stopping swss service ..."
 systemctl stop swss
 
 # Pre-shutdown syncd

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -505,6 +505,7 @@ debug "Stopped nat ..."
 # Kill radv before stopping BGP service to prevent annoucing our departure.
 debug "Stopping radv service..."
 systemctl stop radv
+debug "Stopped radv service..."
 
 # Kill bgpd to start the bgp graceful restart procedure
 debug "Stopping bgp ..."
@@ -537,6 +538,7 @@ fi
 
 debug "Stopping swss service ..."
 systemctl stop swss
+debug "Stopped swss service ..."
 
 # Pre-shutdown syncd
 if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; then


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Special handling is needed for services during fast, warm and cold reboot paths. This procedural handling is better suited in the respective service scripts to:
1) keep fast-reboot script simpler    2) avoid code duplication.

Call swss and radv service scripts to do special handling of reboot process behavior.

**_This PR should be merged only after service scripts changes are merged in following PRs:_**
RADV - https://github.com/Azure/sonic-buildimage/pull/5108
SWSS - https://github.com/Azure/sonic-buildimage/pull/5070

**- How I did it**
Created and modified service scripts to handle reboot procedure depending on the type. Fast-reboot script now simply calls these service scripts.
**- How to verify it**
Tested service scripts independently.
Tested Fast, warm and cold reboot procedures are tested.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

