### PR TITLE
[config/console][consutil] Support enable/disable console switch

### DIFF
--- a/config/console.py
+++ b/config/console.py
@@ -10,6 +10,36 @@ def console():
     pass
 
 #
+# 'console enable' group ('config console enable')
+#
+@console.command('enable')
+@clicommon.pass_db
+def enable_console_switch(db):
+    """Enable console switch"""
+    config_db = db.cfgdb
+
+    table = "CONSOLE_SWITCH"
+    dataKey1 = 'console_mgmt'
+
+    data = { dataKey1 : "1" }
+    config_db.mod_entry(table, '', data)
+
+#
+# 'console disable' group ('config console disable')
+#
+@console.command('disable')
+@clicommon.pass_db
+def disable_console_switch(db):
+    """Disable console switch"""
+    config_db = db.cfgdb
+
+    table = "CONSOLE_SWITCH"
+    dataKey1 = 'console_mgmt'
+
+    data = { dataKey1 : "0" }
+    config_db.mod_entry(table, '', data)
+
+#
 # 'console add' group ('config console add ...')
 #
 @console.command('add')

--- a/config/console.py
+++ b/config/console.py
@@ -20,9 +20,10 @@ def enable_console_switch(db):
 
     table = "CONSOLE_SWITCH"
     dataKey1 = 'console_mgmt'
+    dataKey2 = 'enabled'
 
-    data = { dataKey1 : "1" }
-    config_db.mod_entry(table, '', data)
+    data = { dataKey2 : "yes" }
+    config_db.mod_entry(table, dataKey1, data)
 
 #
 # 'console disable' group ('config console disable')
@@ -35,9 +36,10 @@ def disable_console_switch(db):
 
     table = "CONSOLE_SWITCH"
     dataKey1 = 'console_mgmt'
+    dataKey2 = 'enabled'
 
-    data = { dataKey1 : "0" }
-    config_db.mod_entry(table, '', data)
+    data = { dataKey2 : "no" }
+    config_db.mod_entry(table, dataKey1, data)
 
 #
 # 'console add' group ('config console add ...')

--- a/consutil/lib.py
+++ b/consutil/lib.py
@@ -32,6 +32,7 @@ BAUD_KEY = "baud_rate"
 DEVICE_KEY = "remote_device"
 FLOW_KEY = "flow_control"
 FEATURE_KEY = "console_mgmt"
+FEATURE_ENABLED_KEY = "enabled"
 
 # STATE_DB Keys
 STATE_KEY = "state"

--- a/consutil/lib.py
+++ b/consutil/lib.py
@@ -22,6 +22,8 @@ ERR_CFG = 4
 ERR_BUSY = 5
 
 CONSOLE_PORT_TABLE = "CONSOLE_PORT"
+CONSOLE_SWITCH_TABLE = "CONSOLE_SWITCH"
+
 LINE_KEY = "LINE"
 CUR_STATE_KEY = "CUR_STATE"
 
@@ -29,6 +31,7 @@ CUR_STATE_KEY = "CUR_STATE"
 BAUD_KEY = "baud_rate"
 DEVICE_KEY = "remote_device"
 FLOW_KEY = "flow_control"
+FEATURE_KEY = "console_mgmt"
 
 # STATE_DB Keys
 STATE_KEY = "state"

--- a/consutil/main.py
+++ b/consutil/main.py
@@ -17,8 +17,15 @@ except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
 
 @click.group()
-def consutil():
+@clicommon.pass_db
+def consutil(db):
     """consutil - Command-line utility for interacting with switches via console device"""
+    config_db = db.cfgdb
+    data = config_db.get_entry(CONSOLE_SWITCH_TABLE, "")
+    if FEATURE_KEY not in data or data[FEATURE_KEY] == "0":
+        click.echo("Console switch feature is disabled")
+        sys.exit(ERR_DISABLE)
+
     SysInfoProvider.init_device_prefix()
 
 # 'show' subcommand

--- a/consutil/main.py
+++ b/consutil/main.py
@@ -21,8 +21,8 @@ except ImportError as e:
 def consutil(db):
     """consutil - Command-line utility for interacting with switches via console device"""
     config_db = db.cfgdb
-    data = config_db.get_entry(CONSOLE_SWITCH_TABLE, "")
-    if FEATURE_KEY not in data or data[FEATURE_KEY] == "0":
+    data = config_db.get_entry(CONSOLE_SWITCH_TABLE, FEATURE_KEY)
+    if FEATURE_ENABLED_KEY not in data or data[FEATURE_ENABLED_KEY] == "no":
         click.echo("Console switch feature is disabled")
         sys.exit(ERR_DISABLE)
 

--- a/tests/console_test.py
+++ b/tests/console_test.py
@@ -20,6 +20,24 @@ class TestConfigConsoleCommands(object):
     def setup_class(cls):
         print("SETUP")
     
