### PR TITLE
fix error: interface counters is mismatch after warm-reboot

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -364,13 +364,17 @@ function unload_kernel()
 function save_counters_folder() {
     debug "Saving counters folder before warmboot..."
 
+    counters_folder="/host/counters"
+    if [[ ! -d $counters_folder ]]; then
+        mkdir $counters_folder
+    fi
     if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; then
-	modules=("portstat-0" "dropstat" "pfcstat-0" "queuestat-0" "intfstat-0")
-	for module in ${modules[@]}
+        modules=("portstat-0" "dropstat" "pfcstat-0" "queuestat-0" "intfstat-0")
+        for module in ${modules[@]}
         do
             statfile="/tmp/$module"
             if [[ -d $statfile ]]; then
-                cp -rf $statfile /host/
+                cp -rf $statfile $counters_folder
             fi
         done
     fi

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -361,6 +361,21 @@ function unload_kernel()
     fi
 }
 
+function save_counters_folder() {
+    debug "Saving counters folder before warmboot..."
+
+    if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; then
+	modules=("portstat-0" "dropstat" "pfcstat-0" "queuestat-0" "intfstat-0")
+	for module in ${modules[@]}
+        do
+            statfile="/tmp/$module"
+            if [[ -d $statfile ]]; then
+                cp -rf $statfile /host/
+            fi
+        done
+    fi
+}
+
 # main starts here
 parseOptions $@
 
@@ -399,6 +414,8 @@ case "$REBOOT_TYPE" in
         exit "${EXIT_NOT_SUPPORTED}"
         ;;
 esac
+
+save_counters_folder
 
 unload_kernel
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
There is a issue for counters after warm-reboot:
If I clear counters by command "sonic-clear counters", then execute 'warm-reboot' and whenSONiC is restart, the counters showed with command "show interface counters" is still old counters before "sonic-clear". It is not the right counters because the counters file in '/tmp' is lost in warm-reboot process.

**- How I did it**
I fixed it by saving '/tmp/portstat-0' folders in '/host/' before executing 'warm-reboot', and restore the counters folders back to '/tmp/' after warm-reboot process is finished (in pull request Azure/sonic-buildimage#5346 ).

**- How to verify it**
Clear counters by command 'sonic-clear'
sonic-clear counters
sonic-clear dropcounters
sonic-clear pfccounters
sonic-clear queuecounters
sonic-clear rifcounters
Execute 'warm-reboot'
Use command ‘show interface counters’ to see if the counters is right.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

