### PR TITLE
[sonic-utilities] fixes #5795 show vnet [neighbors | routes [all | tunnel]] c…

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -2291,7 +2291,7 @@ def neighbors():
     appl_db.connect(appl_db.APPL_DB)
 
     # Fetching data from appl_db for neighbors
-    nbrs = appl_db.keys(appl_db.APPL_DB, "NEIGH_TABLE*")
+    nbrs = appl_db.keys(appl_db.APPL_DB, "NEIGH_TABLE:*")
     nbrs_data = {}
     for nbr in nbrs if nbrs else []:
         tbl, intf, ip = nbr.split(":", 2)
@@ -2331,7 +2331,7 @@ def all():
     header = ['vnet name', 'prefix', 'nexthop', 'interface']
 
     # Fetching data from appl_db for VNET ROUTES
-    vnet_rt_keys = appl_db.keys(appl_db.APPL_DB, "VNET_ROUTE_TABLE*")
+    vnet_rt_keys = appl_db.keys(appl_db.APPL_DB, "VNET_ROUTE_TABLE:*")
     vnet_rt_keys = natsorted(vnet_rt_keys) if vnet_rt_keys else []
 
     table = []
@@ -2350,7 +2350,7 @@ def all():
     header = ['vnet name', 'prefix', 'endpoint', 'mac address', 'vni']
 
     # Fetching data from appl_db for VNET TUNNEL ROUTES
-    vnet_rt_keys = appl_db.keys(appl_db.APPL_DB, "VNET_ROUTE_TUNNEL_TABLE*")
+    vnet_rt_keys = appl_db.keys(appl_db.APPL_DB, "VNET_ROUTE_TUNNEL_TABLE:*")
     vnet_rt_keys = natsorted(vnet_rt_keys) if vnet_rt_keys else []
 
     table = []
@@ -2374,7 +2374,7 @@ def tunnel():
     header = ['vnet name', 'prefix', 'endpoint', 'mac address', 'vni']
 
     # Fetching data from appl_db for VNET TUNNEL ROUTES
-    vnet_rt_keys = appl_db.keys(appl_db.APPL_DB, "VNET_ROUTE_TUNNEL_TABLE*")
+    vnet_rt_keys = appl_db.keys(appl_db.APPL_DB, "VNET_ROUTE_TUNNEL_TABLE:*")
     vnet_rt_keys = natsorted(vnet_rt_keys) if vnet_rt_keys else []
 
     table = []


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
When query "NEIGH_TABLE*" or "VNET_ROUTE_TUNNEL_TABLE*" from APPDB,
it may contain a combination of table names with and without ":"

127.0.0.1:6379> keys NEIGH_TABLE*
1) "NEIGH_TABLE_DEL_SET"
2) "NEIGH_TABLE_KEY_SET"

127.0.0.1:6379> keys VNET_ROUTE_TUNNEL_TABLE*
1) "VNET_ROUTE_TUNNEL_TABLE_KEY_SET"
2) "VNET_ROUTE_TUNNEL_TABLE:Vnet_2000:100.100.3.0/24"
However, /src/sonic-utilities/show/main.py split the table name with ":"
without checking if the table name contains ":" or not,
which caused the cli command yields an exception.
`tbl, intf, ip = nbr.split(":", 2)`

**- How I did it**
Modify file: "show/main.py"
Add ":" in the regex for querying "NEIGH_TABLE" and "VNET_ROUTE_TUNNEL_TABLE" in the following functional definitions.
```
@vnet.command()
  def neighbors():
      
@routes.command()
def all():
def tunnel():
```

**- How to verify it**
```
root@VTEP2:~# show vnet neighbor
root@VTEP2:~# show vnet routes all
root@VTEP2:~# show vnet routes tunnel
```

**- Previous command output (if the output of a command-line utility has changed)**

```
root@VTEP1:/home/admin# show vnet neighbors
Traceback (most recent call last):
  File "/usr/bin/show", line 12, in <module>
    sys.exit(cli())
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/show/main.py", line 2936, in neighbors
    tbl, intf, ip = nbr.split(":", 2)
ValueError: need more than 1 value to unpack
```

```
root@VTEP1:/home/admin# show vnet routes all
Traceback (most recent call last):
  File "/usr/bin/show", line 12, in <module>
    sys.exit(cli())
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/show/main.py", line 2980, in all
    val = appl_db.get_all(appl_db.APPL_DB, k)
  File "/usr/local/lib/python2.7/dist-packages/swsssdk/dbconnector.py", line 308, in get_all
    return super(SonicV2Connector, self).get_all(db_id, _hash, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/swsssdk/interface.py", line 38, in wrapped
    ret_data = f(inst, db_id, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/swsssdk/interface.py", line 299, in get_all
    table = client.hgetall(_hash)
  File "/usr/local/lib/python2.7/dist-packages/redis/client.py", line 1967, in hgetall
    return self.execute_command('HGETALL', name)
  File "/usr/local/lib/python2.7/dist-packages/redis/client.py", line 668, in execute_command
    return self.parse_response(connection, command_name, **options)
  File "/usr/local/lib/python2.7/dist-packages/redis/client.py", line 680, in parse_response
    response = connection.read_response()
  File "/usr/local/lib/python2.7/dist-packages/redis/connection.py", line 629, in read_response
    raise response
redis.exceptions.ResponseError: WRONGTYPE Operation against a key holding the wrong kind of value
```

```
root@VTEP1:/home/admin# show vnet routes tunnel
Traceback (most recent call last):
  File "/usr/bin/show", line 12, in <module>
    sys.exit(cli())
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/show/main.py", line 3023, in tunnel
    val = appl_db.get_all(appl_db.APPL_DB, k)
  File "/usr/local/lib/python2.7/dist-packages/swsssdk/dbconnector.py", line 308, in get_all
    return super(SonicV2Connector, self).get_all(db_id, _hash, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/swsssdk/interface.py", line 38, in wrapped
    ret_data = f(inst, db_id, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/swsssdk/interface.py", line 299, in get_all
    table = client.hgetall(_hash)
  File "/usr/local/lib/python2.7/dist-packages/redis/client.py", line 1967, in hgetall
    return self.execute_command('HGETALL', name)
  File "/usr/local/lib/python2.7/dist-packages/redis/client.py", line 668, in execute_command
    return self.parse_response(connection, command_name, **options)
  File "/usr/local/lib/python2.7/dist-packages/redis/client.py", line 680, in parse_response
    response = connection.read_response()
  File "/usr/local/lib/python2.7/dist-packages/redis/connection.py", line 629, in read_response
    raise response
redis.exceptions.ResponseError: WRONGTYPE Operation against a key holding the wrong kind of value
```

**- New command output (if the output of a command-line utility has changed)**
```
root@VTEP2:~# show vnet neighbor
Vnet_3000    neighbor    mac_address    interfaces
-----------  ----------  -------------  ------------

root@VTEP2:~# show vnet routes all
vnet name    prefix          nexthop    interface
-----------  --------------  ---------  -----------
Vnet_3000    100.100.1.2/24             Ethernet11

vnet name    prefix          endpoint    mac address    vni
-----------  --------------  ----------  -------------  -----
Vnet_3000    100.100.4.2/24  10.10.10.1

root@VTEP2:~# show vnet routes tunnel
vnet name    prefix          endpoint    mac address    vni
-----------  --------------  ----------  -------------  -----
Vnet_3000    100.100.4.2/24  10.10.10.1
```

