### PR TITLE
[route_check]Add an option for route_check to control whether log is writen to syslog

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -30,11 +30,13 @@ class Level(Enum):
 
 
 report_level = syslog.LOG_ERR
+write_to_syslog = False
 
-
-def set_level(lvl):
+def set_level(lvl, log_to_syslog):
     global report_level
+    global write_to_syslog
 
+    write_to_syslog = log_to_syslog
     if (lvl == Level.INFO):
         report_level = syslog.LOG_INFO
 
@@ -48,7 +50,8 @@ def print_message(lvl, *args):
         for arg in args:
             msg += " " + str(arg)
         print(msg)
-        syslog.syslog(lvl, msg)
+        if write_to_syslog:
+            syslog.syslog(lvl, msg)
 
 
 def add_prefix(ip):
@@ -167,7 +170,7 @@ def filter_out_local_interfaces(keys):
 
     db = ConfigDBConnector()
     db.db_connect('APPL_DB')
-    
+
     for k in keys:
         e = db.get_entry('ROUTE_TABLE', k)
         if not e:
@@ -240,9 +243,10 @@ def main(argv):
     parser=argparse.ArgumentParser(description="Verify routes between APPL-DB & ASIC-DB are in sync")
     parser.add_argument('-m', "--mode", type=Level, choices=list(Level), default='ERR')
     parser.add_argument("-i", "--interval", type=int, default=0, help="Scan interval in seconds")
+    parser.add_argument("-s", "--log_to_syslog", action="store_true", default=False, help="Write message to syslog")
     args = parser.parse_args()
 
-    set_level(args.mode)
+    set_level(args.mode, args.log_to_syslog)
 
     if args.interval:
         if (args.interval < MIN_SCAN_INTERVAL):


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->
Fix https://github.com/Azure/sonic-buildimage/issues/5804
**- What I did**
By default, route_check.py will report an ERROR in syslog if route mismatch is detected, which is out of the control of monit config file and cause LogAnalyzer to report test error. This commit add an option (-s) to control this behavior. And log is not writen to syslog in default.

**- How I did it**
Add an option (-s) for ```route_checker.py```.

**- How to verify it**
The update is verified on Arista-7260.
1. Add a static route whose nexthop is not reachable.
```
ip route add 1.1.1.1 via 192.168.1.101
```
2. Run ```route_check.py```, and error msg is only printed on stdout. Nothing is writen to syslog
3. Run ```route_check.py -s```. and error msg is writen to both stdout and syslog
4. Wait for 15 minutes, and confirm that monit will report the error
```
Nov  4 09:30:36.917367 str-7260cx3-acs-2 ERR monit[631]: 'routeCheck' status failed (255) -- results: { {#012    "missed_ROUTE_TABLE_routes": [#012        "1.1.1.1/32"#012    ]#012} }#012 Failed. Look at reported mismatches above
```


**- Previous command output (if the output of a command-line utility has changed)**
Output is not changed.

**- New command output (if the output of a command-line utility has changed)**
Output is not changed.