+    def test_enable_console_switch(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["console"].commands["enable"])
+        print(result.exit_code)
+        print(sys.stderr, result.output)
+        assert result.exit_code == 0
+
+    def test_disable_console_switch(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["console"].commands["disable"])
+        print(result.exit_code)
+        print(sys.stderr, result.output)
+        assert result.exit_code == 0
+
     def test_console_add_exists(self):
         runner = CliRunner()
         db = Db()
@@ -464,6 +482,48 @@ class TestConsutilLib(object):
         SysInfoProvider.DEVICE_PREFIX == "/dev/ttyUSB"
         proc = SysInfoProvider.get_active_console_process_info("2")
         assert proc is None
+
+class TestConsutil(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+
+    @mock.patch('consutil.lib.SysInfoProvider.init_device_prefix', mock.MagicMock(return_value=None))
+    @mock.patch('consutil.main.show', mock.MagicMock(return_value=None))
+    def test_consutil_feature_disabled_null_config(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(consutil.consutil, ['show'], obj=db)
+        print(result.exit_code)
+        print(sys.stderr, result.output)
+        assert result.exit_code == 1
+        assert result.output == "Console switch feature is disabled\n"
+
+    @mock.patch('consutil.lib.SysInfoProvider.init_device_prefix', mock.MagicMock(return_value=None))
+    @mock.patch('consutil.main.show', mock.MagicMock(return_value=None))
+    def test_consutil_feature_disabled_config(self):
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb.set_entry("CONSOLE_SWITCH", "", { "console_mgmt" : "0" })
+
+        result = runner.invoke(consutil.consutil, ['show'], obj=db)
+        print(result.exit_code)
+        print(sys.stderr, result.output)
+        assert result.exit_code == 1
+        assert result.output == "Console switch feature is disabled\n"
+
+    @mock.patch('consutil.lib.SysInfoProvider.init_device_prefix', mock.MagicMock(return_value=None))
+    @mock.patch('consutil.main.show', mock.MagicMock(return_value=None))
+    def test_consutil_feature_enabled(self):
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb.set_entry("CONSOLE_SWITCH", "", { "console_mgmt" : "1" })
+
+        result = runner.invoke(consutil.consutil, ['show'], obj=db)
+        print(result.exit_code)
+        print(sys.stderr, result.output)
+        assert result.exit_code == 0
 
 class TestConsutilShow(object):
     @classmethod

--- a/tests/console_test.py
+++ b/tests/console_test.py
@@ -505,7 +505,7 @@ class TestConsutil(object):
     def test_consutil_feature_disabled_config(self):
         runner = CliRunner()
         db = Db()
-        db.cfgdb.set_entry("CONSOLE_SWITCH", "", { "console_mgmt" : "0" })
+        db.cfgdb.set_entry("CONSOLE_SWITCH", "console_mgmt", { "enabled" : "no" })
 
         result = runner.invoke(consutil.consutil, ['show'], obj=db)
         print(result.exit_code)
@@ -518,7 +518,7 @@ class TestConsutil(object):
     def test_consutil_feature_enabled(self):
         runner = CliRunner()
         db = Db()
-        db.cfgdb.set_entry("CONSOLE_SWITCH", "", { "console_mgmt" : "1" })
+        db.cfgdb.set_entry("CONSOLE_SWITCH", "console_mgmt", { "enabled" : "yes" })
 
         result = runner.invoke(consutil.consutil, ['show'], obj=db)
         print(result.exit_code)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
This is the implementation of HLD: https://github.com/Azure/SONiC/blob/master/doc/console/SONiC-Console-Switch-High-Level-Design.md#33136-enabledisable-console-switch-feature

* This PR use below "CONSOLE_SWITCH:console_mgmt" instead the HLD mentioned key "CONSOLE_SWITCH" for better future change. I will update the HLD later.

This PR will allow user to enable/disable console switch management functions on a SONiC device.

**- How I did it**
- Add `config console {enable/disable}` command
- Exit directly if console swtich mgmt function not enabled when call console command
- Add unit tests

**- How to verify it**
1. Added unit test cases and all pass
1. Build py-wheel package and tested on a physical SONiC DUT
```
admin@sonic:~$ consutil show
Console switch feature is disabled

admin@sonic:~$ consutil connect 1
Console switch feature is disabled

admin@sonic:~$ sudo consutil clear 1
Console switch feature is disabled

admin@sonic:~$ show line
Console switch feature is disabled

admin@sonic:~$ sudo sonic-clear line 1
Console switch feature is disabled

admin@sonic:~$ connect line 1
Console switch feature is disabled

admin@sonic:~$ sudo config console disable

admin@sonic:~$ show line
Console switch feature is disabled

admin@sonic:~$ sudo config console enable
admin@sonic:~$ show line
  Line    Baud    PID    Start Time    Device
------  ------  -----  ------------  --------
     0    9600      -             -
     1    9600      -             -
```

**- Previous command output (if the output of a command-line utility has changed)**
N/A

**- New command output (if the output of a command-line utility has changed)**
N/A
