### PR TITLE
Global and Interface commands for IPv6 Link local address enhancements

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -3177,7 +3177,6 @@ def disable_use_link_local_only(ctx, interface_name):
     interface_dict = config_db.get_table(interface_type)
     set_ipv6_link_local_only_on_interface(config_db, interface_dict, interface_type, interface_name, "disable")
 
-
 #
 # 'vrf' group ('config vrf ...')
 #

--- a/config/main.py
+++ b/config/main.py
@@ -3018,7 +3018,6 @@ def bind(ctx, interface_name, vrf_name):
     for interface_del in interface_dependent:
         config_db.set_entry(table_name, interface_del, None)
     config_db.set_entry(table_name, interface_name, None)
-
     # When config_db del entry and then add entry with same key, the DEL will lost.
     if ctx.obj['namespace'] is DEFAULT_NAMESPACE:
         state_db = SonicV2Connector(use_unix_socket_path=True)

--- a/config/main.py
+++ b/config/main.py
@@ -3087,10 +3087,14 @@ def disable():
 @click.argument('interface_name', metavar='<interface_name>', required=True)
 def enable_use_link_local_only(ctx, interface_name):
     """Enable IPv6 link local address on interface"""
-    config_db = ctx.obj["config_db"]
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    ctx.obj = {}
+    ctx.obj['config_db'] = config_db
+    db = ctx.obj["config_db"]
 
     if clicommon.get_interface_naming_mode() == "alias":
-        interface_name = interface_alias_to_name(config_db, interface_name)
+        interface_name = interface_alias_to_name(db, interface_name)
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
@@ -3104,28 +3108,28 @@ def enable_use_link_local_only(ctx, interface_name):
         ctx.fail("'interface_name' is not valid. Valid names [Ethernet/PortChannel/Vlan]")
 
     if (interface_type == "INTERFACE" ) or (interface_type == "PORTCHANNEL_INTERFACE"):
-        if interface_name_is_valid(config_db, interface_name) is False:
+        if interface_name_is_valid(db, interface_name) is False:
             ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" %(interface_name))
 
     if (interface_type == "VLAN_INTERFACE"):
-        vlan = config_db.get_entry('VLAN', interface_name)
+        vlan = db.get_entry('VLAN', interface_name)
         if len(vlan) == 0:
             ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" %(interface_name))
 
-    portchannel_member_table = config_db.get_table('PORTCHANNEL_MEMBER')
+    portchannel_member_table = db.get_table('PORTCHANNEL_MEMBER')
 
     if interface_is_in_portchannel(portchannel_member_table, interface_name):
         ctx.fail("{} is configured as a member of portchannel. Cannot configure the IPv6 link local mode!"
                 .format(interface_name))
 
-    vlan_member_table = config_db.get_table('VLAN_MEMBER')
+    vlan_member_table = db.get_table('VLAN_MEMBER')
 
     if interface_is_in_vlan(vlan_member_table, interface_name):
         ctx.fail("{} is configured as a member of vlan. Cannot configure the IPv6 link local mode!"
                 .format(interface_name))
 
-    interface_dict = config_db.get_table(interface_type)
-    set_ipv6_link_local_only_on_interface(config_db, interface_dict, interface_type, interface_name, "enable")
+    interface_dict = db.get_table(interface_type)
+    set_ipv6_link_local_only_on_interface(db, interface_dict, interface_type, interface_name, "enable")
 
 #
 # 'config interface ipv6 disable use-link-local-only <interface-name>'
@@ -3136,10 +3140,14 @@ def enable_use_link_local_only(ctx, interface_name):
 @click.argument('interface_name', metavar='<interface_name>', required=True)
 def disable_use_link_local_only(ctx, interface_name):
     """Disable IPv6 link local address on interface"""
-    config_db = ctx.obj["config_db"]
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    ctx.obj = {}
+    ctx.obj['config_db'] = config_db
+    db = ctx.obj["config_db"]
 
     if clicommon.get_interface_naming_mode() == "alias":
