### PR TITLE
NAT show commands newline issue after migrated to Python3

### DIFF
--- a/scripts/natconfig
+++ b/scripts/natconfig
@@ -238,9 +238,9 @@ class NatConfig(object):
         for napt in self.static_napt_data:
             output.append([napt[0], napt[1], napt[2], napt[3], napt[4], napt[5], napt[6]])
 
-        print()
+        print("")
         print(tabulate(output, HEADER))
-        print()
+        print("")
 
     def display_pool(self):
         """
@@ -253,9 +253,9 @@ class NatConfig(object):
         for nat in self.nat_pool_data:
             output.append([nat[0], nat[1], nat[2]])
 
-        print()
+        print("")
         print(tabulate(output, HEADER))
-        print()
+        print("")
 
     def display_binding(self):
         """
@@ -268,9 +268,9 @@ class NatConfig(object):
         for nat in self.nat_binding_data:
             output.append([nat[0], nat[1], nat[2], nat[3], nat[4]])
 
-        print()
+        print("")
         print(tabulate(output, HEADER))
-        print()
+        print("")
 
     def display_global(self):
         """
@@ -280,31 +280,31 @@ class NatConfig(object):
 
         global_data = self.config_db.get_entry('NAT_GLOBAL', 'Values')
         if global_data:
-           print()
+           print("")
            if 'admin_mode' in global_data:
-               print("Admin Mode     :", global_data['admin_mode'])
+               print("Admin Mode     : {}".format(global_data['admin_mode']))
            else:
                print("Admin Mode     : disabled")
            if 'nat_timeout' in global_data:
-               print("Global Timeout :", global_data['nat_timeout'], "secs")
+               print("Global Timeout : {}".format(global_data['nat_timeout'], "secs"))
            else:
                print("Global Timeout : 600 secs")
            if 'nat_tcp_timeout' in global_data:
-               print("TCP Timeout    :", global_data['nat_tcp_timeout'], "secs")
+               print("TCP Timeout    : {}".format(global_data['nat_tcp_timeout'], "secs"))
            else:
                print("TCP Timeout    : 86400 secs")
            if 'nat_udp_timeout' in global_data:
-               print("UDP Timeout    :", global_data['nat_udp_timeout'], "secs")
+               print("UDP Timeout    : {}".format(global_data['nat_udp_timeout'], "secs"))
            else:
                print("UDP Timeout    : 300 secs")
-           print()
+           print("")
         else:
-           print()
+           print("")
            print("Admin Mode     : disabled")
            print("Global Timeout : 600 secs")
            print("TCP Timeout    : 86400 secs")
            print("UDP Timeout    : 300 secs")
-           print()
+           print("")
            return
 
     def display_nat_zone(self):
@@ -318,9 +318,9 @@ class NatConfig(object):
         for nat in self.nat_zone_data:
             output.append([nat[0], nat[1]])
 
-        print()
+        print("")
         print(tabulate(output, HEADER))
-        print()
+        print("")
 
 def main():
     parser = argparse.ArgumentParser(description='Display the nat configuration information',

--- a/scripts/natshow
+++ b/scripts/natshow
@@ -331,7 +331,7 @@ class NatShow(object):
         totalEntries = int(self.static_nat_entries) + int(self.dynamic_nat_entries) + int(self.static_napt_entries) + int(self.dynamic_napt_entries)
         totalEntries += (int(self.static_twice_nat_entries) + int(self.dynamic_twice_nat_entries) + int(self.static_twice_napt_entries) + int(self.dynamic_twice_napt_entries))
 
-        print()
+        print("")
         print("Static NAT Entries         ..................... {}".format(self.static_nat_entries))
         print("Static NAPT Entries        ..................... {}".format(self.static_napt_entries))
         print("Dynamic NAT Entries        ..................... {}".format(self.dynamic_nat_entries))
@@ -343,7 +343,7 @@ class NatShow(object):
         print("Total SNAT/SNAPT Entries   ..................... {}".format(self.snat_entries))
         print("Total DNAT/DNAPT Entries   ..................... {}".format(self.dnat_entries))
         print("Total Entries              ..................... {}".format(totalEntries))
-        print()
+        print("")
 
     def display_translations(self):
         """
@@ -357,7 +357,7 @@ class NatShow(object):
             output.append([nat[0], nat[1], nat[2], nat[3], nat[4]])
 
         print(tabulate(output, HEADER))
-        print()
+        print("")
 
     def display_statistics(self):
         """
@@ -370,9 +370,9 @@ class NatShow(object):
         for nat in self.nat_statistics_list:
             output.append([nat[0], nat[1], nat[2], nat[3], nat[4]])
 
-        print()
+        print("")
         print(tabulate(output, HEADER))
-        print()
+        print("")
 
 def main():
     parser = argparse.ArgumentParser(description='Display the nat information',


### PR DESCRIPTION
After migrated to Python 3, seeing some issues in NAT show commands like shown an example below

root@sonic:/home/admin# show nat translations count
()
Static NAT Entries ..................... 2
Static NAPT Entries ..................... 0
Dynamic NAT Entries ..................... 0
Dynamic NAPT Entries ..................... 0
Static Twice NAT Entries ..................... 0
Static Twice NAPT Entries ..................... 0
Dynamic Twice NAT Entries ..................... 0
Dynamic Twice NAPT Entries ..................... 0
Total SNAT/SNAPT Entries ..................... 1
Total DNAT/DNAPT Entries ..................... 1
Total Entries ..................... 2
()
root@sonic:/home/admin#

After fix:

root@sonic:/home/admin# show nat translations count

Static NAT Entries ..................... 2
Static NAPT Entries ..................... 0
Dynamic NAT Entries ..................... 0
Dynamic NAPT Entries ..................... 0
Static Twice NAT Entries ..................... 0
Static Twice NAPT Entries ..................... 0
Dynamic Twice NAT Entries ..................... 0
Dynamic Twice NAPT Entries ..................... 0
Total SNAT/SNAPT Entries ..................... 1
Total DNAT/DNAPT Entries ..................... 1
Total Entries ..................... 2

root@sonic:/home/admin#

Signed-off-by: Akhilesh Samineni <akhilesh.samineni@broadcom.com>

