### PR TITLE
Remove unnecessary conversions to list() and calls to dict.keys()

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -182,7 +182,7 @@ class AclLoader(object):
         # For multi-npu platforms we will read from any one of front asic namespace 
         # config db as the information should be same across all config db
         if self.per_npu_configdb:
-            namespace_configdb = (list(self.per_npu_configdb.values()))[0]
+            namespace_configdb = list(self.per_npu_configdb.values())[0]
             self.policers_db_info = namespace_configdb.get_table(self.POLICER)
         else:
             self.policers_db_info = self.configdb.get_table(self.POLICER)
@@ -199,11 +199,11 @@ class AclLoader(object):
         # For multi-npu platforms we will read from any one of front asic namespace 
         # config db as the information should be same across all config db
         if self.per_npu_configdb:
-            namespace_configdb = (list(self.per_npu_configdb.values()))[0]
+            namespace_configdb = list(self.per_npu_configdb.values())[0]
             self.sessions_db_info = namespace_configdb.get_table(self.CFG_MIRROR_SESSION_TABLE)
         else:
             self.sessions_db_info = self.configdb.get_table(self.CFG_MIRROR_SESSION_TABLE)
-        for key in list(self.sessions_db_info.keys()):
+        for key in self.sessions_db_info:
             if self.per_npu_statedb:
                 # For multi-npu platforms we will read from all front asic name space 
                 # statedb as the monitor port will be differnt for each asic 
@@ -367,7 +367,7 @@ class AclLoader(object):
             # For multi-npu we will read using anyone statedb connector for front asic namespace. 
             # Same information should be there in all state DB's 
             # as it is static information about switch capability
-            namespace_statedb = (list(self.per_npu_statedb.values()))[0]
+            namespace_statedb = list(self.per_npu_statedb.values())[0]
             capability = namespace_statedb.get_all(self.statedb.STATE_DB, "{}|switch".format(self.SWITCH_CAPABILITY_TABLE))
         else: 
             capability = self.statedb.get_all(self.statedb.STATE_DB, "{}|switch".format(self.SWITCH_CAPABILITY_TABLE))
@@ -579,17 +579,17 @@ class AclLoader(object):
         be removed and new rules in that table will be installed.
         :return:
         """
-        for key in list(self.rules_db_info.keys()):
+        for key in self.rules_db_info:
             if self.current_table is None or self.current_table == key[0]:
                 self.configdb.mod_entry(self.ACL_RULE, key, None)
                 # Program for per front asic namespace also if present
-                for namespace_configdb in list(self.per_npu_configdb.values()):
+                for namespace_configdb in self.per_npu_configdb.values():
                     namespace_configdb.mod_entry(self.ACL_RULE, key, None)
 
 
         self.configdb.mod_config({self.ACL_RULE: self.rules_info})
         # Program for per front asic namespace also if present
-        for namespace_configdb in list(self.per_npu_configdb.values()):
+        for namespace_configdb in self.per_npu_configdb.values():
             namespace_configdb.mod_config({self.ACL_RULE: self.rules_info})
 
     def incremental_update(self):
@@ -630,7 +630,7 @@ class AclLoader(object):
         for key in current_dataplane_rules:
             self.configdb.mod_entry(self.ACL_RULE, key, None)
             # Program for per-asic namespace also if present
-            for namespace_configdb in list(self.per_npu_configdb.values()):
+            for namespace_configdb in self.per_npu_configdb.values():
                 namespace_configdb.mod_entry(self.ACL_RULE, key, None)
 
 
@@ -638,7 +638,7 @@ class AclLoader(object):
         for key in new_dataplane_rules:
             self.configdb.mod_entry(self.ACL_RULE, key, self.rules_info[key])
             # Program for per-asic namespace corresponding to front asic also if present. 
-            for namespace_configdb in list(self.per_npu_configdb.values()):
+            for namespace_configdb in self.per_npu_configdb.values():
                 namespace_configdb.mod_entry(self.ACL_RULE, key, self.rules_info[key])
 
         added_controlplane_rules = new_controlplane_rules.difference(current_controlplane_rules)
@@ -649,14 +649,14 @@ class AclLoader(object):
             self.configdb.mod_entry(self.ACL_RULE, key, self.rules_info[key])
             # Program for per-asic namespace corresponding to front asic also if present. 
             # For control plane ACL it's not needed but to keep all db in sync program everywhere
-            for namespace_configdb in list(self.per_npu_configdb.values()):
+            for namespace_configdb in self.per_npu_configdb.values():
                 namespace_configdb.mod_entry(self.ACL_RULE, key, self.rules_info[key])
 
         for key in removed_controlplane_rules:
             self.configdb.mod_entry(self.ACL_RULE, key, None)
             # Program for per-asic namespace corresponding to front asic also if present. 
             # For control plane ACL it's not needed but to keep all db in sync program everywhere
-            for namespace_configdb in list(self.per_npu_configdb.values()):
+            for namespace_configdb in self.per_npu_configdb.values():
                 namespace_configdb.mod_entry(self.ACL_RULE, key, None)
 
         for key in existing_controlplane_rules:
@@ -664,7 +664,7 @@ class AclLoader(object):
                 self.configdb.set_entry(self.ACL_RULE, key, self.rules_info[key])
                 # Program for per-asic namespace corresponding to front asic also if present. 
                 # For control plane ACL it's not needed but to keep all db in sync program everywhere
-                for namespace_configdb in list(self.per_npu_configdb.values()):
+                for namespace_configdb in self.per_npu_configdb.values():
                     namespace_configdb.set_entry(self.ACL_RULE, key, self.rules_info[key])
 
     def delete(self, table=None, rule=None):
@@ -673,12 +673,12 @@ class AclLoader(object):
         :param rule:
         :return:
         """
