### PR TITLE
Fix fast-reboot-dump.py ipaddress error

### DIFF
--- a/scripts/fast-reboot-dump.py
+++ b/scripts/fast-reboot-dump.py
@@ -39,9 +39,12 @@ def generate_neighbor_entries(filename, all_available_macs):
         arp_output.append(obj)
 
         ip_addr = key.split(':')[2]
-        if ipaddress.ip_interface(ip_addr).ip.version != 4:
+        try:
+            ipaddress.IPv4Address(ip_addr)
+        except ipaddress.AddressValueError:
             #This is ipv6 address
             ip_addr = key.replace(key.split(':')[0] + ':' + key.split(':')[1] + ':', '')
+
         neighbor_entries.append((vlan_name, mac, ip_addr))
         syslog.syslog(syslog.LOG_INFO, "Neighbor entry: [Vlan: %s, Mac: %s, Ip: %s]" % (vlan_name, mac, ip_addr))
 

--- a/scripts/fast-reboot-dump.py
+++ b/scripts/fast-reboot-dump.py
@@ -40,7 +40,7 @@ def generate_neighbor_entries(filename, all_available_macs):
 
         ip_addr = key.split(':')[2]
         try:
-            ipaddress.IPv4Address(ip_addr)
+            ipaddress.IPv4Address(ip_addr.decode())
         except ipaddress.AddressValueError:
             #This is ipv6 address
             ip_addr = key.replace(key.split(':')[0] + ':' + key.split(':')[1] + ':', '')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

Fix weird behavior when using ipaddress to parse the ipv4 and ipv6 address.

**- How I did it**

Instead of using ipaddress.ip_interface(IP_ADDR), I change to use ipaddress.IPv4Address to check if the ip address is ipv4.
The same method is also used inside sonic-utilities/config/nat.py

**- How to verify it**

When there are some mac learned by SONIC, execute the fast-reboot. It should not return error.

**- Previous command output (if the output of a command-line utility has changed)**

```
Sep 28 08:26:16.418276 as8000-3 ERR fast-reboot-dump: Got an exception '192.168.0.208' does not appear to be an IPv4 or IPv6 interface:
Traceback:
 Traceback (most recent call last):
  File "/usr/bin/fast-reboot-dump.py", line 298, in <module>
    res = main()
  File "/usr/bin/fast-reboot-dump.py", line 289, in main
    neighbor_entries = generate_neighbor_entries(root_dir + '/arp.json', all_available_macs)
  File "/usr/bin/fast-reboot-dump.py", line 42, in generate_neighbor_entries
    if ipaddress.ip_interface(ip_addr).ip.version != 4:
  File "/usr/local/lib/python2.7/dist-packages/ipaddress.py", line 239, in ip_interface
    address)
ValueError: '192.168.0.208' does not appear to be an IPv4 or IPv6 interface
```

**- New command output (if the output of a command-line utility has changed)**

