### PR TITLE
fdbshow and nbrshow use SonicV2Connector with decode_responses=True, and remove all the decode()

### DIFF
--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -40,7 +40,7 @@ class FdbShow(object):
 
     def __init__(self):
         super(FdbShow,self).__init__()
-        self.db = SonicV2Connector(host="127.0.0.1")
+        self.db = SonicV2Connector(host="127.0.0.1", decode_responses=True)
         self.if_name_map, \
         self.if_oid_map = port_util.get_interface_oid_map(self.db)
         self.if_br_oid_map = port_util.get_bridge_port_map(self.db)
@@ -64,7 +64,7 @@ class FdbShow(object):
 
         oid_pfx = len("oid:0x")
         for s in fdb_str:
-            fdb_entry = s.decode()
+            fdb_entry = s
             fdb = json.loads(fdb_entry .split(":", 2)[-1])
             if not fdb:
                 continue

--- a/scripts/nbrshow
+++ b/scripts/nbrshow
@@ -47,7 +47,7 @@ class NbrBase(object):
 
     def __init__(self, cmd):
         super(NbrBase, self).__init__()
-        self.db = SonicV2Connector(host="127.0.0.1")
+        self.db = SonicV2Connector(host="127.0.0.1", decode_responses=True)
         self.if_name_map, self.if_oid_map = port_util.get_interface_oid_map(self.db)
         self.if_br_oid_map = port_util.get_bridge_port_map(self.db)
         self.fetch_fdb_data()
@@ -73,7 +73,7 @@ class NbrBase(object):
 
         oid_pfx = len("oid:0x")
         for s in fdb_str:
-            fdb_entry = s.decode()
+            fdb_entry = s
             fdb = json.loads(fdb_entry .split(":", 2)[-1])
             if not fdb:
                 continue


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Following the plan in https://github.com/Azure/sonic-py-swsssdk/pull/89
1. fdbshow and nbrshow use SonicV2Connector with `decode_responses=True`
2. remove all the `decode()`

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

