### PR TITLE
[show] Fix 'show int neighbor expected'

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -829,32 +829,32 @@ def expected(interfacename):
 
     #Swap Key and Value from interface: name to name: interface
     device2interface_dict = {}
-    for port in natsorted(neighbor_dict['DEVICE_NEIGHBOR'].keys()):
+    for port in natsorted(neighbor_dict.keys()):
         temp_port = port
         if get_interface_mode() == "alias":
             port = iface_alias_converter.name_to_alias(port)
-            neighbor_dict['DEVICE_NEIGHBOR'][port] = neighbor_dict['DEVICE_NEIGHBOR'].pop(temp_port)
-        device2interface_dict[neighbor_dict['DEVICE_NEIGHBOR'][port]['name']] = {'localPort': port, 'neighborPort': neighbor_dict['DEVICE_NEIGHBOR'][port]['port']}
+            neighbor_dict[port] = neighbor_dict.pop(temp_port)
+        device2interface_dict[neighbor_dict[port]['name']] = {'localPort': port, 'neighborPort': neighbor_dict[port]['port']}
 
     header = ['LocalPort', 'Neighbor', 'NeighborPort', 'NeighborLoopback', 'NeighborMgmt', 'NeighborType']
     body = []
     if interfacename:
-        for device in natsorted(neighbor_metadata_dict['DEVICE_NEIGHBOR_METADATA'].keys()):
+        for device in natsorted(neighbor_metadata_dict.keys()):
             if device2interface_dict[device]['localPort'] == interfacename:
                 body.append([device2interface_dict[device]['localPort'],
                              device,
                              device2interface_dict[device]['neighborPort'],
-                             neighbor_metadata_dict['DEVICE_NEIGHBOR_METADATA'][device]['lo_addr'],
-                             neighbor_metadata_dict['DEVICE_NEIGHBOR_METADATA'][device]['mgmt_addr'],
-                             neighbor_metadata_dict['DEVICE_NEIGHBOR_METADATA'][device]['type']])
+                             neighbor_metadata_dict[device]['lo_addr'],
+                             neighbor_metadata_dict[device]['mgmt_addr'],
+                             neighbor_metadata_dict[device]['type']])
     else:
-        for device in natsorted(neighbor_metadata_dict['DEVICE_NEIGHBOR_METADATA'].keys()):
+        for device in natsorted(neighbor_metadata_dict.keys()):
             body.append([device2interface_dict[device]['localPort'],
                          device,
                          device2interface_dict[device]['neighborPort'],
-                         neighbor_metadata_dict['DEVICE_NEIGHBOR_METADATA'][device]['lo_addr'],
-                         neighbor_metadata_dict['DEVICE_NEIGHBOR_METADATA'][device]['mgmt_addr'],
-                         neighbor_metadata_dict['DEVICE_NEIGHBOR_METADATA'][device]['type']])
+                         neighbor_metadata_dict[device]['lo_addr'],
+                         neighbor_metadata_dict[device]['mgmt_addr'],
+                         neighbor_metadata_dict[device]['type']])
 
     click.echo(tabulate(body, header))
 


### PR DESCRIPTION
Fix `show int neighbor expected`

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**
```
$ show int neighbor expected
Traceback (most recent call last):
  File "/usr/bin/show", line 12, in <module>
    sys.exit(cli())
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/show/main.py", line 836, in expected
    for port in natsorted(neighbor_dict['DEVICE_NEIGHBOR'].keys()):
KeyError: 'DEVICE_NEIGHBOR'
```
**- New command output (if the output of a command-line utility has changed)**
```
$ show int neighbor expected
LocalPort    Neighbor    NeighborPort    NeighborLoopback    NeighborMgmt    NeighborType
-----------  ----------  --------------  ------------------  --------------  --------------
Ethernet64   ARISTA01T0  Ethernet1       None                10.64.247.144   ToRRouter
Ethernet4    ARISTA01T2  Ethernet2       None                10.64.247.136   SpineRouter
Ethernet68   ARISTA02T0  Ethernet1       None                10.64.247.145   ToRRouter
Ethernet72   ARISTA03T0  Ethernet1       None                10.64.247.146   ToRRouter
Ethernet12   ARISTA03T2  Ethernet2       None                10.64.247.137   SpineRouter
Ethernet76   ARISTA04T0  Ethernet1       None                10.64.247.147   ToRRouter
Ethernet80   ARISTA05T0  Ethernet1       None                10.64.247.148   ToRRouter
Ethernet20   ARISTA05T2  Ethernet2       None                10.64.247.138   SpineRouter
Ethernet84   ARISTA06T0  Ethernet1       None                10.64.247.149   ToRRouter
Ethernet88   ARISTA07T0  Ethernet1       None                10.64.247.150   ToRRouter
Ethernet28   ARISTA07T2  Ethernet2       None                10.64.247.139   SpineRouter
Ethernet92   ARISTA08T0  Ethernet1       None                10.64.247.151   ToRRouter
Ethernet96   ARISTA09T0  Ethernet1       None                10.64.247.152   ToRRouter
Ethernet36   ARISTA09T2  Ethernet2       None                10.64.247.140   SpineRouter
Ethernet100  ARISTA10T0  Ethernet1       None                10.64.247.153   ToRRouter
Ethernet104  ARISTA11T0  Ethernet1       None                10.64.247.154   ToRRouter
Ethernet44   ARISTA11T2  Ethernet2       None                10.64.247.141   SpineRouter
Ethernet108  ARISTA12T0  Ethernet1       None                10.64.247.155   ToRRouter
Ethernet112  ARISTA13T0  Ethernet1       None                10.64.247.156   ToRRouter
Ethernet52   ARISTA13T2  Ethernet2       None                10.64.247.142   SpineRouter
Ethernet116  ARISTA14T0  Ethernet1       None                10.64.247.157   ToRRouter
Ethernet120  ARISTA15T0  Ethernet1       None                10.64.247.158   ToRRouter
Ethernet60   ARISTA15T2  Ethernet2       None                10.64.247.143   SpineRouter
Ethernet124  ARISTA16T0  Ethernet1       None                10.64.247.159   ToRRouter
```
