### PR TITLE
Remove stdeb.cfg; no longer used now that we build as wheel

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,2 +1,0 @@
-[DEFAULT]
-Depends: psmisc, grub2-common, bash-completion


### PR DESCRIPTION
stdeb.cfg was needed for building Debian package. Now that we build a Python wheel, it is no longer used.