-        for key in self.rules_db_info.keys():
+        for key in self.rules_db_info:
             if not table or table == key[0]:
                 if not rule or rule == key[1]:
                     self.configdb.set_entry(self.ACL_RULE, key, None)
                     # Program for per-asic namespace corresponding to front asic also if present. 
-                    for namespace_configdb in list(self.per_npu_configdb.values()):
+                    for namespace_configdb in self.per_npu_configdb.values():
                         namespace_configdb.set_entry(self.ACL_RULE, key, None)
     
     def show_table(self, table_name):

--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -545,7 +545,7 @@ class ConfigMgmtDPB(ConfigMgmt):
                     pass
                 return
 
-            for it in list(D1.keys()):
+            for it in D1:
                 # D2 has the key
                 if D2.get(it):
                     _mergeItems(D1[it], D2[it])
@@ -577,7 +577,7 @@ class ConfigMgmtDPB(ConfigMgmt):
         '''
         found = False
         if isinstance(In, dict):
-            for key in list(In.keys()):
+            for key in In:
                 for skey in skeys:
                     # pattern is very specific to current primary keys in
                     # config DB, may need to be updated later.

--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -545,7 +545,7 @@ class ConfigMgmtDPB(ConfigMgmt):
                     pass
                 return
 
-            for it in D1:
+            for it in D1.keys():
                 # D2 has the key
                 if D2.get(it):
                     _mergeItems(D1[it], D2[it])
@@ -577,7 +577,7 @@ class ConfigMgmtDPB(ConfigMgmt):
         '''
         found = False
         if isinstance(In, dict):
-            for key in In:
+            for key in In.keys():
                 for skey in skeys:
                     # pattern is very specific to current primary keys in
                     # config DB, may need to be updated later.

--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -545,7 +545,7 @@ class ConfigMgmtDPB(ConfigMgmt):
                     pass
                 return
 
-            for it in D1.keys():
+            for it in D1:
                 # D2 has the key
                 if D2.get(it):
                     _mergeItems(D1[it], D2[it])
