### PR TITLE
[connect][sonic-clear] Align the exit code with consutil for line commands

### DIFF
--- a/clear/main.py
+++ b/clear/main.py
@@ -1,6 +1,7 @@
 import configparser
 import os
 import subprocess
+import sys
 
 import click
 
@@ -93,11 +94,12 @@ def get_routing_stack():
 routing_stack = get_routing_stack()
 
 
-def run_command(command, pager=False, return_output=False):
+def run_command(command, pager=False, return_output=False, return_exitstatus=False):
     # Provide option for caller function to Process the output.
     proc = subprocess.Popen(command, shell=True, text=True, stdout=subprocess.PIPE)
     if return_output:
-        return proc.communicate()
+        output = proc.communicate()
+        return output if not return_exitstatus else output + (proc.returncode,)
     elif pager:
         #click.echo(click.style("Command: ", fg='cyan') + click.style(command, fg='green'))
         click.echo_via_pager(proc.stdout.read())
@@ -367,7 +369,9 @@ def clear_vlan_fdb(vlanid):
 def line(target, devicename):
     """Clear preexisting connection to line"""
     cmd = "consutil clear {}".format("--devicename " if devicename else "") + str(target)
-    run_command(cmd)
+    (output, _, exitstatus) = run_command(cmd, return_output=True, return_exitstatus=True)
+    click.echo(output)
+    sys.exit(exitstatus)
 
 #
 # 'nat' group ("clear nat ...")

--- a/connect/main.py
+++ b/connect/main.py
@@ -106,7 +106,7 @@ def line(target, devicename):
 def device(devicename):
     """Connect to device DEVICENAME via serial connection"""
     cmd = "consutil connect -d " + devicename
-    run_command(cmd)
+    sys.exit(run_command(cmd))
 
 if __name__ == '__main__':
     connect()

--- a/connect/main.py
+++ b/connect/main.py
@@ -1,6 +1,7 @@
 import configparser
 import os
 import pexpect
+import sys
 
 import click
 
@@ -71,6 +72,8 @@ def run_command(command, display_cmd=False):
 
     proc = pexpect.spawn(command)
     proc.interact()
+    proc.close()
+    return proc.exitstatus
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help', '-?'])
 
@@ -93,7 +96,7 @@ def connect():
 def line(target, devicename):
     """Connect to line LINENUM via serial connection"""
     cmd = "consutil connect {}".format("--devicename " if devicename else "") + str(target)
-    run_command(cmd)
+    sys.exit(run_command(cmd))
 
 #
 # 'device' command ("connect device")

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -2052,6 +2052,33 @@ Optionally, you can connect with a remote device name by specifying the `-d` or 
   Press ^A ^X to disconnect
   ```
 
+**connect device**
+
+This command allows user to connect to a remote device via console line with an interactive cli.
+
+- Usage:
+  ```
+  connect device <devicename>
+  ```
+
+The command is same with `connect line --devicename <devicename>`
+
+- Example:
+  ```
+  admin@sonic:~$ connect line 1
+  Successful connection to line 1
+  Press ^A ^X to disconnect
+  ```
+
+Optionally, you can connect with a remote device name by specifying the `-d` or `--devicename` flag.
+
+- Example:
+  ```
+  admin@sonic:~$ connect device switch1
+  Successful connection to line 1
+  Press ^A ^X to disconnect
+  ```
+
 ### Console clear commands
 
 **sonic-clear line**

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -2070,15 +2070,6 @@ The command is same with `connect line --devicename <devicename>`
   Press ^A ^X to disconnect
   ```
 
-Optionally, you can connect with a remote device name by specifying the `-d` or `--devicename` flag.
-
-- Example:
-  ```
-  admin@sonic:~$ connect device switch1
-  Successful connection to line 1
-  Press ^A ^X to disconnect
-  ```
-
 ### Console clear commands
 
 **sonic-clear line**


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

Align following commands' exit code with consutil commands since there are aliasing commands:
- `connect line`
- `sonic-clear line`

This is a fix for this issue: https://github.com/Azure/sonic-utilities/issues/1241 
The issue will also cause the reverse ssh script couldn't response as expect for console switch feature disabled user(https://github.com/Azure/sonic-buildimage/pull/5438)

**- How I did it**
Bump the inner command's exit code to user.

**- How to verify it**
Installed the script on a Physical DUT and test it.

**- Previous command output (if the output of a command-line utility has changed)**
```
admin@sonic:~$ consutil connect 2
Cannot connect: line [2] has no baud rate
admin@sonic:~$ echo $?
0
```

**- New command output (if the output of a command-line utility has changed)**

```
admin@sonic:~$ consutil connect 2
Cannot connect: line [2] has no baud rate
admin@sonic:~$ echo $?
4
```