### PR TITLE
[config][loopback] Fix Bug that cannot add loopback interface by CLI

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -3188,7 +3188,6 @@ def naming_mode_alias():
     """Set CLI interface naming mode to ALIAS (Vendor port alias)"""
     set_interface_naming_mode('alias')
 
-@config.group()
 def is_loopback_name_valid(loopback_name):
     """Loopback name validation
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Fix that it cannot add loopback interface by CLI, like the following:
```
root@as7816-64x:~# config loopback add Loopback1
Usage: config [OPTIONS] COMMAND [ARGS]...
Try "config --help" for help.

Error: No such command "L".
```
**- How I did it**
Remove `@config.group()` before the function `is_loopback_name_valid(loopback_name)`, which will be called by add/del command

**- How to verify it**
Applied the fix, and the add command works as following.
```
root@as7816-64x:~# config loopback add Loopback1
root@as7816-64x:~# ip link show Loopback1
74: Loopback1: <BROADCAST,NOARP,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/ether 8e:59:1e:43:e8:73 brd ff:ff:ff:ff:ff:ff
root@as7816-64x:~#
```

**- Previous command output (if the output of a command-line utility has changed)**
N/A

**- New command output (if the output of a command-line utility has changed)**
N/A


Signed-off-by: MuLin <mulin_huang@edge-core.com>
