### PR TITLE
[master] fix config sflow enable failed

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -3438,6 +3438,12 @@ def enable(ctx):
 
     if out != "active":
         log.log_info("sflow service is not enabled. Starting sflow docker...")
+        ##make sure sflow unmask before enable and start
+        maskinfo=os.popen('systemctl list-unit-files | grep masked')
+        readinfo="".join(maskinfo.readlines())
+        if 'sflow' in readinfo:
+            clicommon.run_command("sudo systemctl unmask sflow >/dev/null")
+
         clicommon.run_command("sudo systemctl enable sflow")
         clicommon.run_command("sudo systemctl start sflow")
 


### PR DESCRIPTION
Signed-off-by: tim-rj <sonic_rd@ruijie.com.cn>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
fix https://github.com/Azure/sonic-buildimage/issues/5803
**- How I did it**
make sure sflow unmask before enable and start
**- How to verify it**
```
config sflow enalbe
```
**- Previous command output (if the output of a command-line utility has changed)**
```
root@sonic:/home/admin# config sflow enable
Failed to enable unit: Unit file /etc/systemd/system/sflow.service is masked.
root@sonic:/home/admin# systemctl status sflow
● sflow.service
   Loaded: masked (Reason: Unit sflow.service is masked.)
   Active: inactive (dead)

```

**- New command output (if the output of a command-line utility has changed)**

```
root@sonic:/home/admin# config sflow enable
Removed /etc/systemd/system/sflow.service.
root@sonic:/home/admin# systemclt status sflow
bash: systemclt: command not found
root@sonic:/home/admin# systemctl status sflow
● sflow.service - sFlow container
   Loaded: loaded (/lib/systemd/system/sflow.service; enabled; vendor preset: enabled)
   Active: active (running) since Wed 2020-11-04 10:46:01 UTC; 27s ago
  Process: 28203 ExecStartPre=/usr/bin/sflow.sh start (code=exited, status=0/SUCCESS)
 Main PID: 28281 (sflow.sh)
    Tasks: 15 (limit: 4461)
   Memory: 26.9M
   CGroup: /system.slice/sflow.service
           ├─28281 /bin/bash /usr/bin/sflow.sh wait
           └─28282 docker wait sflow

```