### PR TITLE
[201911] Fix load minigraph for multi-asic platforms

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -994,7 +994,7 @@ def load_minigraph(no_service_restart):
         run_command("acl-loader update full /etc/sonic/acl.json", display_cmd=True)
 
     # generate QoS and Buffer configs
-    run_command("{}config qos reload".format(ns_cmd_prefix), display_cmd=True)
+    run_command("config qos reload", display_cmd=True)
 
     # Write latest db version string into db
     db_migrator='/usr/bin/db_migrator.py'


### PR DESCRIPTION
Why I did:
config load_minigraph not working on Multi-asic platforms.
Command config qos reload now runs on all asic so if we using
it with ip netns exec asic0 it creates loop where asic0 can not reach redis server of other asic.

We need this PR https://github.com/Azure/sonic-utilities/pull/1123 in 201911 for complete fix.

How I did:
config qos reload should be called only once.

Verified:
Tested on single and multi-asic platforms.