### PR TITLE
[Mellanox] Fix a typo in mellanox_buffer_migrator

### DIFF
--- a/scripts/mellanox_buffer_migrator.py
+++ b/scripts/mellanox_buffer_migrator.py
@@ -354,7 +354,7 @@ class MellanoxBufferMigrator():
             return True
 
         for name, profile in buffer_profile_old_configure.iteritems():
-            if name in buffer_profile_conf.keys() and profile == buffer_profile_old_configure[name]:
+            if name in buffer_profile_conf.keys() and profile == buffer_profile_conf[name]:
                 continue
             # return if any default profile isn't in cofiguration
             log.log_notice("Default profile {} isn't in database or doesn't match default value".format(name))
@@ -363,3 +363,5 @@ class MellanoxBufferMigrator():
         for name, profile in buffer_profile_new_configure.iteritems():
             log.log_info("Successfully migrate profile {}".format(name))
             self.configDB.set_entry('BUFFER_PROFILE', name, profile)
+
+        return True


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->
Fix a typo in mellanox_buffer_migrator
This typo causes the db_migrator to update the buffer profiles even if they don't match the default

- [ ] 201811
- [x] 201911
- [ ] 202006

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**- What I did**

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

