### PR TITLE
[pfcwd] Fix stats crash with invalid queue name

### DIFF
--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -83,6 +83,8 @@ def stats(empty, queues):
     for queue in queues:
         stats_list = []
         queue_oid = db.get(db.COUNTERS_DB, 'COUNTERS_QUEUE_NAME_MAP', queue)
+        if queue_oid is None:
+            continue
         stats = db.get_all(db.COUNTERS_DB, 'COUNTERS:' + queue_oid)
         if stats is None:
             continue


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->
Pfcwd show stats was crashing when an invalid queue name was specified as argument
fixes #1076 

**- What I did**
Retreive stats only for valid queue names

**- How to verify it**
With the fix,
```
admin@str-7260cx3-acs-7:~$ pfcwd show stats Ethernet0:30                         
  QUEUE    STATUS    STORM DETECTED/RESTORED    TX OK/DROP    RX OK/DROP    TX LAST OK/DROP    RX LAST OK/DROP
-------  --------  -------------------------  ------------  ------------  -----------------  -----------------
```

