### PR TITLE
[sflow] Add mVRF support

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -3582,9 +3582,9 @@ def is_valid_collector_info(name, ip, port, vrf_name):
         click.echo("Invalid IP address")
         return False
 
-    if vrf_name != 'default' or vrf_name != 'mgmt':
+    if vrf_name != 'default' and vrf_name != 'mgmt':
         click.echo("Only 'default' and 'mgmt' VRF are supported")
-        return false
+        return False
 
     return True
 
@@ -3599,7 +3599,7 @@ def is_valid_collector_info(name, ip, port, vrf_name):
 @click.argument('name', metavar='<collector_name>', required=True)
 @click.argument('ipaddr', metavar='<IPv4/v6_address>', required=True)
 @click.pass_context
-def add(ctx, name, ipaddr, port):
+def add(ctx, name, ipaddr, port, vrf):
     """Add a sFlow collector"""
     ipaddr = ipaddr.lower()
 

--- a/config/main.py
+++ b/config/main.py
@@ -3569,7 +3569,7 @@ def collector(ctx):
     """Add/Delete a sFlow collector"""
     pass
 
-def is_valid_collector_info(name, ip, port):
+def is_valid_collector_info(name, ip, port, vrf_name):
     if len(name) > 16:
         click.echo("Collector name must not exceed 16 characters")
         return False
@@ -3582,6 +3582,10 @@ def is_valid_collector_info(name, ip, port):
         click.echo("Invalid IP address")
         return False
 
+    if vrf_name != 'default' or vrf_name != 'mgmt':
+        click.echo("Only 'default' and 'mgmt' VRF are supported")
+        return false
+
     return True
 
 #
@@ -3590,6 +3594,8 @@ def is_valid_collector_info(name, ip, port):
 @collector.command()
 @click.option('--port', required=False, type=int, default=6343,
               help='Collector port number')
+@click.option('--vrf', required=False, type=str, default='default',
+              help='Collector VRF')
 @click.argument('name', metavar='<collector_name>', required=True)
 @click.argument('ipaddr', metavar='<IPv4/v6_address>', required=True)
 @click.pass_context
@@ -3597,7 +3603,7 @@ def add(ctx, name, ipaddr, port):
     """Add a sFlow collector"""
     ipaddr = ipaddr.lower()
 
-    if not is_valid_collector_info(name, ipaddr, port):
+    if not is_valid_collector_info(name, ipaddr, port, vrf):
         return
 
     config_db = ctx.obj['db']
@@ -3608,7 +3614,8 @@ def add(ctx, name, ipaddr, port):
         return
 
     config_db.mod_entry('SFLOW_COLLECTOR', name,
-                        {"collector_ip": ipaddr,  "collector_port": port})
+                        {"collector_ip": ipaddr,  "collector_port": port,
+                         "collector_vrf": vrf})
     return
 
 #

--- a/show/main.py
+++ b/show/main.py
@@ -1686,7 +1686,8 @@ def show_sflow_global(config_db):
     for collector_name in sorted(sflow_info.keys()):
         click.echo("    Name: {}".format(collector_name).ljust(30) +
                    "IP addr: {} ".format(sflow_info[collector_name]['collector_ip']).ljust(25) +
-                   "UDP port: {}".format(sflow_info[collector_name]['collector_port']))
+                   "UDP port: {}".format(sflow_info[collector_name]['collector_port']).ljust(17) +
+                   "VRF: {}".format(sflow_info[collector_name]['collector_vrf']))
 
 
 #

--- a/show/main.py
+++ b/show/main.py
@@ -1684,10 +1684,12 @@ def show_sflow_global(config_db):
     sflow_info = config_db.get_table('SFLOW_COLLECTOR')
     click.echo("\n  {} Collectors configured:".format(len(sflow_info)))
     for collector_name in sorted(sflow_info.keys()):
