### PR TITLE
Fixed porstat rate and util issues

### DIFF
--- a/utilities_common/netstat.py
+++ b/utilities_common/netstat.py
@@ -27,10 +27,10 @@ def ns_brate(newstr, oldstr, delta):
         return STATUS_NA
     else:
         rate = int(ns_diff(newstr, oldstr).replace(',',''))/delta
-        if rate > 1024*1024*10:
-            rate = "{:.2f}".format(rate/1024/1024)+' MB'
-        elif rate > 1024*10:
-            rate = "{:.2f}".format(rate/1024)+' KB'
+        if rate > 1000*1000*10:
+            rate = "{:.2f}".format(rate/1000/1000)+' MB'
+        elif rate > 1000*10:
+            rate = "{:.2f}".format(rate/1000)+' KB'
         else:
             rate = "{:.2f}".format(rate)+' B'
         return rate+'/s'
@@ -53,7 +53,7 @@ def ns_util(newstr, oldstr, delta, port_rate=PORT_RATE):
         return STATUS_NA
     else:
         rate = int(ns_diff(newstr, oldstr).replace(',',''))/delta
-        util = rate/(port_rate*1024*1024*1024/8.0)*100
+        util = rate/(port_rate*1000*1000*1000/8.0)*100
         return "{:.2f}%".format(util)
 
 def table_as_json(table, header):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Fixed "portstat" rate and utilization issue.
Changed size factor from 1024 to 1000 for rate throughput calculation.
**- How I did it**
Pls check the diff.
**- How to verify it**
"portstat",  "portstat -a"
**- Previous command output (if the output of a command-line utility has changed)**
IFACE STATE RX_OK RX_BPS RX_UTIL RX_ERR RX_DRP RX_OVR TX_OK TX_BPS TX_UTIL TX_ERR TX_DRP TX_OVR

Ethernet41 U 353,628,250 98.67 MB/s 1.93% 0 0 0 353,660,334 98.67 MB/s 1.93% 0 0 0
**- New command output (if the output of a command-line utility has changed)**
FACE STATE RX_OK RX_BPS RX_UTIL RX_ERR RX_DRP RX_OVR TX_OK TX_BPS TX_UTIL TX_ERR TX_DRP TX_OVR

Ethernet2 U 5,065,263,485 124.98 MB/s 99.99% 0 0 0 113 7.63 B/s 0.00% 0 0 0
