### PR TITLE
[configlet][portconfig] Remove calls to dict.has_key() which is not available in Python 3

### DIFF
--- a/scripts/configlet
+++ b/scripts/configlet
@@ -102,7 +102,7 @@ def db_update(t, k, lst):
     if tuple_k in ct_keys:
         data = db.get_entry(t, k)
         for i in lst:
-            if not data.has_key(i) or data[i] != lst[i]:
+            if i not in data or data[i] != lst[i]:
                 to_upd = True
                 break
     else:
@@ -116,7 +116,7 @@ def db_delete_fields(t, k, lst):
     to_set = False
     data = db.get_entry(t, k)
     for i in lst:
-        if data.has_key(i):
+        if i in data:
             data.pop(i)
             to_set = True
 

--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -42,13 +42,13 @@ class portconfig(object):
 
         # check whether table for this port exists
         port_tables = self.db.get_table(PORT_TABLE_NAME)
-        if not port_tables.has_key(port):
+        if port not in port_tables:
             raise Exception("Invalid port specified")
 
     def list_params(self, port):
         # chack whether table for this port exists
         port_tables = self.db.get_table(PORT_TABLE_NAME)
-        if port_tables.has_key(port):
+        if port in port_tables:
             print(port_tables[port])
 
     def set_speed(self, port, speed):


### PR DESCRIPTION
Replace calls to `dict.has_key()` with `in`. It appears the `2to3` tool missed these.