### PR TITLE
[show/fgnhg] Fix crash bug

### DIFF
--- a/show/fgnhg.py
+++ b/show/fgnhg.py
@@ -35,6 +35,7 @@ def active_hops(nhg):
     table_keys = []
     table_keys = state_db.keys(state_db.STATE_DB, _hash)
     t_dict = {}
+    header = ["FG_NHG_PREFIX", "Active Next Hops"]
     table = []
     output_dict = {}
 
@@ -49,7 +50,6 @@ def active_hops(nhg):
                     output_dict[nhg_prefix] = [nh_ip.split("@")[0]]
 
             nhg_prefix_report = (nhg_prefix.split("|")[1])
-            header = ["FG_NHG_PREFIX", "Active Next Hops"]
             formatted_nhps = ','.replace(',', '\n').join(output_dict[nhg_prefix])
             table.append([nhg_prefix_report, formatted_nhps])
 
@@ -80,7 +80,6 @@ def active_hops(nhg):
                 nhg_prefix_report = (nhg_prefix.split("|")[1])
                 formatted_nhps = ','.replace(',', '\n').join(output_dict[nhg_prefix])
                 table.append([nhg_prefix_report, formatted_nhps])
-                header = ["FG_NHG_PREFIX", "Active Next Hops"]
                 click.echo(tabulate(table, header, tablefmt="grid"))
 
 
@@ -105,6 +104,7 @@ def hash_view(nhg):
     table_keys = []
     table_keys = state_db.keys(state_db.STATE_DB, _hash)
     t_dict = {}
+    header = ["FG_NHG_PREFIX", "Next Hop", "Hash buckets"]
     table = []
     output_dict = {}
     bank_dict = {}
@@ -128,7 +128,6 @@ def hash_view(nhg):
 
             bank_dict = OrderedDict(sorted(bank_dict.items()))
             nhg_prefix_report = (nhg_prefix.split("|")[1])
-            header = ["FG_NHG_PREFIX", "Next Hop", "Hash buckets"]
 
             for nhip, val in bank_dict.items():
                 formatted_banks = ','.replace(',', '\n').join(bank_dict[nhip])
@@ -163,7 +162,6 @@ def hash_view(nhg):
 
                 nhg_prefix_report = (nhg_prefix.split("|")[1])
                 bank_dict = OrderedDict(sorted(bank_dict.items()))
-                header = ["FG_NHG_PREFIX", "Next Hop", "Hash buckets"]
 
                 for nhip, val in bank_dict.items():
                     formatted_banks = ','.replace(',', '\n').join(bank_dict[nhip])


### PR DESCRIPTION
**- What I did**

Fix crashes like the following:

```
Traceback (most recent call last):
  File "/usr/local/bin/show", line 10, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/show/fgnhg.py", line 56, in active_hops
    click.echo(tabulate(table, header, tablefmt="grid"))
UnboundLocalError: local variable 'header' referenced before assignment
```

**- How I did it**

Define table header outside the loop which processes the rows

**- How to verify it**

Run the following commands, confirm they don't crash like above:

```
show fgnhg active-hops
show fgnhg hash-view
```

Example output with this fix:

```
admin@sonic:~$ show fgnhg active-hops
+-----------------+--------------------+
| FG_NHG_PREFIX   | Active Next Hops   |
+=================+====================+
+-----------------+--------------------+

admin@sonic:~$ show fgnhg hash-view
+-----------------+------------+----------------+
| FG_NHG_PREFIX   | Next Hop   | Hash buckets   |
+=================+============+================+
+-----------------+------------+----------------+
```