### PR TITLE
[config/console] Support add/del console port setting commands

### DIFF
--- a/config/console.py
+++ b/config/console.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+
+import click
+
+import utilities_common.cli as clicommon
+from swsssdk import ConfigDBConnector
+
+#
+# 'console' group ('config console ...')
+#
+@click.group('console')
+def console():
+    """Console-related configuration tasks"""
+    pass
+
+#
+# 'console add' group ('config console add ...')
+#
+@console.command('add')
+@clicommon.pass_db
+@click.argument('linenum', metavar='<line_number>', required=True, type=click.IntRange(0, 65535))
+@click.option('--baud', '-b', metavar='<baud>', required=True, type=click.INT)
+@click.option('--flowcontrol', '-f', metavar='<flow_control>', required=False, is_flag=True)
+@click.option('--devicename', '-d', metavar='<device_name>', required=False)
+def add_console_setting(db, linenum, baud, flowcontrol, devicename):
+    """Add Console-realted configuration tasks"""
+    config_db = db.cfgdb
+
+    table = "CONSOLE_PORT"
+    dataKey1 = 'baud_rate'
+    dataKey2 = 'flow_control'
+    dataKey3 = 'remote_device'
+
+    ctx = click.get_current_context()
+    data = config_db.get_entry(table, linenum)
+    if data:
+        ctx.fail("Trying to add console port setting, which is already exists.")
+    else:
+        console_entry = { dataKey1: baud }
+        console_entry[dataKey2] = "1" if flowcontrol else "0"
+
+        if devicename:
+            if isExistingSameDevice(config_db, devicename, table):
+                ctx.fail("Given device name {} has been used. Please enter a valid device name or remove the existing one !!".format(devicename))
+            console_entry[dataKey3] = devicename
+
+        config_db.set_entry(table, linenum, console_entry)
+
+
+#
+# 'console del' group ('config console del ...')
+#
+@console.command('del')
+@clicommon.pass_db
+@click.argument('linenum', metavar='<line_number>', required=True, type=click.IntRange(0, 65535))
+def remove_console_setting(db, linenum):
+    """Remove Console-related configuration tasks"""
+    config_db = db.cfgdb
+
+    table = "CONSOLE_PORT"
+
+    data = config_db.get_entry(table, linenum)
+    if data:
+        config_db.mod_entry(table, linenum, None)
+    else:
+        ctx = click.get_current_context()
+        ctx.fail("Trying to delete console port setting, which is not present.")
+
+
+def isExistingSameDevice(config_db, deviceName, table):
+    """Check if the given device name is conflict with existing device"""
+    settings = config_db.get_table(table)
+    for key,values in settings.items():
+        if "remote_device" in values and deviceName == values["remote_device"]:
+            return True
+
+    return False

--- a/config/console.py
+++ b/config/console.py
@@ -3,7 +3,6 @@
 import click
 
 import utilities_common.cli as clicommon
-from swsssdk import ConfigDBConnector
 
 #
 # 'console' group ('config console ...')

--- a/config/main.py
+++ b/config/main.py
@@ -24,6 +24,7 @@ from .utils import log
 
 
 import aaa
+import console
 import feature
 import kube
 import mlnx
@@ -876,6 +877,7 @@ def config(ctx):
 # Add groups from other modules
 config.add_command(aaa.aaa)
 config.add_command(aaa.tacacs)
+config.add_command(console.console)
 config.add_command(feature.feature)
 config.add_command(kube.kubernetes)
 config.add_command(nat.nat)

--- a/tests/console_test.py
+++ b/tests/console_test.py
@@ -18,7 +18,7 @@ class TestConfigConsoleCommands(object):
         db = Db()
         db.cfgdb.set_entry("CONSOLE_PORT", 1, { "baud_rate" : "9600" })
 
-        # add a console setting which the port has exists
+        # add a console setting which the port exists
         result = runner.invoke(config.config.commands["console"].commands["add"], ["1", '--baud', "9600"], obj=db)
         print(result.exit_code)
         print(sys.stderr, result.output)
@@ -80,7 +80,7 @@ class TestConfigConsoleCommands(object):
         db = Db()
         db.cfgdb.set_entry("CONSOLE_PORT", "1", { "baud_rate" : "9600" })
 
-        # add a console setting which the port has exists
+        # add a console setting which the port exists
         result = runner.invoke(config.config.commands["console"].commands["del"], ["1"], obj=db)
         print(result.exit_code)
         print(sys.stderr, result.output)

