### PR TITLE
Modify fast-reboot script to use BGP script to stop bgp service

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -509,8 +509,7 @@ debug "Stopped radv service..."
 
 # Kill bgpd to start the bgp graceful restart procedure
 debug "Stopping bgp ..."
-docker exec -i bgp pkill -9 zebra
-docker exec -i bgp pkill -9 bgpd || [ $? == 1 ]
+systemctl stop bgp
 debug "Stopped  bgp ..."
 
 # Kill lldp, otherwise it sends informotion about reboot.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Call BGP service script to do special handling of reboot process behavior.
This is part of cleanup that is being done for `fast-reboot` script as part of which service shutdown is handled by respective service script instead of populating fast-reboot script.

**- How I did it**
Updated `fast-reboot` script to call `systemctl stop bgp` instead of handling this in the script itself.
The service script is already created in `sonic-buildimage` repo as part of https://github.com/Azure/sonic-buildimage/pull/3992

**- How to verify it**
Tested `warm-reboot`:
```
Oct 15 06:24:12.620808 str2-7060cx-32s-29 NOTICE admin: Stopping bgp ...

Oct 15 06:24:12.631107 str2-7060cx-32s-29 INFO systemd[1]: Stopping BGP container...
Oct 15 06:24:12.638316 str2-7060cx-32s-29 NOTICE admin: Stopping bgp service...
Oct 15 06:24:12.971859 str2-7060cx-32s-29 NOTICE admin: Warm boot flag: bgp true.
Oct 15 06:24:12.977610 str2-7060cx-32s-29 NOTICE admin: Fast boot flag: bgp false.
Oct 15 06:24:12.983902 str2-7060cx-32s-29 NOTICE admin: Kill zebra first
Oct 15 06:24:13.126937 str2-7060cx-32s-29 INFO bgp#supervisord: fpmsyncd Connection lost, reconnecting...
Oct 15 06:24:13.126937 str2-7060cx-32s-29 INFO bgp#supervisord: fpmsyncd Waiting for fpm-client connection...
Oct 15 06:24:13.135866 str2-7060cx-32s-29 INFO bgp#supervisor-proc-exit-listener: Process zebra exited unxepectedly. Terminating supervisor...
Oct 15 06:24:13.461392 str2-7060cx-32s-29 INFO bgp#supervisor-proc-exit-listener: Process bgpd exited unxepectedly. Terminating supervisor...
Oct 15 06:24:15.152101 str2-7060cx-32s-29 NOTICE bgp#staticd[30]: Terminating on signal
Oct 15 06:24:16.450006 str2-7060cx-32s-29 INFO bgp.sh[7132]: bgp
Oct 15 06:24:16.450906 str2-7060cx-32s-29 INFO bgp.sh[1673]: 0
Oct 15 06:24:16.458194 str2-7060cx-32s-29 NOTICE admin: Stopped bgp service...
Oct 15 06:24:16.461959 str2-7060cx-32s-29 INFO systemd[1]: bgp.service: Succeeded.
Oct 15 06:24:16.463093 str2-7060cx-32s-29 INFO systemd[1]: Stopped BGP container.

Oct 15 06:24:16.470455 str2-7060cx-32s-29 NOTICE admin: Stopped  bgp ...
```

Tested `fast-reboot` on master image on a T0 device.
```
Oct 15 06:15:39.416962 str2-7060cx-32s-29 NOTICE admin: Stopping bgp ...

Oct 15 06:15:39.429109 str2-7060cx-32s-29 INFO systemd[1]: Stopping BGP container...
Oct 15 06:15:39.432750 str2-7060cx-32s-29 NOTICE admin: Stopping bgp service...
Oct 15 06:15:39.981156 str2-7060cx-32s-29 NOTICE admin: Warm boot flag: bgp false.
Oct 15 06:15:39.992478 str2-7060cx-32s-29 NOTICE admin: Fast boot flag: bgp true.
Oct 15 06:15:40.000709 str2-7060cx-32s-29 NOTICE admin: Kill zebra first
Oct 15 06:15:40.141740 str2-7060cx-32s-29 INFO systemd[1]: run-docker-runtime\x2drunc-moby-ef3c021c809a362385f759c1cbad1082b2771cd5320d5cf7aed7214f8cf876ba-runc.DQlUVQ.mount: Succeeded.
Oct 15 06:15:40.193218 str2-7060cx-32s-29 INFO bgp#supervisord: fpmsyncd Connection lost, reconnecting...
Oct 15 06:15:40.194747 str2-7060cx-32s-29 INFO bgp#supervisord: fpmsyncd Waiting for fpm-client connection...
Oct 15 06:15:40.226978 str2-7060cx-32s-29 INFO bgp#supervisor-proc-exit-listener: Process zebra exited unxepectedly. Terminating supervisor...
Oct 15 06:15:40.619559 str2-7060cx-32s-29 INFO bgp#supervisor-proc-exit-listener: Process bgpd exited unxepectedly. Terminating supervisor...
Oct 15 06:15:42.249197 str2-7060cx-32s-29 NOTICE bgp#staticd[32]: Terminating on signal
Oct 15 06:15:43.537562 str2-7060cx-32s-29 INFO bgp.sh[11769]: bgp
Oct 15 06:15:43.538007 str2-7060cx-32s-29 INFO bgp.sh[11443]: 0
Oct 15 06:15:43.542403 str2-7060cx-32s-29 NOTICE admin: Stopped bgp service...
Oct 15 06:15:43.547097 str2-7060cx-32s-29 INFO systemd[1]: bgp.service: Succeeded.
Oct 15 06:15:43.548055 str2-7060cx-32s-29 INFO systemd[1]: Stopped BGP container.

Oct 15 06:15:43.554842 str2-7060cx-32s-29 NOTICE admin: Stopped  bgp ...
```
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

