### PR TITLE
Fixing python porting errors in fdbshow, natshow and nbrshow

### DIFF
--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -72,8 +72,8 @@ class FdbShow(object):
                 continue
 
             ent = self.db.get_all('ASIC_DB', s, blocking=True)
-            br_port_id = ent[b"SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID"][oid_pfx:]
-            ent_type = ent[b"SAI_FDB_ENTRY_ATTR_TYPE"]
+            br_port_id = ent["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID"][oid_pfx:]
+            ent_type = ent["SAI_FDB_ENTRY_ATTR_TYPE"]
             fdb_type = ['Dynamic','Static'][ent_type == "SAI_FDB_ENTRY_TYPE_STATIC"]
             if br_port_id not in self.if_br_oid_map:
                 continue

--- a/scripts/natshow
+++ b/scripts/natshow
@@ -139,30 +139,30 @@ class NatShow(object):
             nat_type = nat['nat_type']
 
             if nat_type == "SAI_NAT_TYPE_DESTINATION_NAT":
-                translated_dst_ip = ent[b"SAI_NAT_ENTRY_ATTR_DST_IP"]
+                translated_dst_ip = ent["SAI_NAT_ENTRY_ATTR_DST_IP"]
                 if "SAI_NAT_ENTRY_ATTR_L4_DST_PORT" in ent:
-                    translated_dst_port = ent[b"SAI_NAT_ENTRY_ATTR_L4_DST_PORT"]
+                    translated_dst_port = ent["SAI_NAT_ENTRY_ATTR_L4_DST_PORT"]
                     translated_dst = translated_dst_ip + ":" + translated_dst_port
                 else:
                     translated_dst = translated_dst_ip
             elif nat_type == "SAI_NAT_TYPE_SOURCE_NAT":
-                translated_src_ip = ent[b"SAI_NAT_ENTRY_ATTR_SRC_IP"]
+                translated_src_ip = ent["SAI_NAT_ENTRY_ATTR_SRC_IP"]
                 if "SAI_NAT_ENTRY_ATTR_L4_SRC_PORT" in ent:
-                    translated_src_port = ent[b"SAI_NAT_ENTRY_ATTR_L4_SRC_PORT"]
+                    translated_src_port = ent["SAI_NAT_ENTRY_ATTR_L4_SRC_PORT"]
                     translated_src = translated_src_ip + ":" + translated_src_port
                 else:
                     translated_src = translated_src_ip
             elif nat_type == "SAI_NAT_TYPE_DOUBLE_NAT":
-                translated_dst_ip = ent[b"SAI_NAT_ENTRY_ATTR_DST_IP"]
+                translated_dst_ip = ent["SAI_NAT_ENTRY_ATTR_DST_IP"]
                 if "SAI_NAT_ENTRY_ATTR_L4_DST_PORT" in ent:
-                    translated_dst_port = ent[b"SAI_NAT_ENTRY_ATTR_L4_DST_PORT"]
+                    translated_dst_port = ent["SAI_NAT_ENTRY_ATTR_L4_DST_PORT"]
                     translated_dst = translated_dst_ip + ":" + translated_dst_port
                 else:
                     translated_dst = translated_dst_ip
 
-                translated_src_ip = ent[b"SAI_NAT_ENTRY_ATTR_SRC_IP"]
+                translated_src_ip = ent["SAI_NAT_ENTRY_ATTR_SRC_IP"]
                 if "SAI_NAT_ENTRY_ATTR_L4_SRC_PORT" in ent:
-                    translated_src_port = ent[b"SAI_NAT_ENTRY_ATTR_L4_SRC_PORT"]
+                    translated_src_port = ent["SAI_NAT_ENTRY_ATTR_L4_SRC_PORT"]
                     translated_src = translated_src_ip + ":" + translated_src_port
                 else:
                     translated_src = translated_src_ip

--- a/scripts/nbrshow
+++ b/scripts/nbrshow
@@ -82,7 +82,7 @@ class NbrBase(object):
                 continue
 
             ent = self.db.get_all('ASIC_DB', s, blocking=True)
-            br_port_id = ent[b"SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID"][oid_pfx:]
+            br_port_id = ent["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID"][oid_pfx:]
             if br_port_id not in self.if_br_oid_map:
                 continue
             port_id = self.if_br_oid_map[br_port_id]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
I fixed python porting errors in fdbshow, natshow and nbrshow scripts.

**- How I did it**
I removed 'b' from strings of the form b"xxxxx"
  
**- How to verify it**
Without the fix, executing show mac, show arp, show nat throws an error related to this python porting error. So, with this fix, the show mac, show arp and show nat scripts execute successfully.
  
**- Previous command output (if the output of a command-line utility has changed)**
None

**- New command output (if the output of a command-line utility has changed)**
None