--- a/tests/console_test.py
+++ b/tests/console_test.py
@@ -1,0 +1,87 @@
+import os
+import sys
+import pytest
+
+import config.main as config
+import tests.mock_tables.dbconnector
+
+from click.testing import CliRunner
+from utilities_common.db import Db
+
+class TestConfigConsoleCommands(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+    
+    def test_console_add_exists(self):
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb.set_entry("CONSOLE_PORT", 1, { "baud_rate" : "9600" })
+
+        # add a console setting which the port has exists
+        result = runner.invoke(config.config.commands["console"].commands["add"], ["1", '--baud', "9600"], obj=db)
+        print(result.exit_code)
+        print(sys.stderr, result.output)
+        assert result.exit_code != 0
+        assert "Trying to add console port setting, which is already exists." in result.output
+    
+    def test_console_add_no_baud(self):
+        runner = CliRunner()
+        db = Db()
+
+        # add a console setting without baud
+        result = runner.invoke(config.config.commands["console"].commands["add"], ["1"], obj=db)
+        print(result.exit_code)
+        print(sys.stderr, result.output)
+        assert result.exit_code != 0
+        assert "Missing option '--baud'" in result.output
+
+    def test_console_add_name_conflict(self):
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb.set_entry("CONSOLE_PORT", 2, { "remote_device" : "switch1" })
+
+        # add a console setting which the device name has been used by other port
+        result = runner.invoke(config.config.commands["console"].commands["add"], ["1", '--baud', "9600", "--devicename", "switch1"], obj=db)
+        print(result.exit_code)
+        print(sys.stderr, result.output)
+        assert result.exit_code != 0
+        assert "Please enter a valid device name or remove the existing one" in result.output
+
+    def test_console_add_success(self):
+        runner = CliRunner()
+        db = Db()
+
+        # add a console setting without flow control option
+        result = runner.invoke(config.config.commands["console"].commands["add"], ["0", '--baud', "9600"], obj=db)
+        print(result.exit_code)
+        print(sys.stderr, result.output)
+        assert result.exit_code == 0
+
+        # add a console setting with flow control option
+        result = runner.invoke(config.config.commands["console"].commands["add"], ["1", '--baud', "9600", "--flowcontrol"], obj=db)
+        print(result.exit_code)
+        print(sys.stderr, result.output)
+        assert result.exit_code == 0
+
+    def test_console_del_non_exists(self):
+        runner = CliRunner()
+        db = Db()
+
+        # remote a console port setting which is not exists
+        result = runner.invoke(config.config.commands["console"].commands["del"], ["0"], obj=db)
+        print(result.exit_code)
+        print(sys.stderr, result.output)
+        assert result.exit_code != 0
+        assert "Trying to delete console port setting, which is not present." in result.output
+
+    def test_console_del_success(self):
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb.set_entry("CONSOLE_PORT", "1", { "baud_rate" : "9600" })
+
+        # add a console setting which the port has exists
+        result = runner.invoke(config.config.commands["console"].commands["del"], ["1"], obj=db)
+        print(result.exit_code)
+        print(sys.stderr, result.output)
+        assert result.exit_code == 0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

Support `console add` and `console del` commands under config command group. (More detail in HLD: https://github.com/Azure/SONiC/blob/master/doc/console/SONiC-Console-Switch-High-Level-Design.md#33121-adddel-console-port)
Added UT for commands.

**- How I did it**

1. Add new `console.py` file to support `config console` commands
1. Add UTs for console.py

**- How to verify it**

1. UTs are all passed
1. Tested on a physical SONiC DUT, detail output below:
Initial state
```bash
admin@sonic:~$ sudo show line
  Line    Actual/Configured Baud    PID    Start Time    Device
------  ------------------------  -----  ------------  --------
     0      9600/-                                            -
     1      9600/9600                                   switch1
     2      9600/-                                            -
     3      9600/-                                            -
```

Error Handling
```bash
admin@sonic:~$ sudo config console add 1
Usage: config console add [OPTIONS] <line_number>
Try "config console add -h" for help.

Error: Missing option "--baud" / "-b".

admin@sonic:~$ sudo config console add 1 --baud 9600
Usage: config console add [OPTIONS] <line_number>
Try "config console add -h" for help.

Error: Trying to add console port setting, which is already exists

admin@sonic:~$ sudo config console add 2 --baud 9600 --flowcontrol --devicename switch0
Usage: config console add [OPTIONS] <line_number>
Try "config console add -h" for help.

Error: Given device name switch0 has been used. Please enter a valid device name or remove the existing one !!

admin@sonic:~$ sudo config console del 3
Usage: config console del [OPTIONS] <line_number>
Try "config console del -h" for help.

Error: Trying to delete console port setting, which is not present
```

Add new console port setting
```bash
admin@sonic:~$ sudo config console add 0 --baud 9600 --flowcontrol --devicename switch0
admin@sonic:~$ sudo show line
  Line    Actual/Configured Baud    PID    Start Time    Device
------  ------------------------  -----  ------------  --------
     0      9600/9600                                   switch0
     1      9600/9600                                   switch1
     2      9600/-                                            -
     3      9600/-                                            -
```

Remove existing console port setting
```bash
admin@sonic:~$ sudo config console del 0
admin@sonic:~$ sudo show line
  Line    Actual/Configured Baud    PID    Start Time    Device
------  ------------------------  -----  ------------  --------
     0      9600/-                                            -
     1      9600/9600                                   switch1
     2      9600/-                                            -
     3      9600/-                                            -
```


**- Previous command output (if the output of a command-line utility has changed)**
N/A

**- New command output (if the output of a command-line utility has changed)**
N/A
