### PR TITLE
use vtysh in the show ip bgp summary command

### DIFF
--- a/utilities_common/bgp_util.py
+++ b/utilities_common/bgp_util.py
@@ -154,9 +154,9 @@ def run_bgp_command(vtysh_cmd, bgp_namespace=multi_asic.DEFAULT_NAMESPACE):
     bgp_instance_id = ' '
     output = None
     if bgp_namespace is not multi_asic.DEFAULT_NAMESPACE:
-        bgp_instance_id = multi_asic.get_asic_id_from_name(bgp_namespace)
+        bgp_instance_id = " -n {} ".format(multi_asic.get_asic_id_from_name(bgp_namespace))
 
-    cmd = 'sudo docker exec bgp{} vtysh -c "{}"'.format(
+    cmd = 'sudo vtysh {} -c "{}"'.format(
         bgp_instance_id, vtysh_cmd)
     try:
         output = clicommon.run_command(cmd, return_cmd=True)


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
call the vtysh script to get the information from Bgp container, instead of directly executing the docker commands

**- How I did it**
Modify the `run_bgp_command` function to call vtysh with correct instance_id and vtysh cmd.
The vtysh script is modified to take the namespace id in this PR https://github.com/Azure/sonic-buildimage/pull/5479

**- How to verify it**

- On Multi ASIC
`admin@str-acs-2:~$ show ip bgp summary

IPv4 Unicast Summary:
asic0: BGP router identifier 8.0.0.0, local AS number 65100 vrf-id 0
BGP table version 12826
asic1: BGP router identifier 8.0.0.1, local AS number 65100 vrf-id 0
BGP table version 8913
asic2: BGP router identifier 8.0.0.2, local AS number 65100 vrf-id 0
BGP table version 76
asic3: BGP router identifier 8.0.0.3, local AS number 65100 vrf-id 0
BGP table version 69
RIB entries 25940, using 4772960 bytes of memory
Peers 32, using 669440 KiB of memory
Peer groups 16, using 1024 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down    State/PfxRcd    NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.1       4  65200      87666      88720         0      0       0  2d22h23m   6402            ARISTA01T2
10.0.0.5       4  65200      87669      88719         0      0       0  2d22h23m   6402            ARISTA03T2
10.0.0.9       4  65200      87668      87673         0      0       0  2d22h23m   6402            ARISTA05T2
10.0.0.13      4  65200      87664      87673         0      0       0  2d22h23m   6402            ARISTA07T2
10.0.0.33      4  64001      84472      84506         0      0       0  2d22h23m   6               ARISTA01T0
10.0.0.35      4  64002      84465      84509         0      0       0  2d22h23m   6               ARISTA02T0
10.0.0.37      4  64003      84462      84506         0      0       0  2d22h23m   7               ARISTA03T0
10.0.0.39      4  64004      84474      84509         0      0       0  2d22h23m   6               ARISTA04T0
10.0.0.41      4  64005      84466      84506         0      0       0  2d22h23m   7               ARISTA05T0
10.0.0.43      4  64006      84466      84509         0      0       0  2d22h23m   6               ARISTA06T0
10.0.0.45      4  64007      84462      84509         0      0       0  2d22h23m   6               ARISTA07T0
10.0.0.47      4  64008      84468      84506         0      0       0  2d22h23m   6               ARISTA08T0
10.0.0.49      4  64009      84461      84506         0      0       0  2d22h23m   6               ARISTA09T0
10.0.0.51      4  64010      84464      84509         0      0       0  2d22h23m   6               ARISTA10T0
10.0.0.53      4  64011      84472      84504         0      0       0  2d22h23m   6               ARISTA11T0
10.0.0.55      4  64012      84471      84502         0      0       0  2d22h23m   6               ARISTA12T0
10.0.0.57      4  64013      84471      84501         0      0       0  2d22h23m   6               ARISTA13T0
10.0.0.59      4  64014      84469      84501         0      0       0  2d22h23m   6               ARISTA14T0
10.0.0.61      4  64015      84464      84502         0      0       0  2d22h23m   6               ARISTA15T0
10.0.0.63      4  64016      84467      84504         0      0       0  2d22h23m   6               ARISTA16T0
10.0.0.65      4  64017      84470      84502         0      0       0  2d22h23m   6               ARISTA17T0
10.0.0.67      4  64018      84466      84501         0      0       0  2d22h23m   6               ARISTA18T0
10.0.0.69      4  64019      84465      84502         0      0       0  2d22h23m   6               ARISTA19T0
10.0.0.71      4  64020          0          0         0      0       0  never      Active          ARISTA20T0

Total number of neighbors 24
admin@str-acs-2:~$ show ip bgp summary -n asic0

IPv4 Unicast Summary:
asic0: BGP router identifier 8.0.0.0, local AS number 65100 vrf-id 0
BGP table version 12826
RIB entries 12833, using 2361272 bytes of memory
Peers 4, using 83680 KiB of memory
Peer groups 4, using 256 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.1       4  65200      87670      88723         0      0       0  2d22h23m             6402  ARISTA01T2
10.0.0.5       4  65200      87673      88722         0      0       0  2d22h23m             6402  ARISTA03T2

Total number of neighbors 2
admin@str-acs-2:~$ show ip bgp summary -n asic0 -d all

IPv4 Unicast Summary:
asic0: BGP router identifier 8.0.0.0, local AS number 65100 vrf-id 0
BGP table version 12826
RIB entries 12833, using 2361272 bytes of memory
Peers 4, using 83680 KiB of memory
Peer groups 4, using 256 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.1       4  65200      87672      88726         0      0       0  2d22h23m             6402  ARISTA01T2
10.0.0.5       4  65200      87675      88725         0      0       0  2d22h23m             6402  ARISTA03T2
10.1.0.0       4  65100       6414       3325         0      0       0  2d22h23m             6417  ASIC4
10.1.0.2       4  65100       4056       3211         0      0       0  2d22h23m             6417  ASIC5

Total number of neighbors 4
admin@str-acs-2:~$ `


**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

