### PR TITLE
[generate_dump] Ignoring file/directory not found Errors

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -326,7 +326,7 @@ save_redis_info() {
 save_proc() {
     local procfiles="$@"
     $MKDIR $V -p $TARDIR/proc \
-        && $CP $V -r $procfiles $TARDIR/proc \
+	    && (for f in $procfiles; do ( [ -e $f ] && $CP $V -r $f $TARDIR/proc ) || echo "$f not found" > $TARDIR/$f; done) \
         && $TAR $V -rhf $TARFILE -C $DUMPDIR --mode=+rw $BASE/proc \
         && $RM $V -rf $TARDIR/proc
 }
@@ -615,7 +615,7 @@ save_crash_files() {
     done
 
     # archive kernel dump files
-    for file in $(find_files "/var/crash/"); do
+    [ -e /var/crash/ ] && for file in $(find_files "/var/crash/"); do
         # don't gzip already-gzipped dmesg files :)
         if [ ! ${file} = "/var/crash/kexec_cmd" -a ! ${file} = "/var/crash/export" ]; then
             if [[ ${file} == *"kdump."* ]]; then
@@ -742,7 +742,7 @@ main() {
     $MKDIR $V -p $LOGDIR
     $LN $V -s /etc $TARDIR/etc
 
-    ($TAR $V -rhf $TARFILE -C $DUMPDIR --mode=+rw \
+    ($TAR $V -rf $TARFILE -C $DUMPDIR --mode=+rw \
         --exclude="etc/alternatives" \
         --exclude="*/etc/passwd*" \
         --exclude="*/etc/shadow*" \

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -742,7 +742,7 @@ main() {
     $MKDIR $V -p $LOGDIR
     $LN $V -s /etc $TARDIR/etc
 
-    ($TAR $V -rf $TARFILE -C $DUMPDIR --mode=+rw \
+    ($TAR $V -rhf $TARFILE -C $DUMPDIR --mode=+rw \
         --exclude="etc/alternatives" \
         --exclude="*/etc/passwd*" \
         --exclude="*/etc/shadow*" \

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -326,7 +326,7 @@ save_redis_info() {
 save_proc() {
     local procfiles="$@"
     $MKDIR $V -p $TARDIR/proc \
-	    && (for f in $procfiles; do ( [ -e $f ] && $CP $V -r $f $TARDIR/proc ) || echo "$f not found" > $TARDIR/$f; done) \
+        && (for f in $procfiles; do ( [ -e $f ] && $CP $V -r $f $TARDIR/proc ) || echo "$f not found" > $TARDIR/$f; done) \
         && $TAR $V -rhf $TARFILE -C $DUMPDIR --mode=+rw $BASE/proc \
         && $RM $V -rf $TARDIR/proc
 }

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -615,7 +615,7 @@ save_crash_files() {
     done
 
     # archive kernel dump files
-    [ -e /var/crash/ ] && for file in $(find_files "/var/crash/"); do
+    [ -d /var/crash/ ] && for file in $(find_files "/var/crash/"); do
         # don't gzip already-gzipped dmesg files :)
         if [ ! ${file} = "/var/crash/kexec_cmd" -a ! ${file} = "/var/crash/export" ]; then
             if [[ ${file} == *"kdump."* ]]; then


### PR DESCRIPTION
Signed-off-by: Sabareesh Kumar Anandan <sanandan@marvell.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
**- How I did it**
generate_dump fails if some files/directories are not found.
Added checks to ignore files/directories that are not present while generating the dump.

**- How to verify it**
Generated dump using the script and verified it.
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

