### PR TITLE
[dropcounters] Fix clear for non-root users

### DIFF
--- a/scripts/dropstat
+++ b/scripts/dropstat
@@ -30,7 +30,8 @@ try:
         sys.path.insert(0, modules_path)
         sys.path.insert(0, test_path)
         import mock_tables.dbconnector
-        socket.gethostname = lambda : 'sonic_drops_test'
+        socket.gethostname = lambda: 'sonic_drops_test'
+        os.getuid = lambda: 27
 except KeyError:
     pass
 
@@ -75,8 +76,10 @@ std_port_headers_map = {
 # Standard Switch-Level Headers
 std_switch_description_header = ['DEVICE']
 
-# Bookkeeping Files
-dropstat_dir = '/tmp/dropstat/'
+
+def get_dropstat_dir():
+    dropstat_dir_prefix = '/tmp/dropstat'
+    return "{}-{}/".format(dropstat_dir_prefix, os.getuid())
 
 
 class DropStat(object):
@@ -89,8 +92,9 @@ class DropStat(object):
         self.db.connect(self.db.ASIC_DB)
         self.db.connect(self.db.APPL_DB)
 
-        self.port_drop_stats_file = os.path.join(dropstat_dir, 'port-stats-{}'.format(os.getuid()))
-        self.switch_drop_stats_file = os.path.join(dropstat_dir + 'switch-stats-{}'.format(os.getuid()))
+        dropstat_dir = get_dropstat_dir()
+        self.port_drop_stats_file = os.path.join(dropstat_dir, 'port-stats')
+        self.switch_drop_stats_file = os.path.join(dropstat_dir + 'switch-stats')
 
         self.stat_lookup = {}
         self.reverse_stat_lookup = {}
@@ -405,6 +409,8 @@ Examples:
     group = args.group
     counter_type = args.type
 
+    dropstat_dir = get_dropstat_dir()
+
     # Create the directory to hold clear results
     if not os.path.exists(dropstat_dir):
         try:
@@ -421,6 +427,7 @@ Examples:
         dcstat.show_drop_counts(group, counter_type)
     else:
         print("Command not recognized")
+
 
 if __name__ == '__main__':
     main()

--- a/tests/drops_group_test.py
+++ b/tests/drops_group_test.py
@@ -83,7 +83,7 @@ Ethernet8      N/A         0           0         0           0          0       
 sonic_drops_test               0                    0
 """
 
-dropstat_path = "/tmp/dropstat"
+dropstat_path = "/tmp/dropstat-27"
 
 class TestDropCounters(object):
     @classmethod


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Fixes https://github.com/Azure/sonic-buildimage/issues/5602

**- How I did it**
I followed the same pattern from `portstat` and gave each user their own `dropstat` directory instead of indexing the files by uid.

**- How to verify it**
Validated that non-root user can clear after a `sudo sonic-clear dropcounters`. Also verified that each uid has their own `/tmp` directory. Also updated the unit tests.

