### PR TITLE
Fix show ip interfaces

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -4,6 +4,7 @@ import json
 import os
 import subprocess
 import sys
+import netaddr
 
 import click
 from natsort import natsorted


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->
I faced the issue when call `show ip interfaces` on the latest SONiC image(03f82a0107):
```
admin@sonic:~$ show ip interfaces 
sTraceback (most recent call last):
  File "/usr/local/bin/show", line 10, in <module>
    sys.exit(cli())
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/show/main.py", line 727, in interfaces
    netmask = netaddr.IPAddress(ipaddr['netmask']).netmask_bits()
NameError: global name 'netaddr' is not defined

```
In this [PR](https://github.com/Azure/sonic-utilities/pull/1013)  `netaddr` was removed, but we need it to convert subnet mask to cidr  [here](https://github.com/Azure/sonic-utilities/blob/97ad7cecaf9e64e488790c6efbcc9681b454b954/show/main.py#L728) 
**- What I did**
Fix `NameError: global name 'netaddr' is not defined`
**- How I did it**
import netaddr module
**- How to verify it**
- build SONiC with this changes or manually apply them in the running SONiC image
- run `show ip interfaces`
**- Previous command output (if the output of a command-line utility has changed)**
```
admin@sonic:~$ show ip interfaces 
sTraceback (most recent call last):
  File "/usr/local/bin/show", line 10, in <module>
    sys.exit(cli())
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/show/main.py", line 727, in interfaces
    netmask = netaddr.IPAddress(ipaddr['netmask']).netmask_bits()
NameError: global name 'netaddr' is not defined

```
**- New command output (if the output of a command-line utility has changed)**

```
admin@sonic:~$ show ip interfaces 
Interface    Master    IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
-----------  --------  -------------------  ------------  --------------  -------------
Ethernet0              10.0.0.1/24          up/up         N/A             N/A
Ethernet4              20.0.0.1/24          up/up         N/A             N/A
Ethernet8              10.0.0.4/31          up/up         ARISTA03T2      10.0.0.5
 * * *
```