### PR TITLE
[consutil] Fix issue where the ConfigDBConnector's reference is missing

### DIFF
--- a/consutil/lib.py
+++ b/consutil/lib.py
@@ -10,6 +10,7 @@ try:
     import re
     import subprocess
     import sys
+    from swsssdk import ConfigDBConnector
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

fixes #1116 

**- How I did it**

Add missing reference to the header

**- How to verify it**

Install new debs to SONiC and check with commands `sudo consutil show` and `sudo consutil connect 1`

**- Previous command output (if the output of a command-line utility has changed)**

```
admin@sonic:~$ sudo consutil show
Traceback (most recent call last):
  File "/usr/bin/consutil", line 12, in <module>
    sys.exit(consutil())
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/consutil/main.py", line 43, in show
    actBaud, confBaud, _ = getConnectionInfo(lineNum)
  File "/usr/lib/python2.7/dist-packages/consutil/lib.py", line 98, in getConnectionInfo
    config_db = ConfigDBConnector()
NameError: global name 'ConfigDBConnector' is not defined
admin@sonic:~$ 
admin@sonic:~$ 
admin@sonic:~$ sudo consutil connect 1
Traceback (most recent call last):
  File "/usr/bin/consutil", line 12, in <module>
    sys.exit(consutil())
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/consutil/main.py", line 79, in connect
    actBaud, _, flowBool = getConnectionInfo(lineNumber)
  File "/usr/lib/python2.7/dist-packages/consutil/lib.py", line 98, in getConnectionInfo
    config_db = ConfigDBConnector()
NameError: global name 'ConfigDBConnector' is not defined
```

**- New command output (if the output of a command-line utility has changed)**

```
admin@sonic:~$ sudo consutil show
  Line    Actual/Configured Baud    PID    Start Time
------  ------------------------  -----  ------------
     0      9600/-              
     1      9600/9600           
     2      9600/-              
     3      9600/-              
     4      9600/-              
     5      9600/-              
     6      9600/-              
     7      9600/-              
     8      9600/-              
     9      9600/-              
    10      9600/-              
    11      9600/-              
    12      9600/-              
    13      9600/-              
    14      9600/-              
    15      9600/-              
    16      9600/-              
    17      9600/-              
    18      9600/-              
    19      9600/-              
    20      9600/-              
    21      9600/-              
    22      9600/-              
    23      9600/-              
    24      9600/-              
    25      9600/-              
    26      9600/-              
    27      9600/-              
    28      9600/-              
    29      9600/-              
    30      9600/-              
    31      9600/-              
    32      9600/-              
    33      9600/-              
    34      9600/-              
    35      9600/-              
    36      9600/-              
    37      9600/-              
    38      9600/-              
    39      9600/-              
    40      9600/-              
    41      9600/-              
    42      9600/-              
    43      9600/-              
    44      9600/-              
    45      9600/-              
    46      9600/-              
    47      9600/-              
admin@sonic:~$ 
admin@sonic:~$ sudo consutil connect 1
Successful connection to line 1
Press ^A ^X to disconnect


Terminating...
Thanks for using picocom
admin@sonic:~$ 
```