### PR TITLE
[utilities] Define Explicit Dependency On Ipaddress Package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -163,6 +163,7 @@ setup(
     # - tabulate
     install_requires=[
         'click',
+        'ipaddress',
         'natsort',
         'm2crypto'
     ],


### PR DESCRIPTION
201811 branch build fails without taking explicit dependency on
ipaddress package.

singed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

**- What I did**
Resolved 201811 build failure

**- How I did it**
Added `ipaddress` as a required package for installation

**- How to verify it**
`target/debs/python-sonic-utilities_1.2-1_all.deb` builds OK on 201811 branch

**- Previous command output (if the output of a command-line utility has changed)**
N/A
**- New command output (if the output of a command-line utility has changed)**
N/A
