### PR TITLE
[acl-loader] Revert fix for IP protocol == 0

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -413,7 +413,9 @@ class AclLoader(object):
     def convert_ip(self, table_name, rule_idx, rule):
         rule_props = {}
 
-        if rule.ip.config.protocol or rule.ip.config.protocol == 0:  # 0 is a valid protocol number
+        # FIXME: 0 is a valid protocol number, but openconfig seems to use it as a default value,
+        # so there isn't currently a good way to check if the user defined proto=0 or not.
+        if rule.ip.config.protocol:
             if self.ip_protocol_map.has_key(rule.ip.config.protocol):
                 rule_props["IP_PROTOCOL"] = self.ip_protocol_map[rule.ip.config.protocol]
             else:


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Fixes https://github.com/Azure/sonic-buildimage/issues/5469

It appears that the openconfig model includes a 0 default value, so there's no way to differentiate between a user passing in 0 and a user passing in no value at all, so this will add a "protocol == 0" qualifier to any ACL without a protocol explicitly defined.

**- How I did it**
I removed the `protocol == 0` check.

**- How to verify it**
Load an acl.json (like the one from the issue) with a rule with no IP protocol defined. Verify that no IP protocol qualifier is added to this rule.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