@@ -577,7 +577,7 @@ class ConfigMgmtDPB(ConfigMgmt):
         '''
         found = False
         if isinstance(In, dict):
-            for key in In.keys():
+            for key in In:
                 for skey in skeys:
                     # pattern is very specific to current primary keys in
                     # config DB, may need to be updated later.

--- a/config/main.py
+++ b/config/main.py
@@ -94,7 +94,7 @@ def _get_breakout_options(ctx, args, incomplete):
 
 def shutdown_interfaces(ctx, del_intf_dict):
     """ shut down all the interfaces before deletion """
-    for intf in list(del_intf_dict.keys()):
+    for intf in del_intf_dict:
         config_db = ctx.obj['config_db']
         if clicommon.get_interface_naming_mode() == "alias":
             interface_name = interface_alias_to_name(config_db, intf)
@@ -295,7 +295,7 @@ def interface_alias_to_name(config_db, interface_alias):
         if not port_dict:
             click.echo("port_dict is None!")
             raise click.Abort()
-        for port_name in list(port_dict.keys()):
+        for port_name in port_dict:
             if interface_alias == port_dict[port_name]['alias']:
                 return port_name if sub_intf_sep_idx == -1 else port_name + VLAN_SUB_INTERFACE_SEPARATOR + vlan_id
 
@@ -326,15 +326,15 @@ def interface_name_is_valid(config_db, interface_name):
         if not port_dict:
             click.echo("port_dict is None!")
             raise click.Abort()
-        for port_name in list(port_dict.keys()):
+        for port_name in port_dict:
             if interface_name == port_name:
                 return True
         if port_channel_dict:
-            for port_channel_name in list(port_channel_dict.keys()):
+            for port_channel_name in port_channel_dict:
                 if interface_name == port_channel_name:
                     return True
         if sub_port_intf_dict:
-            for sub_port_intf_name in list(sub_port_intf_dict.keys()):
+            for sub_port_intf_name in sub_port_intf_dict:
                 if interface_name == sub_port_intf_name:
                     return True
     return False
@@ -357,7 +357,7 @@ def interface_name_to_alias(config_db, interface_name):
         if not port_dict:
             click.echo("port_dict is None!")
             raise click.Abort()
-        for port_name in list(port_dict.keys()):
+        for port_name in port_dict:
             if interface_name == port_name:
                 return port_dict[port_name]['alias']
 
@@ -410,7 +410,7 @@ def get_port_namespace(port):
         if clicommon.get_interface_naming_mode() == "alias":
             port_dict = config_db.get_table(table_name)
             if port_dict:
-                for port_name in list(port_dict.keys()):
+                for port_name in port_dict:
                     if port == port_dict[port_name]['alias']:
                         return namespace
         else:
@@ -427,7 +427,7 @@ def del_interface_bind_to_vrf(config_db, vrf_name):
     for table_name in tables:
         interface_dict = config_db.get_table(table_name)
         if interface_dict:
-            for interface_name in list(interface_dict.keys()):
+            for interface_name in interface_dict:
                 if 'vrf_name' in interface_dict[interface_name] and vrf_name == interface_dict[interface_name]['vrf_name']:
                     interface_dependent = interface_ipaddr_dependent_on_interface(config_db, interface_name)
                     for interface_del in interface_dependent:
@@ -459,7 +459,7 @@ def set_interface_naming_mode(mode):
         click.echo("port_dict is None!")
         raise click.Abort()
 
-    for port_name in list(port_dict.keys()):
+    for port_name in port_dict:
         try:
             if port_dict[port_name]['alias']:
                 pass
@@ -639,7 +639,7 @@ def _get_disabled_services_list(config_db):
 
     feature_table = config_db.get_table('FEATURE')
     if feature_table is not None:
-        for feature_name in list(feature_table.keys()):
+        for feature_name in feature_table:
             if not feature_name:
                 log.log_warning("Feature is None")
                 continue
@@ -751,7 +751,7 @@ def _restart_services(config_db):
 
 def interface_is_in_vlan(vlan_member_table, interface_name):
     """ Check if an interface is in a vlan """
-    for _, intf in list(vlan_member_table.keys()):
+    for _, intf in vlan_member_table:
         if intf == interface_name:
             return True
 
@@ -759,7 +759,7 @@ def interface_is_in_vlan(vlan_member_table, interface_name):
 
 def interface_is_in_portchannel(portchannel_member_table, interface_name):
     """ Check if an interface is part of portchannel """
-    for _, intf in list(portchannel_member_table.keys()):
+    for _, intf in portchannel_member_table:
         if intf == interface_name:
             return True
 
@@ -2124,17 +2124,17 @@ def startup(ctx, interface_name):
 
     log.log_info("'interface startup {}' executing...".format(interface_name))
     port_dict = config_db.get_table('PORT')
-    for port_name in list(port_dict.keys()):
+    for port_name in port_dict:
         if port_name in intf_fs:
             config_db.mod_entry("PORT", port_name, {"admin_status": "up"})
 
     portchannel_list = config_db.get_table("PORTCHANNEL")
-    for po_name in list(portchannel_list.keys()):
+    for po_name in portchannel_list:
         if po_name in intf_fs:
             config_db.mod_entry("PORTCHANNEL", po_name, {"admin_status": "up"})
 
     subport_list = config_db.get_table("VLAN_SUB_INTERFACE")
-    for sp_name in list(subport_list.keys()):
+    for sp_name in subport_list:
         if sp_name in intf_fs:
             config_db.mod_entry("VLAN_SUB_INTERFACE", sp_name, {"admin_status": "up"})
 
@@ -2164,17 +2164,17 @@ def shutdown(ctx, interface_name):
         ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
 
     port_dict = config_db.get_table('PORT')
-    for port_name in list(port_dict.keys()):
+    for port_name in port_dict:
         if port_name in intf_fs:
             config_db.mod_entry("PORT", port_name, {"admin_status": "down"})
 
     portchannel_list = config_db.get_table("PORTCHANNEL")
-    for po_name in list(portchannel_list.keys()):
+    for po_name in portchannel_list:
         if po_name in intf_fs:
             config_db.mod_entry("PORTCHANNEL", po_name, {"admin_status": "down"})
 
     subport_list = config_db.get_table("VLAN_SUB_INTERFACE")
-    for sp_name in list(subport_list.keys()):
+    for sp_name in subport_list:
         if sp_name in intf_fs:
             config_db.mod_entry("VLAN_SUB_INTERFACE", sp_name, {"admin_status": "down"})
 
@@ -2299,7 +2299,7 @@ def breakout(ctx, interface_name, mode, verbose, force_remove_dependencies, load
         cm = load_ConfigMgmt(verbose)
 
         """ Delete all ports if forced else print dependencies using ConfigMgmt API """
-        final_delPorts = [intf for intf in list(del_intf_dict.keys())]
+        final_delPorts = [intf for intf in del_intf_dict]
         """ Warn user if tables without yang models exist and have final_delPorts """
         breakout_warnUser_extraTables(cm, final_delPorts, confirm=True)
 

--- a/config/nat.py
+++ b/config/nat.py
@@ -107,7 +107,7 @@ def isOverlappingWithAnyDynamicEntry(ipAddress):
     if not nat_pool_dict:
         return False
 
-    for values in list(nat_pool_dict.values()):
+    for values in nat_pool_dict.values():
         global_ip = values["nat_ip"]
         ipAddr = global_ip.split('-')
         if (len(ipAddr) == 1):
@@ -604,7 +604,7 @@ def remove_static_all(ctx):
     for table_name in tables:
         table_dict = config_db.get_table(table_name)
         if table_dict:
-            for table_key_name in list(table_dict.keys()):
+            for table_key_name in table_dict:
                 config_db.set_entry(table_name, table_key_name, None)
 
 #
@@ -828,7 +828,7 @@ def remove_pools(ctx):
     binding_dict = config_db.get_table(binding_table_name)
     pool_dict = config_db.get_table(pool_table_name)
     if pool_dict:
-        for pool_key_name in list(pool_dict.keys()):
+        for pool_key_name in pool_dict:
             entryFound = False
             for binding_name, binding_values in binding_dict.items():
                 if binding_values['nat_pool'] == pool_key_name:
@@ -880,7 +880,7 @@ def remove_bindings(ctx):
     binding_table_name = 'NAT_BINDINGS'
     binding_dict = config_db.get_table(binding_table_name)
     if binding_dict:
-        for binding_key_name in list(binding_dict.keys()):
+        for binding_key_name in binding_dict:
             config_db.set_entry(binding_table_name, binding_key_name, None)
 
 #
@@ -961,7 +961,7 @@ def remove_interfaces(ctx):
     for table_name in tables:
         table_dict = config_db.get_table(table_name)
         if table_dict:
-            for table_key_name in list(table_dict.keys()):
+            for table_key_name in table_dict:
                 if isinstance(table_key_name, str) is False:
                     continue
 

--- a/fdbutil/filter_fdb_entries.py
+++ b/fdbutil/filter_fdb_entries.py
@@ -28,7 +28,7 @@ def get_vlan_cidr_map(filename):
 
     vlan_cidr = defaultdict()
     if "VLAN_INTERFACE" in config_db_entries and "VLAN" in config_db_entries:
-        for vlan_key in list(config_db_entries["VLAN_INTERFACE"].keys()):
+        for vlan_key in config_db_entries["VLAN_INTERFACE"]:
             if '|' not in vlan_key:
                 continue
             vlan, cidr = tuple(vlan_key.split('|'))

--- a/fwutil/lib.py
+++ b/fwutil/lib.py
@@ -518,7 +518,7 @@ class ComponentUpdateProvider(PlatformDataProvider):
                 )
             )
 
-        for key in list(pdp_map.keys()):
+        for key in pdp_map:
             diff_keys = self.__diff_keys(list(pdp_map[key].keys()), list(pcp_map[key].keys()))
 
             if diff_keys:

--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -86,14 +86,14 @@ def get_all_ports(db, namespace=None, display=constants.DISPLAY_ALL):
 def get_server_facing_ports(db):
     candidates = db.get_table('DEVICE_NEIGHBOR')
     server_facing_ports = []
-    for port in list(candidates.keys()):
+    for port in candidates:
         neighbor = db.get_entry(
             'DEVICE_NEIGHBOR_METADATA', candidates[port]['name']
         )
         if neighbor and neighbor['type'].lower() == 'server':
             server_facing_ports.append(port)
     if not server_facing_ports:
-        server_facing_ports = [p[1] for p in list(db.get_table('VLAN_MEMBER').keys())]
+        server_facing_ports = [p[1] for p in db.get_table('VLAN_MEMBER')]
     return server_facing_ports
 
 

--- a/scripts/aclshow
+++ b/scripts/aclshow
@@ -124,7 +124,7 @@ class AclStat(object):
             """
             Get ACL counters from the DB
             """
-            for table, rule in self.acl_rules.keys():
+            for table, rule in self.acl_rules:
                 cnt_props = lowercase_keys(self.db.get_all(self.db.COUNTERS_DB, "COUNTERS:%s:%s" % (table, rule)))
                 self.acl_counters[table, rule] = cnt_props
 
@@ -163,7 +163,7 @@ class AclStat(object):
 
         header = ACL_HEADER
         aclstat = []
-        for rule_key in self.acl_rules.keys():
+        for rule_key in self.acl_rules:
             if not display_all and (self.get_counter_value(rule_key, 'packets') == '0' or \
                     self.get_counter_value(rule_key, 'packets') == 'N/A'):
                 continue

--- a/scripts/configlet
+++ b/scripts/configlet
@@ -101,7 +101,7 @@ def db_update(t, k, lst):
     tuple_k = db.deserialize_key(k[0])
     if tuple_k in ct_keys:
         data = db.get_entry(t, k)
-        for i in lst.keys():
+        for i in lst:
             if not data.has_key(i) or data[i] != lst[i]:
                 to_upd = True
                 break
@@ -115,7 +115,7 @@ def db_delete_fields(t, k, lst):
     init()
     to_set = False
     data = db.get_entry(t, k)
-    for i in lst.keys():
+    for i in lst:
         if data.has_key(i):
             data.pop(i)
             to_set = True
@@ -172,7 +172,7 @@ def do_operate(op_upd, t, k, lst):
 
 
 def process_entry(op_upd, data):
-    for t in data.keys():
+    for t in data:
         do_operate(op_upd, t, (), data[t])
 
 def main():

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -63,7 +63,7 @@ class DBMigrator():
         Migrate all data entries from table PFC_WD_TABLE to PFC_WD
         '''
         data = self.configDB.get_table('PFC_WD_TABLE')
