### PR TITLE
Fix the issue of the show interfaces neighbor expected

### DIFF
--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -238,36 +238,38 @@ def expected(db, interfacename):
         return
 
     #Swap Key and Value from interface: name to name: interface
-    device2interface_dict = {}
-    for port in natsorted(neighbor_dict.keys()):
-        temp_port = port
-        if clicommon.get_interface_naming_mode() == "alias":
+    if clicommon.get_interface_naming_mode() == "alias":
+        for port in natsorted(neighbor_dict.keys()):
+            temp_port = port
             port = clicommon.InterfaceAliasConverter().name_to_alias(port)
             neighbor_dict[port] = neighbor_dict.pop(temp_port)
-        device2interface_dict[neighbor_dict[port]['name']] = {'localPort': port, 'neighborPort': neighbor_dict[port]['port']}
 
     header = ['LocalPort', 'Neighbor', 'NeighborPort', 'NeighborLoopback', 'NeighborMgmt', 'NeighborType']
     body = []
     if interfacename:
-        for device in natsorted(neighbor_metadata_dict.keys()):
-            if device2interface_dict[device]['localPort'] == interfacename:
-                body.append([device2interface_dict[device]['localPort'],
-                             device,
-                             device2interface_dict[device]['neighborPort'],
-                             neighbor_metadata_dict[device]['lo_addr'],
-                             neighbor_metadata_dict[device]['mgmt_addr'],
-                             neighbor_metadata_dict[device]['type']])
+        for port in natsorted(neighbor_dict.keys()):
+            if port == interfacename:
+                device = neighbor_dict[port]['name']
+                if device in neighbor_metadata_dict.keys():
+                    body.append([port,
+                                 device,
+                                 neighbor_dict[port]['port'],
+                                 neighbor_metadata_dict[device]['lo_addr'],
+                                 neighbor_metadata_dict[device]['mgmt_addr'],
+                                 neighbor_metadata_dict[device]['type']])
         if len(body) == 0:
             click.echo("No neighbor information available for interface {}".format(interfacename))
             return
     else:
-        for device in natsorted(neighbor_metadata_dict.keys()):
-            body.append([device2interface_dict[device]['localPort'],
-                         device,
-                         device2interface_dict[device]['neighborPort'],
-                         neighbor_metadata_dict[device]['lo_addr'],
-                         neighbor_metadata_dict[device]['mgmt_addr'],
-                         neighbor_metadata_dict[device]['type']])
+        for port in natsorted(neighbor_dict.keys()):
+            device = neighbor_dict[port]['name']
+            if device in neighbor_metadata_dict.keys():
+                body.append([port,
+                             device,
+                             neighbor_dict[port]['port'],
+                             neighbor_metadata_dict[device]['lo_addr'],
+                             neighbor_metadata_dict[device]['mgmt_addr'],
+                             neighbor_metadata_dict[device]['type']])
 
     click.echo(tabulate(body, header))
 


### PR DESCRIPTION
**- What I did**
      Fix the issue #1068 

**- How I did it**
      Use interface as the keys to find the neighbors expected.

**- How to verify it**
    1. Load configuration with port-channel interfaces with more than one member.
    2. Execute "show interfaces neighbor expected" command.

 Signed-off-by: chiourung_huang <chiourung_huang@edge-core.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

