### PR TITLE
[master] fix-show-reboot-cause-failed

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1809,7 +1809,7 @@ def mmu():
 @cli.command('reboot-cause')
 def reboot_cause():
     """Show cause of most recent reboot"""
-    PREVIOUS_REBOOT_CAUSE_FILE = "/host/reboot-cause/previous-reboot-cause.txt"
+    PREVIOUS_REBOOT_CAUSE_FILE = "/host/reboot-cause/reboot-cause.txt"
 
     # At boot time, PREVIOUS_REBOOT_CAUSE_FILE is generated based on
     # the contents of the 'reboot cause' file as it was left when the device


### PR DESCRIPTION
Signed-off-by: tim-rj <sonic_rd@ruijie.com.cn>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
fix https://github.com/Azure/sonic-buildimage/issues/5354
**- How I did it**
```
change previous-reboot-cause.txt to reboot-cause.txt
```
**- How to verify it**
```
show reboot-cause
```

**- Previous command output (if the output of a command-line utility has changed)**
```
root@sonic:/usr/local/lib/python2.7/dist-packages/sonic_platform# show reboot-cause
Unable to determine cause of previous reboot


```

**- New command output (if the output of a command-line utility has changed)**
```
root@sonic:/home/admin# show reboot-cause
User issued 'reboot' command [User: admin, Time: Thu 05 Nov 2020 04:48:04 PM UTC]

```
