### PR TITLE
Fix `show queue watermark` command fail

### DIFF
--- a/scripts/watermarkstat
+++ b/scripts/watermarkstat
@@ -185,13 +185,13 @@ class Watermarkstat(object):
         header_map = wm_type["obj_map"]
         single_key = header_map.keys()[0]
         header_len = len(header_map[single_key])
-        min_idx = float("inf")
+        min_idx = sys.maxint
 
         for name, counter_oid in header_map[single_key].items():
             curr_idx = int(wm_type["idx_func"](counter_oid))
             min_idx = min(min_idx, curr_idx)
 
-        self.min_idx = int(min_idx)
+        self.min_idx = min_idx
         self.header_list += ["{}{}".format(wm_type["header_prefix"], idx) for idx in range(self.min_idx, self.min_idx + header_len)]
 
     def get_counters(self, table_prefix, port_obj, idx_func, watermark):

--- a/scripts/watermarkstat
+++ b/scripts/watermarkstat
@@ -185,7 +185,7 @@ class Watermarkstat(object):
         header_map = wm_type["obj_map"]
         single_key = header_map.keys()[0]
         header_len = len(header_map[single_key])
-        min_idx = sys.maxint
+        min_idx = sys.maxsize
 
         for name, counter_oid in header_map[single_key].items():
             curr_idx = int(wm_type["idx_func"](counter_oid))


### PR DESCRIPTION
Signed-off-by: Petro Bratash <petrox.bratash@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Fix **_show queue watermark_** command failure when the queue doesn`t exist.

**- How I did it**
Change    `min_idx = float("inf")`  --> `min_idx = sys.maxint  `, because  cannot convert float infinity to integer

**- How to verify it**
Execute` show queue watermark multicast` or `show queue watermark unicast`  when a multicast/unicast queue doesn`t exist.

**- Previous command output (if the output of a command-line utility has changed)**

> $ show queue watermark multicast 
> Traceback (most recent call last):
>   File "/usr/bin/watermarkstat", line 281, in <module>
>     main()
>   File "/usr/bin/watermarkstat", line 276, in main
>     watermarkstat.print_all_stat(table_prefix, args.type)
>   File "/usr/bin/watermarkstat", line 227, in print_all_stat
>     self.build_header(type)
>   File "/usr/bin/watermarkstat", line 192, in build_header
>     self.min_idx = int(min_idx)
> OverflowError: cannot convert float infinity to integer

**- New command output (if the output of a command-line utility has changed)**

> $ show queue watermark multicast
> Egress shared pool occupancy per multicast queue:
>        Port
>  \-----------
>   Ethernet0
>   Ethernet4
>   Ethernet8
>  Ethernet12
>  Ethernet16
>  Ethernet20
>  Ethernet24
>  Ethernet28
>  ......