### PR TITLE
[config] Update SONiC Environment Vars When Loading Minigraph

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -810,6 +810,24 @@ def validate_mirror_session_config(config_db, session_name, dst_port, src_port, 
 
     return True
 
+def update_sonic_environment():
+    """Prepare sonic environment variable using SONiC environment template file.
+    """
+    SONIC_ENV_TEMPLATE_FILE = os.path.join('/', "usr", "share", "sonic", "templates", "sonic-environment.j2")
+    SONIC_VERSION_YML_FILE = os.path.join('/', "etc", "sonic", "sonic_version.yml")
+    SONIC_ENV_FILE = os.path.join('/', "etc", "sonic", "sonic-environment")
+
+    if os.path.isfile(SONIC_ENV_TEMPLATE_FILE) and os.path.isfile(SONIC_VERSION_YML_FILE):
+        clicommon.run_command(
+            "{} -d -y {} -t {},{}".format(
+                SONIC_CFGGEN_PATH,
+                SONIC_VERSION_YML_FILE,
+                SONIC_ENV_TEMPLATE_FILE,
+                SONIC_ENV_FILE
+            ),
+            display_cmd=True
+        )
+
 # This is our main entrypoint - the main 'config' command
 @click.group(cls=clicommon.AbbreviationGroup, context_settings=CONTEXT_SETTINGS)
 @click.pass_context
@@ -1157,6 +1175,9 @@ def load_minigraph(db, no_service_restart):
         if num_npus == 1 or namespace is not DEFAULT_NAMESPACE:
             if device_type != 'MgmtToRRouter':
                 clicommon.run_command('{}pfcwd start_default'.format(ns_cmd_prefix), display_cmd=True)
+
+    # Update SONiC environmnet file
+    update_sonic_environment()
 
     if os.path.isfile('/etc/sonic/acl.json'):
         clicommon.run_command("acl-loader update full /etc/sonic/acl.json", display_cmd=True)


### PR DESCRIPTION
Update SONiC envvars file when loading minigraph.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

**- What I did**
Update SONiC Environment Var when loading minigraph

**- How I did it**
Add code to update those variables

**- How to verify it**
`sudo config load_minigraph -y`

**- Previous command output (if the output of a command-line utility has changed)**
```
Executing stop of service bgp...
Executing stop of service hostcfgd...
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json   --write-to-db
Running command: pfcwd start_default
Running command: config qos reload
Running command: /usr/local/bin/sonic-cfggen  -d -t /usr/share/sonic/device/x86_64-dell_s6000_s1220-r0/Force10-S6000/buffers.json.j2,config-db -t /usr/share/sonic/device/x86_64-dell_s6000_s1220-r0/Force10-S6000/qos.json.j2,config-db -y /etc/sonic/sonic_version.yml --write-to-db
Executing reset-failed of service bgp...
```
**- New command output (if the output of a command-line utility has changed)**
```
Executing stop of service bgp...
Executing stop of service hostcfgd...
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json   --write-to-db
Running command: pfcwd start_default
Running command: /usr/local/bin/sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t /usr/share/sonic/templates/sonic-environment.j2,/etc/sonic/sonic-environment
Running command: config qos reload
Running command: /usr/local/bin/sonic-cfggen  -d -t /usr/share/sonic/device/x86_64-dell_s6000_s1220-r0/Force10-S6000/buffers.json.j2,config-db -t /usr/share/sonic/device/x86_64-dell_s6000_s1220-r0/Force10-S6000/qos.json.j2,config-db -y /etc/sonic/sonic_version.yml --write-to-db
Executing reset-failed of service bgp...
```