-        interface_name = interface_alias_to_name(config_db, interface_name)
+        interface_name = interface_alias_to_name(db, interface_name)
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
@@ -3154,27 +3162,27 @@ def disable_use_link_local_only(ctx, interface_name):
         ctx.fail("'interface_name' is not valid. Valid names [Ethernet/PortChannel/Vlan]")
 
     if (interface_type == "INTERFACE" ) or (interface_type == "PORTCHANNEL_INTERFACE"):
-        if interface_name_is_valid(config_db, interface_name) is False:
+        if interface_name_is_valid(db, interface_name) is False:
             ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" %(interface_name))
 
     if (interface_type == "VLAN_INTERFACE"):
-        vlan = config_db.get_entry('VLAN', interface_name)
+        vlan = db.get_entry('VLAN', interface_name)
         if len(vlan) == 0:
             ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" %(interface_name))
 
-    portchannel_member_table = config_db.get_table('PORTCHANNEL_MEMBER')
+    portchannel_member_table = db.get_table('PORTCHANNEL_MEMBER')
 
     if interface_is_in_portchannel(portchannel_member_table, interface_name):
         ctx.fail("{} is configured as a member of portchannel. Cannot configure the IPv6 link local mode!"
                 .format(interface_name))
 
-    vlan_member_table = config_db.get_table('VLAN_MEMBER')
+    vlan_member_table = db.get_table('VLAN_MEMBER')
     if interface_is_in_vlan(vlan_member_table, interface_name):
         ctx.fail("{} is configured as a member of vlan. Cannot configure the IPv6 link local mode!"
                 .format(interface_name))
 
-    interface_dict = config_db.get_table(interface_type)
-    set_ipv6_link_local_only_on_interface(config_db, interface_dict, interface_type, interface_name, "disable")
+    interface_dict = db.get_table(interface_type)
+    set_ipv6_link_local_only_on_interface(db, interface_dict, interface_type, interface_name, "disable")
 
 #
 # 'vrf' group ('config vrf ...')
@@ -4540,7 +4548,6 @@ def delete(ctx):
 
     sflow_tbl['global'].pop('agent_id')
     config_db.set_entry('SFLOW', 'global', sflow_tbl['global'])
-
 
 #
 # set ipv6 link local mode on a given interface

--- a/config/main.py
+++ b/config/main.py
@@ -511,11 +511,6 @@ def get_intf_ipv6_link_local_mode(ctx, interface_name, table_name):
     else:
         return ""
 
-def disable_intf_ipv6_mode(interface_name):
-    cmd = "sysctl -w net.ipv6.conf.{}.disable_ipv6=1".format(interface_name)
-    proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
-    proc.communicate()
-
 def _is_neighbor_ipaddress(config_db, ipaddress):
     """Returns True if a neighbor has the IP address <ipaddress>, False if not
     """
@@ -3024,10 +3019,6 @@ def bind(ctx, interface_name, vrf_name):
         config_db.set_entry(table_name, interface_del, None)
     config_db.set_entry(table_name, interface_name, None)
 
-    ipv6LinkLocalMode = get_intf_ipv6_link_local_mode(ctx, interface_name, table_name)
-    if ipv6LinkLocalMode is not None and ipv6LinkLocalMode == "enable":
-        disable_intf_ipv6_mode(interface_name)
-
     # When config_db del entry and then add entry with same key, the DEL will lost.
     if ctx.obj['namespace'] is DEFAULT_NAMESPACE:
         state_db = SonicV2Connector(use_unix_socket_path=True)
@@ -3066,10 +3057,6 @@ def unbind(ctx, interface_name):
     for interface_del in interface_dependent:
         config_db.set_entry(table_name, interface_del, None)
     config_db.set_entry(table_name, interface_name, None)
