### PR TITLE
[teamshow] Remove 't' from argument when calling docker exec

### DIFF
--- a/scripts/teamshow
+++ b/scripts/teamshow
@@ -62,7 +62,7 @@ class Teamshow(object):
         team_keys = self.db.keys(self.db.CONFIG_DB, PORT_CHANNEL_CFG_TABLE_PREFIX+"*")
         if team_keys == None:
             return
-        
+
         for key in team_keys:
             team_name = key[len(PORT_CHANNEL_CFG_TABLE_PREFIX):]
             if self.multi_asic.skip_display(constants.PORT_CHANNEL_OBJ, team_name) is True:
@@ -93,7 +93,7 @@ class Teamshow(object):
             Command: 'teamdctl <teamdevname> state dump'.
         """
         for team in self.teams:
-            teamdctl_cmd = "sudo docker exec -it teamd{} teamdctl {} state dump".format(get_asic_id_from_name(self.multi_asic.current_namespace)
+            teamdctl_cmd = "sudo docker exec -i teamd{} teamdctl {} state dump".format(get_asic_id_from_name(self.multi_asic.current_namespace)
                                                                                         if self.multi_asic.current_namespace else '', team)
             p = subprocess.Popen(teamdctl_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
             (output, err) = p.communicate()
@@ -160,7 +160,7 @@ class Teamshow(object):
 def main():
     if os.geteuid() != 0:
         exit("This utility must be run as root")
-        
+
     parser = multi_asic_util.multi_asic_args()
     args = parser.parse_args()
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
teamshow reads teams raw data by running docker exec -it xxx. However, the 't' may lead to error when called without a tty. This commit fix the issue.
**- How I did it**
Remove 't' from argument when calling docker exec.
**- How to verify it**
Verified on Arista 7260.
**before update:**
```
ssh admin@10.64.247.224 "SONIC_CLI_IFACE_MODE=alias sudo show interfaces portchannel" 
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,
       S - selected, D - deselected, * - not synced
  No.  Team Dev         Protocol    Ports
-----  ---------------  ----------  -------
 0001  PortChannel0001  N/A
 0002  PortChannel0002  N/A
 0003  PortChannel0003  N/A
 0004  PortChannel0004  N/A
```
We can see that the Protocols and Ports are invalid.
**after update:**
```
ssh -t admin@10.64.247.224 "SONIC_CLI_IFACE_MODE=alias sudo show interfaces portchannel"
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,
       S - selected, D - deselected, * - not synced
  No.  Team Dev         Protocol     Ports
-----  ---------------  -----------  ---------------------------
 0001  PortChannel0001  LACP(A)(Up)  Ethernet14/1(S) Ethernet13/1(S)
 0002  PortChannel0002  LACP(A)(Up)  Ethernet16/1(S) Ethernet15/1(S)
 0003  PortChannel0003  LACP(A)(Up)  Ethernet17/1(S) Ethernet18/1(S)
 0004  PortChannel0004  LACP(A)(Up)  Ethernet20/1(S) Ethernet19/1(S)
```
**- Previous command output (if the output of a command-line utility has changed)**
N/A
**- New command output (if the output of a command-line utility has changed)**
N/A
