### PR TITLE
Modify fast-reboot script to use teamd service script

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -521,17 +521,7 @@ docker kill lldp &> /dev/null || debug "Docker lldp is not running ($?) ..."
 systemctl stop lldp
 
 if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
-    # Kill teamd processes inside of teamd container with SIGUSR2 to allow them to send last LACP frames
-    # We call `docker kill teamd` to ensure the container stops as quickly as possible,
-    # then immediately call `systemctl stop teamd` to prevent the service from
-    # restarting the container automatically.
-    # Note: teamd must be killed before syncd, because it will send the last packet through CPU port
     debug "Stopping teamd ..."
-    docker exec -i teamd pkill -USR2 teamd || [ $? == 1 ]
-    while docker exec -i teamd pgrep teamd > /dev/null; do
-      sleep 0.05
-    done
-    docker kill teamd &> /dev/null || debug "Docker teamd is not running ($?) ..."
     systemctl stop teamd
     debug "Stopped teamd ..."
 fi
@@ -540,8 +530,8 @@ debug "Stopping swss service ..."
 systemctl stop swss
 debug "Stopped swss service ..."
 
-# Pre-shutdown syncd
 if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; then
+    # Pre-shutdown syncd
     initialize_pre_shutdown
 
     BEFORE_PRE_SHUTDOWN=true
@@ -568,15 +558,10 @@ if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; t
     # TODO: backup_database preserves FDB_TABLE
     # need to cleanup as well for fastfast boot case
     backup_database
-fi
 
-# Stop teamd gracefully
-if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; then
+    # Stop teamd gracefully
     debug "Stopping teamd ..."
-    # Send USR1 signal to all teamd instances to stop them
-    # It will prepare teamd for warm-reboot
-    # Note: We must send USR1 signal before syncd, because it will send the last packet through CPU port
-    docker exec -i teamd pkill -USR1 teamd > /dev/null || [ $? == 1 ]
+    systemctl stop teamd
     debug "Stopped  teamd ..."
 fi
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
A new `teamd` service script has been added in `sonic-buildimage` as part of the PR - https://github.com/Azure/sonic-buildimage/pull/5163

With this change, fast-reboot script will now use the new `teamd` script to handle killing teamd docker in both fast-boot and warm-boot mode.

**- How I did it**
Replaced the existing teamd docker handling with the `systemctl stop teamd`.

**- How to verify it**
Tested the locally modified script in a DUT for `warm-reboot` and `fast-reboot`:

`warm-reboot` teamd shutdown path:
```
Nov 19 23:15:01.073902 str-7260cx3-acs-7 NOTICE admin: Stopping teamd ...
Nov 19 23:15:01.080848 str-7260cx3-acs-7 INFO systemd[1]: Stopping TEAMD container...
Nov 19 23:15:01.086341 str-7260cx3-acs-7 NOTICE admin: Stopping teamd service...
Nov 19 23:15:01.278733 str-7260cx3-acs-7 NOTICE admin: Warm boot flag: teamd true.
Nov 19 23:15:01.284320 str-7260cx3-acs-7 NOTICE admin: Fast boot flag: teamd false.
Nov 19 23:15:01.434833 str-7260cx3-acs-7 INFO teamd#supervisor-proc-exit-listener: Process tlm_teamd exited unxepectedly. Terminating supervisor...
Nov 19 23:15:02.435935 str-7260cx3-acs-7 NOTICE teamd#teamsyncd: :- cleanTeamSync: Cleaning up LAG teamd resources ...
Nov 19 23:15:02.437795 str-7260cx3-acs-7 NOTICE teamd#teamsyncd: :- main: Received SIGTERM Exiting
Nov 19 23:15:04.442791 str-7260cx3-acs-7 NOTICE teamd#teammgrd: :- cleanTeamProcesses: Cleaning up LAGs during shutdown...
Nov 19 23:15:04.448515 str-7260cx3-acs-7 INFO teamd#supervisord: teammgrd Daemon not running
Nov 19 23:15:04.449084 str-7260cx3-acs-7 ERR teamd#teammgrd: :- main: Runtime error: /usr/bin/teamd -k -t "PortChannel0001" :
Nov 19 23:15:05.602317 str-7260cx3-acs-7 INFO containerd[522]: time="2020-11-19T23:15:05.601120455Z" level=info msg="shim reaped" id=db0414c94fd3a8ad150850d0e528644ba842c3c2b818cb4b21d3b53aac281d54
Nov 19 23:15:05.611856 str-7260cx3-acs-7 INFO dockerd[639]: time="2020-11-19T23:15:05.610844787Z" level=info msg="ignoring event" module=libcontainerd namespace=moby topic=/tasks/delete type="*events.TaskDelete"
Nov 19 23:15:05.627398 str-7260cx3-acs-7 INFO systemd[1]: var-lib-docker-containers-db0414c94fd3a8ad150850d0e528644ba842c3c2b818cb4b21d3b53aac281d54-mounts-shm.mount: Succeeded.
Nov 19 23:15:05.640344 str-7260cx3-acs-7 INFO systemd[1]: var-lib-docker-overlay2-daea42184e4b9e86cd4c1ed9e616d38378c199a77c432d571bdc5057724ae89a-merged.mount: Succeeded.
Nov 19 23:15:05.820798 str-7260cx3-acs-7 INFO teamd.sh[11184]: teamd
Nov 19 23:15:05.821947 str-7260cx3-acs-7 INFO teamd.sh[1926]: 0
Nov 19 23:15:05.827080 str-7260cx3-acs-7 NOTICE admin: Stopped teamd service...
Nov 19 23:15:05.830923 str-7260cx3-acs-7 INFO systemd[1]: teamd.service: Succeeded.
Nov 19 23:15:05.831685 str-7260cx3-acs-7 INFO systemd[1]: Stopped TEAMD container.
Nov 19 23:15:05.837243 str-7260cx3-acs-7 NOTICE admin: Stopped  teamd ...
```

