### PR TITLE
[fast-reboot] Fix unicode issue in ipaddress for python2

### DIFF
--- a/scripts/fast-reboot-dump.py
+++ b/scripts/fast-reboot-dump.py
@@ -12,6 +12,7 @@ import argparse
 import syslog
 import traceback
 import ipaddress
+from builtins import str #for unicode conversion in python2
 
 
 ARP_CHUNK = binascii.unhexlify('08060001080006040001') # defines a part of the packet for ARP Request
@@ -39,7 +40,7 @@ def generate_neighbor_entries(filename, all_available_macs):
         arp_output.append(obj)
 
         ip_addr = key.split(':')[2]
-        if ipaddress.ip_interface(ip_addr).ip.version != 4:
+        if ipaddress.ip_interface(str(ip_addr)).ip.version != 4:
             #This is ipv6 address
             ip_addr = key.replace(key.split(':')[0] + ':' + key.split(':')[1] + ':', '')
         neighbor_entries.append((vlan_name, mac, ip_addr))
@@ -232,7 +233,7 @@ def send_garp_nd(neighbor_entries, map_mac_ip_per_vlan):
     # send arp/ndp packets
     for vlan_name, dst_mac, dst_ip in neighbor_entries:
         src_if = map_mac_ip_per_vlan[vlan_name][dst_mac]
-        if ipaddress.ip_interface(dst_ip).ip.version == 4:
+        if ipaddress.ip_interface(str(dst_ip)).ip.version == 4:
             send_arp(sockets[src_if], src_mac_addrs[src_if], src_ip_addrs[vlan_name], dst_mac, dst_ip)
         else:
             send_ndp(sockets[src_if], src_mac_addrs[src_if], src_ip_addrs[vlan_name], dst_mac, dst_ip)


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
The ```ipaddress.ip_interface``` accepts only unicode string as input. However, an exception will be raised on python 2.
```
Oct 12 03:32:41.758040 str-dx010-acs-4 ERR fast-reboot-dump: Got an exception '192.168.0.240' does not appear to be an IPv4 or IPv6 interface: 
Traceback: 
Traceback (most recent call last):
#012  File "/usr/local/bin/fast-reboot-dump.py", line 298, in <module>
#012    res = main()
#012  File "/usr/local/bin/fast-reboot-dump.py", line 289, in main
#012    neighbor_entries = generate_neighbor_entries(root_dir + '/arp.json', all_available_macs)
#012  File "/usr/local/bin/fast-reboot-dump.py", line 42, in generate_neighbor_entries
#012    if ipaddress.ip_interface(ip_addr).ip.version != 4:
#012  File "/usr/local/lib/python2.7/dist-packages/ipaddress.py", line 239, in ip_interface
#012  ValueError: '192.168.0.240' does not appear to be an IPv4 or IPv6 interface
```
As a result, fast-reboot aborted with error code 2.
```
admin@str-dx010-acs-4:~$ sudo fast-reboot -v
Failed to run fast-reboot-dump.py. Exit code: 2
Mon 12 Oct 2020 03:34:21 AM UTC fast-reboot failure (12) cleanup ...
```
This PR is to fix the issue.
**- How I did it**
Use ```str``` in ```builtins``` to handle the conversion of unicode. 

**- How to verify it**
Verified on both python2 and python3.
For python2, running ```fast-reboot```, and the command complete successfully without exception.
For python3, a demo script is tested to verify the update.
**- Previous command output (if the output of a command-line utility has changed)**
N/A
**- New command output (if the output of a command-line utility has changed)**
N/A
