### PR TITLE
[connect][clear] Support --devicename option for connect/clear line commands

### DIFF
--- a/clear/main.py
+++ b/clear/main.py
@@ -368,10 +368,11 @@ def clear_vlan_fdb(vlanid):
 # 'line' command
 #
 @cli.command('line')
-@click.argument('linenum')
-def line(linenum):
+@click.argument('target')
+@click.option('--devicename', '-d', is_flag=True, help="clear by name - if flag is set, interpret target as device name instead")
+def line(target, devicename):
     """Clear preexisting connection to line"""
-    cmd = "consutil clear " + str(linenum)
+    cmd = "consutil clear {}".format("--devicename " if devicename else "") + str(target)
     run_command(cmd)
 
 #

--- a/connect/main.py
+++ b/connect/main.py
@@ -95,10 +95,11 @@ def connect():
 # 'line' command ("connect line")
 #
 @connect.command('line')
-@click.argument('linenum')
-def line(linenum):
+@click.argument('target')
+@click.option('--devicename', '-d', is_flag=True, help="connect by name - if flag is set, interpret target as device name instead")
+def line(target, devicename):
     """Connect to line LINENUM via serial connection"""
-    cmd = "consutil connect " + linenum
+    cmd = "consutil connect {}".format("--devicename " if devicename else "") + str(target)
     run_command(cmd)
 
 #

--- a/consutil/main.py
+++ b/consutil/main.py
@@ -52,7 +52,7 @@ def show(db, brief):
 @consutil.command()
 @clicommon.pass_db
 @click.argument('target')
-@click.option('--devicename', '-d', is_flag=True, help="clear by name - if flag is set, interpret linenum as device name instead")
+@click.option('--devicename', '-d', is_flag=True, help="clear by name - if flag is set, interpret target as device name instead")
 def clear(db, target, devicename):
     """Clear preexisting connection to line"""
     # identify the target line
@@ -70,7 +70,7 @@ def clear(db, target, devicename):
 @consutil.command()
 @clicommon.pass_db
 @click.argument('target')
