### PR TITLE
[config] Remove _get_breakout_cfg_file_name helper function

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -12,7 +12,7 @@ import sys
 import threading
 import time
 
-from minigraph import earse_device_desc_xml
+from minigraph import parse_device_desc_xml
 from portconfig import get_child_ports, get_port_config_file_name
 from sonic_py_common import device_info
 from swsssdk import ConfigDBConnector, SonicV2Connector, SonicDBConfig

--- a/config/main.py
+++ b/config/main.py
@@ -13,7 +13,7 @@ import threading
 import time
 
 from minigraph import parse_device_desc_xml
-from portconfig import get_child_ports, get_port_config_file_name
+from portconfig import get_child_ports
 from sonic_py_common import device_info
 from swsssdk import ConfigDBConnector, SonicV2Connector, SonicDBConfig
 from utilities_common.db import Db

--- a/config/main.py
+++ b/config/main.py
@@ -12,7 +12,7 @@ import sys
 import threading
 import time
 
-from minigraph import parse_device_desc_xml
+from minigraph import earse_device_desc_xml
 from portconfig import get_child_ports, get_port_config_file_name
 from sonic_py_common import device_info
 from swsssdk import ConfigDBConnector, SonicV2Connector, SonicDBConfig
@@ -67,25 +67,6 @@ def readJsonFile(fileName):
     except Exception as e:
         raise Exception(str(e))
     return result
-
-def _get_breakout_cfg_file_name():
-    """
-    Get name of config file for Dynamic Port Breakout
-    """
-    try:
-        (platform, hwsku) = device_info.get_platform_and_hwsku()
-    except Exception as e:
-        click.secho("Failed to get platform and hwsku with error:{}".format(str(e)), fg='red')
-        raise click.Abort()
-
-    try:
-        breakout_cfg_file_name = get_port_config_file_name(hwsku, platform)
-    except Exception as e:
-        click.secho("Breakout config file not found with error:{}".format(str(e)), fg='red')
-        raise click.Abort()
-
-    return breakout_cfg_file_name
-
 
 def _get_breakout_options(ctx, args, incomplete):
     """ Provides dynamic mode option as per user argument i.e. interface name """

--- a/config/main.py
+++ b/config/main.py
@@ -92,7 +92,7 @@ def _get_breakout_options(ctx, args, incomplete):
     all_mode_options = []
     interface_name = args[-1]
 
-    breakout_cfg_file = _get_breakout_cfg_file_name()
+    breakout_cfg_file = device_info.get_path_to_port_config_file()
 
     if not os.path.isfile(breakout_cfg_file) or not breakout_cfg_file.endswith('.json'):
         return []
@@ -2153,7 +2153,7 @@ def speed(ctx, interface_name, interface_speed, verbose):
 @click.pass_context
 def breakout(ctx, interface_name, mode, verbose, force_remove_dependencies, load_predefined_config):
     """ Set interface breakout mode """
-    breakout_cfg_file = _get_breakout_cfg_file_name()
+    breakout_cfg_file = device_info.get_path_to_port_config_file()
 
     if not os.path.isfile(breakout_cfg_file) or not breakout_cfg_file.endswith('.json'):
         click.secho("[ERROR] Breakout feature is not available without platform.json file", fg='red')


### PR DESCRIPTION
this PR addresses replacing _get_breakout_cfg_file_name
function with device_info.get_path_to_port_config_file().
This is part of a larger clean up of functions which return
the port_config_file which reside outside of
sonic_py_common packages. This is motivated due to
redundancy of code as well as making it easier to change
the default behaviour of helper utility function
port_config_file unified and in one place.

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

