### PR TITLE
[setup.py] Add aliases.ini to sonic_installer package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
     ],
     package_data={
         'show': ['aliases.ini'],
+        'sonic_installer': ['aliases.ini'],
         'tests': ['acl_input/*',
                   'mock_tables/*.py',
                   'mock_tables/*.json',


### PR DESCRIPTION
Ensure aliases.ini gets installed with the sonic_installer package to enable backward-compatibility with the versions of subcommands which contain underscores.

This was missed in https://github.com/Azure/sonic-utilities/pull/983