### PR TITLE
[acl_loader] Fix default DENY rule for V6 dataplane ACLs

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -539,7 +539,7 @@ class AclLoader(object):
         rule_props["PRIORITY"] = str(self.min_priority)
         rule_props["PACKET_ACTION"] = "DROP"
         if 'v6' in table_name.lower():
-            rule_props["ETHER_TYPE"] = str(self.ethertype_map["ETHERTYPE_IPV6"])
+            rule_props["IP_TYPE"] = "IPV6ANY"  # ETHERTYPE is not supported for DATAACLV6
         else:
             rule_props["ETHER_TYPE"] = str(self.ethertype_map["ETHERTYPE_IPV4"])
         return rule_data


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
I updated the default DENY rule for V6 to use IP type rather than Ethertype. This is necessary because L3V6 tables do not support Ethertype as a qualifier.

**- How I did it**
Updated the deny_rule method to use the new field.

**- How to verify it**
1. Run acl-loader on a table of type L3V6
2. Verify there are no errors in the logs
3. Verify that IPv6 traffic that does not hit any of the ALLOW rules is dropped.
4. Verify that `aclshow` shows these drops under the DEFAULT_RULE.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