-
-    ipv6LinkLocalMode = get_intf_ipv6_link_local_mode(ctx, interface_name, table_name)
-    if ipv6LinkLocalMode is not None and ipv6LinkLocalMode == "enable":
-        disable_intf_ipv6_mode(interface_name)
 
 
 #
@@ -4654,7 +4641,7 @@ def disable(ctx):
         table_dict = config_db.get_table(table_type)
         if table_dict:
             for key in table_dict.keys():
-                if isinstance(key, unicode) is False:
+                if isinstance(key, str) is False:
                     continue
                 set_ipv6_link_local_only_on_interface(config_db, table_dict, table_type, key, mode)
 

--- a/config/main.py
+++ b/config/main.py
@@ -3112,8 +3112,7 @@ def enable_use_link_local_only(ctx, interface_name):
             ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" %(interface_name))
 
     if (interface_type == "VLAN_INTERFACE"):
-        vlan = db.get_entry('VLAN', interface_name)
-        if len(vlan) == 0:
+        if not clicommon.is_valid_vlan_interface(db, interface_name):
             ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" %(interface_name))
 
     portchannel_member_table = db.get_table('PORTCHANNEL_MEMBER')
@@ -3166,8 +3165,7 @@ def disable_use_link_local_only(ctx, interface_name):
             ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" %(interface_name))
 
     if (interface_type == "VLAN_INTERFACE"):
-        vlan = db.get_entry('VLAN', interface_name)
-        if len(vlan) == 0:
+        if not clicommon.is_valid_vlan_interface(db, interface_name):
             ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" %(interface_name))
 
     portchannel_member_table = db.get_table('PORTCHANNEL_MEMBER')
@@ -4599,10 +4597,18 @@ def ipv6(ctx):
 #
 # 'enable' command ('config ipv6 enable ...')
 #
-@ipv6.command()
+@ipv6.group()
 @click.pass_context
 def enable(ctx):
     """Enable IPv6 on all interfaces """
+
+#
+# 'link-local' command ('config ipv6 enable link-local')
+#
+@enable.command('link-local')
+@click.pass_context
+def enable_link_local(ctx):
+    """Enable IPv6 link-local on all interfaces """
     config_db = ConfigDBConnector()
     config_db.connect()
     vlan_member_table = config_db.get_table('VLAN_MEMBER')
@@ -4631,10 +4637,18 @@ def enable(ctx):
 #
 # 'disable' command ('config ipv6 disable ...')
 #
-@ipv6.command()
+@ipv6.group()
 @click.pass_context
 def disable(ctx):
     """Disable IPv6 on all interfaces """
