### PR TITLE
Remove unnecessary calls to str.decode() now that the package is Python 3

### DIFF
--- a/scripts/natshow
+++ b/scripts/natshow
@@ -125,8 +125,7 @@ class NatShow(object):
         if not nat_str:
             return
 
-        for s in nat_str:
-            nat_entry = s.decode()
+        for nat_entry in nat_str:
             nat = json.loads(nat_entry .split(":", 2)[-1])
             if not nat:
                 continue

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -67,12 +67,12 @@ def add_prefix_ifnot(ip):
 
 
 def is_local(ip):
-    t = ipaddress.ip_address(ip.split("/")[0]
+    t = ipaddress.ip_address(ip.split("/")[0])
     return t.is_link_local
 
 
 def is_default_route(ip):
-    t = ipaddress.ip_address(ip.split("/")[0]
+    t = ipaddress.ip_address(ip.split("/")[0])
     return t.is_unspecified and ip.split("/")[1] == "0"
 
 

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -67,12 +67,12 @@ def add_prefix_ifnot(ip):
 
 
 def is_local(ip):
-    t = ipaddress.ip_address(ip.split("/")[0].decode('utf-8'))
+    t = ipaddress.ip_address(ip.split("/")[0]
     return t.is_link_local
 
 
 def is_default_route(ip):
-    t = ipaddress.ip_address(ip.split("/")[0].decode('utf-8'))
+    t = ipaddress.ip_address(ip.split("/")[0]
     return t.is_unspecified and ip.split("/")[1] == "0"
 
 

--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -65,12 +65,8 @@ def run_command(cmd, use_shell=False):
                 shcmd = cmd
         proc = subprocess.Popen(shcmd, shell=use_shell, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=1, close_fds=True)
         output_stdout, output_stderr = proc.communicate()
-        list_stdout = []
-        for l in output_stdout.splitlines():
-            list_stdout.append(str(l.decode()))
-        list_stderr = []
-        for l in output_stderr.splitlines():
-            list_stderr.append(str(l.decode()))
+        list_stdout = output_stdout.splitlines()
+        list_stderr = output_stderr.splitlines()
         return (proc.returncode, list_stdout, list_stderr)
     except (OSError, ValueError) as e:
         print("!Exception [%s] encountered while processing the command : %s" % (str(e), str(cmd)))

--- a/show/main.py
+++ b/show/main.py
@@ -82,7 +82,7 @@ def run_command(command, display_cmd=False, return_cmd=False):
 
     while True:
         if return_cmd:
-            output = proc.communicate()[0].decode("utf-8")
+            output = proc.communicate()[0]
             return output
         output = proc.stdout.readline()
         if output == "" and proc.poll() is not None:

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -476,7 +476,7 @@ def run_command(command, display_cmd=False, ignore_error=False, return_cmd=False
     proc = subprocess.Popen(command, shell=True, text=True, stdout=subprocess.PIPE)
 
     if return_cmd:
-        output = proc.communicate()[0].decode("utf-8")
+        output = proc.communicate()[0]
         return output
 
     if not interactive_mode:


### PR DESCRIPTION
Now that the package is built as Python 3, all strings are unicode by default and `str.decode()` no longer exists.