### PR TITLE
Add ASIC namespace ID to core filename, if any

### DIFF
--- a/scripts/coredump-compress
+++ b/scripts/coredump-compress
@@ -2,9 +2,16 @@
 
 # Collect all parameters in order and build a file name prefix
 PREFIX=""
-while [[ $# > 0 ]]; do
+while [[ $# > 1 ]]; do
     PREFIX=${PREFIX}$1.
     shift
 done
+
+if [ $# > 0 ]; then
+    ns=`xargs -0 -L1 -a /proc/${1}/environ | grep -e "^NAMESPACE_ID" | cut -f2 -d'='`
+    if [ ! -z ${ns} ]; then
+        PREFIX=${PREFIX}${ns}.
+    fi
+fi
 
 /bin/gzip -1 - > /var/core/${PREFIX}core.gz


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Look for namespace of this process in crashing process's environ file.If any, add it to core filename as
< binary name >.< timestamp >.< local pid inside container >.< ns > .core.gz.
e.g. orchagent.1599073263.45.5.core.gz  <-- 5 is the asic namespace.

For processes that don't have asic namespace, there is no change.
e.g. snmpd.1599073245.27.core.gz

The /etc/sysctl.conf kernel.core_pattern is set to pass `pid in host`
as last arg.

**- How I did it**

**- How to verify it**
Crash a process running in a namespace and another process that is *not* running in a namepsace and  verify, the core filenames.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

