### PR TITLE
[consutil][show] Remove root need from show line command

### DIFF
--- a/consutil/lib.py
+++ b/consutil/lib.py
@@ -34,7 +34,7 @@ FLOW_KEY = "flow_control"
 # STATE_DB Keys
 STATE_KEY = "state"
 PID_KEY = "pid"
-START_TIME_KEY = "state_time"
+START_TIME_KEY = "start_time"
 
 BUSY_FLAG = "busy"
 IDLE_FLAG = "idle"

--- a/consutil/main.py
+++ b/consutil/main.py
@@ -19,9 +19,6 @@ except ImportError as e:
 @click.group()
 def consutil():
     """consutil - Command-line utility for interacting with switches via console device"""
-    if os.geteuid() != 0:
-        click.echo("Root privileges are required for this operation")
-        sys.exit(ERR_CMD)
     SysInfoProvider.init_device_prefix()
 
 # 'show' subcommand
@@ -55,6 +52,10 @@ def show(db, brief):
 @click.option('--devicename', '-d', is_flag=True, help="clear by name - if flag is set, interpret linenum as device name instead")
 def clear(db, target, devicename):
     """Clear preexisting connection to line"""
+    if os.geteuid() != 0:
+        click.echo("Root privileges are required for this operation")
+        sys.exit(ERR_CMD)
+
     # identify the target line
     port_provider = ConsolePortProvider(db, configured_only=False)
     try:
@@ -73,6 +74,10 @@ def clear(db, target, devicename):
 @click.option('--devicename', '-d', is_flag=True, help="connect by name - if flag is set, interpret linenum as device name instead")
 def connect(db, target, devicename):
     """Connect to switch via console device - TARGET is line number or device name of switch"""
+    if os.geteuid() != 0:
+        click.echo("Root privileges are required for this operation")
+        sys.exit(ERR_CMD)
+
     # identify the target line
     port_provider = ConsolePortProvider(db, configured_only=False)
     try:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

Remove root privilege need for `consutil show` and `show line` command.

As discuss in this thread (https://github.com/Azure/sonic-buildimage/pull/5438), I am going to remove unnecessary root privilege need from console commands.

**- How I did it**

* Simply remove the check
* Add unit test for `consutil show` command
* Fix a known typo (found by adding unittest)

**- How to verify it**

Build py-wheel package and install+test on a physical SONiC DUT

**- Previous command output (if the output of a command-line utility has changed)**
```
admin@sonic:~$ show line
Root privileges are required for this operation
```

**- New command output (if the output of a command-line utility has changed)**
```
admin@sonic:~$ show line
  Line    Baud    PID    Start Time    Device
------  ------  -----  ------------  --------
     0       -      -             -
     1    9600      -             -   switch1
     2       -      -             -
     3       -      -             -
     4       -      -             -
     5       -      -             -
     6       -      -             -
     7       -      -             -
     8       -      -             -
     9       -      -             -
    10       -      -             -
    11       -      -             -
    12       -      -             -
    13       -      -             -
    14       -      -             -
    15       -      -             -
    16       -      -             -
    17       -      -             -
    18       -      -             -
    19       -      -             -
    20       -      -             -
    21       -      -             -
    22       -      -             -
    23       -      -             -
    24       -      -             -
    25       -      -             -
    26       -      -             -
    27       -      -             -
    28       -      -             -
    29       -      -             -
    30       -      -             -
    31       -      -             -
    32       -      -             -
    33       -      -             -
    34       -      -             -
    35       -      -             -
    36       -      -             -
    37       -      -             -
    38       -      -             -
    39       -      -             -
    40       -      -             -
    41       -      -             -
    42       -      -             -
    43       -      -             -
    44       -      -             -
    45       -      -             -
    46       -      -             -
    47       -      -             -
```
