### PR TITLE
[consutil] Add brief option to show line command

### DIFF
--- a/consutil/lib.py
+++ b/consutil/lib.py
@@ -61,7 +61,7 @@ def run_command(cmd, abort=True):
     return output if abort else (output, error)
 
 # returns a list of all lines
-def getAllLines():
+def getAllLines(brief=False):
     config_db = ConfigDBConnector()
     config_db.connect()
 
@@ -73,16 +73,17 @@ def getAllLines():
         line[LINE_KEY] = k
         lines.append(line)
 
-    # Querying device directory to get all available console ports 
-    cmd = "ls " + DEVICE_PREFIX + "*"
-    output, _ = run_command(cmd, abort=False)
-    availableTtys = output.split('\n')
-    availableTtys = list(filter(lambda dev: re.match(DEVICE_PREFIX + r"\d+", dev) != None, availableTtys))
-    for tty in availableTtys:
-        k = tty[len(DEVICE_PREFIX):]
-        if k not in keys:
-            line = { LINE_KEY: k }
-            lines.append(line)
+    # Querying device directory to get all available console ports
+    if not brief:
+        cmd = "ls " + DEVICE_PREFIX + "*"
+        output, _ = run_command(cmd, abort=False)
+        availableTtys = output.split('\n')
+        availableTtys = list(filter(lambda dev: re.match(DEVICE_PREFIX + r"\d+", dev) != None, availableTtys))
+        for tty in availableTtys:
+            k = tty[len(DEVICE_PREFIX):]
+            if k not in keys:
+                line = { LINE_KEY: k }
+                lines.append(line)
     return lines
 
 # returns a dictionary of busy lines and their info

--- a/consutil/main.py
+++ b/consutil/main.py
@@ -25,9 +25,10 @@ def consutil():
 
 # 'show' subcommand
 @consutil.command()
-def show():
-    """Show all lines and their info"""
-    lines = getAllLines()
+@click.option('--brief', '-b', metavar='<brief_mode>', required=False, is_flag=True)
+def show(brief):
+    """Show all lines and their info include available ttyUSB devices unless specified brief mode"""
+    lines = getAllLines(brief)
     busyLines = getBusyLines()
 
     # sort lines for table rendering
@@ -59,7 +60,7 @@ def clear(target):
     """Clear preexisting connection to line"""
     targetLine = getLine(target)
     if not targetLine:
-        click.echo("Target [{}] does not exist".format(linenum))
+        click.echo("Target [{}] does not exist".format(target))
         sys.exit(ERR_DEV)
     lineNumber = targetLine[LINE_KEY]
 

--- a/show/main.py
+++ b/show/main.py
@@ -1827,10 +1827,11 @@ def reboot_cause():
 # 'line' command ("show line")
 #
 @cli.command('line')
+@click.option('--brief', '-b', metavar='<brief_mode>', required=False, is_flag=True)
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
-def line(verbose):
-    """Show all /dev/ttyUSB lines and their info"""
-    cmd = "consutil show"
+def line(brief, verbose):
+    """Show all console lines and their info include available ttyUSB devices unless specified brief mode"""
+    cmd = "consutil show" + (" -b" if brief else "")
     run_command(cmd, display_cmd=verbose)
     return
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

Add `--brief` and `-b` option to show line command.
By default, show line command will render a table which includes all console lines in `CONSOLE_PORT` table and all `ttyUSB*` devices under `\dev`. We display `ttyUSB*` because we want to provide convenience to user when adding console line settings from scratch.
We add this optional option is for reduce noise for some user because the user are not allowed to connect a console line which is not present in CONFIG_DB.

**- How I did it**

Stop merge console line result into the result table when user specified `--brief` or `-b` option.

**- How to verify it**

Build python-wheel package and tested on physical DUT.

**- Previous command output (if the output of a command-line utility has changed)**

N/A

**- New command output (if the output of a command-line utility has changed)**

```
admin@sonic:~$ sudo show line -b
  Line    Baud    PID    Start Time    Device
------  ------  -----  ------------  --------
     1  115000                        switch1
     2    9600                              -
```
