### PR TITLE
[setup.py] Pin external runtime dependencies at known working versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,7 @@ setup(
         'ipaddress==1.0.23',
         'jsondiff==1.2.0',
         'm2crypto==0.31.0',
-        'natsort==6.2.1', # 6.2.1 is the last version which supports Python 2
+        'natsort==6.2.1',  # 6.2.1 is the last version which supports Python 2
         'netaddr==0.8.0',
         'netifaces==0.10.7',
         'pexpect==4.8.0',
@@ -152,7 +152,8 @@ setup(
         'sonic-yang-mgmt',
         'swsssdk>=2.0.1',
         'tabulate==0.8.2',
-        'xmltodict==0.12.0'
+        'xmltodict==0.12.0',
+        'zipp==1.2.0'  # Need to pin this down for Python 2, for Python 3 we should be able to remove altogether
     ],
     setup_requires= [
         'pytest-runner',

--- a/setup.py
+++ b/setup.py
@@ -140,14 +140,14 @@ setup(
         ]
     },
     install_requires=[
-        'click',
-        'ipaddress',
+        'click==7.0',
+        'ipaddress==1.0.23',
         'jsondiff==1.2.0',
-        'm2crypto',
+        'm2crypto==0.31.0',
         'natsort==6.2.1', # 6.2.1 is the last version which supports Python 2
-        'netaddr',
-        'netifaces',
-        'pexpect',
+        'netaddr==0.8.0',
+        'netifaces==0.10.7',
+        'pexpect==4.8.0',
         'sonic-py-common',
         'sonic-yang-mgmt',
         'swsssdk>=2.0.1',

--- a/tests/bgp_commands_test.py
+++ b/tests/bgp_commands_test.py
@@ -86,7 +86,7 @@ Total number of neighbors 24
 
 show_error_invalid_json = """\
 Usage: summary [OPTIONS]
-Try 'summary --help' for help.
+Try "summary --help" for help.
 
 Error: bgp summary from bgp container not in json format
 """

--- a/tests/console_test.py
+++ b/tests/console_test.py
@@ -34,7 +34,7 @@ class TestConfigConsoleCommands(object):
         print(result.exit_code)
         print(sys.stderr, result.output)
         assert result.exit_code != 0
-        assert "Missing option '--baud'" in result.output
+        assert "Missing option \"--baud\"" in result.output
 
     def test_console_add_name_conflict(self):
         runner = CliRunner()

--- a/tests/counterpoll_test.py
+++ b/tests/counterpoll_test.py
@@ -47,7 +47,7 @@ class TestCounterpoll(object):
         runner = CliRunner()
         result = runner.invoke(counterpoll.cli.commands["port-buffer-drop"].commands["interval"], ["1000"])
         print(result.output)
-        expected = "Invalid value for 'POLL_INTERVAL': 1000 is not in the valid range of 30000 to 300000."
+        expected = "Invalid value for \"POLL_INTERVAL\": 1000 is not in the valid range of 30000 to 300000."
         assert result.exit_code == 2
         assert expected in result.output
 


### PR DESCRIPTION
To ensure a smooth transition once we stop installing the dependencies explicitly in the SONiC image.

We can upgrade dependencies selectively in the future.

Also had to replace single-quotes with double-quotes in expected Click error messages, as it seems the Click package installed via pip uses double quotes, whereas the package installed via Debian used single-quotes.