### PR TITLE
[config/console] Support update console configuration related commands

### DIFF
--- a/tests/console_test.py
+++ b/tests/console_test.py
@@ -64,6 +64,12 @@ class TestConfigConsoleCommands(object):
         print(sys.stderr, result.output)
         assert result.exit_code == 0
 
+        # add a console setting with device name option
+        result = runner.invoke(config.config.commands["console"].commands["add"], ["2", '--baud', "9600", "--devicename", "switch1"], obj=db)
+        print(result.exit_code)
+        print(sys.stderr, result.output)
+        assert result.exit_code == 0
+
     def test_console_del_non_exists(self):
         runner = CliRunner()
         db = Db()
@@ -82,6 +88,129 @@ class TestConfigConsoleCommands(object):
 
         # add a console setting which the port exists
         result = runner.invoke(config.config.commands["console"].commands["del"], ["1"], obj=db)
+        print(result.exit_code)
+        print(sys.stderr, result.output)
+        assert result.exit_code == 0
+
+    def test_update_console_remote_device_name_non_exists(self):
+        runner = CliRunner()
+        db = Db()
+
+        # trying to update a console line remote device configuration which is not exists
+        result = runner.invoke(config.config.commands["console"].commands["remote_device"], ["1", "switch1"], obj=db)
+        print(result.exit_code)
+        print(sys.stderr, result.output)
+        assert result.exit_code != 0
+        assert "Trying to update console port setting, which is not present." in result.output
+
+    def test_update_console_remote_device_name_conflict(self):
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb.set_entry("CONSOLE_PORT", 1, { "baud": "9600" })
+        db.cfgdb.set_entry("CONSOLE_PORT", 2, { "baud": "9600", "remote_device" : "switch1" })
+
+        # trying to update a console line remote device configuration which is not exists
+        result = runner.invoke(config.config.commands["console"].commands["remote_device"], ["1", "switch1"], obj=db)
+        print(result.exit_code)
+        print(sys.stderr, result.output)
+        assert result.exit_code != 0
+        assert "Please enter a valid device name or remove the existing one" in result.output
+    
+    def test_update_console_remote_device_name_existing_and_same(self):
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb.set_entry("CONSOLE_PORT", 2, { "remote_device" : "switch1" })
+
+        # trying to update a console line remote device configuration which is existing and same with user provided value
+        result = runner.invoke(config.config.commands["console"].commands["remote_device"], ["2", "switch1"], obj=db)
+        print(result.exit_code)
+        print(sys.stderr, result.output)
+        assert result.exit_code == 0
+
+    def test_update_console_remote_device_name_reset(self):
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb.set_entry("CONSOLE_PORT", 2, { "remote_device" : "switch1" })
+
+        # trying to reset a console line remote device configuration which is not exists
+        result = runner.invoke(config.config.commands["console"].commands["remote_device"], ["2"], obj=db)
+        print(result.exit_code)
+        print(sys.stderr, result.output)
+        assert result.exit_code == 0
+
+    def test_update_console_remote_device_name_success(self):
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb.set_entry("CONSOLE_PORT", "1", { "baud_rate" : "9600" })
+
+        # trying to set a console line remote device configuration
+        result = runner.invoke(config.config.commands["console"].commands["remote_device"], ["1", "switch1"], obj=db)
+        print(result.exit_code)
+        print(sys.stderr, result.output)
+        assert result.exit_code == 0
+
+    def test_update_console_baud_no_change(self):
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb.set_entry("CONSOLE_PORT", "1", { "baud_rate" : "9600" })
+
+        # trying to set a console line baud which is same with existing one
+        result = runner.invoke(config.config.commands["console"].commands["baud"], ["1", "9600"], obj=db)
+        print(result.exit_code)
+        print(sys.stderr, result.output)
+        assert result.exit_code == 0
+    
+    def test_update_console_baud_non_exists(self):
+        runner = CliRunner()
+        db = Db()
+
+        # trying to set a console line baud which is not exists
+        result = runner.invoke(config.config.commands["console"].commands["baud"], ["1", "9600"], obj=db)
+        print(result.exit_code)
+        print(sys.stderr, result.output)
+        assert result.exit_code != 0
+        assert "Trying to update console port setting, which is not present." in result.output
+    
+    def test_update_console_baud_success(self):
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb.set_entry("CONSOLE_PORT", "1", { "baud_rate" : "9600" })
+
+        # trying to set a console line baud
+        result = runner.invoke(config.config.commands["console"].commands["baud"], ["1", "115200"], obj=db)
+        print(result.exit_code)
+        print(sys.stderr, result.output)
+        assert result.exit_code == 0
+
+    def test_update_console_flow_control_no_change(self):
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb.set_entry("CONSOLE_PORT", "1", { "baud_rate" : "9600", "flow_control" : "0" })
+
+        # trying to set a console line flow control option which is same with existing one
+        result = runner.invoke(config.config.commands["console"].commands["flow_control"], ["disable", "1"], obj=db)
+        print(result.exit_code)
+        print(sys.stderr, result.output)
+        assert result.exit_code == 0
+
+    def test_update_console_flow_control_non_exists(self):
+        runner = CliRunner()
+        db = Db()
+
+        # trying to set a console line flow control option which is not exists
+        result = runner.invoke(config.config.commands["console"].commands["flow_control"], ["enable", "1"], obj=db)
+        print(result.exit_code)
+        print(sys.stderr, result.output)
+        assert result.exit_code != 0
+        assert "Trying to update console port setting, which is not present." in result.output
+
+    def test_update_console_flow_control_success(self):
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb.set_entry("CONSOLE_PORT", "1", { "baud_rate" : "9600", "flow_control" : "0" })
+
+        # trying to set a console line flow control option
+        result = runner.invoke(config.config.commands["console"].commands["flow_control"], ["enable", "1"], obj=db)
         print(result.exit_code)
         print(sys.stderr, result.output)
         assert result.exit_code == 0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

* Support `config console remote_device` command
* Support `config console baud` command
* Support `config console flow_control` command

For more detail regarding the design, please refer to HLD(section 3.3.1.2.2/3.3.1.2.3/3.3.1.2.4): https://github.com/Azure/SONiC/blob/master/doc/console/SONiC-Console-Switch-High-Level-Design.md#3312-config

**- How I did it**

* Add new commands in `console.py` file to support update related `config console` commands
* Add UTs for new added commands

**- How to verify it**

1. UTs are all passed

```
---------- coverage: platform linux2, python 2.7.16-final-0 ----------
Name                                       Stmts   Miss  Cover
--------------------------------------------------------------
config/console.py                             94      1    99%
```

2. Tested on a physical SONiC DUT

**Error handling:**
```bash
sudo config console baud 2 9600
Usage: config console baud [OPTIONS] <line_number> <baud>
Try "config console baud -h" for help.

admin@sonic:~$ sudo config console remote_device 2 switch1
Usage: config console remote_device [OPTIONS] <line_number> <device_name>
Try "config console remote_device -h" for help.

Error: Given device name switch1 has been used. Please enter a valid device name or remove the existing one !!
```

**Positive result:**
```
admin@sonic:~$ sudo config console baud 1 115000
admin@sonic:~$ sudo config console remote_device 1 switch1
admin@sonic:~$ sudo config console flow_control enable 1
admin@sonic:~$ sudo config console flow_control disable 1
```

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

