### PR TITLE
[pfcwd] Use floor division in Python3

### DIFF
--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -359,7 +359,7 @@ class PfcwdCli(object):
         port_num = len(list(self.config_db.get_table('PORT').keys()))
 
         # Paramter values positively correlate to the number of ports.
-        multiply = max(1, (port_num-1)/DEFAULT_PORT_NUM+1)
+        multiply = max(1, (port_num-1)//DEFAULT_PORT_NUM+1)
         pfcwd_info = {
             'detection_time': DEFAULT_DETECTION_TIME * multiply,
             'restoration_time': DEFAULT_RESTORATION_TIME * multiply,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->
Fixes: #https://github.com/Azure/sonic-buildimage/issues/6075

Fix the float division due to recent transfer to Python3, use floor division instead to
generate integer result in the PFCWD detect/restore time calculation.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


**- What I did**
Use `//` instead of `/` in Python3 to enforce integer output.

**- How I did it**

**- How to verify it**
```
# sudo pfcwd start_default
```

**- Previous command output (if the output of a command-line utility has changed)**
```
$ pfcwd show config
Changed polling interval to 606.25ms
       PORT    ACTION    DETECTION TIME    RESTORATION TIME
-----------  --------  ----------------  ------------------
  Ethernet0      drop            606.25              606.25
  Ethernet4      drop            606.25              606.25
 Ethernet16      drop            606.25              606.25
 Ethernet20      drop            606.25              606.25
 Ethernet24      drop            606.25              606.25
 Ethernet28      drop            606.25              606.25
 Ethernet32      drop            606.25              606.25
 Ethernet36      drop            606.25              606.25
 Ethernet40      drop            606.25              606.25
 Ethernet44      drop            606.25              606.25
 Ethernet48      drop            606.25              606.25
 Ethernet52      drop            606.25              606.25
 Ethernet56      drop            606.25              606.25
 Ethernet60      drop            606.25              606.25
 Ethernet64      drop            606.25              606.25
 Ethernet68      drop            606.25              606.25
 Ethernet80      drop            606.25              606.25
 Ethernet84      drop            606.25              606.25
 Ethernet88      drop            606.25              606.25
 Ethernet92      drop            606.25              606.25
 Ethernet96      drop            606.25              606.25
Ethernet100      drop            606.25              606.25
Ethernet104      drop            606.25              606.25
Ethernet108      drop            606.25              606.25
Ethernet112      drop            606.25              606.25
Ethernet116      drop            606.25              606.25
Ethernet120      drop            606.25              606.25
Ethernet124      drop            606.25              606.25
Ethernet128      drop            606.25              606.25
Ethernet144      drop            606.25              606.25
Ethernet148      drop            606.25              606.25
Ethernet152      drop            606.25              606.25
Ethernet156      drop            606.25              606.25
Ethernet160      drop            606.25              606.25
Ethernet164      drop            606.25              606.25
Ethernet168      drop            606.25              606.25
Ethernet192      drop            606.25              606.25
Ethernet208      drop            606.25              606.25
Ethernet212      drop            606.25              606.25
Ethernet216      drop            606.25              606.25
Ethernet220      drop            606.25              606.25
Ethernet224      drop            606.25              606.25
Ethernet228      drop            606.25              606.25
Ethernet232      drop            606.25              606.25
```

**- New command output (if the output of a command-line utility has changed)**
```
$ pfcwd show config
Changed polling interval to 600ms
       PORT    ACTION    DETECTION TIME    RESTORATION TIME
-----------  --------  ----------------  ------------------
  Ethernet0      drop               600                 600
  Ethernet4      drop               600                 600
 Ethernet16      drop               600                 600
 Ethernet20      drop               600                 600
 Ethernet24      drop               600                 600
 Ethernet28      drop               600                 600
 Ethernet32      drop               600                 600
 Ethernet36      drop               600                 600
 Ethernet40      drop               600                 600
 Ethernet44      drop               600                 600
 Ethernet48      drop               600                 600
 Ethernet52      drop               600                 600
 Ethernet56      drop               600                 600
 Ethernet60      drop               600                 600
 Ethernet64      drop               600                 600
 Ethernet68      drop               600                 600
 Ethernet80      drop               600                 600
 Ethernet84      drop               600                 600
 Ethernet88      drop               600                 600
 Ethernet92      drop               600                 600
 Ethernet96      drop               600                 600
Ethernet100      drop               600                 600
Ethernet104      drop               600                 600
Ethernet108      drop               600                 600
Ethernet112      drop               600                 600
Ethernet116      drop               600                 600
Ethernet120      drop               600                 600
Ethernet124      drop               600                 600
Ethernet128      drop               600                 600
Ethernet144      drop               600                 600
Ethernet148      drop               600                 600
Ethernet152      drop               600                 600
Ethernet156      drop               600                 600
Ethernet160      drop               600                 600
Ethernet164      drop               600                 600
Ethernet168      drop               600                 600
Ethernet192      drop               600                 600
Ethernet208      drop               600                 600
Ethernet212      drop               600                 600
Ethernet216      drop               600                 600
Ethernet220      drop               600                 600
Ethernet224      drop               600                 600
Ethernet228      drop               600                 600
Ethernet232      drop               600                 600
```
