### PR TITLE
[acl-loader] Make list sorting compliant with Python 3

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -826,11 +826,7 @@ class AclLoader(object):
 
             raw_data.append([priority, rule_data])
 
-        def cmp_rules(a, b):
-            return cmp(a[0], b[0])
-
-        raw_data.sort(cmp_rules)
-        raw_data.reverse()
+        raw_data.sort(key=lambda x: x[0], reverse=True)
 
         data = []
         for _, d in raw_data:


### PR DESCRIPTION
In Python 3, `sort()` takes no positional arguments, only keyword arguments. Fix acl-loader to comply.

Fixes vsimage build failure in https://github.com/Azure/sonic-buildimage/pull/5926