### PR TITLE
[load_minigraph]: Add support to load default_config.json file

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,7 @@ def set_mock_apis():
     cwd = os.path.dirname(os.path.realpath(__file__))
     config.asic_type = mock.MagicMock(return_value="broadcom")
     config._get_device_type = mock.MagicMock(return_value="ToRRouter")
+    config._get_hwsku = mock.MagicMock(return_value="Arista-VM")
 
 @pytest.fixture
 def setup_qos_mock_apis():


### PR DESCRIPTION
This change add support for a per-device/per-npu default_config.json
file that contains platform-specific or hwsku-specific configuration to
be used when generating config_db*.json

An example of such file in a VoQ chassis could be:
```json
{
    "DEVICE_METADATA": {
        "localhost": {
            "asic_id": "06:00.0"
        }
    }
}
```

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

Added support for a default_config.json file present in platform directory for each NPU and for the host. This file will be loaded when `config load_minigraph` is called.

**- Why I did it**

Some VoQ devices require per-platform/per-NPU configurations to be present in CONFIG_DB. `default_config.json` provides a way for a vendor to give the required initial configuration of a device.

**- How to verify it**

Verified manually on a single and multi-NPU platform with and without a `default_config.json` present in the platform directory.
