### PR TITLE
Update to make config load/reload backward compatible.

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -980,7 +980,7 @@ def load(filename, yes):
                 file = "/etc/sonic/config_db{}.json".format(inst)
 
         # if any of the config files in linux host OR namespace is not present, return
-        if not os.path.isfile(file):
+        if not os.path.exists(file):
             click.echo("The config_db file {} doesn't exist".format(file))
             return
 
@@ -1064,7 +1064,7 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart):
                 file = "/etc/sonic/config_db{}.json".format(inst)
 
         # Check the file exists before proceeding.
-        if not os.path.isfile(file):
+        if not os.path.exists(file):
             click.echo("The config_db file {} doesn't exist".format(file))
             continue
 


### PR DESCRIPTION
**- What I did**
To take care of comment https://github.com/Azure/sonic-utilities/pull/877#discussion_r487324882.  To support the way the config reload command is used in https://github.com/Azure/SONiC/wiki/L2-Switch-mode

**- How I did it**
Changed os.path.isfile check to os.path.exists.

**- How to verify it**
Verified the command give in https://github.com/Azure/SONiC/wiki/L2-Switch-mode works ok.

**- Previous command output (if the output of a command-line utility has changed)**
admin@str-s6000-acs-8:~$ sudo config reload /dev/stdin -y
Executing stop of service telemetry...
Warning: Stopping telemetry.service, but it can still be activated by:
  telemetry.timer
Executing stop of service swss...
Executing stop of service lldp...
Executing stop of service pmon...
Executing stop of service bgp...
Executing stop of service hostcfgd...
**The config_db file /dev/stdin doesn't exist**
Executing reset-failed of service bgp...
Executing reset-failed of service dhcp_relay...
Executing reset-failed of service hostcfgd...
Executing reset-failed of service hostname-config...
Executing reset-failed of service interfaces-config...
Executing reset-failed of service lldp...
Executing reset-failed of service ntp-config...
Executing reset-failed of service pmon...
Executing reset-failed of service radv...
Executing reset-failed of service rsyslog-config...
Executing reset-failed of service snmp...
Executing reset-failed of service swss...
Executing reset-failed of service syncd...
Executing reset-failed of service teamd...
Executing reset-failed of service telemetry...
Executing restart of service hostname-config...
Executing restart of service interfaces-config...
Executing restart of service ntp-config...
Executing restart of service rsyslog-config...
Executing restart of service swss...
Executing restart of service bgp...
Executing restart of service pmon...
Executing restart of service lldp...
Executing restart of service hostcfgd...
Executing restart of service telemetry...

**- New command output (if the output of a command-line utility has changed)**
admin@str-s6000-acs-8:/$ cat <<EOF | sudo config reload /dev/stdin -y
> {
>     "MGMT_INTERFACE": {
>         "eth0|10.3.147.46/23": {
>             "gwaddr": "10.3.146.1"
>         }
>     },
>     "DEVICE_METADATA": {
>         "localhost": {
>             "hostname": "sonic"
>         }
>     }
> }
> EOF
Executing stop of service telemetry...
Warning: Stopping telemetry.service, but it can still be activated by:
  telemetry.timer
Executing stop of service swss...
Executing stop of service lldp...
Executing stop of service pmon...
Executing stop of service bgp...
Executing stop of service hostcfgd...
Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/init_cfg.json -j /dev/stdin --write-to-db
Running command: /usr/bin/db_migrator.py -o migrate
Executing reset-failed of service bgp...
Executing reset-failed of service dhcp_relay...
Executing reset-failed of service hostcfgd...
Executing reset-failed of service hostname-config...
Executing reset-failed of service interfaces-config...
Executing reset-failed of service lldp...
Executing reset-failed of service ntp-config...
Executing reset-failed of service pmon...
Executing reset-failed of service radv...
Executing reset-failed of service rsyslog-config...
Executing reset-failed of service snmp...
Executing reset-failed of service swss...
Executing reset-failed of service syncd...
Executing reset-failed of service teamd...
Executing reset-failed of service telemetry...
Executing restart of service hostname-config...
Executing restart of service interfaces-config...

