### PR TITLE
Add 'requests' as install dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -150,6 +150,7 @@ setup(
         'netaddr==0.8.0',
         'netifaces==0.10.7',
         'pexpect==4.8.0',
+        'requests==2.25.0',
         'sonic-py-common',
         'sonic-yang-mgmt',
         'swsssdk>=2.0.1',


### PR DESCRIPTION
The `requests` package is used by a couple modules (config/kube.py and scripts/neighbor_advertiser), but it was not specified as an install-time dependency. Now that the package is built as Python 3, some commands are crashing with `ModuleNotFoundError: No module named 'requests'`.