### PR TITLE
[show][techsupport][multi-ASIC] Add support to collect tech support on multi ASIC platform

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -669,7 +669,7 @@ main() {
     $MKDIR $V -p $TARDIR
 
     # Start with this script so its obvious what code is responsible
-    $CP $V ./generate_dump $TARDIR
+    $LN $V -s /usr/local/bin/generate_dump $TARDIR	
     $TAR $V -chf $TARFILE -C $DUMPDIR $BASE
     $RM $V -f $TARDIR/sonic_dump
 

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -182,7 +182,7 @@ save_vtysh() {
 #  None
 ###############################################################################
 save_ip() {
-    local ip_args=""$1
+    local ip_args=$1
     local filename="ip.$2"
     local do_gzip=${3:-false}
     save_cmd_all_ns "ip $ip_args" "$filename" "$do_gzip"
@@ -411,7 +411,6 @@ save_platform_info() {
     save_platform "ssdhealth" "platform"
     save_platform "temperature" "platform"
     save_platform "fan" "platform"
-
 }
 
 ###############################################################################
@@ -628,7 +627,6 @@ save_crash_files() {
             fi
         fi
     done
-
 }
 
 ###############################################################################
@@ -669,7 +667,7 @@ main() {
     $MKDIR $V -p $TARDIR
 
     # Start with this script so its obvious what code is responsible
-    $LN $V -s /usr/local/bin/generate_dump $TARDIR	
+    $LN $V -s /usr/local/bin/generate_dump $TARDIR
     $TAR $V -chf $TARFILE -C $DUMPDIR $BASE
     $RM $V -f $TARDIR/sonic_dump
 

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -321,6 +321,68 @@ enable_logrotate() {
     sed -i '/\/usr\/sbin\/logrotate/s/^#*//g' /etc/cron.d/logrotate
 }
 
+
+###############################################################################
+# Collect Mellanox specific information
+# Globals:
+#  CMD_PREFIX
+# Arguments:
+#  None
+# Returns:
+#  None
+###############################################################################
+collect_mellanox() {
+    local sai_dump_filename="/tmp/sai_sdk_dump_$(date +"%m_%d_%Y_%I_%M_%p")"
+    ${CMD_PREFIX}docker exec -it syncd saisdkdump -f $sai_dump_filename
+    ${CMD_PREFIX}docker exec syncd tar Ccf $(dirname $sai_dump_filename) - $(basename $sai_dump_filename) | tar Cxf /tmp/ -
+    save_file $sai_dump_filename sai_sdk_dump true
+
+    local mst_dump_filename="/tmp/mstdump"
+    local max_dump_count="3"
+    for i in $(seq 1 $max_dump_count); do
+        ${CMD_PREFIX}/usr/bin/mstdump /dev/mst/mt*conf0 > "${mst_dump_filename}${i}"
+        save_file "${mst_dump_filename}${i}" mstdump true
+    done
+}
+
+###############################################################################
+# Collect Broadcom specific information
+# Globals:
+#  None
+# Arguments:
+#  None
+# Returns:
+#  None
+###############################################################################
+collect_broadcom() {
+    save_cmd "bcmcmd -t5 version" "broadcom.version"
+    save_cmd "bcmcmd -t5 soc" "broadcom.soc"
+    save_cmd "bcmcmd -t5 ps" "broadcom.ps"
+    save_cmd "cat /proc/bcm/knet/debug" "broadcom.knet.debug"
+    save_cmd "cat /proc/bcm/knet/dma" "broadcom.knet.dma"
+    save_cmd "cat /proc/bcm/knet/dstats" "broadcom.knet.dstats"
+    save_cmd "cat /proc/bcm/knet/link" "broadcom.knet.link"
+    save_cmd "cat /proc/bcm/knet/rate" "broadcom.knet.rate"
+    save_cmd "cat /proc/bcm/knet/stats" "broadcom.knet.stats"
+    save_cmd "bcmcmd \"l3 nat_ingress show\"" "broadcom.nat.ingress"
+    save_cmd "bcmcmd \"l3 nat_egress show\"" "broadcom.nat.egress"
+}
+
+###############################################################################
+# Collect Arista specific information
+# Globals:
+#  None
+# Arguments:
+#  None
+# Returns:
+#  None
+###############################################################################
+collect_arista() {
+    save_cmd "cat /proc/scd" "scd"
+    save_cmd "arista syseeprom" "arista.syseeprom"
+    save_cmd "arista dump" "arista.dump"
+}
+
 ###############################################################################
 # Main generate_dump routine
 # Globals:
@@ -423,37 +485,15 @@ main() {
 
     local asic="$(/usr/local/bin/sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)"
     if [[ "$asic" = "mellanox" ]]; then
-        local sai_dump_filename="/tmp/sai_sdk_dump_$(date +"%m_%d_%Y_%I_%M_%p")"
-        ${CMD_PREFIX}docker exec -it syncd saisdkdump -f $sai_dump_filename
-        ${CMD_PREFIX}docker exec syncd tar Ccf $(dirname $sai_dump_filename) - $(basename $sai_dump_filename) | tar Cxf /tmp/ -
-        save_file $sai_dump_filename sai_sdk_dump true
-
-        local mst_dump_filename="/tmp/mstdump"
-        local max_dump_count="3"
-        for i in $(seq 1 $max_dump_count); do
-            ${CMD_PREFIX}/usr/bin/mstdump /dev/mst/mt*conf0 > "${mst_dump_filename}${i}"
-            save_file "${mst_dump_filename}${i}" mstdump true
-        done
+        collect_mellanox
     fi
 
     if [ "$asic" = "broadcom" ]; then
-        save_cmd "bcmcmd -t5 version" "broadcom.version"
-        save_cmd "bcmcmd -t5 soc" "broadcom.soc"
-        save_cmd "bcmcmd -t5 ps" "broadcom.ps"
-        save_cmd "cat /proc/bcm/knet/debug" "broadcom.knet.debug"
-        save_cmd "cat /proc/bcm/knet/dma" "broadcom.knet.dma"
-        save_cmd "cat /proc/bcm/knet/dstats" "broadcom.knet.dstats"
-        save_cmd "cat /proc/bcm/knet/link" "broadcom.knet.link"
-        save_cmd "cat /proc/bcm/knet/rate" "broadcom.knet.rate"
-        save_cmd "cat /proc/bcm/knet/stats" "broadcom.knet.stats"
-        save_cmd "bcmcmd \"l3 nat_ingress show\"" "broadcom.nat.ingress"
-        save_cmd "bcmcmd \"l3 nat_egress show\"" "broadcom.nat.egress"
+        collect_broadcom
     fi
 
     if $GREP -qi "aboot_platform=.*arista" /host/machine.conf; then
-        save_cmd "cat /proc/scd" "scd"
-        save_cmd "arista syseeprom" "arista.syseeprom"
-        save_cmd "arista dump" "arista.dump"
+        collect_arista
     fi
 
     $RM $V -rf $TARDIR
@@ -589,7 +629,8 @@ OPTIONS
 EOF
 }
 
-while getopts ":xnvhzs:" opt; do
+while getopts ":xnvhzas:" opt; do
+    echo $opt
     case $opt in
         x)
             # enable bash debugging
@@ -616,6 +657,7 @@ while getopts ":xnvhzs:" opt; do
             CP="echo cp"
             TOUCH="echo touch"
             NOOP=true
+            exit 0
             ;;
         z)
             DO_COMPRESS=false
@@ -624,6 +666,10 @@ while getopts ":xnvhzs:" opt; do
             SINCE_DATE="${OPTARG}"
             # validate date expression
             date --date="${SINCE_DATE}" &> /dev/null || abort "${ERROR_INVALID_ARGUMENT}" "Invalid date expression passed: '${SINCE_DATE}'"
+            ;;
+        a)
+            echo "Run comand in namespace"
+            exit 0
             ;;
         /?)
             echo "Invalid option: -$OPTARG" >&2

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -30,6 +30,7 @@ DUMPDIR=/var/dump
 TARDIR=$DUMPDIR/$BASE
 TARFILE=$DUMPDIR/$BASE.tar
 LOGDIR=$DUMPDIR/$BASE/dump