+        vrf_name = (sflow_info[collector_name]['collector_vrf']
+                    if 'collector_vrf' in sflow_info[collector_name] else 'default')
         click.echo("    Name: {}".format(collector_name).ljust(30) +
                    "IP addr: {} ".format(sflow_info[collector_name]['collector_ip']).ljust(25) +
                    "UDP port: {}".format(sflow_info[collector_name]['collector_port']).ljust(17) +
-                   "VRF: {}".format(sflow_info[collector_name]['collector_vrf']))
+                   "VRF: {}".format(vrf_name))
 
 
 #

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -5,11 +5,13 @@
     },
     "SFLOW_COLLECTOR|prod": {
         "collector_ip": "fe80::6e82:6aff:fe1e:cd8e",
-        "collector_port": "6343"
+        "collector_port": "6343",
+        "collector_vrf": "mgmt"
     },
     "SFLOW_COLLECTOR|ser5": {
         "collector_ip": "172.21.35.15",
-        "collector_port": "6343"
+        "collector_port": "6343",
+        "collector_vrf": "default"
     },
     "BREAKOUT_CFG|Ethernet0": {
         "brkout_mode": "4x25G[10G]"

--- a/tests/sflow_test.py
+++ b/tests/sflow_test.py
@@ -20,8 +20,8 @@ sFlow Global Information:
   sFlow AgentID:              default
 
   2 Collectors configured:
-    Name: prod                IP addr: fe80::6e82:6aff:fe1e:cd8e UDP port: 6343
-    Name: ser5                IP addr: 172.21.35.15    UDP port: 6343
+    Name: prod                IP addr: fe80::6e82:6aff:fe1e:cd8e UDP port: 6343   VRF: mgmt
+    Name: ser5                IP addr: 172.21.35.15    UDP port: 6343   VRF: default
 """
 
 # Expected output for 'show sflow interface'
@@ -117,7 +117,8 @@ class TestShowSflow(object):
         # change the output
         global show_sflow_output
         show_sflow_output_local = \
-            show_sflow_output.replace('default', 'Ethernet0')
+            show_sflow_output.replace('sFlow AgentID:              default',
+                                      'sFlow AgentID:              Ethernet0')
 
         # run show and check
         result = runner.invoke(show.cli.commands["sflow"], [], obj=db)
@@ -154,10 +155,10 @@ class TestShowSflow(object):
         global show_sflow_output
         show_sflow_output_local = show_sflow_output.replace(\
     "2 Collectors configured:\n\
-    Name: prod                IP addr: fe80::6e82:6aff:fe1e:cd8e UDP port: 6343\n\
-    Name: ser5                IP addr: 172.21.35.15    UDP port: 6343", \
+    Name: prod                IP addr: fe80::6e82:6aff:fe1e:cd8e UDP port: 6343   VRF: mgmt\n\
+    Name: ser5                IP addr: 172.21.35.15    UDP port: 6343   VRF: default", \
     "1 Collectors configured:\n\
-    Name: ser5                IP addr: 172.21.35.15    UDP port: 6343")
+    Name: ser5                IP addr: 172.21.35.15    UDP port: 6343   VRF: default")
 
         # run show and check
         result = runner.invoke(show.cli.commands["sflow"], [], obj=db)
@@ -168,7 +169,7 @@ class TestShowSflow(object):
         # add collector
         result = runner.invoke(config.config.commands["sflow"].\
             commands["collector"].commands["add"], \
-            ["prod", "fe80::6e82:6aff:fe1e:cd8e"], obj=obj)
+            ["prod", "fe80::6e82:6aff:fe1e:cd8e", "--vrf", "mgmt"], obj=obj)
         assert result.exit_code == 0
 
         # run show and check


### PR DESCRIPTION
* Add mVRF support and options to CLICK CLI

Signed-off-by: Garrick He <garrick_he@dell.com>

**- What I did**
Add options to allow mVRF configuration for sFlow collectors

**- How I did it**
Update the show/main.py and confg/main.py scripts

**- How to verify it**
Check output of CLICK CLI:

```
admin@sonic:~$ sudo config sflow collector add col1 1.1.1.1 --port 1111 --vrf mgmt
admin@sonic:~$ show sflow

sFlow Global Information:
  sFlow Admin State:          down
  sFlow Polling Interval:     default
  sFlow AgentID:              default

  1 Collectors configured:
    Name: col1                IP addr: 1.1.1.1         UDP port: 1111   VRF: mgmt
admin@sonic:~$ sudo config sflow collector add col2 1.1.1.2
admin@sonic:~$ show sflow

sFlow Global Information:
  sFlow Admin State:          down
  sFlow Polling Interval:     default
  sFlow AgentID:              default

  2 Collectors configured:
    Name: col1                IP addr: 1.1.1.1         UDP port: 1111   VRF: mgmt
    Name: col2                IP addr: 1.1.1.2         UDP port: 6343   VRF: default
admin@sonic:~$ sudo config sflow collector add col1 1.1.1.1 --port 1111 --vrf wrong
Invalid VRF (only default or mgmt)
admin@sonic:~$
```

**- Previous command output (if the output of a command-line utility has changed)**
```
admin@sonic:~$ sudo config sflow collector add col1 1.1.1.1 --port 1111
admin@sonic:~$ show sflow

sFlow Global Information:
  sFlow Admin State:          down
  sFlow Polling Interval:     default
  sFlow AgentID:              default

  1 Collectors configured:
    Name: col1                IP addr: 1.1.1.1         UDP port: 1111
admin@sonic:~$ sudo config sflow collector add col2 1.1.1.2
admin@sonic:~$ show sflow

sFlow Global Information:
  sFlow Admin State:          down
  sFlow Polling Interval:     default
  sFlow AgentID:              default

  2 Collectors configured:
    Name: col1                IP addr: 1.1.1.1         UDP port: 1111
    Name: col2                IP addr: 1.1.1.2         UDP port: 6343
```

**- New command output (if the output of a command-line utility has changed)**
```
admin@sonic:~$ sudo config sflow collector add col1 1.1.1.1 --port 1111 --vrf mgmt
admin@sonic:~$ show sflow

sFlow Global Information:
  sFlow Admin State:          down
  sFlow Polling Interval:     default
  sFlow AgentID:              default

  1 Collectors configured:
    Name: col1                IP addr: 1.1.1.1         UDP port: 1111   VRF: mgmt
admin@sonic:~$ sudo config sflow collector add col2 1.1.1.2
admin@sonic:~$ show sflow

sFlow Global Information:
  sFlow Admin State:          down
  sFlow Polling Interval:     default
  sFlow AgentID:              default

  2 Collectors configured:
    Name: col1                IP addr: 1.1.1.1         UDP port: 1111   VRF: mgmt
    Name: col2                IP addr: 1.1.1.2         UDP port: 6343   VRF: default
admin@sonic:~$ sudo config sflow collector add col1 1.1.1.1 --port 1111 --vrf wrong
Invalid VRF (only default or mgmt)
admin@sonic:~$
```
