### PR TITLE
Fix bug "Observing the binding field is not proper while executing "show acl table" command"

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -707,7 +707,10 @@ class AclLoader(object):
                 if not val["ports"]:
                     data.append([key, val["type"], "", val["policy_desc"], stage])
                 else:
-                    ports = natsorted(val["ports"])
+                    if isinstance(val['ports'], str):
+                        ports = [val['ports']]
+                    else:
+                        ports = natsorted(val["ports"])
                     data.append([key, val["type"], ports[0], val["policy_desc"], stage])
 
                     if len(ports) > 1:


### PR DESCRIPTION
Observing the binding field is not proper while
executing "show acl table" command
https://github.com/Azure/SONiC/issues/305

Signed-off-by: Valerii Zhelezniakov <valeriy.zheleznyakov@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Fixed the bug "Observing the binding field is not proper while executing "show acl table" command"
#https://github.com/Azure/SONiC/issues/305

**- How I did it**
Added changes to the function show_table in acl_lader.
Added the checking of a value type for the ports. If the value is a string then we print it as is in other cases we split and sort the values.

**- How to verify it**
Follow the description in the bug.
1.Create an acl :

"ACL_TABLE": {
    "1": {
        "stage": "INGRESS",
        "type": "MIRROR",
        "policy_desc": "Mirror Session",
        "ports": "Ethernet16"
        }
}

2. Reload configuration
3. Perform "show acl table" and check that output is correct

**- Previous command output (if the output of a command-line utility has changed)**

`$ show acl table`

`Name    Type    Binding    Description     Stage
------  ------  ---------  --------------  -------
1       MIRROR  1          Mirror Session  ingress
                6
                E
                e
                e
                h
                n
                r
                t
                t
`

**- New command output (if the output of a command-line utility has changed)**
`$ show acl table

  Name  Type    Binding     Description     Stage
------  ------  ---------  --------------  -------
     1  MIRROR  Ethernet16  Mirror Session  ingress`