+
+#
+# 'link-local' command ('config ipv6 disable link-local')
+#
+@disable.command('link-local')
+@click.pass_context
+def disable_link_local(ctx):
+    """Disable IPv6 link local on all interfaces """
     config_db = ConfigDBConnector()
     config_db.connect()
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -65,6 +65,9 @@
 * [IP / IPv6](#ip--ipv6)
   * [IP show commands](#ip-show-commands)
   * [IPv6 show commands](#ipv6-show-commands)
+* [IPv6 Link Local](#ipv6-link-local)
+  * [IPv6 Link Local config commands](#ipv6-link-local-config-commands)
+  * [IPv6 Link Local show commands](#ipv6-link-local-show-commands)
 * [Kubernetes](#Kubernetes)
   * [Kubernetes show commands](#Kubernetes-show-commands)
   * [Kubernetes config commands](#Kubernetes-config-commands)
@@ -4116,6 +4119,96 @@ Refer the routing stack [Quagga Command Reference](https://www.quagga.net/docs/q
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#ip--ipv6)
 
+## IPv6 Link Local
+
+### IPv6 Link Local config commands
+
+This section explains all the commands that are supported in SONiC to configure IPv6 Link-local.
+
+**config interface ipv6 enable use-link-local-only <interface_name>**
+
+This command enables user to enable an interface to forward L3 traffic with out configuring an address. This command creates the routing interface based on the auto generated IPv6 link-local address. This command can be used even if an address is configured on the interface.
+
+- Usage:
+  ```
+  config interface ipv6 enable use-link-local-only <interface_name>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config interface ipv6 enable use-link-local-only Vlan206
+  admin@sonic:~$ sudo config interface ipv6 enable use-link-local-only PortChannel007
+  admin@sonic:~$ sudo config interface ipv6 enable use-link-local-only Ethernet52
+  ```
+
+**config interface ipv6 disable use-link-local-only <interface_name>**
+
+This command enables user to disable use-link-local-only configuration on an interface.
+
+- Usage:
+  ```
+  config interface ipv6 disable use-link-local-only <interface_name>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config interface ipv6 disable use-link-local-only Vlan206
+  admin@sonic:~$ sudo config interface ipv6 disable use-link-local-only PortChannel007
+  admin@sonic:~$ sudo config interface ipv6 disable use-link-local-only Ethernet52
+  ```
+
+**config ipv6 enable link-local**
+
+This command enables user to enable use-link-local-only command on all the interfaces globally.
+
+- Usage:
+  ```
+  sudo config ipv6 enable link-local
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config ipv6 enable link-local
+  ```
+
+**config ipv6 disable link-local**
+
+This command enables user to disable use-link-local-only command on all the interfaces globally.
+
+- Usage:
+  ```
+  sudo config ipv6 disable link-local
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config ipv6 disable link-local
+  ```
+
+### IPv6 Link Local show commands
+
+**show ipv6 link-local-mode**
+
+This command displays the link local mode of all the interfaces.
+
+- Usage:
+  ```
+  show ipv6 link-local-mode
+  ```
+
+- Example:
+  ```
+  root@sonic:/home/admin# show ipv6 link-local-mode
+  +------------------+----------+
+  | Interface Name   | Mode     |
+  +==================+==========+
+  | Ethernet16       | Disabled |
+  +------------------+----------+
+  | Ethernet18       | Enabled  |
+  +------------------+----------+
+  ```
+
+Go Back To [Beginning of the document](#) or [Beginning of this section](#ipv6-link-local)
 
 ## Kubernetes
 

--- a/show/main.py
+++ b/show/main.py
@@ -879,6 +879,36 @@ elif routing_stack == "frr":
     ipv6.add_command(bgp)
 
 #
+# 'link-local-mode' subcommand ("show ipv6 link-local-mode")
+#
+
+@ipv6.command('link-local-mode')
+@click.option('--verbose', is_flag=True, help="Enable verbose output")
+def link_local_mode(verbose):
+    """show ipv6 link-local-mode"""
+    header = ['Interface Name', 'Mode']
+    body = []
+    link_local = []
+    interfaces = ['INTERFACE', 'PORTCHANNEL_INTERFACE', 'VLAN_INTERFACE']
+    config_db = ConfigDBConnector()
+    config_db.connect()
+
+    for i in interfaces:
+        interface_dict = config_db.get_table(i)
+        link_local_data = {}
+
+        if interface_dict:
+          for interface,value in interface_dict.items():
+             if 'ipv6_use_link_local_only' in value:
+                 link_local_data[interface] = interface_dict[interface]['ipv6_use_link_local_only']
+                 if link_local_data[interface] == 'enable':
+                     body.append([interface, 'Enabled'])
+                 else:
+                     body.append([interface, 'Disabled'])
+
+    click.echo(tabulate(body, header, tablefmt="grid"))
+
+#
 # 'lldp' group ("show lldp ...")
 #
 

--- a/show/main.py
+++ b/show/main.py
@@ -888,7 +888,6 @@ def link_local_mode(verbose):
     """show ipv6 link-local-mode"""
     header = ['Interface Name', 'Mode']
     body = []
-    link_local = []
     interfaces = ['INTERFACE', 'PORTCHANNEL_INTERFACE', 'VLAN_INTERFACE']
     config_db = ConfigDBConnector()
     config_db.connect()

--- a/tests/ipv6_link_local_test.py
+++ b/tests/ipv6_link_local_test.py
@@ -1,0 +1,153 @@
+import os
+
+from click.testing import CliRunner
+
+import config.main as config
+import show.main as show
+from utilities_common.db import Db
+
+show_ipv6_link_local_mode_output="""\
++------------------+----------+
+| Interface Name   | Mode     |
++==================+==========+
+| Ethernet0        | Disabled |
++------------------+----------+
+| PortChannel0001  | Disabled |
++------------------+----------+
+"""
+
+class TestIPv6LinkLocal(object):
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "1"
+        print("SETUP")
+
+    def test_show_ipv6_link_local_mode(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+
+        # show ipv6 link-local-mode output
+        result = runner.invoke(show.cli.commands["ipv6"].commands["link-local-mode"], [], obj=obj)
+        print(result.output)
+        assert result.output == show_ipv6_link_local_mode_output
+
+    def test_config_enable_disable_ipv6_link_local_on_physical_interface(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+
+        # Enable ipv6 link local on Ethernet0
+        result = runner.invoke(config.config.commands["interface"].commands["ipv6"].commands["enable"].commands["use-link-local-only"], ["Ethernet0"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == ''
+
+        # Disable ipv6 link local on Ethernet0
+        result = runner.invoke(config.config.commands["interface"].commands["ipv6"].commands["disable"].commands["use-link-local-only"], ["Ethernet0"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == ''
+
+    def test_config_enable_disable_ipv6_link_local_on_portchannel_interface(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+
+        # Enable ipv6 link local on PortChannel0001
+        result = runner.invoke(config.config.commands["interface"].commands["ipv6"].commands["enable"].commands["use-link-local-only"], ["PortChannel0001"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == ''
+
+        # Disable ipv6 link local on PortChannel0001
+        result = runner.invoke(config.config.commands["interface"].commands["ipv6"].commands["disable"].commands["use-link-local-only"], ["PortChannel0001"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == ''
+
+    def test_config_enable_disable_ipv6_link_local_on_invalid_interface(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+
+        # Enable ipv6 link local on PortChannel1
+        result = runner.invoke(config.config.commands["interface"].commands["ipv6"].commands["enable"].commands["use-link-local-only"], ["PortChannel1"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert 'Error: Interface name PortChannel1 is invalid. Please enter a valid interface name!!' in result.output
+
+        # Disable ipv6 link local on Ethernet500
+        result = runner.invoke(config.config.commands["interface"].commands["ipv6"].commands["disable"].commands["use-link-local-only"], ["Ethernet500"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert 'Error: Interface name Ethernet500 is invalid. Please enter a valid interface name!!' in result.output
+
+    def test_config_enable_disable_ipv6_link_local_on_interface_which_is_member_of_vlan(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+
+        # Enable ipv6 link local on Ethernet16
+        result = runner.invoke(config.config.commands["interface"].commands["ipv6"].commands["enable"].commands["use-link-local-only"], ["Ethernet16"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert 'Error: Ethernet16 is configured as a member of vlan. Cannot configure the IPv6 link local mode!' in result.output
+
+        # Disable ipv6 link local on Ethernet16
+        result = runner.invoke(config.config.commands["interface"].commands["ipv6"].commands["disable"].commands["use-link-local-only"], ["Ethernet16"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert 'Error: Ethernet16 is configured as a member of vlan. Cannot configure the IPv6 link local mode!' in result.output
+
+    def test_config_enable_disable_ipv6_link_local_on_interface_which_is_member_of_portchannel(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+        
+        # Enable ipv6 link local on Ethernet32
+        result = runner.invoke(config.config.commands["interface"].commands["ipv6"].commands["enable"].commands["use-link-local-only"], ["Ethernet32"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert 'Error: Ethernet32 is configured as a member of portchannel. Cannot configure the IPv6 link local mode!' in result.output
+
+        # Disable ipv6 link local on Ethernet32
+        result = runner.invoke(config.config.commands["interface"].commands["ipv6"].commands["disable"].commands["use-link-local-only"], ["Ethernet32"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert 'Error: Ethernet32 is configured as a member of portchannel. Cannot configure the IPv6 link local mode!' in result.output
+
+    def test_config_enable_disable_ipv6_link_local_on_all_valid_interfaces(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+
+        # Enable ipv6 link local on all interfaces
+        result = runner.invoke(config.config.commands["ipv6"].commands["enable"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == ''
+
+        # Disable ipv6 link local on all interfaces
+        result = runner.invoke(config.config.commands["ipv6"].commands["disable"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == ''
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        print("TEARDOWN")
+

--- a/tests/ipv6_link_local_test.py
+++ b/tests/ipv6_link_local_test.py
@@ -133,14 +133,14 @@ class TestIPv6LinkLocal(object):
         obj = {'db':db.cfgdb}
 
         # Enable ipv6 link local on all interfaces
-        result = runner.invoke(config.config.commands["ipv6"].commands["enable"], obj=obj)
+        result = runner.invoke(config.config.commands["ipv6"].commands["enable"].commands["link-local"], obj=obj)
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
         assert result.output == ''
 
         # Disable ipv6 link local on all interfaces
-        result = runner.invoke(config.config.commands["ipv6"].commands["disable"], obj=obj)
+        result = runner.invoke(config.config.commands["ipv6"].commands["disable"].commands["link-local"], obj=obj)
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -537,7 +537,6 @@
         "NULL": "NULL"
     },
     "PORTCHANNEL_INTERFACE|PortChannel0001": {
-        "NULL": "NULL",
         "ipv6_use_link_local_only": "disable"
     },
     "PORTCHANNEL_INTERFACE|PortChannel0002": {
@@ -574,7 +573,6 @@
         "NULL": "NULL"
     },
     "INTERFACE|Ethernet0": {
-        "NULL": "NULL",
         "ipv6_use_link_local_only": "disable"
     },
     "INTERFACE|Ethernet0|14.14.0.1/24": {

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -537,7 +537,8 @@
         "NULL": "NULL"
     },
     "PORTCHANNEL_INTERFACE|PortChannel0001": {
-        "NULL": "NULL"
+        "NULL": "NULL",
+        "ipv6_use_link_local_only": "disable"
     },
     "PORTCHANNEL_INTERFACE|PortChannel0002": {
         "NULL": "NULL"
@@ -573,7 +574,8 @@
         "NULL": "NULL"
     },
     "INTERFACE|Ethernet0": {
-        "NULL": "NULL"
+        "NULL": "NULL",
+        "ipv6_use_link_local_only": "disable"
     },
     "INTERFACE|Ethernet0|14.14.0.1/24": {
         "NULL": "NULL"


### PR DESCRIPTION
As per the HLD - https://github.com/Azure/SONiC/pull/625 , added config and interface commands.

SONiC CLI per interface configuration command to enable and disable the IPv6 link-local address mode when addresses are not configured manually.

Example:
```
config interface ipv6 enable use-link-local-only Ethernet24
config interface ipv6 disable use-link-local-only Ethernet24
```
SONiC CLI global command to enable or disable the IPv6 auto link-local address mode on all eligible interfaces.
```
config ipv6 enable link-local
config ipv6 disable link-local
```
Show command to display the link local mode of all interfaces.
```
root@sonic:/home/admin# show ipv6 link-local-mode 
+------------------+----------+
| Interface Name   | Mode     |
+==================+==========+
| Ethernet16       | Disabled |
+------------------+----------+
| Ethernet18       | Enabled  |
+------------------+----------+
root@sonic:/home/admin# 
```

Depends on:
https://github.com/Azure/sonic-buildimage/pull/5584
https://github.com/Azure/sonic-swss/pull/1463

Signed-off-by: Akhilesh Samineni <akhilesh.samineni@broadcom.com>
