### PR TITLE
[Pytest][Multi ASIC] Update the environment variable in the teardown

### DIFF
--- a/sonic-utilities-tests/multi_asic_intfutil_test.py
+++ b/sonic-utilities-tests/multi_asic_intfutil_test.py
@@ -169,4 +169,4 @@ class TestInterfacesMultiAsic(object):
         os.environ["PATH"] = os.pathsep.join(
             os.environ["PATH"].split(os.pathsep)[:-1])
         os.environ["UTILITIES_UNIT_TESTING"] = "0"
-        os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = "multi_asic"
+        os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = ""


### PR DESCRIPTION
**- What I did**
Fix a bug in Multi ASIC interface test.
'multi ASIC' env variable was causing a subsequent test to fail.

**- How I did it**
Updated the env variable in teardown function.

**- How to verify it**
verified by running the pytest
```
running build_ext                                                        
================================================================================ test session starts =================================================================================
platform linux2 -- Python 2.7.13, pytest-3.0.6, py-1.4.32, pluggy-0.4.0
rootdir: /sonic/src/sonic-utilities, inifile: pytest.ini                                                                                                                              
plugins: cov-2.4.0                                            
collected 88 items                                            
                                                              
sonic-utilities-tests/acl_loader_test.py ....                 
sonic-utilities-tests/aclshow_test.py ..........              
sonic-utilities-tests/bgp_commands_test.py ...
sonic-utilities-tests/counterpoll_test.py ...
sonic-utilities-tests/drops_group_test.py ...FFF.                                                                                                                                     
sonic-utilities-tests/feature_test.py .........                                                 
sonic-utilities-tests/filter_fdb_entries_test.py ..........                 
sonic-utilities-tests/intfstat_test.py ........ 
sonic-utilities-tests/intfutil_test.py ........
sonic-utilities-tests/multi_asic_intfutil_test.py .........          
sonic-utilities-tests/pfcstat_test.py .......
sonic-utilities-tests/port2alias_test.py ....
sonic-utilities-tests/psu_test.py ...
sonic-utilities-tests/sfp_test.py ...                             
```

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

