### PR TITLE
[config_mgmt.py]: Remove sort_data call, we do not need it now.

### DIFF
--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -20,7 +20,7 @@ try:
     # Using load_source to 'import /usr/local/bin/sonic-cfggen as sonic_cfggen'
     # since /usr/local/bin/sonic-cfggen does not have .py extension.
     load_source('sonic_cfggen', '/usr/local/bin/sonic-cfggen')
-    from sonic_cfggen import deep_update, FormatConverter, sort_data
+    from sonic_cfggen import deep_update, FormatConverter
 
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
@@ -213,7 +213,6 @@ class ConfigMgmt():
         configdb = ConfigDBConnector(**db_kwargs)
         configdb.connect(False)
         deep_update(data, FormatConverter.to_deserialized(jDiff))
-        data = sort_data(data)
         self.sysLog(msg="Write in DB: {}".format(data))
         configdb.mod_config(FormatConverter.output_to_db(data))
 


### PR DESCRIPTION
[config_mgmt.py]: Remove sort_data call, we do not need it now.

Backend handles unsorted Port creation.

Signed-off-by: Praveen Chaudhary<pchaudhary@linkedin.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
[config_mgmt.py]: Remove sort_data call, we do not need it now.

**- How I did it**
[config_mgmt.py]: Remove sort_data call, we do not need it now.

**- How to verify it**
Build the PKG.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