+NUM_ASICS=1
 
 ###############################################################################
 # Runs a comamnd and saves its output to the incrementally built tar.
@@ -83,8 +84,65 @@ save_cmd() {
         && $RM $V -rf "$filepath"
 }
 
+
 ###############################################################################
-# Runs a vtysh command and saves its output to the incrementally built tar.
+# Runs a given command in all namesapces in case of multi ASIC platform, in
+# default (host) namespace in single ASIC platform
+# Globals:
+#  NUM_ASICS
+# Arguments:
+#  cmd: The command to run. Make sure that arguments with spaces have quotes
+#  filename: the filename to save the output as in $BASE/dump
+#  do_gzip: (OPTIONAL) true or false. Should the output be gzipped
+# Returns:
+#  None
+###############################################################################
+save_cmd_all_ns() {
+    echo $1
+    echo $2
+    local do_zip=${3:-false}
+    echo ${do_zip}
+
+    # host or default namespace
+    save_cmd "$1" "$2" "$do_zip"
+
+    if [[ ( "$NUM_ASICS" > 1 ) ]] ; then
+      for (( i=1; i<=$NUM_ASICS; i++ ))
+      do
+          ns_cmd="ip netns exec asic$i"
+          local cmd="$ns_cmd $1"
+          local file="$2.$i"
+          save_cmd "$cmd" "$file" "$do_zip"
+      done
+    fi
+}
+
+###############################################################################
+# Returns namespace option to be used with vtysh commmand, based on the ASIC ID.
+# Returns empty string if no ASIC ID is provided
+# Globals:
+#  None
+# Arguments:
+#  asic_id: (OPTIONAL) ASIC ID
+# Returns:
+#  vtysh namespace option
+###############################################################################
+get_vtysh_namespace() {
+    local asic_id=${1:-""}
+    local ns=""
+    if [[ ( $asic_id =  "" || $asic_id =  0 ) ]] ; then
+        ns=""
+    else
+        asic_id=`expr $asic_id - 1`
+        ns=" -n  ${asic_id}"
+    fi
+    echo "$ns"
+}
+
+###############################################################################
+# Runs a vtysh command in all namesapces for a multi ASIC platform, and in
+# default (host) namespace in single ASIC platforms. Saves its output to the
+# incrementally built tar.
 # Globals:
 #  None
 # Arguments:
