### PR TITLE
[config/show] Add CLI support for proxy arp

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -5949,7 +5949,7 @@ Go Back To [Beginning of the document](#) or [Beginning of this section](#System
 
 **show vlan brief**
 
-This command displays brief information about all the vlans configured in the device. It displays the vlan ID, IP address (if configured for the vlan), list of vlan member ports, whether the port is tagged or in untagged mode and the DHCP Helper Address.
+This command displays brief information about all the vlans configured in the device. It displays the vlan ID, IP address (if configured for the vlan), list of vlan member ports, whether the port is tagged or in untagged mode, the DHCP Helper Address, and the proxy ARP status
 
 - Usage:
   ```
@@ -5960,13 +5960,13 @@ This command displays brief information about all the vlans configured in the de
   ```
   admin@sonic:~$ show vlan brief
 
-  +-----------+--------------+-----------+----------------+-----------------------+
-  |   VLAN ID | IP Address   | Ports     | Port Tagging   | DHCP Helper Address   |
-  +===========+==============+===========+================+=======================+
-  |       100 | 1.1.2.2/16   | Ethernet0 | tagged         | 192.0.0.1             |
-  |           |              | Ethernet4 | tagged         | 192.0.0.2             |
-  |           |              |           |                | 192.0.0.3             |
-  +-----------+--------------+-----------+----------------+-----------------------+
+  +-----------+--------------+-----------+----------------+-----------------------+-------------+
+  |   VLAN ID | IP Address   | Ports     | Port Tagging   | DHCP Helper Address   | Proxy ARP   |
+  +===========+==============+===========+================+=======================+=============+
+  |       100 | 1.1.2.2/16   | Ethernet0 | tagged         | 192.0.0.1             | disabled    |
+  |           |              | Ethernet4 | tagged         | 192.0.0.2             |             |
+  |           |              |           |                | 192.0.0.3             |             |
+  +-----------+--------------+-----------+----------------+-----------------------+-------------+
   ```
 
 **show vlan config**
@@ -6025,6 +6025,21 @@ This command is to add or delete a member port into the already created vlan.
 
   admin@sonic:~$ sudo config vlan member add 100 Ethernet4
   This command will add Ethernet4 as member of the vlan 100.
+  ```
+
+**config proxy_arp enabled/disabled**
+
+This command is used to enable or disable proxy ARP for a VLAN interface
+
+- Usage:
+  ```
+  config vlan proxy_arp <vlan_id> enabled/disabled
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config vlan proxy_arp 1000 enabled
+  This command will enable proxy ARP for the interface 'Vlan1000'
   ```
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#vlan--FDB)

--- a/tests/vlan_test.py
+++ b/tests/vlan_test.py
@@ -8,63 +8,63 @@ import show.main as show
 from utilities_common.db import Db
 
 show_vlan_brief_output="""\
-+-----------+-----------------+------------+----------------+-----------------------+
-|   VLAN ID | IP Address      | Ports      | Port Tagging   | DHCP Helper Address   |
-+===========+=================+============+================+=======================+
-|      1000 | 192.168.0.1/21  | Ethernet4  | untagged       | 192.0.0.1             |
-|           | fc02:1000::1/64 | Ethernet8  | untagged       | 192.0.0.2             |
-|           |                 | Ethernet12 | untagged       | 192.0.0.3             |
-|           |                 | Ethernet16 | untagged       | 192.0.0.4             |
-+-----------+-----------------+------------+----------------+-----------------------+
-|      2000 | 192.168.0.10/21 | Ethernet24 | untagged       | 192.0.0.1             |
-|           | fc02:1011::1/64 | Ethernet28 | untagged       | 192.0.0.2             |
-|           |                 |            |                | 192.0.0.3             |
-|           |                 |            |                | 192.0.0.4             |
-+-----------+-----------------+------------+----------------+-----------------------+
++-----------+-----------------+------------+----------------+-----------------------+-------------+
+|   VLAN ID | IP Address      | Ports      | Port Tagging   | DHCP Helper Address   | Proxy ARP   |
++===========+=================+============+================+=======================+=============+
+|      1000 | 192.168.0.1/21  | Ethernet4  | untagged       | 192.0.0.1             | disabled    |
+|           | fc02:1000::1/64 | Ethernet8  | untagged       | 192.0.0.2             |             |
+|           |                 | Ethernet12 | untagged       | 192.0.0.3             |             |
+|           |                 | Ethernet16 | untagged       | 192.0.0.4             |             |
++-----------+-----------------+------------+----------------+-----------------------+-------------+
+|      2000 | 192.168.0.10/21 | Ethernet24 | untagged       | 192.0.0.1             | enabled     |
+|           | fc02:1011::1/64 | Ethernet28 | untagged       | 192.0.0.2             |             |
+|           |                 |            |                | 192.0.0.3             |             |
+|           |                 |            |                | 192.0.0.4             |             |
++-----------+-----------------+------------+----------------+-----------------------+-------------+
 """
 
 show_vlan_brief_in_alias_mode_output="""\
-+-----------+-----------------+---------+----------------+-----------------------+
-|   VLAN ID | IP Address      | Ports   | Port Tagging   | DHCP Helper Address   |
-+===========+=================+=========+================+=======================+
-|      1000 | 192.168.0.1/21  | etp2    | untagged       | 192.0.0.1             |
-|           | fc02:1000::1/64 | etp3    | untagged       | 192.0.0.2             |
-|           |                 | etp4    | untagged       | 192.0.0.3             |
-|           |                 | etp5    | untagged       | 192.0.0.4             |
-+-----------+-----------------+---------+----------------+-----------------------+
-|      2000 | 192.168.0.10/21 | etp7    | untagged       | 192.0.0.1             |
-|           | fc02:1011::1/64 | etp8    | untagged       | 192.0.0.2             |
-|           |                 |         |                | 192.0.0.3             |
-|           |                 |         |                | 192.0.0.4             |
-+-----------+-----------------+---------+----------------+-----------------------+
++-----------+-----------------+---------+----------------+-----------------------+-------------+
+|   VLAN ID | IP Address      | Ports   | Port Tagging   | DHCP Helper Address   | Proxy ARP   |
++===========+=================+=========+================+=======================+=============+
+|      1000 | 192.168.0.1/21  | etp2    | untagged       | 192.0.0.1             | disabled    |
+|           | fc02:1000::1/64 | etp3    | untagged       | 192.0.0.2             |             |
+|           |                 | etp4    | untagged       | 192.0.0.3             |             |
+|           |                 | etp5    | untagged       | 192.0.0.4             |             |
++-----------+-----------------+---------+----------------+-----------------------+-------------+
+|      2000 | 192.168.0.10/21 | etp7    | untagged       | 192.0.0.1             | enabled     |
+|           | fc02:1011::1/64 | etp8    | untagged       | 192.0.0.2             |             |
+|           |                 |         |                | 192.0.0.3             |             |
+|           |                 |         |                | 192.0.0.4             |             |
++-----------+-----------------+---------+----------------+-----------------------+-------------+
 """
 
 show_vlan_brief_empty_output="""\
-+-----------+-----------------+------------+----------------+-----------------------+
-|   VLAN ID | IP Address      | Ports      | Port Tagging   | DHCP Helper Address   |
-+===========+=================+============+================+=======================+
-|      2000 | 192.168.0.10/21 | Ethernet24 | untagged       | 192.0.0.1             |
-|           | fc02:1011::1/64 | Ethernet28 | untagged       | 192.0.0.2             |
-|           |                 |            |                | 192.0.0.3             |
-|           |                 |            |                | 192.0.0.4             |
-+-----------+-----------------+------------+----------------+-----------------------+
++-----------+-----------------+------------+----------------+-----------------------+-------------+
+|   VLAN ID | IP Address      | Ports      | Port Tagging   | DHCP Helper Address   | Proxy ARP   |
++===========+=================+============+================+=======================+=============+
+|      2000 | 192.168.0.10/21 | Ethernet24 | untagged       | 192.0.0.1             | enabled     |
+|           | fc02:1011::1/64 | Ethernet28 | untagged       | 192.0.0.2             |             |
+|           |                 |            |                | 192.0.0.3             |             |
+|           |                 |            |                | 192.0.0.4             |             |
++-----------+-----------------+------------+----------------+-----------------------+-------------+
 """
 
 show_vlan_brief_with_portchannel_output="""\
-+-----------+-----------------+-----------------+----------------+-----------------------+
-|   VLAN ID | IP Address      | Ports           | Port Tagging   | DHCP Helper Address   |
-+===========+=================+=================+================+=======================+
-|      1000 | 192.168.0.1/21  | Ethernet4       | untagged       | 192.0.0.1             |
-|           | fc02:1000::1/64 | Ethernet8       | untagged       | 192.0.0.2             |
-|           |                 | Ethernet12      | untagged       | 192.0.0.3             |
-|           |                 | Ethernet16      | untagged       | 192.0.0.4             |
-|           |                 | PortChannel1001 | untagged       |                       |
-+-----------+-----------------+-----------------+----------------+-----------------------+
-|      2000 | 192.168.0.10/21 | Ethernet24      | untagged       | 192.0.0.1             |
-|           | fc02:1011::1/64 | Ethernet28      | untagged       | 192.0.0.2             |
-|           |                 |                 |                | 192.0.0.3             |
-|           |                 |                 |                | 192.0.0.4             |
-+-----------+-----------------+-----------------+----------------+-----------------------+
++-----------+-----------------+-----------------+----------------+-----------------------+-------------+
+|   VLAN ID | IP Address      | Ports           | Port Tagging   | DHCP Helper Address   | Proxy ARP   |
++===========+=================+=================+================+=======================+=============+
+|      1000 | 192.168.0.1/21  | Ethernet4       | untagged       | 192.0.0.1             | disabled    |
+|           | fc02:1000::1/64 | Ethernet8       | untagged       | 192.0.0.2             |             |
+|           |                 | Ethernet12      | untagged       | 192.0.0.3             |             |
+|           |                 | Ethernet16      | untagged       | 192.0.0.4             |             |
+|           |                 | PortChannel1001 | untagged       |                       |             |
++-----------+-----------------+-----------------+----------------+-----------------------+-------------+
+|      2000 | 192.168.0.10/21 | Ethernet24      | untagged       | 192.0.0.1             | enabled     |
+|           | fc02:1011::1/64 | Ethernet28      | untagged       | 192.0.0.2             |             |
+|           |                 |                 |                | 192.0.0.3             |             |
+|           |                 |                 |                | 192.0.0.4             |             |
++-----------+-----------------+-----------------+----------------+-----------------------+-------------+
 """
 
 show_vlan_config_output="""\
@@ -100,56 +100,56 @@ Restarting DHCP relay service...
 """
 
 show_vlan_brief_output_with_new_dhcp_relay_address="""\
-+-----------+-----------------+------------+----------------+-----------------------+
-|   VLAN ID | IP Address      | Ports      | Port Tagging   | DHCP Helper Address   |
-+===========+=================+============+================+=======================+
-|      1000 | 192.168.0.1/21  | Ethernet4  | untagged       | 192.0.0.1             |
-|           | fc02:1000::1/64 | Ethernet8  | untagged       | 192.0.0.2             |
-|           |                 | Ethernet12 | untagged       | 192.0.0.3             |
-|           |                 | Ethernet16 | untagged       | 192.0.0.4             |
-|           |                 |            |                | 192.0.0.100           |
-+-----------+-----------------+------------+----------------+-----------------------+
-|      2000 | 192.168.0.10/21 | Ethernet24 | untagged       | 192.0.0.1             |
-|           | fc02:1011::1/64 | Ethernet28 | untagged       | 192.0.0.2             |
-|           |                 |            |                | 192.0.0.3             |
-|           |                 |            |                | 192.0.0.4             |
-+-----------+-----------------+------------+----------------+-----------------------+
++-----------+-----------------+------------+----------------+-----------------------+-------------+
+|   VLAN ID | IP Address      | Ports      | Port Tagging   | DHCP Helper Address   | Proxy ARP   |
++===========+=================+============+================+=======================+=============+
+|      1000 | 192.168.0.1/21  | Ethernet4  | untagged       | 192.0.0.1             | disabled    |
+|           | fc02:1000::1/64 | Ethernet8  | untagged       | 192.0.0.2             |             |
+|           |                 | Ethernet12 | untagged       | 192.0.0.3             |             |
+|           |                 | Ethernet16 | untagged       | 192.0.0.4             |             |
+|           |                 |            |                | 192.0.0.100           |             |
++-----------+-----------------+------------+----------------+-----------------------+-------------+
+|      2000 | 192.168.0.10/21 | Ethernet24 | untagged       | 192.0.0.1             | enabled     |
+|           | fc02:1011::1/64 | Ethernet28 | untagged       | 192.0.0.2             |             |
+|           |                 |            |                | 192.0.0.3             |             |
+|           |                 |            |                | 192.0.0.4             |             |
++-----------+-----------------+------------+----------------+-----------------------+-------------+
 """
 
 config_add_del_vlan_and_vlan_member_output="""\
-+-----------+-----------------+------------+----------------+-----------------------+
-|   VLAN ID | IP Address      | Ports      | Port Tagging   | DHCP Helper Address   |
-+===========+=================+============+================+=======================+
-|      1000 | 192.168.0.1/21  | Ethernet4  | untagged       | 192.0.0.1             |
-|           | fc02:1000::1/64 | Ethernet8  | untagged       | 192.0.0.2             |
-|           |                 | Ethernet12 | untagged       | 192.0.0.3             |
-|           |                 | Ethernet16 | untagged       | 192.0.0.4             |
-+-----------+-----------------+------------+----------------+-----------------------+
-|      1001 |                 | Ethernet20 | untagged       |                       |
-+-----------+-----------------+------------+----------------+-----------------------+
-|      2000 | 192.168.0.10/21 | Ethernet24 | untagged       | 192.0.0.1             |
-|           | fc02:1011::1/64 | Ethernet28 | untagged       | 192.0.0.2             |
-|           |                 |            |                | 192.0.0.3             |
-|           |                 |            |                | 192.0.0.4             |
-+-----------+-----------------+------------+----------------+-----------------------+
++-----------+-----------------+------------+----------------+-----------------------+-------------+
+|   VLAN ID | IP Address      | Ports      | Port Tagging   | DHCP Helper Address   | Proxy ARP   |
++===========+=================+============+================+=======================+=============+
+|      1000 | 192.168.0.1/21  | Ethernet4  | untagged       | 192.0.0.1             | disabled    |
+|           | fc02:1000::1/64 | Ethernet8  | untagged       | 192.0.0.2             |             |
+|           |                 | Ethernet12 | untagged       | 192.0.0.3             |             |
+|           |                 | Ethernet16 | untagged       | 192.0.0.4             |             |
++-----------+-----------------+------------+----------------+-----------------------+-------------+
+|      1001 |                 | Ethernet20 | untagged       |                       | disabled    |
++-----------+-----------------+------------+----------------+-----------------------+-------------+
+|      2000 | 192.168.0.10/21 | Ethernet24 | untagged       | 192.0.0.1             | enabled     |
+|           | fc02:1011::1/64 | Ethernet28 | untagged       | 192.0.0.2             |             |
+|           |                 |            |                | 192.0.0.3             |             |
+|           |                 |            |                | 192.0.0.4             |             |
++-----------+-----------------+------------+----------------+-----------------------+-------------+
 """
 
 config_add_del_vlan_and_vlan_member_in_alias_mode_output="""\
-+-----------+-----------------+---------+----------------+-----------------------+
-|   VLAN ID | IP Address      | Ports   | Port Tagging   | DHCP Helper Address   |
-+===========+=================+=========+================+=======================+
-|      1000 | 192.168.0.1/21  | etp2    | untagged       | 192.0.0.1             |
-|           | fc02:1000::1/64 | etp3    | untagged       | 192.0.0.2             |
-|           |                 | etp4    | untagged       | 192.0.0.3             |
-|           |                 | etp5    | untagged       | 192.0.0.4             |
-+-----------+-----------------+---------+----------------+-----------------------+
-|      1001 |                 | etp6    | untagged       |                       |
-+-----------+-----------------+---------+----------------+-----------------------+
-|      2000 | 192.168.0.10/21 | etp7    | untagged       | 192.0.0.1             |
-|           | fc02:1011::1/64 | etp8    | untagged       | 192.0.0.2             |
-|           |                 |         |                | 192.0.0.3             |
-|           |                 |         |                | 192.0.0.4             |
-+-----------+-----------------+---------+----------------+-----------------------+
++-----------+-----------------+---------+----------------+-----------------------+-------------+
+|   VLAN ID | IP Address      | Ports   | Port Tagging   | DHCP Helper Address   | Proxy ARP   |
++===========+=================+=========+================+=======================+=============+
+|      1000 | 192.168.0.1/21  | etp2    | untagged       | 192.0.0.1             | disabled    |
+|           | fc02:1000::1/64 | etp3    | untagged       | 192.0.0.2             |             |
+|           |                 | etp4    | untagged       | 192.0.0.3             |             |
+|           |                 | etp5    | untagged       | 192.0.0.4             |             |
++-----------+-----------------+---------+----------------+-----------------------+-------------+
+|      1001 |                 | etp6    | untagged       |                       | disabled    |
++-----------+-----------------+---------+----------------+-----------------------+-------------+
+|      2000 | 192.168.0.10/21 | etp7    | untagged       | 192.0.0.1             | enabled     |
+|           | fc02:1011::1/64 | etp8    | untagged       | 192.0.0.2             |             |
+|           |                 |         |                | 192.0.0.3             |             |
+|           |                 |         |                | 192.0.0.4             |             |
++-----------+-----------------+---------+----------------+-----------------------+-------------+
 """
 class TestVlan(object):
     @classmethod
@@ -189,6 +189,12 @@ class TestVlan(object):
         print(result.output)
         assert result.exit_code == 0
         assert result.output == show_vlan_brief_in_alias_mode_output
+
+    def test_show_vlan_brief_explicit_proxy_arp_disable(self):
+        runner = CliRunner()
+        db = Db()
+
+        db.cfgdb.set_entry("VLAN_INTERFACE", "Vlan1000", {"proxy_arp": "disabled"})
 
     def test_show_vlan_config(self):
         runner = CliRunner()
@@ -400,6 +406,7 @@ class TestVlan(object):
 
         # show output
         result = runner.invoke(show.cli.commands["vlan"].commands["brief"], [], obj=db)
+        print(result.exit_code)
         print(result.output)
         assert result.output == config_add_del_vlan_and_vlan_member_in_alias_mode_output
 
@@ -423,7 +430,7 @@ class TestVlan(object):
         assert result.exit_code == 0
         assert result.output == show_vlan_brief_in_alias_mode_output
 
-        os.environ['SONIC_CLI_IFACE_MODE'] = ""
+        os.environ['SONIC_CLI_IFACE_MODE'] = "default"
 
     def test_config_vlan_add_dhcp_relay_with_nonexist_vlanid(self):
         runner = CliRunner()
@@ -514,6 +521,59 @@ class TestVlan(object):
         # traceback.print_tb(result.exc_info[2])
         assert result.exit_code != 0
         assert "Error: Vlan1001 doesn't exist" in result.output
+
+    def test_config_vlan_proxy_arp_with_nonexist_vlan_intf_table(self):
+        modes = ["enabled", "disabled"]
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb.delete_table("VLAN_INTERFACE")
+
+        for mode in modes:
+            result = runner.invoke(config.config.commands["vlan"].commands["proxy_arp"], ["1000", mode], obj=db)
+
+            print(result.exit_code)
+            print(result.output)
+
+            assert result.exit_code != 0
+            assert "Interface Vlan1000 does not exist" in result.output
+
+    def test_config_vlan_proxy_arp_with_nonexist_vlan_intf(self):
+        modes = ["enabled", "disabled"]
+        runner = CliRunner()
+        db = Db()
+
+        for mode in modes:
+            result = runner.invoke(config.config.commands["vlan"].commands["proxy_arp"], ["1001", mode], obj=db)
+
+            print(result.exit_code)
+            print(result.output)
+
+            assert result.exit_code != 0
+            assert "Interface Vlan1001 does not exist" in result.output
+
+    def test_config_vlan_proxy_arp_enable(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["vlan"].commands["proxy_arp"], ["1000", "enabled"], obj=db)
+
+        print(result.exit_code)
+        print(result.output)
+
+        assert result.exit_code == 0 
+        assert db.cfgdb.get_entry("VLAN_INTERFACE", "Vlan1000") == {"proxy_arp": "enabled"}
+
+    def test_config_vlan_proxy_arp_disable(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["vlan"].commands["proxy_arp"], ["2000", "disabled"], obj=db)
+
+        print(result.exit_code)
+        print(result.output)
+
+        assert result.exit_code == 0
+        assert db.cfgdb.get_entry("VLAN_INTERFACE", "Vlan2000") == {"proxy_arp": "disabled"}
 
     @classmethod
     def teardown_class(cls):

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -262,6 +262,10 @@ def interface_is_in_vlan(vlan_member_table, interface_name):
 
     return False
 
+def is_valid_vlan_interface(config_db, interface):
+    """ Check an interface is a valid VLAN interface """
+    return interface in config_db.get_table("VLAN_INTERFACE")
+
 def interface_is_in_portchannel(portchannel_member_table, interface_name):
     """ Check if an interface is part of portchannel """
     for _,intf in portchannel_member_table.keys():


### PR DESCRIPTION

Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Enable CLI management for proxy ARP setting
**- How I did it**
* Add `config vlan proxy_arp <vid> <enable/disable>
    * Edits VLAN_INTERFACE table to set the "proxy_arp" setting for an interface
    * Restarts the `ndppd` daemon running inside the SWSS container to grab changes
* Add proxy ARP info to `show vlan brief`

**- How to verify it**
* Run unit tests

**- Previous command output (if the output of a command-line utility has changed)**
```
> show vlan brief
+-----------+-----------------+------------+----------------+-----------------------+
|   VLAN ID | IP Address      | Ports      | Port Tagging   | DHCP Helper Address   |
+===========+=================+============+================+=======================+
|      1000 | 192.168.0.1/21  | Ethernet4  | untagged       | 192.0.0.1             |
|           | fc02:1000::1/64 | Ethernet8  | untagged       | 192.0.0.2             |
|           |                 | Ethernet12 | untagged       | 192.0.0.3             |
|           |                 | Ethernet16 | untagged       | 192.0.0.4             |
+-----------+-----------------+------------+----------------+-----------------------+
|      2000 | 192.168.0.10/21 | Ethernet24 | untagged       | 192.0.0.1             |
|           | fc02:1011::1/64 | Ethernet28 | untagged       | 192.0.0.2             |
|           |                 |            |                | 192.0.0.3             |
|           |                 |            |                | 192.0.0.4             |
+-----------+-----------------+------------+----------------+-----------------------+
```

**- New command output (if the output of a command-line utility has changed)**
```
> show vlan brief
+-----------+-----------------+------------+----------------+-----------------------+-------------+
|   VLAN ID | IP Address      | Ports      | Port Tagging   | DHCP Helper Address   | Proxy ARP   |
+===========+=================+============+================+=======================+=============+
|      1000 | 192.168.0.1/21  | Ethernet4  | untagged       | 192.0.0.1             | disabled    |
|           | fc02:1000::1/64 | Ethernet8  | untagged       | 192.0.0.2             |             |
|           |                 | Ethernet12 | untagged       | 192.0.0.3             |             |
|           |                 | Ethernet16 | untagged       | 192.0.0.4             |             |
+-----------+-----------------+------------+----------------+-----------------------+-------------+
|      2000 | 192.168.0.10/21 | Ethernet24 | untagged       | 192.0.0.1             | enabled     |
|           | fc02:1011::1/64 | Ethernet28 | untagged       | 192.0.0.2             |             |
|           |                 |            |                | 192.0.0.3             |             |
|           |                 |            |                | 192.0.0.4             |             |
+-----------+-----------------+------------+----------------+-----------------------+-------------+
```
