### PR TITLE
Fix db_migrator to copy missing values from INIT_CFG to config_db

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1049,7 +1049,7 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart):
         log.log_info("'reload' stopping services...")
         _stop_services(db.cfgdb)
 
-    # In Single AISC platforms we have single DB service. In multi-ASIC platforms we have a global DB
+    # In Single ASIC platforms we have single DB service. In multi-ASIC platforms we have a global DB
     # service running in the host + DB services running in each ASIC namespace created per ASIC.
     # In the below logic, we get all namespaces in this platform and add an empty namespace ''
     # denoting the current namespace which we are in ( the linux host )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Proposed fix for missing `FEATURE` table during warm-upgrade from 201811to 201911.
Fixes: https://github.com/Azure/sonic-buildimage/issues/5738

FEATURE table is a part of 201911 image database, but absent in 201811 images. The warm upgrade from 201811 image to 201911 image fails as the feature table is missing in the DB and multiple errors are seen in syslog.

This PR fixes DB_MIGRATOR code to update missing init_cfg tables into config_db.

**- How I did it**
Iterate through the tables in `/etc/sonic/init_cfg.json`, if a table is found missing in `configDB`, update the `configDB` with the missing table. Otherwise, ignore it, so to avoid overriding `configDB` tables with `init_cfg`.

**- How to verify it**
Error is easily reproducible. Manually tested the fix by modifying `db_migrator` and issuing the `migrate` command.
The result is that the `FEATURE` table is updated in the in memory database and `show feature status` command starts displaying these features.

```
root@sonic-device:~# show feature status
Feature    State    AutoRestart
---------  -------  -------------
root@sonic-device:~#
root@sonic-device:~# db_migrator.py -o migrate
root@sonic-device:~#
root@sonic-device:/etc/sonic# show feature status
Feature     State    AutoRestart
----------  -------  -------------
acms        enabled  enabled
bgp         enabled  enabled
database    enabled  disabled
dhcp_relay  enabled  enabled
lldp        enabled  enabled
pmon        enabled  enabled
radv        enabled  enabled
snmp        enabled  enabled
swss        enabled  enabled
syncd       enabled  enabled
teamd       enabled  enabled
telemetry   enabled  enabled
root@sonic-device:/etc/sonic# 
```

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

