### PR TITLE
[consutil][connect] Remove root need from connect line command

### DIFF
--- a/consutil/lib.py
+++ b/consutil/lib.py
@@ -158,7 +158,7 @@ class ConsolePortInfo(object):
 
         # build and start picocom command
         flow_cmd = "h" if self.flow_control else "n"
-        cmd = "sudo picocom -b {} -f {} {}{}".format(self.baud, flow_cmd, SysInfoProvider.DEVICE_PREFIX, self.line_num)
+        cmd = "picocom -b {} -f {} {}{}".format(self.baud, flow_cmd, SysInfoProvider.DEVICE_PREFIX, self.line_num)
 
         # start connection
         try:
@@ -228,10 +228,11 @@ class ConsolePortInfo(object):
         state_db.set(state_db.STATE_DB, line_key, STATE_KEY, state)
         state_db.set(state_db.STATE_DB, line_key, PID_KEY, pid)
         state_db.set(state_db.STATE_DB, line_key, START_TIME_KEY, date)
-        self._info[CUR_STATE_KEY] = {} if CUR_STATE_KEY not in self._info else self._info[CUR_STATE_KEY]
-        self._info[CUR_STATE_KEY][STATE_KEY] = state
-        self._info[CUR_STATE_KEY][PID_KEY] = pid
-        self._info[CUR_STATE_KEY][START_TIME_KEY] = date
+        self._info[CUR_STATE_KEY] = {
+            STATE_KEY: state,
+            PID_KEY: pid,
+            START_TIME_KEY: date
+        }
 
 class ConsoleSession(object):
     """

--- a/consutil/main.py
+++ b/consutil/main.py
@@ -74,10 +74,6 @@ def clear(db, target, devicename):
 @click.option('--devicename', '-d', is_flag=True, help="connect by name - if flag is set, interpret target as device name instead")
 def connect(db, target, devicename):
     """Connect to switch via console device - TARGET is line number or device name of switch"""
-    if os.geteuid() != 0:
-        click.echo("Root privileges are required for this operation")
-        sys.exit(ERR_CMD)
-
     # identify the target line
     port_provider = ConsolePortProvider(db, configured_only=False)
     try:
@@ -92,7 +88,7 @@ def connect(db, target, devicename):
     try:
         session = target_port.connect()
     except LineBusyError:
-        click.echo("Cannot connect: line {} is busy".format(line_num))
+        click.echo("Cannot connect: line [{}] is busy".format(line_num))
         sys.exit(ERR_BUSY)
     except InvalidConfigurationError as cfg_err:
         click.echo("Cannot connect: {}".format(cfg_err.message))
@@ -102,7 +98,7 @@ def connect(db, target, devicename):
         sys.exit(ERR_DEV)
 
     # interact
-    click.echo("Successful connection to line {}\nPress ^A ^X to disconnect".format(line_num))
+    click.echo("Successful connection to line [{}]\nPress ^A ^X to disconnect".format(line_num))
     session.interact()
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

Remove root privilege need for `consutil connect` and `show line` command.

As discuss in this thread (https://github.com/Azure/sonic-buildimage/pull/5438), I am going to remove unnecessary root privilege need from console commands.

**- How I did it**

* Base on this change (https://github.com/Azure/sonic-buildimage/pull/5840), we are safe to remove the root need from `consutil command`
* Add unit tests for `consutil connect` command


**- How to verify it**

Build py-wheel package and install+test on a physical SONiC DUT

**- Previous command output (if the output of a command-line utility has changed)**

```
admin@sonic:~$ consutil connect 1
Root privileges are required for this operation
```

**- New command output (if the output of a command-line utility has changed)**

```
admin@sonic:~$ consutil connect 1
Successful connection to line [1]
Press ^A ^X to disconnect
```
