### PR TITLE
[show] [lldp] Fix error 'the input device is not a TTY' when running 'show lldp table/neighbor'

### DIFF
--- a/scripts/lldpshow
+++ b/scripts/lldpshow
@@ -79,7 +79,7 @@ class Lldpshow(object):
             lldp_interface_list = lldp_port if lldp_port is not None else self.lldp_interface[lldp_instace_num]
             # In detail mode we will pass interface list (only front ports) and get O/P as plain text
             # and in table format we will get xml output
-            lldp_cmd = 'sudo docker exec -it lldp{} lldpctl '.format(self.lldp_instance[lldp_instace_num]) + (
+            lldp_cmd = 'sudo docker exec -i lldp{} lldpctl '.format(self.lldp_instance[lldp_instace_num]) + (
                 '-f xml' if not lldp_detail_info else lldp_interface_list)
             p = subprocess.Popen(lldp_cmd, stdout=subprocess.PIPE, shell=True)
             (output, err) = p.communicate()


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
This PR is to fix https://github.com/Azure/sonic-buildimage/issues/5239
The command 'show lldp table/neighbor' always return error message 'the input device is not a TTY' when running in a SSH command or running with Ansible. This commit is to fix this issue.

This is a backport of https://github.com/Azure/sonic-utilities/pull/1016 to the 201911 branch.
```
ssh admin@10.64.247.224 "show lldp table"   
the input device is not a TTY

ssh admin@10.64.247.224 "show lldp neighbors" 
the input device is not a TTY
```
**- How I did it**
Update lldpshow. Replace the **-it** in **docker exec** with **-i**, because there is no need for a pseudo-TTY when running in command line.
**- How to verify it**
Verify on Arista-7260.
Before update:
```
ssh admin@10.64.247.224 "show lldp table"   
the input device is not a TTY

ssh admin@10.64.247.224 "show lldp neighbors" 
the input device is not a TTY
```
After Update:
```
ssh admin@10.64.247.224 "show lldp table"   
Capability codes: (R) Router, (B) Bridge, (O) Other
LocalPort    RemoteDevice    RemotePortID    Capability    RemotePortDescr
-----------  --------------  --------------  ------------  -----------------
Ethernet48   ARISTA01T1      Ethernet1       BR
Ethernet52   ARISTA01T1      Ethernet2       BR
Ethernet56   ARISTA02T1      Ethernet1       BR
Ethernet60   ARISTA02T1      Ethernet2       BR
Ethernet64   ARISTA03T1      Ethernet1       BR
Ethernet68   ARISTA03T1      Ethernet2       BR
Ethernet72   ARISTA04T1      Ethernet1       BR
Ethernet76   ARISTA04T1      Ethernet2       BR
eth0         2200-ACS-1      ge-0/0/29       BR            ge-0/0/29.0
--------------------------------------------------
Total entries displayed:  9

ssh admin@10.64.247.224 "show lldp neighbor"
-------------------------------------------------------------------------------
LLDP neighbors:
-------------------------------------------------------------------------------
Interface:    eth0, via: LLDP, RID: 5, Time: 0 day, 02:35:29
  Chassis:     
    ChassisID:    mac dc:38:e1:96:ce:c0
    SysName:      2200-ACS-1
    SysDescr:     Juniper Networks, Inc. ex2200-48t-4g , version 12.3R6.6 Build date: 2014-03-13 07:02:54 UTC 
    TTL:          90
    Capability:   Bridge, on
    Capability:   Router, on
  Port:        
    PortID:       ifname ge-0/0/29
    PortDescr:    ge-0/0/29.0
    MFS:          1514
    PMD autoneg:  supported: yes, enabled: yes
      Adv:          10Base-T, HD: yes, FD: yes
      Adv:          100Base-TX, HD: yes, FD: yes
      Adv:          1000Base-T, HD: no, FD: yes
      MAU oper type: unknown
......
```
**- Previous command output (if the output of a command-line utility has changed)**
N/A
**- New command output (if the output of a command-line utility has changed)**
N/A