-        for key in list(data.keys()):
+        for key in data:
             self.configDB.set_entry('PFC_WD', key, data[key])
         self.configDB.delete_table('PFC_WD_TABLE')
 
@@ -91,14 +91,14 @@ class DBMigrator():
                     }
         for table in if_tables:
             data = self.configDB.get_table(table)
-            for key in list(data.keys()):
+            for key in data:
                 if not self.is_ip_prefix_in_key(key):
                     if_db.append(key)
                     continue
 
         for table in if_tables:
             data = self.configDB.get_table(table)
-            for key in list(data.keys()):
+            for key in data:
                 if not self.is_ip_prefix_in_key(key) or key[0] in if_db:
                     continue
                 log.log_info('Migrating interface table for ' + key[0])

--- a/scripts/fast-reboot-dump.py
+++ b/scripts/fast-reboot-dump.py
@@ -239,7 +239,7 @@ def send_garp_nd(neighbor_entries, map_mac_ip_per_vlan):
             send_ndp(sockets[src_if], src_mac_addrs[src_if], src_ip_addrs[vlan_name], dst_mac, dst_ip)
 
     # close the raw sockets
-    for s in list(sockets.values()):
+    for s in sockets.values():
         s.close()
 
     return

--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -50,7 +50,7 @@ SUB_PORT = "subport"
 def get_frontpanel_port_list(config_db):
     ports_dict = config_db.get_table('PORT')
     front_panel_ports_list = []
