### PR TITLE
[show] Fix `show ip bgp sum`

### DIFF
--- a/utilities_common/bgp_util.py
+++ b/utilities_common/bgp_util.py
@@ -12,27 +12,27 @@ from tabulate import tabulate
 from utilities_common import constants
 
 
-def is_ipv4_address(ipaddress):
+def is_ipv4_address(ip_address):
     """
     Checks if given ip is ipv4
-    :param ipaddress: unicode ipv4
+    :param ip_address: unicode ipv4
     :return: bool
     """
     try:
-        ipaddress.IPv4Address(ipaddress)
+        ipaddress.IPv4Address(ip_address)
         return True
     except ipaddress.AddressValueError as err:
         return False
 
 
-def is_ipv6_address(ipaddress):
+def is_ipv6_address(ip_address):
     """
     Checks if given ip is ipv6
-    :param ipaddress: unicode ipv6
+    :param ip_address: unicode ipv6
     :return: bool
     """
     try:
-        ipaddress.IPv6Address(ipaddress)
+        ipaddress.IPv6Address(ip_address)
         return True
     except ipaddress.AddressValueError as err:
         return False


### PR DESCRIPTION
Function `is_ipv6_address` and `is_ipv4_address` use `ipaddress` as
function argument, which override the module in global namespace.

Fix Azure/sonic-buildimage#5440

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**
```
$ show ip bgp sum
Traceback (most recent call last):
  File "/usr/bin/show", line 12, in <module>
    sys.exit(cli())
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/show/bgp_frr_v4.py", line 26, in summary
    bgp_summary = bgp_util.get_bgp_summary_from_all_bgp_instances(constants.IPV4,  namespace,display)
  File "/usr/lib/python2.7/dist-packages/utilities_common/bgp_util.py", line 194, in get_bgp_summary_from_all_bgp_instances
    process_bgp_summary_json(bgp_summary, cmd_output_json[key], device)
  File "/usr/lib/python2.7/dist-packages/utilities_common/bgp_util.py", line 296, in process_bgp_summary_json
    peer_ip, static_neighbors, dynamic_neighbors)
  File "/usr/lib/python2.7/dist-packages/utilities_common/bgp_util.py", line 88, in get_bgp_neighbor_ip_to_name
    elif is_ipv4_address(unicode(ip)):
  File "/usr/lib/python2.7/dist-packages/utilities_common/bgp_util.py", line 23, in is_ipv4_address
    except ipaddress.AddressValueError as err:
AttributeError: 'unicode' object has no attribute 'AddressValueError'
```
**- New command output (if the output of a command-line utility has changed)**

```
$ show ip bgp sum

IPv4 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 64601 vrf-id 0
BGP table version 9
RIB entries 15, using 2760 bytes of memory
Peers 7, using 146440 KiB of memory
Peer groups 4, using 256 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.1       4  64802        195        204         0      0       0  03:10:47                1  ARISTA01T1
10.0.0.5       4  64802        195        204         0      0       0  03:10:47                1  ARISTA02T1
10.0.0.9       4  64802        195        204         0      0       0  03:10:47                1  ARISTA03T1
10.0.0.13      4  64802        195        201         0      0       0  03:10:47                1  ARISTA04T1
10.255.0.1     4  64523         23         25         0      0       0  00:18:03                1  BGPSLBPassive
10.255.0.2     4  64523         22         24         0      0       0  00:17:57                1  BGPSLBPassive
192.168.0.2    4  64523        194        196         0      0       0  03:09:50                1  BGPVac

Total number of neighbors 7
```