### PR TITLE
[nbrshow] Convert the output of 'arp -n' from bytes to str.

### DIFF
--- a/scripts/nbrshow
+++ b/scripts/nbrshow
@@ -106,7 +106,7 @@ class NbrBase(object):
         """
             Fetch Neighbor data (ARP/IPv6 Neigh) from kernel.
         """
-        p = subprocess.Popen(self.cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p = subprocess.Popen(self.cmd, shell=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (output, err) = p.communicate()
         rc = p.wait()
 


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Fix https://github.com/Azure/sonic-buildimage/issues/6085

The output of 'arp -n' is bytes in python3, as a result, the search of 'ether' or other str failed. This commit addresses the issue.

I guess there are similar issues when upgrading to python3. I think we need to come up with a universal method to address these issues.

**- How I did it**
Convert the output of 'arp -n' from bytes to str.

**- How to verify it**
Verified on dx010-6, running master image.
```
admin@str2-dx010-acs-6:~$ show arp
Address       MacAddress         Iface            Vlan
------------  -----------------  ---------------  ------
10.0.0.1      52:54:00:b7:a8:31  PortChannel0002  -
10.0.0.5      52:54:00:b9:b9:23  PortChannel0005  -
......
10.64.246.1   00:e0:ec:83:b8:0f  eth0             -
10.64.247.30  80:3f:5d:08:0d:8e  eth0             -
Total number of entries 26 
```
```
admin@str2-dx010-acs-6:~$ show ndp
Address                    MacAddress         Iface            Vlan    Status
-------------------------  -----------------  ---------------  ------  ---------
fc00::1a                   52:54:00:a8:5b:e7  PortChannel0011  -       REACHABLE
fc00::2                    52:54:00:b7:a8:31  PortChannel0002  -       REACHABLE
......
fe80::9a03:9bff:fe03:2289  98:03:9b:03:22:89  PortChannel0005  -       STALE
fe80::e42:a1ff:fed9:26fe   1c:34:da:eb:bc:80  eth0             -       STALE
Total number of entries 49 
```
**- Previous command output (if the output of a command-line utility has changed)**


**- New command output (if the output of a command-line utility has changed)**