-    for port in ports_dict.keys():
+    for port in ports_dict:
         front_panel_ports_list.append(port)
     return front_panel_ports_list
 
@@ -58,7 +58,7 @@ def get_frontpanel_port_list(config_db):
 def get_sub_port_intf_list(config_db):
     sub_intf_dict = config_db.get_table('VLAN_SUB_INTERFACE')
     sub_intf_list = []
-    for sub_intf in sub_intf_dict.keys():
+    for sub_intf in sub_intf_dict:
         if isinstance(sub_intf, str):
             sub_intf_list.append(sub_intf)
     return sub_intf_list

--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -102,7 +102,7 @@ def is_dip_in_device_vlan(ferret_dip):
 
     ferret_dip = IPAddress(ferret_dip)
 
-    for vlan_interface in vlan_interface_query.keys():
+    for vlan_interface in vlan_interface_query:
         if not is_ip_prefix_in_key(vlan_interface):
             log.log_info('{} does not have a subnet, skipping...'.format(vlan_interface))
             continue
@@ -153,7 +153,7 @@ def get_loopback_addr(ip_ver):
     loopback_intfs = config_db.get_table('LOOPBACK_INTERFACE')
     loopback_addr = ''
 
-    for intf in loopback_intfs.keys():
+    for intf in loopback_intfs:
         if not is_ip_prefix_in_key(intf):
              continue
         if 'Loopback0' in intf:
@@ -170,7 +170,7 @@ def get_vlan_interfaces():
     vlan_info = config_db.get_table('VLAN')
     vlan_interfaces = []
 
-    for vlan_name in vlan_info.keys():
+    for vlan_name in vlan_info:
         vlan_interfaces.append(vlan_name)
 
     return vlan_interfaces
@@ -180,7 +180,7 @@ def get_vlan_interface_members(vlan_intf_name):
     vlan_info = config_db.get_table('VLAN_MEMBER')
     vlan_interface_members = []
 
-    for vlan_member in vlan_info.keys():
+    for vlan_member in vlan_info:
         if vlan_member[0] == vlan_intf_name:
             vlan_interface_members.append(vlan_member[1])
 
@@ -211,7 +211,7 @@ def get_vlan_addr_prefix(vlan_intf_name, ip_ver):
     vlan_addr = []
     vlan_prefix = []
 
-    for intf in vlan_intfs.keys():
+    for intf in vlan_intfs:
         if not is_ip_prefix_in_key(intf):
              continue
         if vlan_intf_name in intf:

--- a/scripts/pcmping
+++ b/scripts/pcmping
@@ -101,7 +101,7 @@ def get_portchannel_ipv4(portchannel_name):
     configdb.connect()
     config = configdb.get_config()
     portchannel_interfaces = config["PORTCHANNEL_INTERFACE"]
-    for key in portchannel_interfaces.keys():
+    for key in portchannel_interfaces:
         if not is_ip_prefix_in_key(key):
             continue
         pc, ip = key

--- a/scripts/sonic_sku_create.py
+++ b/scripts/sonic_sku_create.py
@@ -605,7 +605,7 @@ class SkuCreate(object):
             exit(1)
         header = PORTCONFIG_HEADER # ["name", "lanes", "alias", "index"]
         port_config = []
-        for line in list(self.portconfig_dict.values()):
+        for line in self.portconfig_dict.values():
             port_config.append(line)
 
         port_config.sort(key=lambda x: (int(re.search(('\d+'),x[0]).group(0)))) # sort the list with interface name
@@ -616,7 +616,7 @@ class SkuCreate(object):
         #print a port_config.ini file based on the sku definition 
         header = PORTCONFIG_HEADER # ["name", "lanes", "alias", "index"]
         port_config = []
-        for line in list(self.portconfig_dict.values()):
+        for line in self.portconfig_dict.values():
             port_config.append(line)
 
         port_config.sort(key=lambda x: (int(re.search(('\d+'),x[0]).group(0)))) # sort the list with interface name

--- a/scripts/update_json.py
+++ b/scripts/update_json.py
@@ -8,7 +8,7 @@ TMP_SUFFIX = ".tmp"
 BAK_SUFFIX = ".bak"
 
 def dict_update(dst, patch):
-    for k in list(patch.keys()):
+    for k in patch:
         if type(patch[k]) == dict:
             dst[k] = dict_update(dst[k], patch[k])
         else:

--- a/show/fgnhg.py
+++ b/show/fgnhg.py
@@ -41,7 +41,7 @@ def active_hops(nhg):
     if nhg is None:
         for nhg_prefix in table_keys:
             t_dict = state_db.get_all(state_db.STATE_DB, nhg_prefix)
-            vals = sorted(set([val for val in list(t_dict.values())]))
+            vals = sorted(set([val for val in t_dict.values()]))
             for nh_ip in vals:
                 if nhg_prefix in output_dict:
                     output_dict[nhg_prefix].append(nh_ip.split("@")[0])
@@ -69,7 +69,7 @@ def active_hops(nhg):
                     nhg_prefix = "FG_ROUTE_TABLE|" + nhg_prefix
                     t_dict = state_db.get_all(state_db.STATE_DB, nhg_prefix)
 
-                vals = sorted(set([val for val in list(t_dict.values())]))
+                vals = sorted(set([val for val in t_dict.values()]))
 
                 for nh_ip in vals:
                     if nhg_prefix in output_dict:
