### PR TITLE
Handling deletion of Port Channel before deletion of its members

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1231,7 +1231,7 @@ def remove_portchannel(ctx, portchannel_name):
     """Remove port channel"""
     db = ctx.obj['db']
     if len([(k, v) for k, v in db.get_table('PORTCHANNEL_MEMBER') if k == portchannel_name]) != 0:
-        ctx.fail("Portchannel {} contains members. Remove members before deleting Portchannel!".format(portchannel_name))
+        click.echo("Error: Portchannel {} contains members. Remove members before deleting Portchannel!".format(portchannel_name))
     else:
         db.set_entry('PORTCHANNEL', portchannel_name, None)
 

--- a/config/main.py
+++ b/config/main.py
@@ -1230,7 +1230,7 @@ def add_portchannel(ctx, portchannel_name, min_links, fallback):
 def remove_portchannel(ctx, portchannel_name):
     """Remove port channel"""
     db = ctx.obj['db']
-    if len([ (k, v) for k, v in db.get_table('PORTCHANNEL_MEMBER') if k == portchannel_name]) != 0:
+    if len([(k, v) for k, v in db.get_table('PORTCHANNEL_MEMBER') if k == portchannel_name]) != 0:
         ctx.fail("Portchannel {} contains members. Remove members before deleting Portchannel!".format(portchannel_name))
     else:
         db.set_entry('PORTCHANNEL', portchannel_name, None)

--- a/config/main.py
+++ b/config/main.py
@@ -1230,7 +1230,10 @@ def add_portchannel(ctx, portchannel_name, min_links, fallback):
 def remove_portchannel(ctx, portchannel_name):
     """Remove port channel"""
     db = ctx.obj['db']
-    db.set_entry('PORTCHANNEL', portchannel_name, None)
+    if len([ (k, v) for k, v in db.get_table('PORTCHANNEL_MEMBER') if k == portchannel_name]) != 0:
+        ctx.fail("Portchannel {} contains members. Remove members before deleting Portchannel!".format(portchannel_name))
+    else:
+        db.set_entry('PORTCHANNEL', portchannel_name, None)
 
 @portchannel.group(cls=clicommon.AbbreviationGroup, name='member')
 @click.pass_context

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -4838,7 +4838,7 @@ Command takes two optional arguements given below.
 1) min-links  - minimum number of links required to bring up the portchannel
 2) fallback - true/false. LACP fallback feature can be enabled / disabled.  When it is set to true, only one member port will be selected as active per portchannel during fallback mode. Refer https://github.com/Azure/SONiC/blob/master/doc/lag/LACP%20Fallback%20Feature%20for%20SONiC_v0.5.md for more details about fallback feature.
 
-A portchannel can be deleted only if it does not have any members or the members are already deleted. When a user tries to delete a portchannel and the portchannel still has one or more members that exist, the deletion of portchannel is blocked. 
+A port channel can be deleted only if it does not have any members or the members are already deleted. When a user tries to delete a port channel and the port channel still has one or more members that exist, the deletion of port channel is blocked. 
 
 - Usage:
   ```

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -4838,6 +4838,8 @@ Command takes two optional arguements given below.
 1) min-links  - minimum number of links required to bring up the portchannel
 2) fallback - true/false. LACP fallback feature can be enabled / disabled.  When it is set to true, only one member port will be selected as active per portchannel during fallback mode. Refer https://github.com/Azure/SONiC/blob/master/doc/lag/LACP%20Fallback%20Feature%20for%20SONiC_v0.5.md for more details about fallback feature.
 
+A portchannel can be deleted only if it does not have any members or the members are already deleted. When a user tries to delete a portchannel and the portchannel still has one or more members that exist, the deletion of portchannel is blocked. 
+
 - Usage:
   ```
   config portchannel (add | del) <portchannel_name> [min-links <num_min_links>] [fallback (true | false)]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

- What I did
Handled configuration code to block deletion of Port channel when user tries to delete a Port channel before deleting its members.

- How I did it
In the sonic-utilities/config/main.py, where the removal of Port channel configuration is handled, I added a check whether the Port channel to be deleted has any members. If members exist, I will block the configuration of deleting the port channel.

- How to verify it
Create a Portchannel. Add 2 switch ports to it as members. Then try to delete the port channel. Now, the deletion of port channel should be blocked by the config since it has port channel members still existing.

- Previous command output (if the output of a command-line utility has changed)
```
admin@r-qa-sw-eth-53:/tmp$ sudo config portchannel add portchannel100
admin@r-qa-sw-eth-53:/tmp$ sudo config portchannel member add portchannel100 Ethernet4
admin@r-qa-sw-eth-53:/tmp$ sudo config portchannel member add portchannel100 Ethernet8
admin@r-qa-sw-eth-53:/tmp$ show interfaces portchannel
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,
       S - selected, D - deselected, * - not synced
  No.  Team Dev        Protocol     Ports
-----  --------------  -----------  -------------------------
  100  PortChannel100  LACP(A)(Dw)  Ethernet8(D) Ethernet4(D)
admin@r-qa-sw-eth-53:/tmp$ sudo config portchannel del portchannel100
admin@r-qa-sw-eth-53:/tmp$ show interfaces portchannel
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,
       S - selected, D - deselected, * - not synced
No.    Team Dev    Protocol    Ports
-----  ----------  ----------  -------
admin@r-qa-sw-eth-53:/tmp$
```
- New command output (if the output of a command-line utility has changed)
```
admin@r-qa-sw-eth-53:~$ sudo config portchannel add portchannel100
admin@r-qa-sw-eth-53:~$ sudo config portchannel member add portchannel100 Ethernet4
admin@r-qa-sw-eth-53:~$ sudo config portchannel member add portchannel100 Ethernet8
admin@r-qa-sw-eth-53:~$ show interfaces portchannel
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,
       S - selected, D - deselected, * - not synced
  No.  Team Dev        Protocol     Ports
-----  --------------  -----------  -------------------------
  100  PortChannel100  LACP(A)(Dw)  Ethernet8(D) Ethernet4(D)
admin@r-qa-sw-eth-53:~$ sudo config portchannel del portchannel100
Error: Portchannel portchannel100 contains members. Remove members before deleting Portchannel!
admin@r-qa-sw-eth-53:~$ show interfaces portchannel
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,
       S - selected, D - deselected, * - not synced
  No.  Team Dev        Protocol     Ports
-----  --------------  -----------  -------------------------
  100  PortChannel100  LACP(A)(Dw)  Ethernet8(D) Ethernet4(D)
admin@r-qa-sw-eth-53:~$ sudo config portchannel member del portchannel100 Ethernet4
admin@r-qa-sw-eth-53:~$ sudo config portchannel member del portchannel100 Ethernet8
admin@r-qa-sw-eth-53:~$ sudo config portchannel del portchannel100
admin@r-qa-sw-eth-53:~$ show interfaces portchannel
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,
       S - selected, D - deselected, * - not synced
No.    Team Dev    Protocol    Ports
-----  ----------  ----------  -------
admin@r-qa-sw-eth-53:~$
```