### PR TITLE
Remove SKU create pytest output directory before execution of the script

### DIFF
--- a/tests/sku_create_test.py
+++ b/tests/sku_create_test.py
@@ -8,6 +8,7 @@ test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, "scripts")
 input_path = os.path.join(modules_path, "tests/sku_create_input")
+output_dir_path = os.path.join(modules_path, "tests/sku_create_input/Mellanox-SN2700-D48C8_NEW")
 sku_def_file = os.path.join(input_path, "Mellanox-SN2700-D48C8.xml")
 sku_create_script = os.path.join(scripts_path, "sonic_sku_create.py")
 output_file_path = os.path.join(modules_path, "tests/sku_create_input/Mellanox-SN2700-D48C8_NEW/port_config.ini")
@@ -49,6 +50,9 @@ class TestSkuCreate(object):
         return True
     
     def test_no_param(self):
+        if (os.path.exists(output_dir_path)):
+            shutil.rmtree(output_dir_path)
+
         my_command = sku_create_script + " -f "  + sku_def_file  + " -d " + input_path
 
         #Test case execution without stdout

--- a/tests/sku_create_test.py
+++ b/tests/sku_create_test.py
@@ -3,6 +3,7 @@ import os
 import pytest
 import subprocess
 import re
+import shutil
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)

--- a/tests/sku_create_test.py
+++ b/tests/sku_create_test.py
@@ -1,9 +1,10 @@
-import sys
 import os
-import pytest
-import subprocess
 import re
 import shutil
+import subprocess
+import sys
+
+import pytest
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
I removed the output directory of the SKU create pytest before execution of the script, otherwise the pytest execution will fail when run for the second time.

**- How I did it**
I checked for existence of the output directory and if it exists, I remove it.

**- How to verify it**
Run SKU creator pytest for the second time and ensure it runs successfully.

**- Previous command output (if the output of a command-line utility has changed)**
None

**- New command output (if the output of a command-line utility has changed)**
None