@@ -113,7 +113,7 @@ def hash_view(nhg):
         for nhg_prefix in table_keys:
             bank_dict = {}
             t_dict = state_db.get_all(state_db.STATE_DB, nhg_prefix)
-            vals = sorted(set([val for val in list(t_dict.values())]))
+            vals = sorted(set([val for val in t_dict.values()]))
 
             for nh_ip in vals:
                 bank_ids = sorted([int(k) for k, v in t_dict.items() if v == nh_ip])
@@ -150,7 +150,7 @@ def hash_view(nhg):
                     nhg_prefix = "FG_ROUTE_TABLE|" + nhg_prefix
                     t_dict = state_db.get_all(state_db.STATE_DB, nhg_prefix)
 
-                vals = sorted(set([val for val in list(t_dict.values())]))
+                vals = sorted(set([val for val in t_dict.values()]))
 
                 for nh_ip in vals:
                     bank_ids = sorted([int(k) for k, v in t_dict.items() if v == nh_ip])

--- a/show/fgnhg.py
+++ b/show/fgnhg.py
@@ -41,7 +41,7 @@ def active_hops(nhg):
     if nhg is None:
         for nhg_prefix in table_keys:
             t_dict = state_db.get_all(state_db.STATE_DB, nhg_prefix)
-            vals = sorted(t_dict.values())
+            vals = sorted(set([val for val in t_dict.values()]))
             for nh_ip in vals:
                 if nhg_prefix in output_dict:
                     output_dict[nhg_prefix].append(nh_ip.split("@")[0])
@@ -69,7 +69,7 @@ def active_hops(nhg):
                     nhg_prefix = "FG_ROUTE_TABLE|" + nhg_prefix
                     t_dict = state_db.get_all(state_db.STATE_DB, nhg_prefix)
 
-                vals = sorted(t_dict.values())
+                vals = sorted(set([val for val in t_dict.values()]))
 
                 for nh_ip in vals:
                     if nhg_prefix in output_dict:
@@ -113,7 +113,7 @@ def hash_view(nhg):
         for nhg_prefix in table_keys:
             bank_dict = {}
             t_dict = state_db.get_all(state_db.STATE_DB, nhg_prefix)
-            vals = sorted(t_dict.values())
+            vals = sorted(set([val for val in t_dict.values()]))
 
             for nh_ip in vals:
                 bank_ids = sorted([int(k) for k, v in t_dict.items() if v == nh_ip])
@@ -150,7 +150,7 @@ def hash_view(nhg):
                     nhg_prefix = "FG_ROUTE_TABLE|" + nhg_prefix
                     t_dict = state_db.get_all(state_db.STATE_DB, nhg_prefix)
 
-                vals = sorted(t_dict.values())
+                vals = sorted(set([val for val in t_dict.values()]))
 
                 for nh_ip in vals:
                     bank_ids = sorted([int(k) for k, v in t_dict.items() if v == nh_ip])

--- a/show/fgnhg.py
+++ b/show/fgnhg.py
@@ -41,7 +41,7 @@ def active_hops(nhg):
     if nhg is None:
         for nhg_prefix in table_keys:
             t_dict = state_db.get_all(state_db.STATE_DB, nhg_prefix)
-            vals = sorted(set([val for val in t_dict.values()]))
+            vals = sorted(t_dict.values())
             for nh_ip in vals:
                 if nhg_prefix in output_dict:
                     output_dict[nhg_prefix].append(nh_ip.split("@")[0])
@@ -69,7 +69,7 @@ def active_hops(nhg):
                     nhg_prefix = "FG_ROUTE_TABLE|" + nhg_prefix
                     t_dict = state_db.get_all(state_db.STATE_DB, nhg_prefix)
 
-                vals = sorted(set([val for val in t_dict.values()]))
+                vals = sorted(t_dict.values())
 
                 for nh_ip in vals:
                     if nhg_prefix in output_dict:
@@ -113,7 +113,7 @@ def hash_view(nhg):
         for nhg_prefix in table_keys:
             bank_dict = {}
             t_dict = state_db.get_all(state_db.STATE_DB, nhg_prefix)
-            vals = sorted(set([val for val in t_dict.values()]))
+            vals = sorted(t_dict.values())
 
             for nh_ip in vals:
                 bank_ids = sorted([int(k) for k, v in t_dict.items() if v == nh_ip])
@@ -150,7 +150,7 @@ def hash_view(nhg):
                     nhg_prefix = "FG_ROUTE_TABLE|" + nhg_prefix
                     t_dict = state_db.get_all(state_db.STATE_DB, nhg_prefix)
 
-                vals = sorted(set([val for val in t_dict.values()]))
+                vals = sorted(t_dict.values())
 
                 for nh_ip in vals:
                     bank_ids = sorted([int(k) for k, v in t_dict.items() if v == nh_ip])

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -153,7 +153,7 @@ def breakout(ctx):
             click.echo("Can not load port config from {} or {} file".format(PLATFORM_JSON, HWSKU_JSON))
             raise click.Abort()
 
-        for port_name in list(platform_dict.keys()):
+        for port_name in platform_dict:
             cur_brkout_mode = cur_brkout_tbl[port_name]["brkout_mode"]
 
             # Update deafult breakout mode and current breakout mode to platform_dict

--- a/show/main.py
+++ b/show/main.py
@@ -146,7 +146,7 @@ def get_interface_bind_to_vrf(config_db, vrf_name):
     for table_name in tables:
         interface_dict = config_db.get_table(table_name)
         if interface_dict:
-            for interface in list(interface_dict.keys()):
+            for interface in interface_dict:
                 if 'vrf_name' in interface_dict[interface] and vrf_name == interface_dict[interface]['vrf_name']:
                     data.append(interface)
     return data
@@ -305,7 +305,7 @@ def snmpagentaddress (ctx):
 
     header = ['ListenIP', 'ListenPort', 'ListenVrf']
     body = []
-    for agent in list(agenttable.keys()):
+    for agent in agenttable:
         body.append([agent[0], agent[1], agent[2]])
     click.echo(tabulate(body, header))
 
@@ -323,7 +323,7 @@ def snmptrap (ctx):
 
     header = ['Version', 'TrapReceiverIP', 'Port', 'VRF', 'Community']
     body = []
-    for row in list(traptable.keys()):
+    for row in traptable:
         if row == "v1TrapDest":
             ver=1
         elif row == "v2TrapDest":
@@ -777,7 +777,7 @@ def get_bgp_peer():
 
     for table in bgp_neighbor_tables:
         data = config_db.get_table(table)
-        for neighbor_ip in list(data.keys()):
+        for neighbor_ip in data:
             local_addr = data[neighbor_ip]['local_addr']
             neighbor_name = data[neighbor_ip]['name']
             bgp_peer.setdefault(local_addr, [neighbor_name, neighbor_ip])
@@ -1684,7 +1684,7 @@ def show_sflow_global(config_db):
 
     sflow_info = config_db.get_table('SFLOW_COLLECTOR')
     click.echo("\n  {} Collectors configured:".format(len(sflow_info)))
-    for collector_name in sorted(sflow_info.keys()):
+    for collector_name in sorted(list(sflow_info.keys())):
         vrf_name = (sflow_info[collector_name]['collector_vrf']
                     if 'collector_vrf' in sflow_info[collector_name] else 'default')
         click.echo("    Name: {}".format(collector_name).ljust(30) +

--- a/show/vlan.py
+++ b/show/vlan.py
@@ -39,7 +39,7 @@ def brief(db, verbose):
             vlan_dhcp_helper_dict[key.strip('Vlan')] = " "
 
     # Parsing VLAN Gateway info
-    for key in list(vlan_ip_data.keys()):
+    for key in vlan_ip_data:
         if clicommon.is_ip_prefix_in_key(key):
             interface_key = key[0].strip("Vlan")
             interface_value = key[1]

--- a/tests/config_mgmt_test.py
+++ b/tests/config_mgmt_test.py
@@ -45,13 +45,13 @@ class TestConfigMgmt(TestCase):
             ["Ethernet8","Ethernet9"])
         assert "VLAN" not in out
         assert "INTERFACE" not in out
-        for k in list(out['ACL_TABLE'].keys()):
+        for k in out['ACL_TABLE']:
             # only ports must be chosen
             len(out['ACL_TABLE'][k]) == 1
         out = cmdpb.configWithKeys(portBreakOutConfigDbJson, \
             ["Ethernet10","Ethernet11"])
         assert "INTERFACE" in out
-        for k in list(out['ACL_TABLE'].keys()):
+        for k in out['ACL_TABLE']:
             # only ports must be chosen
             len(out['ACL_TABLE'][k]) == 1
         return
@@ -173,7 +173,7 @@ class TestConfigMgmt(TestCase):
             conf will be updated with uconf, i.e. config diff.
         '''
         try:
-            for it in list(uconf.keys()):
+            for it in uconf:
                 # if conf has the key
                 if conf.get(it):
                     # if marked for deletion

--- a/tests/config_mgmt_test.py
+++ b/tests/config_mgmt_test.py
@@ -173,7 +173,7 @@ class TestConfigMgmt(TestCase):
             conf will be updated with uconf, i.e. config diff.
         '''
         try:
-            for it in uconf:
+            for it in list(uconf.keys()):
                 # if conf has the key
                 if conf.get(it):
                     # if marked for deletion

--- a/tests/mock_tables/dbconnector.py
+++ b/tests/mock_tables/dbconnector.py
@@ -144,7 +144,7 @@ class SwssSyncClient(mockredis.MockRedis):
         regex = re.compile(regex)
 
         # Find every key that matches the pattern
-        return [key for key in list(self.redis.keys()) if regex.match(key)]
+        return [key for key in self.redis if regex.match(key)]
 
 
 swsssdk.interface.DBInterface._subscribe_keyspace_notification = _subscribe_keyspace_notification

--- a/utilities_common/bgp_util.py
+++ b/utilities_common/bgp_util.py
@@ -47,7 +47,7 @@ def get_dynamic_neighbor_subnet(db):
     v6_subnet = {}
     neighbor_data = db.get_table('BGP_PEER_RANGE')
     try:
-        for entry in list(neighbor_data.keys()):
+        for entry in neighbor_data:
             new_key = neighbor_data[entry]['ip_range'][0]
             new_value = neighbor_data[entry]['name']
             if is_ipv4_address(neighbor_data[entry]['src_address']):
@@ -88,11 +88,11 @@ def get_bgp_neighbor_ip_to_name(ip, static_neighbors, dynamic_neighbors):
     if ip in static_neighbors:
         return static_neighbors[ip]
     elif is_ipv4_address(ip):