@@ -98,7 +156,18 @@ save_vtysh() {
     local vtysh_cmd=$1
     local filename=$2
     local do_gzip=${3:-false}
-    save_cmd "vtysh -c '${vtysh_cmd}'" "$filename" $do_gzip
+
+    if [[ ( "$NUM_ASICS" == 1 ) ]] ; then
+        save_cmd "vtysh -c '${vtysh_cmd}'" "$filename" $do_gzip
+    else
+        for (( i=1; i<=$NUM_ASICS; i++ ))
+        do
+            ns_cmd=$(get_vtysh_namespace $i)
+            local cmd="vtysh $ns_cmd -c '${vtysh_cmd}'"
+            local file=$filename.$i
+            save_cmd "$cmd" "$file" "$do_gzip"
+        done
+    fi
 }
 
 ###############################################################################
@@ -113,33 +182,58 @@ save_vtysh() {
 #  None
 ###############################################################################
 save_ip() {
-    local ip_args=$1
+    local ip_args=""$1
     local filename="ip.$2"
     local do_gzip=${3:-false}
-    save_cmd "ip $ip_args" "$filename" $do_gzip
+    save_cmd_all_ns "ip $ip_args" "$filename" "$do_gzip"
 }
 
 ###############################################################################
 # Iterates all neighbors and runs save_vtysh to save each neighbor's
 # advertised-routes and received-routes
+# On multi ASIC platform, collects information from all namespaces
 # Globals:
 #  None
+# Arguments:
+#  Optional arg namespace
+# Returns:
+#  None
+###############################################################################
+save_bgp_neighbor() {
+    local asic_id=${1:-0}
+    local ns=$(get_vtysh_namespace $asic_id)
+
+    neighbor_list_v4=$(vtysh $ns -c "show ip bgp neighbors" | grep "BGP neighbor is" | awk -F '[, ]' '{print $4}')
+    for word in $neighbor_list_v4; do
+        save_cmd "vtysh $ns -c \"show ip bgp neighbors $word advertised-routes\"" "ip.bgp.neighbor.$word.adv$asic_id"
+        save_cmd "vtysh $ns -c \"show ip bgp neighbors $word routes\"" "ip.bgp.neighbor.$word.rcv$asic_id"
+    done
+    neighbor_list_v6=$(vtysh $ns -c "show bgp ipv6 neighbors" | grep "BGP neighbor is" | awk -F '[, ]' '{print $4}' | fgrep ':')
+    for word in $neighbor_list_v6; do
+        save_cmd "vtysh $ns -c \"show bgp ipv6 neighbors $word advertised-routes\"" "ipv6.bgp.neighbor.$word.adv$asic_id"
+        save_cmd "vtysh $ns -c \"show bgp ipv6 neighbors $word routes\"" "ipv6.bgp.neighbor.$word.rcv$asic_id"
+    done
+}
+
+###############################################################################
+# Iterates all ASIC namespaces on multi ASIC platform and on default (host)
+# namespace on single ASIC platform
+# Globals:
+#  NUM_ASICS
 # Arguments:
 #  None
 # Returns:
 #  None
 ###############################################################################
-save_bgp_neighbor() {
-    neighbor_list_v4=$(vtysh -c "show ip bgp neighbors" | grep "BGP neighbor is" | awk -F '[, ]' '{print $4}')
-    for word in $neighbor_list_v4; do
-        save_vtysh "show ip bgp neighbors $word advertised-routes" "ip.bgp.neighbor.$word.adv"
-        save_vtysh "show ip bgp neighbors $word routes" "ip.bgp.neighbor.$word.rcv"
-    done
-    neighbor_list_v6=$(vtysh -c "show bgp ipv6 neighbors" | grep "BGP neighbor is" | awk -F '[, ]' '{print $4}' | fgrep ':')
-    for word in $neighbor_list_v6; do
-        save_vtysh "show bgp ipv6 neighbors $word advertised-routes" "ipv6.bgp.neighbor.$word.adv"
-        save_vtysh "show bgp ipv6 neighbors $word routes" "ipv6.bgp.neighbor.$word.rcv"
-    done
+save_bgp_neighbor_all_ns() {
+    if [[ ( "$NUM_ASICS" == 1 ) ]] ; then
+        save_bgp_neighbor
+    else
+        for (( i=1; i<=$NUM_ASICS; i++ ))
+        do
+            save_bgp_neighbor $i
+        done
+    fi
 }
 
 ###############################################################################
@@ -152,15 +246,67 @@ save_bgp_neighbor() {
 #  None
 ###############################################################################
 save_nat_info() {
-    save_cmd "iptables -t nat -nv -L" "nat.iptables"
-    save_cmd "conntrack -j -L" "nat.conntrack"
-    save_cmd "conntrack -j -L | wc" "nat.conntrackcount"
-    save_cmd "conntrack -L" "nat.conntrackall"
-    save_cmd "conntrack -L | wc" "nat.conntrackallcount"
-    save_cmd "show nat config" "nat.config"
+    save_cmd_all_ns "iptables -t nat -nv -L" "nat.iptables"
+    save_cmd_all_ns "conntrack -j -L" "nat.conntrack"
+    save_cmd_all_ns "conntrack -j -L | wc" "nat.conntrackcount"
+    save_cmd_all_ns "conntrack -L" "nat.conntrackall"
+    save_cmd_all_ns "conntrack -L | wc" "nat.conntrackallcount"
+    save_cmd_all_ns "show nat config" "nat.config"
 }
 
 ###############################################################################
+# Save IP related info
+# Globals:
+#  None
+# Arguments:
+#  None
+# Returns:
+#  None
+###############################################################################
+save_ip_info() {
+    save_ip "link" "link"
+    save_ip "addr" "addr"
+    save_ip "rule" "rule"
+    save_ip "route show table all" "route"
+    save_ip "neigh" "neigh"
+}
+
+###############################################################################
+# Save BGP related info
+# Globals:
+#  None
+# Arguments:
+#  None
+# Returns:
+#  None
+###############################################################################
+save_bgp_info() {
+    save_vtysh "show ip bgp summary" "bgp.summary"
+    save_vtysh "show ip bgp neighbors" "bgp.neighbors"
+    save_vtysh "show ip bgp" "bgp.table"
+    save_vtysh "show bgp ipv6 summary" "bgp.ipv6.summary"
+    save_vtysh "show bgp ipv6 neighbors" "bgp.ipv6.neighbors"
+    save_vtysh "show bgp ipv6" "bgp.ipv6.table"
+    save_bgp_neighbor_all_ns
+}
+
+###############################################################################
+# Save Redis DB contents
+# Globals:
+#  None
+# Arguments:
+#  None
+# Returns:
+#  None
+###############################################################################
+save_redis_info() {
+    save_redis "APPL_DB"
+    save_redis "ASIC_DB"
+    save_redis "COUNTERS_DB"
+    save_redis "CONFIG_DB"
+    save_redis "FLEX_COUNTER_DB"
+    save_redis "STATE_DB"
+}
 
 ###############################################################################
 # Given list of proc files, saves proc files to tar.
@@ -196,7 +342,27 @@ save_proc() {
 ###############################################################################
 save_redis() {
     local db_name=$1
-    save_cmd "sonic-db-dump -n '$db_name' -y" "$db_name.json"
+    save_cmd_all_ns "sonic-db-dump -n '$db_name' -y" "$db_name.json"
+}
+
+###############################################################################
+# SAI DUMP from syncd
+# Globals:
+#  NUM_ASICS
+# Arguments:
+#  None
+# Returns:
+#  None
+###############################################################################
+save_saidump() {
+    if [[ ( "$NUM_ASICS" == 1 ) ]] ; then
+        save_cmd "docker exec -it syncd saidump" "saidump"
+    else
+        for (( i=1; i<=$NUM_ASICS; i++ ))
+        do
+            save_cmd "docker exec -it syncd$i saidump" "saidump$i"
+        done
+    fi
 }
 
 ###############################################################################
@@ -228,6 +394,24 @@ save_platform() {
 
     ($TAR $V -uhf $TARFILE -C $DUMPDIR "$tarpath" \
         || abort "${ERROR_TAR_FAILED}" "tar append operation failed. Aborting to prevent data loss.")
+}
+
+###############################################################################
+# Save platform related info
+# Globals:
+#  None
+# Arguments:
+#  None
+# Returns:
+#  None
+###############################################################################
+save_platform_info() {
+    save_platform "syseeprom" "platform"
+    save_platform "psustatus" "platform"
+    save_platform "ssdhealth" "platform"
+    save_platform "temperature" "platform"
+    save_platform "fan" "platform"
+
 }
 
 ###############################################################################
@@ -384,6 +568,86 @@ collect_arista() {
 }
 
 ###############################################################################
+# Save log file
+# Globals:
+#  None
+# Arguments:
+#  None
+# Returns:
+#  None
+###############################################################################
+save_log_files() {
+    disable_logrotate
+    trap enable_logrotate HUP INT QUIT TERM KILL ABRT ALRM
+
+    # gzip up all log files individually before placing them in the incremental tarball
+    for file in $(find_files "/var/log/"); do
+        # ignore the sparse file lastlog
+        if [ "$file" = "/var/log/lastlog" ]; then
+            continue
+        fi
+        # don't gzip already-gzipped log files :)
+        if [ -z "${file##*.gz}" ]; then
+            save_file $file log false
+        else
+            save_file $file log true
+        fi
+    done
+
+    enable_logrotate
+}
+
+###############################################################################
+# Save crash files
+# Globals:
+#  None
+# Arguments:
+#  None
+# Returns:
+#  None
+###############################################################################
+save_crash_files() {
+    # archive core dump files
+    for file in $(find_files "/var/core/"); do
+        # don't gzip already-gzipped log files :)
+        if [ -z "${file##*.gz}" ]; then
+            save_file $file core false
+        else
+            save_file $file core true
+        fi
+    done
+
+    # archive kernel dump files
+    for file in $(find_files "/var/crash/"); do
+        # don't gzip already-gzipped dmesg files :)
+        if [ ! ${file} = "/var/crash/kexec_cmd" -a ! ${file} = "/var/crash/export" ]; then
+            if [[ ${file} == *"kdump."* ]]; then
+                save_file $file kdump false
+            else
+                save_file $file kdump true
+            fi
+        fi
+    done
+
+}
+
+###############################################################################
+# Get number of ASICs in the platform
+# Globals:
+#  None
+# Arguments:
+#  None
+# Returns:
+#  ASIC Count
+###############################################################################
+get_asic_count() {
+    local cmd="show platform summary --json | python -c 'import sys, json; \
+               print(json.load(sys.stdin)[\"asic_count\"])'"
+    echo `eval ${cmd} 2>&1`
+}
+
+
+###############################################################################
 # Main generate_dump routine
 # Globals:
 #  All of them.
@@ -398,13 +662,14 @@ main() {
         echo "$0: must be run as root (or in sudo)" >&2
         exit 10
     fi
+    NUM_ASICS=$(get_asic_count)
     ${CMD_PREFIX}renice +5 -p $$ >> /dev/null
     ${CMD_PREFIX}ionice -c 2 -n 5 -p $$ >> /dev/null
 
     $MKDIR $V -p $TARDIR
 
     # Start with this script so its obvious what code is responsible
-    $LN $V -s /usr/local/bin/generate_dump $TARDIR
+    $CP $V ./generate_dump $TARDIR
     $TAR $V -chf $TARFILE -C $DUMPDIR $BASE
     $RM $V -f $TARDIR/sonic_dump
 
@@ -424,11 +689,7 @@ main() {
     save_cmd "systemd-analyze dump" "systemd.analyze.dump"
     save_cmd "systemd-analyze plot" "systemd.analyze.plot.svg"
 
-    save_platform "syseeprom" "platform"
-    save_platform "psustatus" "platform"
-    save_platform "ssdhealth" "platform"
-    save_platform "temperature" "platform"
-    save_platform "fan" "platform"
+    save_platform_info
 
     save_cmd "show version" "version"
     save_cmd "show platform summary" "platform.summary"
@@ -439,22 +700,12 @@ main() {
     save_cmd "lspci -vvv -xx" "lspci"
     save_cmd "lsusb -v" "lsusb"
     save_cmd "sysctl -a" "sysctl"
-    save_ip "link" "link"
-    save_ip "addr" "addr"
-    save_ip "rule" "rule"
-    save_ip "route show table all" "route"
-    save_ip "neigh" "neigh"
 
-    save_vtysh "show ip bgp summary" "bgp.summary"
-    save_vtysh "show ip bgp neighbors" "bgp.neighbors"
-    save_vtysh "show ip bgp" "bgp.table"
-    save_vtysh "show bgp ipv6 summary" "bgp.ipv6.summary"
-    save_vtysh "show bgp ipv6 neighbors" "bgp.ipv6.neighbors"
-    save_vtysh "show bgp ipv6" "bgp.ipv6.table"
-    save_bgp_neighbor
+    save_ip_info
+    save_bgp_info
 
-    save_cmd "show interface status" "interface.status"
-    save_cmd "show interface counters" "interface.counters"
+    save_cmd "show interface status -d all" "interface.status"
+    save_cmd "show interface counters -d all" "interface.counters"
     save_cmd "show interface transceiver presence" "interface.xcvrs.presence"
     save_cmd "show interface transceiver eeprom --dom" "interface.xcvrs.eeprom"
 
@@ -470,18 +721,12 @@ main() {
     save_cmd "dmesg" "dmesg"
 
     save_nat_info
-
-    save_redis "APPL_DB"
-    save_redis "ASIC_DB"
-    save_redis "COUNTERS_DB"
-    save_redis "CONFIG_DB"
-    save_redis "FLEX_COUNTER_DB"
-    save_redis "STATE_DB"
+    save_redis_info
 
     save_cmd "docker ps -a" "docker.ps"
     save_cmd "docker top pmon" "docker.pmon"
 
-    save_cmd "docker exec -it syncd saidump" "saidump"
+    save_saidump
 
     local asic="$(/usr/local/bin/sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)"
     if [[ "$asic" = "mellanox" ]]; then
@@ -516,51 +761,18 @@ main() {
         || abort "${ERROR_TAR_FAILED}" "Tar append operation failed. Aborting for safety.") \
         && $RM $V -rf $TARDIR
 
-    disable_logrotate
-    trap enable_logrotate HUP INT QUIT TERM KILL ABRT ALRM
-
-    # gzip up all log files individually before placing them in the incremental tarball
-    for file in $(find_files "/var/log/"); do
-        # ignore the sparse file lastlog
-        if [ "$file" = "/var/log/lastlog" ]; then
-            continue
-        fi
-        # don't gzip already-gzipped log files :)
-        if [ -z "${file##*.gz}" ]; then
-            save_file $file log false
-        else
-            save_file $file log true
-        fi
-    done
-
-    enable_logrotate
-
-    # archive core dump files
-    for file in $(find_files "/var/core/"); do
-        # don't gzip already-gzipped log files :)
-        if [ -z "${file##*.gz}" ]; then
-            save_file $file core false
-        else
-            save_file $file core true
-        fi
-    done
-
-    # archive kernel dump files
-    for file in $(find_files "/var/crash/"); do
-        # don't gzip already-gzipped dmesg files :)
-        if [ ! ${file} = "/var/crash/kexec_cmd" -a ! ${file} = "/var/crash/export" ]; then
-            if [[ ${file} == *"kdump."* ]]; then
-                save_file $file kdump false
-            else
-                save_file $file kdump true
-            fi
-        fi
-    done
+    save_log_files
+    save_crash_files
 
     # run 'hw-management-generate-dump.sh' script and save the result file
-    /usr/bin/hw-management-generate-dump.sh
-    save_file "/tmp/hw-mgmt-dump*" "hw-mgmt" false
-    rm -f /tmp/hw-mgmt-dump*
+    HW_DUMP_FILE=/usr/bin/hw-management-generate-dump.sh
+    if [ -f "$HW_DUMP_FILE" ]; then
+      /usr/bin/hw-management-generate-dump.sh
+      save_file "/tmp/hw-mgmt-dump*" "hw-mgmt" false
+      rm -f /tmp/hw-mgmt-dump*
+    else
+      echo "HW Mgmt dump script $HW_DUMP_FILE does not exist"
+    fi
 
     # clean up working tar dir before compressing
     $RM $V -rf $TARDIR
@@ -629,8 +841,7 @@ OPTIONS
 EOF
 }
 
-while getopts ":xnvhzas:" opt; do
-    echo $opt
+while getopts ":xnvhzs:" opt; do
     case $opt in
         x)
             # enable bash debugging
@@ -657,7 +868,6 @@ while getopts ":xnvhzas:" opt; do
             CP="echo cp"
             TOUCH="echo touch"
             NOOP=true
-            exit 0
             ;;
         z)
             DO_COMPRESS=false
@@ -666,10 +876,6 @@ while getopts ":xnvhzas:" opt; do
             SINCE_DATE="${OPTARG}"
             # validate date expression
             date --date="${SINCE_DATE}" &> /dev/null || abort "${ERROR_INVALID_ARGUMENT}" "Invalid date expression passed: '${SINCE_DATE}'"
-            ;;
-        a)
-            echo "Run comand in namespace"
-            exit 0
             ;;
         /?)
             echo "Invalid option: -$OPTARG" >&2

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -107,10 +107,9 @@ save_cmd_all_ns() {
     save_cmd "$1" "$2" "$do_zip"
 
     if [[ ( "$NUM_ASICS" > 1 ) ]] ; then
-      for (( i=1; i<=$NUM_ASICS; i++ ))
+      for (( i=0; i<$NUM_ASICS; i++ ))
       do
-          ns_cmd="ip netns exec asic$i"
-          local cmd="$ns_cmd $1"
+          local cmd="sonic-netns-exec asic$i $1"
           local file="$2.$i"
           save_cmd "$cmd" "$file" "$do_zip"
       done
@@ -130,10 +129,9 @@ save_cmd_all_ns() {
 get_vtysh_namespace() {
     local asic_id=${1:-""}
     local ns=""
-    if [[ ( $asic_id =  "" || $asic_id =  0 ) ]] ; then
+    if [[ ( $asic_id = "" ) ]] ; then
         ns=""
     else
-        asic_id=`expr $asic_id - 1`
         ns=" -n  ${asic_id}"
     fi
     echo "$ns"
@@ -160,7 +158,7 @@ save_vtysh() {
     if [[ ( "$NUM_ASICS" == 1 ) ]] ; then
         save_cmd "vtysh -c '${vtysh_cmd}'" "$filename" $do_gzip
     else
-        for (( i=1; i<=$NUM_ASICS; i++ ))
+        for (( i=0; i<$NUM_ASICS; i++ ))
         do
             ns_cmd=$(get_vtysh_namespace $i)
             local cmd="vtysh $ns_cmd -c '${vtysh_cmd}'"
@@ -200,7 +198,7 @@ save_ip() {
 #  None
 ###############################################################################
 save_bgp_neighbor() {
-    local asic_id=${1:-0}
+    local asic_id=${1:-""}
     local ns=$(get_vtysh_namespace $asic_id)
 
     neighbor_list_v4=$(vtysh $ns -c "show ip bgp neighbors" | grep "BGP neighbor is" | awk -F '[, ]' '{print $4}')
@@ -229,7 +227,7 @@ save_bgp_neighbor_all_ns() {
     if [[ ( "$NUM_ASICS" == 1 ) ]] ; then
         save_bgp_neighbor
     else
-        for (( i=1; i<=$NUM_ASICS; i++ ))
+        for (( i=0; i<$NUM_ASICS; i++ ))
         do
             save_bgp_neighbor $i
         done
@@ -358,7 +356,7 @@ save_saidump() {
     if [[ ( "$NUM_ASICS" == 1 ) ]] ; then
         save_cmd "docker exec -it syncd saidump" "saidump"
     else
-        for (( i=1; i<=$NUM_ASICS; i++ ))
+        for (( i=0; i<$NUM_ASICS; i++ ))
         do
             save_cmd "docker exec -it syncd$i saidump" "saidump$i"
         done


### PR DESCRIPTION
**- What I did**
Add support to collect tech support on multi ASIC platform

Refactored code to put together related commands in a function.

**- How I did it**
Modified generate_dump script to run relevant commands on all namespaces for multi ASIC platform. On single ASIC the commands are run in default (host) namesapce.

**- How to verify it**

Manual verification, and pytest.

```
samaddik@str-serv-acs-14:/var/sonic-mgmt/tests$ pytest show_techsupport/test_techsupport.py --testbed=vms12-t1-lag-1 ....
========= 2 passed in 7049.32 seconds ======


For 2 ASIC output (ASIC hardcoded to 2):

admin@str2-nswitch-acs-4:/var/dump/sonic_dump_str2-nswitch-acs-4_20201105_015555/dump$ ls
APPL_DB.json                             ip.bgp.neighbor.fc00::2.rcv1
APPL_DB.json.1                           ip.bgp.neighbor.fc00::6.adv1
APPL_DB.json.2                           ip.bgp.neighbor.fc00::6.rcv1
ASIC_DB.json                             ip.bgp.neighbor.fc00::a.adv2
ASIC_DB.json.1                           ip.bgp.neighbor.fc00::a.rcv2
ASIC_DB.json.2                           ip.bgp.neighbor.fc00::e.adv2
bgp.ipv6.neighbors.1                     ip.bgp.neighbor.fc00::e.rcv2
bgp.ipv6.neighbors.2                     ip.link
bgp.ipv6.summary.1                       ip.link.1
bgp.ipv6.summary.2                       ip.link.2
bgp.ipv6.table.1                         ip.neigh
bgp.ipv6.table.2                         ip.neigh.1
bgp.neighbors.1                          ip.neigh.2
bgp.neighbors.2                          ip.route
bgp.summary.1                            ip.route.1
bgp.summary.2                            ip.route.2
bgp.table.1                              ip.rule
bgp.table.2                              ip.rule.1
broadcom.knet.debug                      ip.rule.2
broadcom.knet.dma                        ipv6.bgp.neighbor.2603:10e2:400:1::1.adv1
broadcom.knet.dstats                     ipv6.bgp.neighbor.2603:10e2:400:1::1.rcv1
broadcom.knet.link                       ipv6.bgp.neighbor.2603:10e2:400:1::5.adv1
broadcom.knet.rate                       ipv6.bgp.neighbor.2603:10e2:400:1::5.rcv1
broadcom.knet.stats                      ipv6.bgp.neighbor.2603:10e2:400:1::9.adv2
broadcom.nat.egress                      ipv6.bgp.neighbor.2603:10e2:400:1::9.rcv2
broadcom.nat.ingress                     ipv6.bgp.neighbor.2603:10e2:400:1::d.adv2
broadcom.ps                              ipv6.bgp.neighbor.2603:10e2:400:1::d.rcv2
broadcom.soc                             ipv6.bgp.neighbor.fc00::2.adv1
broadcom.version                         ipv6.bgp.neighbor.fc00::2.rcv1
CONFIG_DB.json                           ipv6.bgp.neighbor.fc00::6.adv1
CONFIG_DB.json.1                         ipv6.bgp.neighbor.fc00::6.rcv1
CONFIG_DB.json.2                         ipv6.bgp.neighbor.fc00::a.adv2
COUNTERS_DB.json                         ipv6.bgp.neighbor.fc00::a.rcv2
COUNTERS_DB.json.1                       ipv6.bgp.neighbor.fc00::e.adv2
COUNTERS_DB.json.2                       ipv6.bgp.neighbor.fc00::e.rcv2
df                                       lldpctl

admin@str2-nswitch-acs-4:/var/dump/sonic_dump_str2-nswitch-acs-4_20201105_015555/dump$ head -n 10 ip.neigh.1
10.0.0.13 dev PortChannel0011 lladdr 52:54:00:59:42:aa REACHABLE
240.127.1.1 dev eth0 lladdr 02:42:e9:5b:4f:b0 REACHABLE
10.1.0.6 dev PortChannel4004 lladdr 02:42:f0:7f:01:05 STALE
10.0.0.9 dev PortChannel0008 lladdr 52:54:00:ce:64:93 REACHABLE
10.1.0.4 dev PortChannel4003 lladdr 02:42:f0:7f:01:07 STALE
fe80::9a03:9bff:fe03:2289 dev PortChannel0011 lladdr 98:03:9b:03:22:89 STALE
fe80::9a03:9bff:fe03:2289 dev PortChannel0008 lladdr 98:03:9b:03:22:89 STALE
fc00::a dev PortChannel0008 lladdr 52:54:00:ce:64:93 REACHABLE
2603:10e2:400:1::d dev PortChannel4004 lladdr 02:42:f0:7f:01:05 STALE
fe80::5054:ff:fe59:42aa dev PortChannel0011 lladdr 52:54:00:59:42:aa router STALE

admin@str2-nswitch-acs-4:/var/dump/sonic_dump_str2-nswitch-acs-4_20201105_015555/dump$ head -n 10 ip.neigh.2
10.0.0.39 dev PortChannel0006 lladdr 52:54:00:74:7e:25 REACHABLE
10.0.0.43 dev PortChannel0009 lladdr 52:54:00:c9:2a:65 REACHABLE
10.0.0.45 dev PortChannel0010 lladdr 52:54:00:28:88:af REACHABLE
10.0.0.49 dev PortChannel0013 lladdr 52:54:00:da:b6:77 REACHABLE
10.1.0.10 dev PortChannel4006 lladdr 02:42:f0:7f:01:05 STALE
10.0.0.41 dev PortChannel0007 lladdr 52:54:00:e9:3c:9f REACHABLE
10.0.0.33 dev PortChannel0001 lladdr 52:54:00:ff:ff:06 REACHABLE
10.1.0.8 dev PortChannel4005 lladdr 02:42:f0:7f:01:07 STALE
10.0.0.47 dev PortChannel0012 lladdr 52:54:00:4c:c3:4c REACHABLE
10.0.0.35 dev PortChannel0003 lladdr 52:54:00:6e:90:69 REACHABLE

admin@str2-nswitch-acs-4:/var/dump/sonic_dump_str2-nswitch-acs-4_20201105_015555/dump$ head -n 10 CONFIG_DB.json.2
{
  "ACL_TABLE|DATAACL": {
    "type": "hash",
    "value": {
      "policy_desc": "DATAACL",
      "ports@": "PortChannel0001,PortChannel0003,PortChannel0004,PortChannel0006,PortChannel0007,PortChannel0009,PortChannel0010,PortChannel0012,PortChannel0013,PortChannel0014",
      "stage": "ingress",
      "type": "L3"
    }
  },


```

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

