### PR TITLE
[config] "BREAKOUT_CFG" would not cause harm to system when perform b…

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -165,13 +165,16 @@ def breakout_warnUser_extraTables(cm, final_delPorts, confirm=True):
     try:
         # check if any extra tables exist
         eTables = cm.tablesWithOutYang()
+        # Don't care "BREAKOUT_CFG"
+        eTables.pop('BREAKOUT_CFG', None)
         if len(eTables):
             # find relavent tables in extra tables, i.e. one which can have deleted
             # ports
             tables = cm.configWithKeys(configIn=eTables, keys=final_delPorts)
-            click.secho("Below Config can not be verified, It may cause harm "\
-                "to the system\n {}".format(json.dumps(tables, indent=2)))
-            click.confirm('Do you wish to Continue?', abort=True)
+            if len(tables):
+                click.secho("Below Config can not be verified, It may cause harm "\
+                    "to the system\n {}".format(json.dumps(tables, indent=2)))
+                click.confirm('Do you wish to Continue?', abort=True)
     except Exception as e:
         raise Exception("Failed in breakout_warnUser_extraTables. Error: {}".format(str(e)))
     return


### PR DESCRIPTION
…reakout command.

Signed-off-by: chiourung_huang <chiourung_huang@edge-core.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
   skip "BREAKOUT_CFG" when check if the configure would cause harm to system

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

