### PR TITLE
Replace swsssdk.SonicV2Connector with swsscommon.SonicV2Connector (SWIG wrapper of C++ implementation) in production code

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -10,7 +10,8 @@ import tabulate
 import pyangbind.lib.pybindJSON as pybindJSON
 from natsort import natsorted
 from sonic_py_common import device_info
-from swsssdk import ConfigDBConnector, SonicV2Connector, SonicDBConfig
+from swsssdk import ConfigDBConnector, SonicDBConfig
+from swsscommon.swsscommon import SonicV2Connector
 
 
 def info(msg):

--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -14,7 +14,8 @@ try:
 
     # SONiC specific imports
     import sonic_yang
-    from swsssdk import ConfigDBConnector, SonicV2Connector, port_util
+    from swsssdk import ConfigDBConnector, port_util
+    from swsscommon.swsscommon import SonicV2Connector
 
     # Using load_source to 'import /usr/local/bin/sonic-cfggen as sonic_cfggen'
     # since /usr/local/bin/sonic-cfggen does not have .py extension.

--- a/config/main.py
+++ b/config/main.py
@@ -16,7 +16,8 @@ from minigraph import parse_device_desc_xml
 from portconfig import get_child_ports
 from sonic_py_common import device_info, multi_asic
 from sonic_py_common.interface import get_interface_table_name, get_port_table_name
-from swsssdk import ConfigDBConnector, SonicV2Connector, SonicDBConfig
+from swsssdk import ConfigDBConnector, SonicDBConfig
+from swsscommon.swsscommon import SonicV2Connector
 from utilities_common.db import Db
 from utilities_common.intf_filter import parse_interface_in_filter
 import utilities_common.cli as clicommon

--- a/config/nat.py
+++ b/config/nat.py
@@ -3,7 +3,7 @@
 import click
 import ipaddress
 from swsssdk import ConfigDBConnector
-from swsssdk import SonicV2Connector
+from swsscommon.swsscommon import SonicV2Connector
 
 def is_valid_ipv4_address(address):
     """Check if the given ipv4 address is valid"""

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -5,7 +5,8 @@ import sys
 import traceback
 
 from sonic_py_common import device_info, logger
-from swsssdk import ConfigDBConnector, SonicDBConfig, SonicV2Connector
+from swsssdk import ConfigDBConnector, SonicDBConfig
+from swsscommon.swsscommon import SonicV2Connector
 
 
 SYSLOG_IDENTIFIER = 'db_migrator'

--- a/scripts/fanshow
+++ b/scripts/fanshow
@@ -7,7 +7,6 @@ from __future__ import print_function
 import os
 import sys
 from tabulate import tabulate
-from swsssdk import SonicV2Connector
 from natsort import natsorted
 
 # mock the redis for unit test purposes #
@@ -21,6 +20,7 @@ try:
 except KeyError:
     pass
 
+from swsscommon.swsscommon import SonicV2Connector
 
 header = ['Drawer', 'LED', 'FAN', 'Speed', 'Direction', 'Presence', 'Status', 'Timestamp']
 

--- a/scripts/fdbclear
+++ b/scripts/fdbclear
@@ -15,7 +15,6 @@ import argparse
 import json
 import sys
 
-from swsssdk import SonicV2Connector
 
 class FdbClear(object):
 
@@ -31,6 +30,8 @@ class FdbClear(object):
         msg = json.dumps(opdata,separators=(',',':'))
         self.db.publish('APPL_DB','FLUSHFDBREQUEST', msg)
         return
+
+from swsscommon.swsscommon import SonicV2Connector
 
 def main():
 

--- a/scripts/fdbclear
+++ b/scripts/fdbclear
@@ -15,6 +15,7 @@ import argparse
 import json
 import sys
 
+from swsscommon.swsscommon import SonicV2Connector
 
 class FdbClear(object):
 
@@ -30,8 +31,6 @@ class FdbClear(object):
         msg = json.dumps(opdata,separators=(',',':'))
         self.db.publish('APPL_DB','FLUSHFDBREQUEST', msg)
         return
-
-from swsscommon.swsscommon import SonicV2Connector
 
 def main():
 

--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -30,7 +30,8 @@ import json
 import sys
 
 from natsort import natsorted
-from swsssdk import SonicV2Connector, port_util
+from swsssdk import port_util
+from swsscommon.swsscommon import SonicV2Connector
 from tabulate import tabulate
 
 class FdbShow(object):

--- a/scripts/natclear
+++ b/scripts/natclear
@@ -13,7 +13,7 @@ import argparse
 import json
 import sys
 
