### PR TITLE
[fast-reboot/warm-reboot] Enable watchdog before running platform specific reboot plugin

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -633,15 +633,16 @@ if [ -x /sbin/hwclock ]; then
     /sbin/hwclock -w || /bin/true
 fi
 
-if [ -x ${DEVPATH}/${PLATFORM}/${PLATFORM_PLUGIN} ]; then
-    debug "Running ${PLATFORM} specific plugin..."
-    ${DEVPATH}/${PLATFORM}/${PLATFORM_PLUGIN}
-fi
-
 # Enable Watchdog Timer
 if [ -x ${WATCHDOG_UTIL} ]; then
     debug "Enabling Watchdog before ${REBOOT_TYPE}"
     ${WATCHDOG_UTIL} arm
+fi
+
+# Run platform specific reboot plugin
+if [ -x ${DEVPATH}/${PLATFORM}/${PLATFORM_PLUGIN} ]; then
+    debug "Running ${PLATFORM} specific plugin..."
+    ${DEVPATH}/${PLATFORM}/${PLATFORM_PLUGIN}
 fi
 
 # Reboot: explicity call Linux native reboot under sbin


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Enable the watchdog before running platform specific reboot plugin
**- How I did it**
Move the WatchdogUtil call before calling platform specific reboot plugin
**- How to verify it**
Warm reboot without error for hw watchdog support platforms.
**- Previous command output (if the output of a command-line utility has changed)**
N/A
**- New command output (if the output of a command-line utility has changed)**
N/A

Fixes https://github.com/Azure/sonic-buildimage/issues/5118
