### PR TITLE
[portchannel] Check for member being part of some other portchannel

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1329,8 +1329,13 @@ def portchannel_member(ctx):
 def add_portchannel_member(ctx, portchannel_name, port_name):
     """Add member to port channel"""
     db = ctx.obj['db']
+    portchannel_member_table = db.get_table('PORTCHANNEL_MEMBER')
     if clicommon.is_port_mirror_dst_port(db, port_name):
         ctx.fail("{} is configured as mirror destination port".format(port_name))
+
+    # Check if the member interface given by user is already used. 
+    if interface_is_in_portchannel(portchannel_member_table, port_name) is True:
+         ctx.fail("Interface is already member of portchannel!")
 
     # Check if the member interface given by user is valid in the namespace.
     if interface_name_is_valid(db, port_name) is False:

--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -247,8 +247,11 @@ def po_speed_dict(po_int_dict, appl_db):
             po_list.append(key)
             if len(value) == 1:
                 interface_speed = appl_db.get(appl_db.APPL_DB, "PORT_TABLE:" + value[0], "speed")
-                interface_speed = '{}G'.format(interface_speed[:-3])
-                po_list.append(interface_speed)
+                if interface_speed == None:
+                    po_list.append("N/A")
+                else:
+                    interface_speed = '{}G'.format(interface_speed[:-3])
+                    po_list.append(interface_speed)
             elif len(value) > 1:
                 for intf in value:
                     temp_speed = appl_db.get(appl_db.APPL_DB, "PORT_TABLE:" + intf, "speed")


### PR DESCRIPTION
**- What I did** 
Added message "Interface is already member of portchannel!" if user tries to add a port to a portchannel but if the same port is already made member of some other portchannel.
fix https://github.com/Azure/SONiC/issues/360

**- How I did it**
When port is member of some other portchannel, return message

**- How to verify it**
Create two portchannels and add member port for first portchannel, try to add this port for second portchannel

admin@sonic: sudo config portchannel add PortChannel0001
admin@sonic: sudo config portchannel add PortChannel0002
admin@sonic: sudo config portchannel member add PortChannel0001 Ethernet4
admin@sonic: sudo config portchannel member add PortChannel0002 Ethernet4

**- New command output**
Usage: config portchannel member add [OPTIONS] <portchannel_name> <port_name>
Try "config portchannel member add -h" for help.

Error: Interface is already member of portchannel!

Signed-off-by: dmytro_dashkov@Jabil.com
