### PR TITLE
[sonic-installer] Import 're' module

### DIFF
--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -6,6 +6,7 @@ except ImportError:
     import configparser
 
 import os
+import re
 import subprocess
 import sys
 import time


### PR DESCRIPTION
The `import re` line was removed from the file in https://github.com/Azure/sonic-utilities/pull/953. However, it is still referenced in the `update_sonic_environment()` function. Adding it back.

Was causing the following traceback during `sonic-installer install` command on certain platforms:

```
Installed SONiC base image SONiC-OS successfully

Command: grub-set-default --boot-directory=/host 0

Command: config-setup backup
Taking backup of curent configuration

Traceback (most recent call last):
  File "/usr/bin/sonic-installer", line 12, in <module>
    sys.exit(sonic_installer())
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/sonic_installer/main.py", line 329, in install
    update_sonic_environment(click, binary_image_version)
  File "/usr/lib/python2.7/dist-packages/sonic_installer/main.py", line 230, in update_sonic_environment
    sonic_version = re.sub("SONiC-OS-", '', binary_image_version)
NameError: global name 're' is not defined
```