-@click.option('--devicename', '-d', is_flag=True, help="connect by name - if flag is set, interpret linenum as device name instead")
+@click.option('--devicename', '-d', is_flag=True, help="connect by name - if flag is set, interpret target as device name instead")
 def connect(db, target, devicename):
     """Connect to switch via console device - TARGET is line number or device name of switch"""
     # identify the target line

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -31,6 +31,11 @@
 * [BGP](#bgp)
   * [BGP show commands](#bgp-show-commands)
   * [BGP config commands](#bgp-config-commands)
+* [Console](#console)
+  * [Console show commands](#console-show-commands)
+  * [Console config commands](#console-config-commands)
+  * [Console connect commands](#console-connect-commands)
+  * [Console clear commands](#console-clear-commands)
 * [Container Auto-restart](#container-auto-restart)
   * [Container Auto-restart show commands](#container-auto-restart-show-commands)
   * [Container Auto-restart config command](#container-auto-restart-config-command)
@@ -140,6 +145,7 @@
 
 | Version | Modification Date | Details |
 | --- | --- | --- |
+| v5 | Nov-05-2020 | Add document for console commands |
 | v4 | Oct-17-2019 | Unify usage statements and other formatting; Replace tabs with spaces; Modify heading sizes; Fix spelling, grammar and other errors; Fix organization of new commands |
 | v3 | Jun-26-2019 | Update based on 201904 (build#19) release, "config interface" command changes related to interfacename order, FRR/Quagga show command changes, platform specific changes, ACL show changes and few formatting changes |
 | v2 | Apr-22-2019 | CLI Guide for SONiC 201811 version (build#32) with complete "config" command set |
@@ -1901,6 +1907,177 @@ This command is used to remove particular IPv4 or IPv6 BGP neighbor configuratio
   ```
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#bgp)
+
+## Console
+
+This section explains all Console show commands and configuration options that are supported in SONiC.
+
+All commands are used only when SONiC is used as console switch.
+
+All commands under this section are not applicable when SONiC used as regular switch.
+
+### Console show commands
+
+**show line**
+
+This command displays serial port or a virtual network connection status.
+
+- Usage:
+  ```
+  show line (-b|--breif)
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ show line
+  Line    Baud    PID    Start Time    Device
+  ------  ------  -----  ------------  --------
+      0       -      -             -
+      1    9600      -             -   switch1
+      2       -      -             -
+      3       -      -             -
+      4       -      -             -
+  ```
+
+Optionally, you can display configured console ports only by specifying the `-b` or `--breif` flag.
+
+- Example:
+  ```
+  admin@sonic:~$ show line -b
+    Line    Baud    PID    Start Time    Device
+  ------  ------  -----  ------------  --------
+       1    9600      -             -   switch1
+  ```
+
+## Console config commands
+
+This sub-section explains the list of configuration options available for console management module.
+
+**config console add**
+
+This command is used to add a console port setting.
+
+- Usage:
+  ```
+  config console add <port_name> [--baud|-b <baud_rate>] [--flowcontrol|-f] [--devicename|-d <remote_device>]
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ config console add 1 --baud 9600 --devicename switch1
+  ```
+
+**config console del**
+
+This command is used to remove a console port setting.
+
+- Usage:
+  ```
+  config console del <port_name>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config console del 1
+  ```
+
+**config console remote_device**
+
+This command is used to update the remote device name for a console port.
+
+- Usage:
+  ```
+  config console remote_device <port_name> <remote_device>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config console remote_device 1 switch1
+  ```
+
+**config console baud**
+
+This command is used to update the baud rate for a console port.
+
+- Usage:
+  ```
+  config console baud <port_name> <baud_rate>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config console baud 1 9600
+  ```
+
+**config console flow_control**
+
+This command is used to enable or disable flow control feature for a console port.
+
+- Usage:
+  ```
+  config console flow_control {enable|disable} <port_name>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config console flow_control enable 1
+  ```
+
+### Console connect commands
+
+**connect line**
+
+This command allows user to connect to a remote device via console line with an interactive cli.
+
+- Usage:
+  ```
+  connect line <target> (-d|--devicename)
+  ```
+
+By default, the target is `port_name`.
+
+- Example:
+  ```
+  admin@sonic:~$ connect line 1
+  Successful connection to line 1
+  Press ^A ^X to disconnect
+  ```
+
+Optionally, you can connect with a remote device name by specifying the `-d` or `--devicename` flag.
+
+- Example:
+  ```
+  admin@sonic:~$ connect line --devicename switch1
+  Successful connection to line 1
+  Press ^A ^X to disconnect
+  ```
+
+### Console clear commands
+
+**sonic-clear line**
+
+This command allows user to connect to a remote device via console line with an interactive cli.
+
+- Usage:
+  ```
+  sonc-clear line <target> (-d|--devicename)
+  ```
+
+By default, the target is `port_name`.
+
+- Example:
+  ```
+  admin@sonic:~$ sonic-clear line 1
+  ```
+
+Optionally, you can clear with a remote device name by specifying the `-d` or `--devicename` flag.
+
+- Example:
+  ```
+  admin@sonic:~$ sonic-clear --devicename switch1
+  ```
+
+Go Back To [Beginning of the document](#) or [Beginning of this section](#console)
 
 ## Container Auto-restart
 
@@ -5920,23 +6097,6 @@ This command displays virtual address to the physical address translation status
   pool        [BUFFER_POOL|ingress_lossless_pool]
   size        1248
   ----------  -----------------------------------
-  ```
-
-**show line**
-
-This command displays serial port or a virtual network connection status.
-This command is used only when SONiC is used as console switch.
-This command is not applicable when SONiC used as regular switch.
-NOTE: This command is not working. It crashes as follows. A bug ticket is opened for this issue.
-
-- Usage:
-  ```
-  show line
-  ```
-
-- Example:
-  ```
-  admin@sonic:~$ show line
   ```
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#System-State)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Support `--devicename` and `-d` option for sonic-clear/connect line commands

**- How I did it**
Add missing options.

**- How to verify it**
Tested on physical SONiC DUT with below initial configuration.
```
admin@sonic:~$ sudo show line -b
  Line    Baud    PID    Start Time    Device
------  ------  -----  ------------  --------
     1    9600      -             -   switch1
```

**- Previous command output (if the output of a command-line utility has changed)**
```
admin@sonic:~$ sudo connect line --devicename switch1
Usage: connect line [OPTIONS] LINENUM
Try "connect line -h" for help.

Error: no such option: --devicename
admin@sonic:~$ sonic-clear line --devicename switch1
Usage: sonic-clear line [OPTIONS] LINENUM
Try "sonic-clear line -h" for help.

Error: no such option: --devicename
```

**- New command output (if the output of a command-line utility has changed)**
```
admin@sonic:~$ sudo connect line --devicename switch1
Successful connection to line 1
Press ^A ^X to disconnect


admin@sonic:~$ sudo sonic-clear line --devicename switch1
admin@sonic:~$ sudo show line -b
  Line    Baud    PID    Start Time    Device
------  ------  -----  ------------  --------
     1    9600      -             -   switch1
```