-        for subnet in list(dynamic_neighbors[constants.IPV4].keys()):
+        for subnet in dynamic_neighbors[constants.IPV4]:
             if ipaddress.IPv4Address(ip) in ipaddress.IPv4Network(subnet):
                 return dynamic_neighbors[constants.IPV4][subnet]
     elif is_ipv6_address(ip):
-        for subnet in list(dynamic_neighbors[constants.IPV6].keys()):
+        for subnet in dynamic_neighbors[constants.IPV6]:
             if ipaddress.IPv6Address(ip) in ipaddress.IPv6Network(subnet):
                 return dynamic_neighbors[constants.IPV6][subnet]
     else:
@@ -139,7 +139,7 @@ def get_neighbor_dict_from_table(db, table_name):
     neighbor_dict = {}
     neighbor_data = db.get_table(table_name)
     try:
-        for entry in list(neighbor_data.keys()):
+        for entry in neighbor_data:
             neighbor_dict[entry] = neighbor_data[entry].get(
                 'name') if 'name' in neighbor_data[entry] else 'NotAvailable'
         return neighbor_dict
@@ -209,7 +209,7 @@ def display_bgp_summary(bgp_summary, af):
         click.echo("\nIP{} Unicast Summary:".format(af))
         # display the bgp instance information
         for router_info in bgp_summary['router_info']:
-            for k in list(router_info.keys()):
+            for k in router_info:
                 v = router_info[k]
                 instance = "{}: ".format(k) if k is not "" else ""
                 click.echo(

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -130,7 +130,7 @@ class InterfaceAliasConverter(object):
             click.echo(message="Warning: failed to retrieve PORT table from ConfigDB!", err=True)
             self.port_dict = {}
 
-        for port_name in list(self.port_dict.keys()):
+        for port_name in self.port_dict:
             try:
                 if self.alias_max_length < len(
                         self.port_dict[port_name]['alias']):
@@ -152,7 +152,7 @@ class InterfaceAliasConverter(object):
                 # interface_name holds the parent port name
                 interface_name = interface_name[:sub_intf_sep_idx]
 
-            for port_name in list(self.port_dict.keys()):
+            for port_name in self.port_dict:
                 if interface_name == port_name:
                     return self.port_dict[port_name]['alias'] if sub_intf_sep_idx == -1 \
                             else self.port_dict[port_name]['alias'] + VLAN_SUB_INTERFACE_SEPARATOR + vlan_id
@@ -173,7 +173,7 @@ class InterfaceAliasConverter(object):
                 # interface_alias holds the parent port alias
                 interface_alias = interface_alias[:sub_intf_sep_idx]
 
-            for port_name in list(self.port_dict.keys()):
+            for port_name in self.port_dict:
                 if interface_alias == self.port_dict[port_name]['alias']:
                     return port_name if sub_intf_sep_idx == -1 else port_name + VLAN_SUB_INTERFACE_SEPARATOR + vlan_id
 
@@ -246,7 +246,7 @@ def is_port_vlan_member(config_db, port, vlan):
     """Check if port is a member of vlan"""
 
     vlan_ports_data = config_db.get_table('VLAN_MEMBER')
-    for key in list(vlan_ports_data.keys()):
+    for key in vlan_ports_data:
         if key[0] == vlan and key[1] == port:
             return True
 
@@ -254,7 +254,7 @@ def is_port_vlan_member(config_db, port, vlan):
 
 def interface_is_in_vlan(vlan_member_table, interface_name):
     """ Check if an interface  is in a vlan """
-    for _,intf in list(vlan_member_table.keys()):
+    for _,intf in vlan_member_table:
         if intf == interface_name:
             return True
 
@@ -266,7 +266,7 @@ def is_valid_vlan_interface(config_db, interface):
 
 def interface_is_in_portchannel(portchannel_member_table, interface_name):
     """ Check if an interface is part of portchannel """
-    for _,intf in list(portchannel_member_table.keys()):
+    for _,intf in portchannel_member_table:
         if intf == interface_name:
             return True
 
@@ -276,7 +276,7 @@ def is_port_router_interface(config_db, port):
     """Check if port is a router interface"""
 
     interface_table = config_db.get_table('INTERFACE')
-    for intf in list(interface_table.keys()):
+    for intf in interface_table:
         if port == intf[0]:
             return True
 
@@ -286,7 +286,7 @@ def is_pc_router_interface(config_db, pc):
     """Check if portchannel is a router interface"""
 
     pc_interface_table = config_db.get_table('PORTCHANNEL_INTERFACE')
-    for intf in list(pc_interface_table.keys()):
+    for intf in pc_interface_table:
         if pc == intf[0]:
             return True
 
@@ -446,7 +446,7 @@ def run_command_in_alias_mode(command):
                 or a comma followed by whitespace
                 """
                 converted_output = raw_output
-                for port_name in list(iface_alias_converter.port_dict.keys()):
+                for port_name in iface_alias_converter.port_dict:
                     converted_output = re.sub(r"(^|\s){}($|,{{0,1}}\s)".format(port_name),
                             r"\1{}\2".format(iface_alias_converter.name_to_alias(port_name)),
                             converted_output)


### PR DESCRIPTION
**- What I did**

After conversion to Python 3 using the 2to3 tool, all calls to `dict.keys()` and `dict.values()` were converted to lists. In the instances where the returned view objects from these calls are iterated over, there is no need to convert to a list, so I removed those.

Also, when iterating over the keys of a dictionary, one need not call `dict.keys()`, one can simply iterate over the dictionary as `for key in dict:`, so I cleaned those up as well.

Also remove some unnecessary parentheses.