### PR TITLE
[show] fix "show interfaces breakout" command

### DIFF
--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -21,8 +21,14 @@ def readJsonFile(fileName):
     try:
         with open(fileName) as f:
             result = json.load(f)
+    except FileNotFoundError as e:
+        click.echo("{}".format(str(e)), err=True)
+        raise click.Abort()
+    except json.decoder.JSONDecodeError as e:
+        click.echo("Invalid JSON file format('{}')\n{}".format(fileName, str(e)), err=True)
+        raise click.Abort()
     except Exception as e:
-        click.echo(str(e))
+        click.echo("{}\n{}".format(type(e), str(e)), err=True)
         raise click.Abort()
     return result
 

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 import click
 import utilities_common.cli as clicommon
@@ -6,8 +7,24 @@ import utilities_common.multi_asic as multi_asic_util
 from natsort import natsorted
 from tabulate import tabulate
 from sonic_py_common import multi_asic
+from sonic_py_common import device_info
+from swsssdk import ConfigDBConnector
+from portconfig import get_child_ports
 
 from . import portchannel
+from collections import OrderedDict
+
+HWSKU_JSON = 'hwsku.json'
+
+# Read given JSON file
+def readJsonFile(fileName):
+    try:
+        with open(fileName) as f:
+            result = json.load(f)
+    except Exception as e:
+        click.echo(str(e))
+        raise click.Abort()
+    return result
 
 def try_convert_interfacename_from_alias(ctx, interfacename):
     """try to convert interface name from alias"""
@@ -144,13 +161,14 @@ def breakout(ctx):
 
     if ctx.invoked_subcommand is None:
         # Get port capability from platform and hwsku related files
-        platform_path, hwsku_path = device_info.get_paths_to_platform_and_hwsku_dirs()
-        platform_file = os.path.join(platform_path, PLATFORM_JSON)
+        hwsku_path = device_info.get_path_to_hwsku_dir()
+        platform_file = device_info.get_path_to_port_config_file()
         platform_dict = readJsonFile(platform_file)['interfaces']
-        hwsku_dict = readJsonFile(os.path.join(hwsku_path, HWSKU_JSON))['interfaces']
+        hwsku_file = os.path.join(hwsku_path, HWSKU_JSON)
+        hwsku_dict = readJsonFile(hwsku_file)['interfaces']
 
         if not platform_dict or not hwsku_dict:
-            click.echo("Can not load port config from {} or {} file".format(PLATFORM_JSON, HWSKU_JSON))
+            click.echo("Can not load port config from {} or {} file".format(platform_file, hwsku_file))
             raise click.Abort()
 
         for port_name in platform_dict:
@@ -161,9 +179,9 @@ def breakout(ctx):
             platform_dict[port_name]["Current Breakout Mode"] = cur_brkout_mode
 
             # List all the child ports if present
-            child_port_dict = get_child_ports(port_name, cur_brkout_mode, platformFile)
+            child_port_dict = get_child_ports(port_name, cur_brkout_mode, platform_file)
             if not child_port_dict:
-                click.echo("Cannot find ports from {} file ".format(PLATFORM_JSON))
+                click.echo("Cannot find ports from {} file ".format(platform_file))
                 raise click.Abort()
 
             child_ports = natsorted(list(child_port_dict.keys()))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Fixed `show interface breakout` command

**- How I did it**

**- How to verify it**
From command line type `show interface breakout`

**- Previous command output (if the output of a command-line utility has changed)**
```
Traceback (most recent call last):
  File "/usr/local/bin/show", line 10, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 1114, in invoke
    return Command.invoke(self, ctx)
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/show/interfaces/__init__.py", line 135, in breakout
    config_db = ConfigDBConnector()
NameError: global name 'ConfigDBConnector' is not defined
```
**- New command output (if the output of a command-line utility has changed)**
Related from DPB config.
e.g.
```
{
    "Ethernet0": {
        "index": "0,0,0,0",
        "default_brkout_mode": "1x100G[40G]",
        "child ports": "Ethernet0",
        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
        "child port speeds": "100G",
        "Current Breakout Mode": "1x100G[40G]",
        "lanes": "25,26,27,28",
        "alias_at_lanes": "Ethernet0/0,Ethernet0/1,Ethernet0/2,Ethernet0/3"
    }
}
```