### PR TITLE
[tests]:add coverage for config/main/utilities_common module

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 filterwarnings =
     ignore::DeprecationWarning
+addopts = --cov=config --cov=show --cov=utilities_common --cov-report html --cov-report term --cov-report xml


### PR DESCRIPTION
generate xml, html and term report

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
generate xml, html and term report

**- How I did it**
modify pytest.ini

**- How to verify it**
check the report. below is the term report. xml/html has lots of more details.

```
---------- coverage: platform linux2, python 2.7.16-final-0 ----------
Name                              Stmts   Miss  Cover
-----------------------------------------------------
config/__init__.py                    0      0   100%
config/aaa.py                       132     82    38%
config/config_mgmt.py               345    116    66%
config/feature.py                    25      5    80%
config/main.py                     2280   1683    26%
config/mlnx.py                      134     93    31%
config/nat.py                       680    570    16%
show/__init__.py                      0      0   100%
show/bgp_frr_v4.py                   36     36     0%
show/bgp_frr_v6.py                   33     33     0%
show/bgp_quagga_v4.py                20     20     0%
show/bgp_quagga_v6.py                15     15     0%
show/feature.py                      34      0   100%
show/main.py                       1892   1359    28%
show/mlnx.py                         80     62    23%
utilities_common/__init__.py          0      0   100%
utilities_common/cli.py              26      9    65%
utilities_common/db.py                5      0   100%
utilities_common/intf_filter.py      30     18    40%
utilities_common/netstat.py          35     15    57%
utilities_common/util_base.py        32     32     0%
-----------------------------------------------------
TOTAL                              5834   4148    29%
Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml
```

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

