### PR TITLE
[show] Add missing import to fix `show ip interfaces`

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1,6 +1,7 @@
 #! /usr/bin/python -u
 
 import json
+import netaddr
 import os
 import subprocess
 import sys


### PR DESCRIPTION
Add the missing import of `netaddr` for `show ip interfaces`.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**
```
$ show ip interfaces
Traceback (most recent call last):
  File "/usr/bin/show", line 12, in <module>
    sys.exit(cli())
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/show/main.py", line 727, in interfaces
    netmask = netaddr.IPAddress(ipaddr['netmask']).netmask_bits()
NameError: global name 'netaddr' is not defined
```
**- New command output (if the output of a command-line utility has changed)**
```
$ show ip interfaces
Interface    Master    IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
-----------  --------  -------------------  ------------  --------------  -------------
Ethernet0              192.168.1.2/24       up/down       N/A             N/A
Ethernet28             192.168.4.1/24       up/up         N/A             N/A
docker0                240.127.1.1/24       up/down       N/A             N/A
eth0                   10.3.146.241/23      up/up         N/A             N/A
lo                     127.0.0.1/16         up/up         N/A             N/A
```
