### PR TITLE
[show] Moving some py imports inside specific cmds

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1,5 +1,4 @@
 import json
-#import netaddr
 import os
 import subprocess
 import sys
@@ -55,7 +54,7 @@ def get_routing_stack():
 
 
 # Global Routing-Stack variable
-routing_stack = "frr"
+routing_stack = get_routing_stack()
 
 # Read given JSON file
 def readJsonFile(fileName):

--- a/show/main.py
+++ b/show/main.py
@@ -1,5 +1,5 @@
 import json
-import netaddr
+#import netaddr
 import os
 import subprocess
 import sys
@@ -9,7 +9,6 @@ import netifaces
 import utilities_common.cli as clicommon
 import utilities_common.multi_asic as multi_asic_util
 from natsort import natsorted
-from pkg_resources import parse_version
 from sonic_py_common import device_info, multi_asic
 from swsssdk import ConfigDBConnector
 from swsscommon.swsscommon import SonicV2Connector
@@ -56,7 +55,7 @@ def get_routing_stack():
 
 
 # Global Routing-Stack variable
-routing_stack = get_routing_stack()
+routing_stack = "frr"
 
 # Read given JSON file
 def readJsonFile(fileName):
@@ -717,6 +716,7 @@ def get_if_master(iface):
 @ip.command()
 def interfaces():
     """Show interfaces IPv4 address"""
+    import netaddr
     header = ['Interface', 'Master', 'IPv4 address/mask', 'Admin/Oper', 'BGP Neighbor', 'Neighbor IP']
     data = []
     bgp_peer = get_bgp_peer()
@@ -1387,6 +1387,7 @@ def bgp(verbose):
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def ntp(ctx, verbose):
     """Show NTP information"""
+    from pkg_resources import parse_version
     ntpstat_cmd = "ntpstat"
     ntpcmd = "ntpq -p -n"
     if is_mgmt_vrf_enabled(ctx) is True:

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -6,7 +6,6 @@ import sys
 
 import click
 import json
-#import netaddr
 
 from natsort import natsorted
 from sonic_py_common import multi_asic

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -6,7 +6,7 @@ import sys
 
 import click
 import json
-import netaddr
+#import netaddr
 
 from natsort import natsorted
 from sonic_py_common import multi_asic
@@ -191,6 +191,7 @@ def get_interface_naming_mode():
 
 def is_ipaddress(val):
     """ Validate if an entry is a valid IP """
+    import netaddr
     if not val:
         return False
     try:


### PR DESCRIPTION
Signed-off-by: Sabareesh Kumar Anandan <sanandan@marvell.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Some py imports in show/main.py script are taking more time on arm cpu.
modules - pkg_resources, netaddr are taking around 500ms causing delay for all show cmds.
These modules are used by only specific cmds. So, I have included these imports only for the commands that are using them.

**- How I did it**

**- How to verify it**
Test all show commands. Execution time of show commands is better than before.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

