### PR TITLE
[sflow_test.py]: tests for config sflow commands.

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1591,11 +1591,12 @@ def policer(policer_name, verbose):
 # 'sflow command ("show sflow ...")
 #
 @cli.group(invoke_without_command=True)
+@clicommon.pass_db
 @click.pass_context
-def sflow(ctx):
+def sflow(ctx, db):
     """Show sFlow related information"""
     if ctx.invoked_subcommand is None:
-        show_sflow_global(ctx.obj.cfgdb)
+        show_sflow_global(db.cfgdb)
 
 #
 # 'sflow command ("show sflow interface ...")

--- a/show/main.py
+++ b/show/main.py
@@ -1595,7 +1595,7 @@ def policer(policer_name, verbose):
 def sflow(ctx):
     """Show sFlow related information"""
     if ctx.invoked_subcommand is None:
-        show_sflow_global(ctx.obj['db'])
+        show_sflow_global(ctx.obj.cfgdb)
 
 #
 # 'sflow command ("show sflow interface ...")

--- a/show/main.py
+++ b/show/main.py
@@ -1595,8 +1595,7 @@ def policer(policer_name, verbose):
 def sflow(ctx):
     """Show sFlow related information"""
     if ctx.invoked_subcommand is None:
-        db = Db()
-        show_sflow_global(db.cfgdb)
+        show_sflow_global(ctx.obj['db'])
 
 #
 # 'sflow command ("show sflow interface ...")

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -1,7 +1,6 @@
 {
     "SFLOW|global": {
         "admin_state": "up",
-        "agent_id": "eth0",
         "polling_interval": "0"
     },
     "SFLOW_COLLECTOR|prod": {

--- a/tests/sflow_test.py
+++ b/tests/sflow_test.py
@@ -1,11 +1,15 @@
 import os
 import sys
 import pytest
+import mock
+
 from click.testing import CliRunner
 from utilities_common.db import Db
 
 import show.main as show
-import mock_tables.dbconnector
+import config.main as config
+
+config.asic_type = mock.MagicMock(return_value = "broadcom")
 
 # Expected output for 'show sflow'
 show_sflow_output = ''+ \
@@ -13,7 +17,7 @@ show_sflow_output = ''+ \
 sFlow Global Information:
   sFlow Admin State:          up
   sFlow Polling Interval:     0
-  sFlow AgentID:              eth0
+  sFlow AgentID:              default
 
   2 Collectors configured:
     Name: prod                IP addr: fe80::6e82:6aff:fe1e:cd8e UDP port: 6343
@@ -45,20 +49,222 @@ class TestShowSflow(object):
 
     def test_show_sflow(self):
         runner = CliRunner()
-        result = runner.invoke(show.cli.commands["sflow"], [], obj=Db())
-        print(sys.stderr, result.output)
+        db = Db()
+        result = runner.invoke(show.cli.commands["sflow"], [], obj={'db':db.cfgdb})
+        print(result.exit_code, result.output)
         assert result.exit_code == 0
         assert result.output == show_sflow_output
 
     def test_show_sflow_intf(self):
         runner = CliRunner()
-        result = runner.invoke(show.cli.commands["sflow"].commands["interface"], [], obj=Db())
-        print(sys.stderr, result.output)
+        result = runner.invoke(show.cli.commands["sflow"].commands["interface"], \
+            [], obj=Db())
+        print(result.exit_code, result.output)
         assert result.exit_code == 0
         assert result.output == show_sflow_intf_output
+
+    def test_config_sflow_disable_enable(self):
+        # config sflow <enable|disable>
+        db = Db()
+        runner = CliRunner()
+        obj = {'db':db.cfgdb}
+
+        #disable
+        result = runner.invoke(config.config.commands["sflow"].\
+            commands["disable"], [], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
+        # change the output
+        global show_sflow_output
+        show_sflow_output_local = show_sflow_output.replace(\
+            'Admin State:          up', \
+            'Admin State:          down')
+
+        # run show and check
+        result = runner.invoke(show.cli.commands["sflow"], [], obj=obj)
+        print(result.exit_code, result.output, show_sflow_output_local)
+        assert result.exit_code == 0
+        assert result.output == show_sflow_output_local
+
+        #enable
+        result = runner.invoke(config.config.commands["sflow"].\
+            commands["enable"], [], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
+        # run show and check
+        result = runner.invoke(show.cli.commands["sflow"], [], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+        assert result.output == show_sflow_output
+
+        return
+
+    def test_config_sflow_agent_id(self):
+        db = Db()
+        runner = CliRunner()
+        obj = {'db':db.cfgdb}
+
+        # mock netifaces.interface
+        config.netifaces.interfaces = mock.MagicMock(return_value = "Ethernet0")
+
+        # set agent-id
+        result = runner.invoke(config.config.commands["sflow"].\
+            commands["agent-id"].commands["add"], ["Ethernet0"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
+        # change the output
+        global show_sflow_output
+        show_sflow_output_local = \
+            show_sflow_output.replace('default', 'Ethernet0')
+
+        # run show and check
+        result = runner.invoke(show.cli.commands["sflow"], [], obj=obj)
+        print(result.exit_code, result.output, show_sflow_output_local)
+        assert result.exit_code == 0
+        assert result.output == show_sflow_output_local
+
+        #del agent id
+        result = runner.invoke(config.config.commands["sflow"].\
+            commands["agent-id"].commands["del"], [], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
+        # run show and check
+        result = runner.invoke(show.cli.commands["sflow"], [], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+        assert result.output == show_sflow_output
+
+        return
+
+    def test_config_sflow_collector(self):
+        db = Db()
+        runner = CliRunner()
+        obj = {'db':db.cfgdb}
+
+        # del a collector
+        result = runner.invoke(config.config.commands["sflow"].\
+            commands["collector"].commands["del"], ["prod"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
+        # change the output
+        global show_sflow_output
+        show_sflow_output_local = show_sflow_output.replace(\
+    "2 Collectors configured:\n\
+    Name: prod                IP addr: fe80::6e82:6aff:fe1e:cd8e UDP port: 6343\n\
+    Name: ser5                IP addr: 172.21.35.15    UDP port: 6343", \
+    "1 Collectors configured:\n\
+    Name: ser5                IP addr: 172.21.35.15    UDP port: 6343")
+
+        # run show and check
+        result = runner.invoke(show.cli.commands["sflow"], [], obj=obj)
+        print(result.exit_code, result.output, show_sflow_output_local)
+        assert result.exit_code == 0
+        assert result.output == show_sflow_output_local
+
+        # add collector
+        result = runner.invoke(config.config.commands["sflow"].\
+            commands["collector"].commands["add"], \
+            ["prod", "fe80::6e82:6aff:fe1e:cd8e"], obj=obj)
+        assert result.exit_code == 0
+
+        # run show and check
+        result = runner.invoke(show.cli.commands["sflow"], [], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+        assert result.output == show_sflow_output
+
+        return
+
+    def test_config_sflow_polling_interval(self):
+        db = Db()
+        runner = CliRunner()
+        obj = {'db':db.cfgdb}
+
+        # set to 20
+        result = runner.invoke(config.config.commands["sflow"].\
+            commands["polling-interval"], ["20"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
+        # change the expected output
+        global show_sflow_output
+        show_sflow_output_local = show_sflow_output.replace(\
+            'sFlow Polling Interval:     0', \
+            'sFlow Polling Interval:     20')
+
+        # run show and check
+        result = runner.invoke(show.cli.commands["sflow"], [], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+        assert result.output == show_sflow_output_local
+
+        #reset to 0, no need to verify this one
+        result = runner.invoke(config.config.commands["sflow"].\
+            commands["polling-interval"], ["0"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
+        return
+
+    def test_config_sflow_intf_enable_disable(self):
+        db = Db()
+        runner = CliRunner()
+        obj = {'db':db.cfgdb}
+
+        # mock interface_name_is_valid
+        config.interface_name_is_valid = mock.MagicMock(return_value = True)
+
+        # intf enable
+        result = runner.invoke(config.config.commands["sflow"].\
+            commands["interface"].commands["enable"], ["Ethernet1"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
+        # we can not use 'show sflow interface', becasue 'show sflow interface'
+        # gets data from appDB, we need to fetch data from configDB for verification
+        sflowSession = db.cfgdb.get_table('SFLOW_SESSION')
+        assert sflowSession["Ethernet1"]["admin_state"] == "up"
+
+        # intf disable
+        result = runner.invoke(config.config.commands["sflow"].\
+            commands["interface"].commands["disable"], ["Ethernet1"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
+        # verify in configDb
+        sflowSession = db.cfgdb.get_table('SFLOW_SESSION')
+        assert sflowSession["Ethernet1"]["admin_state"] == "down"
+
+        return
+
+    def test_config_sflow_intf_sample_rate(self):
+        db = Db()
+        runner = CliRunner()
+        obj = {'db':db.cfgdb}
+
+        # mock interface_name_is_valid
+        config.interface_name_is_valid = mock.MagicMock(return_value = True)
+
+        # set sample-rate to 2500
+        result = runner.invoke(config.config.commands["sflow"].\
+            commands["interface"].commands["sample-rate"], \
+            ["Ethernet2", "2500"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
+        # we can not use 'show sflow interface', becasue 'show sflow interface'
+        # gets data from appDB, we need to fetch data from configDB for verification
+        sflowSession = db.cfgdb.get_table('SFLOW_SESSION')
+        assert sflowSession["Ethernet2"]["sample_rate"] == "2500"
+
+        return
 
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")
-        os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])
         os.environ["UTILITIES_UNIT_TESTING"] = "0"

--- a/tests/sflow_test.py
+++ b/tests/sflow_test.py
@@ -49,8 +49,7 @@ class TestShowSflow(object):
 
     def test_show_sflow(self):
         runner = CliRunner()
-        db = Db()
-        result = runner.invoke(show.cli.commands["sflow"], [], obj={'db':db.cfgdb})
+        result = runner.invoke(show.cli.commands["sflow"], [], obj=Db())
         print(result.exit_code, result.output)
         assert result.exit_code == 0
         assert result.output == show_sflow_output
@@ -82,7 +81,7 @@ class TestShowSflow(object):
             'Admin State:          down')
 
         # run show and check
-        result = runner.invoke(show.cli.commands["sflow"], [], obj=obj)
+        result = runner.invoke(show.cli.commands["sflow"], [], obj=db)
         print(result.exit_code, result.output, show_sflow_output_local)
         assert result.exit_code == 0
         assert result.output == show_sflow_output_local
@@ -94,7 +93,7 @@ class TestShowSflow(object):
         assert result.exit_code == 0
 
         # run show and check
-        result = runner.invoke(show.cli.commands["sflow"], [], obj=obj)
+        result = runner.invoke(show.cli.commands["sflow"], [], obj=db)
         print(result.exit_code, result.output)
         assert result.exit_code == 0
         assert result.output == show_sflow_output
@@ -121,7 +120,7 @@ class TestShowSflow(object):
             show_sflow_output.replace('default', 'Ethernet0')
 
         # run show and check
-        result = runner.invoke(show.cli.commands["sflow"], [], obj=obj)
+        result = runner.invoke(show.cli.commands["sflow"], [], obj=db)
         print(result.exit_code, result.output, show_sflow_output_local)
         assert result.exit_code == 0
         assert result.output == show_sflow_output_local
@@ -133,7 +132,7 @@ class TestShowSflow(object):
         assert result.exit_code == 0
 
         # run show and check
-        result = runner.invoke(show.cli.commands["sflow"], [], obj=obj)
+        result = runner.invoke(show.cli.commands["sflow"], [], obj=db)
         print(result.exit_code, result.output)
         assert result.exit_code == 0
         assert result.output == show_sflow_output
@@ -161,7 +160,7 @@ class TestShowSflow(object):
     Name: ser5                IP addr: 172.21.35.15    UDP port: 6343")
 
         # run show and check
-        result = runner.invoke(show.cli.commands["sflow"], [], obj=obj)
+        result = runner.invoke(show.cli.commands["sflow"], [], obj=db)
         print(result.exit_code, result.output, show_sflow_output_local)
         assert result.exit_code == 0
         assert result.output == show_sflow_output_local
@@ -173,7 +172,7 @@ class TestShowSflow(object):
         assert result.exit_code == 0
 
         # run show and check
-        result = runner.invoke(show.cli.commands["sflow"], [], obj=obj)
+        result = runner.invoke(show.cli.commands["sflow"], [], obj=db)
         print(result.exit_code, result.output)
         assert result.exit_code == 0
         assert result.output == show_sflow_output
@@ -198,7 +197,7 @@ class TestShowSflow(object):
             'sFlow Polling Interval:     20')
 
         # run show and check
-        result = runner.invoke(show.cli.commands["sflow"], [], obj=obj)
+        result = runner.invoke(show.cli.commands["sflow"], [], obj=db)
         print(result.exit_code, result.output)
         assert result.exit_code == 0
         assert result.output == show_sflow_output_local

--- a/tests/sflow_test.py
+++ b/tests/sflow_test.py
@@ -266,4 +266,5 @@ class TestShowSflow(object):
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")
+        os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])
         os.environ["UTILITIES_UNIT_TESTING"] = "0"


### PR DESCRIPTION
Changes:
-- show sflow use ctx.obj['db'] instead of creating new instance,
   this is must for test, else config change will not be reflected.

-- config SFLOW tests for
   config sflow <enable|disable>
   config sflow agent-id <add | del>
   config sflow collector add|del
   config sflow interface <enable|disable>
   config sflow interface sample-rate

Signed-off-by: Praveen Chaudhary <pchaudhary@linkedin.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
    Changes:
    -- show sflow use ctx.obj['db'] instead of creating new instance,
       this is must for test, else config change will not be reflected.

    -- config SFLOW tests for
       config sflow <enable|disable>
       config sflow agent-id <add | del>
       config sflow collector add|del
       config sflow interface <enable|disable>
       config sflow interface sample-rate

**- How I did it**

    -- show sflow use ctx.obj['db'] instead of creating new instance,
       this is must for test, else config change will not be reflected.

    -- config SFLOW tests for
       config sflow <enable|disable>
       config sflow agent-id <add | del>
       config sflow collector add|del
       config sflow interface <enable|disable>
       config sflow interface sample-rate


**- How to verify it**

Built PKG with tests:
```
"SONIC_DPKG_CACHE_METHOD"         : "none"

[ 01 ] [ target/python-debs/python-sonic-utilities_1.2-1_all.deb ]
make[1]: Leaving directory '/home/pchaudha/srcCode/azure_myforks/sonic-buildimage'

pchaudha@server05:/home/pchaudha/srcCode/azure_myforks/sonic-buildimage$ ls -l target/python-debs/python-sonic-utilities_1.2-1_all.deb
-rw-r--r-- 1 pchaudha pchaudha 168712 Sep 11 15:57 target/python-debs/python-sonic-utilities_1.2-1_all.deb

pchaudha@server05:/home/pchaudha/srcCode/azure_myforks/sonic-buildimage$ date
Fri Sep 11 15:58:04 PDT 2020
pchaudha@server05:/home/pchaudha/srcCode/azure_myforks/sonic-buildimage$
```

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

