### PR TITLE
[show_sflow_test.py]: Fix show sflow display.

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1714,20 +1714,18 @@ def policer(policer_name, verbose):
 @click.pass_context
 def sflow(ctx):
     """Show sFlow related information"""
-    config_db = ConfigDBConnector()
-    config_db.connect()
-    ctx.obj = {'db': config_db}
     if ctx.invoked_subcommand is None:
-        show_sflow_global(config_db)
+        db = Db()
+        show_sflow_global(db.cfgdb)
 
 #
 # 'sflow command ("show sflow interface ...")
 #
 @sflow.command('interface')
-@click.pass_context
-def sflow_interface(ctx):
+@clicommon.pass_db
+def sflow_interface(db):
     """Show sFlow interface information"""
-    show_sflow_interface(ctx.obj['db'])
+    show_sflow_interface(db.cfgdb)
 
 def sflow_appDB_connect():
     db = SonicV2Connector(host='127.0.0.1')

--- a/show/main.py
+++ b/show/main.py
@@ -1789,7 +1789,7 @@ def show_sflow_global(config_db):
     click.echo("\n  {} Collectors configured:".format(len(sflow_info)))
     for collector_name in sorted(sflow_info.keys()):
         click.echo("    Name: {}".format(collector_name).ljust(30) +
-                   "IP addr: {}".format(sflow_info[collector_name]['collector_ip']).ljust(20) +
+                   "IP addr: {} ".format(sflow_info[collector_name]['collector_ip']).ljust(25) +
                    "UDP port: {}".format(sflow_info[collector_name]['collector_port']))
 
 