`fast-reboot` teamd shutdown path:
```
Nov 19 23:34:36.180300 str-7260cx3-acs-7 NOTICE admin: Stopping teamd ...
Nov 19 23:34:36.186619 str-7260cx3-acs-7 INFO systemd[1]: Stopping TEAMD container...
Nov 19 23:34:36.192215 str-7260cx3-acs-7 NOTICE admin: Stopping teamd service...
Nov 19 23:34:36.414572 str-7260cx3-acs-7 NOTICE admin: Warm boot flag: teamd false.
Nov 19 23:34:36.421209 str-7260cx3-acs-7 NOTICE admin: Fast boot flag: teamd true.
Nov 19 23:34:36.597069 str-7260cx3-acs-7 INFO teamd#supervisor-proc-exit-listener: Process tlm_teamd exited unxepectedly. Terminating supervisor...
Nov 19 23:34:36.906270 str-7260cx3-acs-7 INFO containerd[485]: time="2020-11-19T23:34:36.906148279Z" level=info msg="shim reaped" id=db0414c94fd3a8ad150850d0e528644ba842c3c2b818cb4b21d3b53aac281d54
Nov 19 23:34:36.916315 str-7260cx3-acs-7 INFO dockerd[649]: time="2020-11-19T23:34:36.916203497Z" level=info msg="ignoring event" module=libcontainerd namespace=moby topic=/tasks/delete type="*events.TaskDelete"
Nov 19 23:34:36.933087 str-7260cx3-acs-7 INFO systemd[1]: var-lib-docker-containers-db0414c94fd3a8ad150850d0e528644ba842c3c2b818cb4b21d3b53aac281d54-mounts-shm.mount: Succeeded.
Nov 19 23:34:36.962163 str-7260cx3-acs-7 INFO systemd[1]: var-lib-docker-overlay2-daea42184e4b9e86cd4c1ed9e616d38378c199a77c432d571bdc5057724ae89a-merged.mount: Succeeded.
Nov 19 23:34:37.011012 str-7260cx3-acs-7 INFO teamd.sh[1977]: 137
Nov 19 23:34:37.064579 str-7260cx3-acs-7 INFO teamd.sh[10294]: teamd
Nov 19 23:34:37.069420 str-7260cx3-acs-7 NOTICE admin: Stopped teamd service...
Nov 19 23:34:37.073007 str-7260cx3-acs-7 INFO systemd[1]: teamd.service: Succeeded.
Nov 19 23:34:37.075058 str-7260cx3-acs-7 INFO systemd[1]: Stopped TEAMD container.
Nov 19 23:34:37.082920 str-7260cx3-acs-7 NOTICE admin: Stopped teamd ...
```


**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

