### PR TITLE
SONiC installer - fix string formatting during image type check

### DIFF
--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -314,8 +314,8 @@ def install(url, force, skip_migration=False):
     else:
         # Verify that the binary image is of the same type as the running image
         if not bootloader.verify_binary_image(image_path) and not force:
-            click.echo("Image file '{}' is of a different type than running image.\n".format(url) +\
-                "If you are sure you want to install this image, use -f|--force.\n" +\
+            click.echo("Image file '{}' is of a different type than running image.\n".format(url) +
+                "If you are sure you want to install this image, use -f|--force.\n" +
                 "Aborting...")
             raise click.Abort()
 

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -314,9 +314,9 @@ def install(url, force, skip_migration=False):
     else:
         # Verify that the binary image is of the same type as the running image
         if not bootloader.verify_binary_image(image_path) and not force:
-            click.echo("Image file '{}' is of a different type than running image.\n"
-                       "If you are sure you want to install this image, use -f|--force.\n"
-                       "Aborting...".format(image_path))
+            click.echo("Image file '{}' is of a different type than running image.\n".format(url) +\
+                "If you are sure you want to install this image, use -f|--force.\n" +\
+                "Aborting...")
             raise click.Abort()
 
         click.echo("Installing image {} and setting it as default...".format(binary_image_version))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
`sonic_installer` error message misses the filename due to string formatting error.
This fixes the missing string substitution in the message:
**Before (note that {} is missing the variable name.):**
```
Downloading image...
Image file '{}' is of a different type than running image.
If you are sure you want to install this image, use -f|--force.
Aborting...
Aborted!
```
**Now:**
```
Downloading image...
...95%, 724 MB, 57044 KB/s, 0 seconds left...   Image file 'sonic-broadcom.bin' is of a different type than running image.
If you are sure you want to install this image, use -f|--force.
Aborting...
Aborted!
```

**- How I did it**

**- How to verify it**
Verified in a DUT, the error message is now printed correctly.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