--- a/tests/mock_tables/appl_db.json
+++ b/tests/mock_tables/appl_db.json
@@ -1,4 +1,20 @@
 {
+    "SFLOW_SESSION_TABLE:Ethernet0": {
+        "admin_state": "up",
+        "sample_rate": "2500"
+    },
+    "SFLOW_SESSION_TABLE:Ethernet1": {
+        "admin_state": "up",
+        "sample_rate": "1000"
+    },
+    "SFLOW_SESSION_TABLE:Ethernet112": {
+        "admin_state": "up",
+        "sample_rate": "1000"
+    },
+    "SFLOW_SESSION_TABLE:Ethernet116": {
+        "admin_state": "up",
+        "sample_rate": "5000"
+    },
     "PORT_TABLE:Ethernet0": {
         "index": "0",
         "lanes": "0",

--- a/tests/mock_tables/appl_db.json
+++ b/tests/mock_tables/appl_db.json
@@ -3,7 +3,7 @@
         "admin_state": "up",
         "sample_rate": "2500"
     },
-    "SFLOW_SESSION_TABLE:Ethernet1": {
+    "SFLOW_SESSION_TABLE:Ethernet4": {
         "admin_state": "up",
         "sample_rate": "1000"
     },

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -550,7 +550,7 @@
         "high_mem_alert": "disabled"
     },
     "FEATURE|sflow": {
-        "state": "enabled",
+        "state": "disabled",
         "auto_restart": "enabled",
         "high_mem_alert": "disabled"
     },

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -1,4 +1,17 @@
 {
+    "SFLOW|global": {
+        "admin_state": "up",
+        "agent_id": "eth0",
+        "polling_interval": "0"
+    },
+    "SFLOW_COLLECTOR|prod": {
+            "collector_ip": "fe80::6e82:6aff:fe1e:cd8e",
+            "collector_port": "6343"
+    },
+    "SFLOW_COLLECTOR|ser5": {
+            "collector_ip": "172.21.35.15",
+            "collector_port": "6343"
+    },
     "BREAKOUT_CFG|Ethernet0": {
         "brkout_mode": "4x25G[10G]"
     },
@@ -537,7 +550,7 @@
         "high_mem_alert": "disabled"
     },
     "FEATURE|sflow": {
-        "state": "disabled",
+        "state": "enabled",
         "auto_restart": "enabled",
         "high_mem_alert": "disabled"
     },

--- a/tests/sflow_test.py
+++ b/tests/sflow_test.py
@@ -1,19 +1,19 @@
 import os
 import sys
+import pytest
 from click.testing import CliRunner
-from unittest import TestCase
-from swsssdk import ConfigDBConnector
+from utilities_common.db import Db
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 sys.path.insert(0, test_path)
 sys.path.insert(0, modules_path)
 
-import mock_tables.dbconnector
 import show.main as show
+import mock_tables.dbconnector
 
 # Expected output for 'show sflow'
-show_sflow = ''+ \
+show_sflow_output = ''+ \
 """
 sFlow Global Information:
   sFlow Admin State:          up
@@ -26,7 +26,7 @@ sFlow Global Information:
 """
 
 # Expected output for 'show sflow interface'
-show_sflow_intf = ''+ \
+show_sflow_intf_output = ''+ \
 """
 sFlow interface configurations
 +-------------+---------------+-----------------+
@@ -34,7 +34,7 @@ sFlow interface configurations
 +=============+===============+=================+
 | Ethernet0   | up            |            2500 |
 +-------------+---------------+-----------------+
-| Ethernet1   | up            |            1000 |
+| Ethernet4   | up            |            1000 |
 +-------------+---------------+-----------------+
 | Ethernet112 | up            |            1000 |
 +-------------+---------------+-----------------+
@@ -50,19 +50,20 @@ class TestShowSflow(TestCase):
 
     def setUp(self):
         self.runner = CliRunner()
-        self.config_db = ConfigDBConnector()
-        self.config_db.connect()
-        self.obj = {'db': self.config_db}
+        self.db = Db()
+        self.obj = {'db': self.db}
 
     def test_show_sflow(self):
         result = self.runner.invoke(show.cli.commands["sflow"], [], obj=self.obj)
         print(sys.stderr, result.output)
-        assert result.output == show_sflow
+        assert result.exit_code == 0
+        assert result.output == show_sflow_output
 
     def test_show_sflow_intf(self):
         result = self.runner.invoke(show.cli.commands["sflow"].commands["interface"], [], obj=self.obj)
         print(sys.stderr, result.output)
-        assert result.output == show_sflow_intf
+        assert result.exit_code == 0
+        assert result.output == show_sflow_intf_output
 
     @classmethod
     def teardown_class(cls):

--- a/tests/sflow_test.py
+++ b/tests/sflow_test.py
@@ -4,11 +4,6 @@ import pytest
 from click.testing import CliRunner
 from utilities_common.db import Db
 
-test_path = os.path.dirname(os.path.abspath(__file__))
-modules_path = os.path.dirname(test_path)
-sys.path.insert(0, test_path)
-sys.path.insert(0, modules_path)
-
 import show.main as show
 import mock_tables.dbconnector
 
@@ -42,25 +37,22 @@ sFlow interface configurations
 +-------------+---------------+-----------------+
 """
 
-class TestShowSflow(TestCase):
+class TestShowSflow(object):
     @classmethod
     def setup_class(cls):
         print("SETUP")
         os.environ["UTILITIES_UNIT_TESTING"] = "1"
 
-    def setUp(self):
-        self.runner = CliRunner()
-        self.db = Db()
-        self.obj = {'db': self.db}
-
     def test_show_sflow(self):
-        result = self.runner.invoke(show.cli.commands["sflow"], [], obj=self.obj)
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["sflow"], [], obj=Db())
         print(sys.stderr, result.output)
         assert result.exit_code == 0
         assert result.output == show_sflow_output
 
     def test_show_sflow_intf(self):
-        result = self.runner.invoke(show.cli.commands["sflow"].commands["interface"], [], obj=self.obj)
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["sflow"].commands["interface"], [], obj=Db())
         print(sys.stderr, result.output)
         assert result.exit_code == 0
         assert result.output == show_sflow_intf_output

