### PR TITLE
[consutil][test] Add unit tests for consutil clear command

### DIFF
--- a/tests/console_test.py
+++ b/tests/console_test.py
@@ -589,24 +589,26 @@ class TestConsutilClear(object):
     @mock.patch('os.geteuid', mock.MagicMock(return_value=1))
     def test_clear_without_root(self):
         runner = CliRunner()
+        db = Db()
 
         result = runner.invoke(consutil.consutil.commands["clear"], ['1'], obj=db)
         print(result.exit_code)
         print(sys.stderr, result.output)
         assert result.exit_code == 2
-        assert result.output == "Root privileges are required for this operation"
+        assert "Root privileges are required for this operation" in result.output
 
     @mock.patch('consutil.lib.SysInfoProvider.list_console_ttys', mock.MagicMock(return_value=["/dev/ttyUSB1"]))
     @mock.patch('consutil.lib.SysInfoProvider.init_device_prefix', mock.MagicMock(return_value=None))
     @mock.patch('os.geteuid', mock.MagicMock(return_value=0))
     def test_clear_line_not_found(self):
         runner = CliRunner()
+        db = Db()
 
         result = runner.invoke(consutil.consutil.commands["clear"], ['2'], obj=db)
         print(result.exit_code)
         print(sys.stderr, result.output)
         assert result.exit_code == 3
-        assert result.output == "Target [2] does not exist"
+        assert "Target [2] does not exist" in result.output
 
     @mock.patch('consutil.lib.SysInfoProvider.list_console_ttys', mock.MagicMock(return_value=["/dev/ttyUSB1"]))
     @mock.patch('consutil.lib.SysInfoProvider.init_device_prefix', mock.MagicMock(return_value=None))
@@ -621,7 +623,7 @@ class TestConsutilClear(object):
         print(result.exit_code)
         print(sys.stderr, result.output)
         assert result.exit_code == 0
-        assert result.output == "No process is connected to line 1"
+        assert "No process is connected to line 1" in result.output
 
     @mock.patch('consutil.lib.SysInfoProvider.list_console_ttys', mock.MagicMock(return_value=["/dev/ttyUSB1"]))
     @mock.patch('consutil.lib.SysInfoProvider.init_device_prefix', mock.MagicMock(return_value=None))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Add unit tests for `consutil clear` command.

**- How I did it**
Write unit test cases.

**- How to verify it**
Run unit tests locally and all pass.
```
Name                                       Stmts   Miss  Cover
--------------------------------------------------------------
consutil/lib.py                              218      8    96%
consutil/main.py                              67      4    94%
```

**- Previous command output (if the output of a command-line utility has changed)**
N/A

**- New command output (if the output of a command-line utility has changed)**
N/A

