### PR TITLE
[201911] fix show version 

### DIFF
--- a/scripts/decode-syseeprom
+++ b/scripts/decode-syseeprom
@@ -26,7 +26,7 @@ def main():
         raise RuntimeError("must be root to run")
 
     # Get platform name
-    platform = device_info.get_platform_info()
+    platform = device_info.get_platform()
 
     platform_path = '/'.join([PLATFORM_ROOT, platform])
 


### PR DESCRIPTION
what I did:
Fix show version on 201911. When using new sonic_py-common package
we have to use get_platform() instead of get_platform_info()

How i Verified:
show version is fine after this change 