--- a/tests/show_sflow_test.py
+++ b/tests/show_sflow_test.py
@@ -1,0 +1,71 @@
+import os
+import sys
+from click.testing import CliRunner
+from unittest import TestCase
+from swsssdk import ConfigDBConnector
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(test_path)
+sys.path.insert(0, test_path)
+sys.path.insert(0, modules_path)
+
+import mock_tables.dbconnector
+import show.main as show
+
+# Expected output for 'show sflow'
+show_sflow = ''+ \
+"""
+sFlow Global Information:
+  sFlow Admin State:          up
+  sFlow Polling Interval:     0
+  sFlow AgentID:              eth0
+
+  2 Collectors configured:
+    Name: prod                IP addr: fe80::6e82:6aff:fe1e:cd8e UDP port: 6343
+    Name: ser5                IP addr: 172.21.35.15    UDP port: 6343
+"""
+
+# Expected output for 'show sflow interface'
+show_sflow_intf = ''+ \
+"""
+sFlow interface configurations
++-------------+---------------+-----------------+
+| Interface   | Admin State   |   Sampling Rate |
++=============+===============+=================+
+| Ethernet0   | up            |            2500 |
++-------------+---------------+-----------------+
+| Ethernet1   | up            |            1000 |
++-------------+---------------+-----------------+
+| Ethernet112 | up            |            1000 |
++-------------+---------------+-----------------+
+| Ethernet116 | up            |            5000 |
++-------------+---------------+-----------------+
+"""
+
+class TestShowSflow(TestCase):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        os.environ["UTILITIES_UNIT_TESTING"] = "1"
+
+    def setUp(self):
+        self.runner = CliRunner()
+        self.config_db = ConfigDBConnector()
+        self.config_db.connect()
+        self.obj = {'db': self.config_db}
+
+    def test_show_sflow(self):
+        result = self.runner.invoke(show.cli.commands["sflow"], [], obj=self.obj)
+        print(sys.stderr, result.output)
+        assert result.output == show_sflow
+
+    def test_show_sflow_intf(self):
+        result = self.runner.invoke(show.cli.commands["sflow"].commands["interface"], [], obj=self.obj)
+        print(sys.stderr, result.output)
+        assert result.output == show_sflow_intf
+
+    @classmethod
+    def teardown_class(cls):
+        print("TEARDOWN")
+        os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])
+        os.environ["UTILITIES_UNIT_TESTING"] = "0"


### PR DESCRIPTION
Changes:
-- Display ipv4 address with left adjust of 25 width and with space before UDP.
-- IPv6 address will be displayed as is.
-- Add test data to appl_db.json and config_db.json
-- add test file show_sflow_test.py

Signed-off-by: Praveen Chaudhary pchaudhary@linkedin.com

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Changes:
-- Display ipv4 address with left adjust of 25 width and with space before UDP.
-- IPv6 address will be displayed as is.
-- Add test data to appl_db.json and config_db.json
-- add test file show_sflow_test.py

**- How I did it**
Display ipv4 address with left adjust of 25 width and with space before UDP.

**- How to verify it**
-- Add test data to appl_db.json and config_db.json
-- add test file show_sflow_test.py

Built with above test:
```
pchaudha@server05:/home/pchaudha/srcCode/azure_myforks/sonic-buildimage$ date
Fri Aug 14 14:01:58 PDT 2020
pchaudha@server05:/home/pchaudha/srcCode/azure_myforks/sonic-buildimage$ ls -l target/python-debs/python-sonic-utilities_1.2-1_all.deb
-rw-r--r-- 1 pchaudha pchaudha 168448 Aug 14 14:01 target/python-debs/python-sonic-utilities_1.2-1_all.deb
```
**- Previous command output (if the output of a command-line utility has changed)**
Before Fix:
```
show sflow
 
sFlow Global Information:
  sFlow Admin State:          up
  sFlow Polling Interval:     0
  sFlow AgentID:              eth0
 
  2 Collectors configured:
    Name: prod                IP addr: 10.252.194.107UDP port: 6343
    Name: ser5                IP addr: 172.21.47.15UDP port: 6343

```

**- New command output (if the output of a command-line utility has changed)**
After Fix:
```
admin@lnos-x1-a-asw04:~$ show sflow

sFlow Global Information:
  sFlow Admin State:          up
  sFlow Polling Interval:     0
  sFlow AgentID:              eth0

  2 Collectors configured:
    Name: prod                IP addr: 10.252.194.107  UDP port: 6343
    Name: ser5                IP addr: 172.21.47.15    UDP port: 6343


admin@lnos-x1-a-asw04:~$ show sflow

sFlow Global Information:
  sFlow Admin State:          up
  sFlow Polling Interval:     0
  sFlow AgentID:              eth0

  2 Collectors configured:
    Name: prod                IP addr: fe80::6e41:6aff:fe1e:cd8e UDP port: 6343
    Name: ser5                IP addr: 172.21.47.15    UDP port: 6343
```
