### PR TITLE
[CLI][show][platform] Added ASIC count in the output. (#1185)

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -17,6 +17,7 @@ from swsssdk import ConfigDBConnector
 from swsssdk import SonicV2Connector
 from tabulate import tabulate
 import mlnx
+import utilities_common.cli as clicommon
 import utilities_common.multi_asic as multi_asic_util
 
 SONIC_CFGGEN_PATH = '/usr/local/bin/sonic-cfggen'
@@ -1509,6 +1510,7 @@ def get_hw_info_dict():
     hw_info_dict['platform'] = device_info.get_platform()
     hw_info_dict['hwsku'] = device_info.get_hwsku()
     hw_info_dict['asic_type'] = version_info['asic_type']
+    hw_info_dict['asic_count'] = device_info.get_num_npus()
 
     return hw_info_dict
 
@@ -1523,12 +1525,18 @@ if (version_info and version_info.get('asic_type') == 'mellanox'):
 
 # 'summary' subcommand ("show platform summary")
 @platform.command()
-def summary():
+@click.option('--json', is_flag=True, help="JSON output")
+def summary(json):
     """Show hardware platform information"""
+
     hw_info_dict = get_hw_info_dict()
-    click.echo("Platform: {}".format(hw_info_dict['platform']))
-    click.echo("HwSKU: {}".format(hw_info_dict['hwsku']))
-    click.echo("ASIC: {}".format(hw_info_dict['asic_type']))
+    if json:
+        click.echo(clicommon.json_dump(hw_info_dict))
+    else:
+        click.echo("Platform: {}".format(hw_info_dict['platform']))
+        click.echo("HwSKU: {}".format(hw_info_dict['hwsku']))
+        click.echo("ASIC: {}".format(hw_info_dict['asic_type']))
+        click.echo("ASIC Count: {}".format(hw_info_dict['asic_count']))
 
 # 'syseeprom' subcommand ("show platform syseeprom")
 @platform.command()

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -1,0 +1,9 @@
+import json
+
+def json_dump(data):
+    """
+    Dump data in JSON format
+    """
+    return json.dumps(
+        data, sort_keys=True, indent=2, ensure_ascii=False
+    )


### PR DESCRIPTION
**- What I did**

Added platform ASIC count output to platform summary. Also added option for JSON output.
Note: This is a merge from "master".

**- How I did it**

Added ASIC count in hardware info.

**- How to verify it**

Manual CLI verification.

**- Previous command output (if the output of a command-line utility has changed)**

```
admin@str-s6000-acs-9:~$ show platform summary 
Platform: x86_64-dell_s6000_s1220-r0
HwSKU: Force10-S6000
ASIC: broadcom
```

**- New command output (if the output of a command-line utility has changed)**

```
admin@str-s6000-acs-9:~$ show platform summary 
Platform: x86_64-dell_s6000_s1220-r0
HwSKU: Force10-S6000
ASIC: broadcom
ASIC Count: 1
admin@str-s6000-acs-9:~$ show platform summary --json
{
  "asic_count": 1, 
  "asic_type": "broadcom", 
  "hwsku": "Force10-S6000", 
  "platform": "x86_64-dell_s6000_s1220-r0"
}

admin@str-nswitch-acs-2:/usr/lib/python2.7/dist-packages/utilities_common$ show platform summary
Platform: x86_64-nswitch-r0      
HwSKU: nswitch                          
ASIC: broadcom
ASIC Count: 6                              
admin@str-n3164-acs-2:/usr/lib/python2.7/dist-packages/utilities_common$ show platform summary --json
{                    
  "asic_count": 6,
  "asic_type": "broadcom",               
  "hwsku": "nswitch",
  "platform": "x86_64-nswitch-r0"
}  

```
