### PR TITLE
[config] Fix Breakout mode option and BREAKOUT_CFG table check method

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -90,7 +90,7 @@ def _get_breakout_options(ctx, args, incomplete):
             for i in breakout_mode_list.split(','):
                     breakout_mode_options.append(i)
             all_mode_options = [str(c) for c in breakout_mode_options if incomplete in c]
-            return all_mode_options
+        return all_mode_options
 
 def shutdown_interfaces(ctx, del_intf_dict):
     """ shut down all the interfaces before deletion """
@@ -2235,6 +2235,14 @@ def breakout(ctx, interface_name, mode, verbose, force_remove_dependencies, load
 
     # Get current breakout mode
     cur_brkout_dict = config_db.get_table('BREAKOUT_CFG')
+    if len(cur_brkout_dict) == 0:
+        click.secho("[ERROR] BREAKOUT_CFG table is NOT present in CONFIG DB", fg='red')
+        raise click.Abort()
+
+    if interface_name not in cur_brkout_dict.keys():
+        click.secho("[ERROR] {} interface is NOT present in BREAKOUT_CFG table of CONFIG DB".format(interface_name), fg='red')
+        raise click.Abort()
+
     cur_brkout_mode = cur_brkout_dict[interface_name]["brkout_mode"]
 
     # Validate Interface and Breakout mode


### PR DESCRIPTION
Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>

**- What I did**
Made a robust check for below cases.

1. when the interface is wrong and the mode is correct.
2. BREAKOUT_CFG table is NOT present in CONFIG DB

Also, Fixed Breakout mode option when options are not available for easy readability.

**- How I did it**
Made changes in the `config/main.py` file for an extra check 

**- How to verify it**
`sudo config interface breakout`
