### PR TITLE
Remove unnecessary calls to str.encode() now that the package is Python 3; Fix deprecation warning

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -429,14 +429,14 @@ class AclLoader(object):
                 rule_props["IP_PROTOCOL"] = rule.ip.config.protocol
 
         if rule.ip.config.source_ip_address:
-            source_ip_address = rule.ip.config.source_ip_address.encode("ascii")
+            source_ip_address = rule.ip.config.source_ip_address
             if ipaddress.ip_network(source_ip_address).version == 4:
                 rule_props["SRC_IP"] = source_ip_address
             else:
                 rule_props["SRC_IPV6"] = source_ip_address
 
         if rule.ip.config.destination_ip_address:
-            destination_ip_address = rule.ip.config.destination_ip_address.encode("ascii")
+            destination_ip_address = rule.ip.config.destination_ip_address
             if ipaddress.ip_network(destination_ip_address).version == 4:
                 rule_props["DST_IP"] = destination_ip_address
             else:
@@ -550,7 +550,7 @@ class AclLoader(object):
         :return:
         """
         for acl_set_name in self.yang_acl.acl.acl_sets.acl_set:
-            table_name = acl_set_name.replace(" ", "_").replace("-", "_").upper().encode('ascii')
+            table_name = acl_set_name.replace(" ", "_").replace("-", "_").upper()
             acl_set = self.yang_acl.acl.acl_sets.acl_set[acl_set_name]
 
             if not self.is_table_valid(table_name):

--- a/fwutil/lib.py
+++ b/fwutil/lib.py
@@ -417,24 +417,6 @@ class PlatformComponentsParser(object):
             self.__module_component_map[key] = OrderedDict()
             self.__parse_component_section(key, value[self.COMPONENT_KEY], True)
 
-    # TODO: This function should not be necessary once we no longer support Python 2
-    def __deunicodify_hook(self, pairs):
-        new_pairs = [ ]
-
-        for key, value in pairs:
-            try:
-                key = key.encode(self.UTF8_ENCODING)
-            except Exception:
-                pass
-
-            try:
-                value = value.encode(self.UTF8_ENCODING)
-            except Exception:
-                pass
-
-            new_pairs.append((key, value))
-
-        return OrderedDict(new_pairs)
 
     def get_chassis_component_map(self):
         return self.__chassis_component_map
@@ -451,7 +433,7 @@ class PlatformComponentsParser(object):
             platform_components_path = self.__get_platform_components_path(root_path)
 
         with open(platform_components_path) as platform_components:
-            data = json.load(platform_components, object_pairs_hook=self.__deunicodify_hook)
+            data = json.load(platform_components)
 
             if not self.__is_dict(data):
                 self.__parser_platform_fail("dictionary is expected: key=root")

--- a/scripts/decode-syseeprom
+++ b/scripts/decode-syseeprom
@@ -6,11 +6,11 @@
 #
 try:
     import glob
-    import imp
     import optparse
     import os
     import sys
     import warnings
+    from importlib.machinery import SourceFileLoader
 
     from sonic_py_common import device_info
 except ImportError as e:
@@ -39,7 +39,7 @@ def main():
     # load the target class file and instantiate the object
     #
     try:
-        m = imp.load_source('eeprom','/'.join([platform_path, 'plugins', 'eeprom.py']))
+        m = SourceFileLoader('eeprom','/'.join([platform_path, 'plugins', 'eeprom.py'])).load_module()
     except IOError:
         raise IOError("cannot load module: " + '/'.join([platform_path, 'plugins', 'eeprom.py']))
 


### PR DESCRIPTION
In Python 3, all strings are unicode by default. There is no need to encode strings to bytes.

Fixes vsimage check build failure in Azure/sonic-buildimage#5926, due to caclmgrd test failing because acl-loader was encoding the table names to bytes and comparing them against strings, thus failing to match table names and therefore failing to load ACL rules.

Also fix Python 3 deprecation warning in decode-syseeprom, as the `imp` module is deprecated in favor of `importlib`