### PR TITLE
[sonic-cfggen][QoS][multi ASIC] Multi ASIC QoS and Buffer config generation support, merge from master

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         'scripts/fast-reboot-dump.py',
         'scripts/fdbclear',
         'scripts/fdbshow',
-        'scripts/filter_fdb_entries.py',
+        'fdbutil/filter_fdb_entries.py',
         'scripts/generate_dump',
         'scripts/intfutil',
         'scripts/intfstat',


### PR DESCRIPTION

**- What I did**

[ merge from #978 ]

To support buffer and QoS config generation for multi ASIC platform. In case of multi ASIC platforms each ASIC has its own buffer and qos configuration template which is used to populate corresponding ASIC's config DB.

Following commands were modified for this purpose:

# config qos reload
# config qos clear
In multi ASIC platforms the command runs on all namespaces. In case of single ASIC platform the command runs in global namespace.

admin@str-nSonic-acs-2:~$ sudo config qos reload --help                                                                                                                                
Usage: config qos reload [OPTIONS]                                                                                                                                                    

  Reload QoS configuration

Options:
  -?, -h, --help        Show this message and exit.
admin@str-nSonic-acs-2:~$ sudo config qos clear --help                                                                                                                                 
Usage: config qos clear [OPTIONS]

  Clear QoS configuration

Options:
  -?, -h, --help        Show this message and exit.         

**- How I did it**

Modified config generation script to generate configs for all ASICs in case of multi-ASIC platform.

**- How to verify it**

```
admin@str-n3164-acs-2:/usr/lib/python2.7/dist-packages/config$ sudo config qos reload
Running command: /usr/local/bin/sonic-cfggen -n asic0 -d -t /usr/share/sonic/device/x86_64-n3164-r0/Nexus-3164/0/buffers.json.j2 > /tmp/buffers0.json
Running command: /usr/local/bin/sonic-cfggen -n asic0 -d -t /usr/share/sonic/device/x86_64-n3164-r0/Nexus-3164/0/qos.json.j2 -y /etc/sonic/sonic_version.yml > /tmp/qos0.json
Running command: /usr/local/bin/sonic-cfggen -n asic0 -j /tmp/buffers0.json --write-to-db
Running command: /usr/local/bin/sonic-cfggen -n asic0 -j /tmp/qos0.json --write-to-db
Running command: /usr/local/bin/sonic-cfggen -n asic1 -d -t /usr/share/sonic/device/x86_64-n3164-r0/Nexus-3164/1/buffers.json.j2 > /tmp/buffers1.json
Running command: /usr/local/bin/sonic-cfggen -n asic1 -d -t /usr/share/sonic/device/x86_64-n3164-r0/Nexus-3164/1/qos.json.j2 -y /etc/sonic/sonic_version.yml > /tmp/qos1.json
Running command: /usr/local/bin/sonic-cfggen -n asic1 -j /tmp/buffers1.json --write-to-db
Running command: /usr/local/bin/sonic-cfggen -n asic1 -j /tmp/qos1.json --write-to-db
Running command: /usr/local/bin/sonic-cfggen -n asic2 -d -t /usr/share/sonic/device/x86_64-n3164-r0/Nexus-3164/2/buffers.json.j2 > /tmp/buffers2.json
Running command: /usr/local/bin/sonic-cfggen -n asic2 -d -t /usr/share/sonic/device/x86_64-n3164-r0/Nexus-3164/2/qos.json.j2 -y /etc/sonic/sonic_version.yml > /tmp/qos2.json
Running command: /usr/local/bin/sonic-cfggen -n asic2 -j /tmp/buffers2.json --write-to-db
Running command: /usr/local/bin/sonic-cfggen -n asic2 -j /tmp/qos2.json --write-to-db
Running command: /usr/local/bin/sonic-cfggen -n asic3 -d -t /usr/share/sonic/device/x86_64-n3164-r0/Nexus-3164/3/buffers.json.j2 > /tmp/buffers3.json
Running command: /usr/local/bin/sonic-cfggen -n asic3 -d -t /usr/share/sonic/device/x86_64-n3164-r0/Nexus-3164/3/qos.json.j2 -y /etc/sonic/sonic_version.yml > /tmp/qos3.json
Running command: /usr/local/bin/sonic-cfggen -n asic3 -j /tmp/buffers3.json --write-to-db
Running command: /usr/local/bin/sonic-cfggen -n asic3 -j /tmp/qos3.json --write-to-db
Running command: /usr/local/bin/sonic-cfggen -n asic4 -d -t /usr/share/sonic/device/x86_64-n3164-r0/Nexus-3164/4/buffers.json.j2 > /tmp/buffers4.json
Running command: /usr/local/bin/sonic-cfggen -n asic4 -d -t /usr/share/sonic/device/x86_64-n3164-r0/Nexus-3164/4/qos.json.j2 -y /etc/sonic/sonic_version.yml > /tmp/qos4.json
Running command: /usr/local/bin/sonic-cfggen -n asic4 -j /tmp/buffers4.json --write-to-db
Running command: /usr/local/bin/sonic-cfggen -n asic4 -j /tmp/qos4.json --write-to-db
Running command: /usr/local/bin/sonic-cfggen -n asic5 -d -t /usr/share/sonic/device/x86_64-n3164-r0/Nexus-3164/5/buffers.json.j2 > /tmp/buffers5.json
Running command: /usr/local/bin/sonic-cfggen -n asic5 -d -t /usr/share/sonic/device/x86_64-n3164-r0/Nexus-3164/5/qos.json.j2 -y /etc/sonic/sonic_version.yml > /tmp/qos5.json
Running command: /usr/local/bin/sonic-cfggen -n asic5 -j /tmp/buffers5.json --write-to-db
Running command: /usr/local/bin/sonic-cfggen -n asic5 -j /tmp/qos5.json --write-to-db
admin@str-n3164-acs-2:/usr/lib/python2.7/dist-packages/config$

admin@str-n3164-acs-2:/usr/lib/python2.7/dist-packages/config$ head -n 50 /tmp/buffers0.json

{
    "CABLE_LENGTH": {
        "AZURE": {
            "Ethernet0": "300m",
            "Ethernet4": "300m",
            "Ethernet8": "300m",
            "Ethernet12": "300m",
            "Ethernet16": "300m",
            "Ethernet20": "300m",
            "Ethernet24": "300m",
            "Ethernet28": "300m",
            "Ethernet32": "300m",
            "Ethernet36": "300m",
            "Ethernet40": "300m",
            "Ethernet44": "300m",
            "Ethernet48": "300m",
            "Ethernet52": "300m",
            "Ethernet56": "300m",
            "Ethernet60": "300m",
            "Ethernet-BP0": "5m",
            "Ethernet-BP4": "5m",
            "Ethernet-BP8": "5m",
            "Ethernet-BP12": "5m",
            "Ethernet-BP16": "5m",
            "Ethernet-BP20": "5m",
            "Ethernet-BP24": "5m",
            "Ethernet-BP28": "5m",
            "Ethernet-BP32": "5m",
            "Ethernet-BP36": "5m",
            "Ethernet-BP40": "5m",
            "Ethernet-BP44": "5m",
            "Ethernet-BP48": "5m",
            "Ethernet-BP52": "5m",
            "Ethernet-BP56": "5m",
            "Ethernet-BP60": "5m"
        }
    },

    "BUFFER_POOL": {
        "ingress_lossless_pool": {
            "size": "12766208",
            "type": "ingress",
            "mode": "dynamic"
        },
        "egress_lossless_pool": {
            "size": "12766208",


.
.
.



admin@str-n3164-acs-2:/usr/lib/python2.7/dist-packages/config$ head -n 50 /tmp/qos0.json
{
    "TC_TO_PRIORITY_GROUP_MAP": {
        "AZURE": {
            "0": "0",
            "1": "0",
            "2": "0",
            "3": "3",
            "4": "4",
            "5": "0",
            "6": "0",
            "7": "7"
        }
    },
    "MAP_PFC_PRIORITY_TO_QUEUE": {
        "AZURE": {
            "0": "0",
            "1": "1",
            "2": "2",
            "3": "3",
            "4": "4",
            "5": "5",
            "6": "6",
            "7": "7"
        }
    },
    "TC_TO_QUEUE_MAP": {
        "AZURE": {
            "0": "0",
            "1": "1",
            "2": "2",
            "3": "3",
            "4": "4",
            "5": "5",
            "6": "6",
            "7": "7"
        }
    },
    "DSCP_TO_TC_MAP": {
        "AZURE": {
            "0" : "1",
            "1" : "1",
            "2" : "1",
            "3" : "3",
            "4" : "4",
            "5" : "2",
            "6" : "1",

.....
.
.
```

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

