### PR TITLE
[show][bgp] Display the Total number of neighbors in the  show ip bgp(v6) summary

### DIFF
--- a/tests/bgp_commands_test.py
+++ b/tests/bgp_commands_test.py
@@ -40,6 +40,8 @@ Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down 
 10.0.0.59      4  64014          0          0         0      0       0  never      Active          ARISTA14T0
 10.0.0.61      4  64015          0          0         0      0       0  never      Active          ARISTA15T0
 10.0.0.63      4  64016          0          0         0      0       0  never      Active          ARISTA16T0
+
+Total number of neighbors 24
 """
 
 show_bgp_summary_v6 = """\
@@ -78,6 +80,8 @@ fc00::66       4  64010          0          0         0      0       0  never   
 fc00::72       4  64013          0          0         0      0       0  never      Active          ARISTA13T0
 fc00::76       4  64014          0          0         0      0       0  never      Active          ARISTA14T0
 fc00::a        4  65200       6665       6671         0      0       0  2d09h38m   6402            ARISTA03T2
+
+Total number of neighbors 24
 """
 
 show_error_invalid_json = """\

--- a/tests/multi_asic_intfutil_test.py
+++ b/tests/multi_asic_intfutil_test.py
@@ -180,3 +180,4 @@ class TestInterfacesMultiAsic(object):
         os.environ["PATH"] = os.pathsep.join(
             os.environ["PATH"].split(os.pathsep)[:-1])
         os.environ["UTILITIES_UNIT_TESTING"] = "0"
+        os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = ""

--- a/utilities_common/bgp_util.py
+++ b/utilities_common/bgp_util.py
@@ -231,6 +231,8 @@ def display_bgp_summary(bgp_summary, af):
         click.echo("\n")
 
         click.echo(tabulate(natsorted(bgp_summary['peers']), headers=headers))
+        click.echo("\nTotal number of neighbors {}".
+                   format(len(bgp_summary['peers'])))
     except KeyError as e:
         ctx = click.get_current_context()
         ctx.fail("{} missing in the bgp_summary".format(e.args[0]))


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Two minor Fixes to the done 
- reset the os environ UTILITIES_UNIT_TESTING_TOPOLOGY multi_asic_intfutil_test after the test is done
 - add the line "Total number of neighbors" to the show ip(v6) bgp summary

**- How I did it**
Update the bgp display function to display the` Total number of neighbors`

**- How to verify it**
**UT results**
```
============================= test session starts ==============================
platform linux2 -- Python 2.7.16, pytest-3.10.1, py-1.7.0, pluggy-0.8.0
rootdir: /sonic/src/sonic-utilities, inifile: pytest.ini
plugins: cov-2.6.0
collected 143 items

tests/acl_loader_test.py ....                                            [  2%]
tests/aclshow_test.py ...........                                        [ 10%]
tests/bgp_commands_test.py ...                                           [ 12%]
tests/config_mgmt_test.py ....                                           [ 15%]
tests/config_test.py ..                                                  [ 16%]
tests/drops_group_test.py .......                                        [ 21%]
tests/fan_test.py .                                                      [ 22%]
tests/feature_test.py ..........                                         [ 29%]
tests/filter_fdb_entries_test.py ..........                              [ 36%]
tests/gearbox_test.py ..                                                 [ 37%]
tests/interfaces_test.py .............                                   [ 46%]
tests/intfstat_test.py ........                                          [ 52%]
tests/intfutil_test.py ...............                                   [ 62%]
tests/multi_asic_intfutil_test.py .........                              [ 69%]
tests/neighbor_advertiser_test.py .                                      [ 69%]
tests/port2alias_test.py ....                                            [ 72%]
tests/psu_test.py ...                                                    [ 74%]
tests/sflow_test.py ..                                                   [ 76%]
tests/sfp_test.py ...                                                    [ 78%]
tests/show_breakout_test.py ..                                           [ 79%]
tests/show_platform_test.py .                                            [ 80%]
tests/vlan_test.py ............................                          [100%]

```
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

