### PR TITLE
Improve MockRedis _encode(): so it will work on all types of value

### DIFF
--- a/tests/mock_tables/dbconnector.py
+++ b/tests/mock_tables/dbconnector.py
@@ -116,20 +116,14 @@ class SwssSyncClient(mockredis.MockRedis):
 
     # Patch mockredis/mockredis/client.py
     # The offical implementation assume decode_responses=False
-    # Here we detect the option first and only encode when decode_responses=False
+    # Here we detect the option and decode after doing encode
     def _encode(self, value):
         "Return a bytestring representation of the value. Taken from redis-py connection.py"
-        if isinstance(value, bytes):
-            return value
-        elif isinstance(value, int):
-            value = str(value).encode('utf-8')
-        elif isinstance(value, float):
-            value = repr(value).encode('utf-8')
-        elif not isinstance(value, str):
-            value = str(value).encode('utf-8')
-        elif not self.decode_responses:
-            value = value.encode('utf-8', 'strict')
-        return value
+
+        value = super(SwssSyncClient, self)._encode(value)
+
+        if self.decode_responses:
+           return value.decode('utf-8')
 
     # Patch mockredis/mockredis/client.py
     # The official implementation will filter out keys with a slash '/'


### PR DESCRIPTION
The original code only works on `str` value
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

