### PR TITLE
[watermarkstat] Import print_function from __future__

### DIFF
--- a/scripts/watermarkstat
+++ b/scripts/watermarkstat
@@ -6,9 +6,12 @@
 #
 #####################################################################
 
+from __future__ import print_function
+
 import argparse
 import json
 import sys
+
 import swsssdk
 from natsort import natsorted
 from tabulate import tabulate


### PR DESCRIPTION
To support the `file=` argument in `print()` function in Python 2.7. 