-from swsssdk import SonicV2Connector
+from swsscommon.swsscommon import SonicV2Connector
 
 class NatClear(object):
 

--- a/scripts/natshow
+++ b/scripts/natshow
@@ -61,7 +61,7 @@ import json
 import sys
 import re
 
-from swsssdk import SonicV2Connector
+from swsscommon.swsscommon import SonicV2Connector
 from tabulate import tabulate
 
 class NatShow(object):

--- a/scripts/nbrshow
+++ b/scripts/nbrshow
@@ -32,7 +32,8 @@ import subprocess
 import re
 
 from natsort import natsorted
-from swsssdk import SonicV2Connector, port_util
+from swsssdk import port_util
+from swsscommon.swsscommon import SonicV2Connector
 from tabulate import tabulate
 
 """

--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -17,7 +17,8 @@ import traceback
 import warnings
 
 from sonic_py_common import logger
-from swsssdk import ConfigDBConnector, SonicV2Connector
+from swsssdk import ConfigDBConnector
+from swsscommon.swsscommon import SonicV2Connector
 from netaddr import IPAddress, IPNetwork
 
 

--- a/scripts/psushow
+++ b/scripts/psushow
@@ -3,7 +3,6 @@
 import argparse
 import sys
 import os
-from swsssdk import SonicV2Connector
 from tabulate import tabulate
 
 # mock the redis for unit test purposes #
@@ -16,6 +15,8 @@ try:
         import mock_tables.dbconnector
 except KeyError:
     pass
+
+from swsscommon.swsscommon import SonicV2Connector
 
 def psu_status_show(index):
     db = SonicV2Connector(host="127.0.0.1")

--- a/scripts/tempershow
+++ b/scripts/tempershow
@@ -5,7 +5,7 @@
 from __future__ import print_function
 
 from tabulate import tabulate
-from swsssdk import SonicV2Connector
+from swsscommon.swsscommon import SonicV2Connector
 from natsort import natsorted
 
 

--- a/show/fgnhg.py
+++ b/show/fgnhg.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 import click
 import utilities_common.cli as clicommon
 from swsssdk import ConfigDBConnector
-from swsssdk import SonicV2Connector
+from swsscommon.swsscommon import SonicV2Connector
 from tabulate import tabulate
 
 

--- a/show/main.py
+++ b/show/main.py
@@ -21,7 +21,8 @@ import system_health
 import fgnhg
 
 from sonic_py_common import device_info, multi_asic
-from swsssdk import ConfigDBConnector, SonicV2Connector
+from swsssdk import ConfigDBConnector
+from swsscommon.swsscommon import SonicV2Connector
 from tabulate import tabulate
 from utilities_common.db import Db
 import utilities_common.multi_asic as multi_asic_util

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -14,7 +14,7 @@ import urllib
 
 import click
 from sonic_py_common import logger
-from swsssdk import SonicV2Connector
+from swsscommon.swsscommon import SonicV2Connector
 
 from .bootloader import get_bootloader
 from .common import run_command, run_command_or_raise

--- a/tests/mock_tables/dbconnector.py
+++ b/tests/mock_tables/dbconnector.py
@@ -4,10 +4,11 @@ import os
 
 import mock
 import mockredis
-import swsssdk.interface
+import redis
+import swsssdk
 from sonic_py_common import multi_asic
 from swsssdk import SonicDBConfig, SonicV2Connector
-from swsssdk.interface import redis
+from swsscommon import swsscommon
 
 topo = None
 
@@ -137,3 +138,5 @@ swsssdk.interface.DBInterface._subscribe_keyspace_notification = _subscribe_keys
 mockredis.MockRedis.config_set = config_set
 redis.StrictRedis = SwssSyncClient
 SonicV2Connector.connect = connect_SonicV2Connector
+swsssdk.SonicV2Connector = SonicV2Connector
+swsscommon.SonicV2Connector = SonicV2Connector

--- a/tests/mock_tables/dbconnector.py
+++ b/tests/mock_tables/dbconnector.py
@@ -138,5 +138,4 @@ swsssdk.interface.DBInterface._subscribe_keyspace_notification = _subscribe_keys
 mockredis.MockRedis.config_set = config_set
 redis.StrictRedis = SwssSyncClient
 SonicV2Connector.connect = connect_SonicV2Connector
-swsssdk.SonicV2Connector = SonicV2Connector
 swsscommon.SonicV2Connector = SonicV2Connector


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
This is the following step for merging sonic-py-swsssdk into sonic-swss-common https://github.com/Azure/sonic-swss-common/pull/387

**- How I did it**

**- How to verify it**
Unit test and tested in DUT

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

