### PR TITLE
Mgmt vrf validations and bug fixes

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -12,6 +12,7 @@ import sys
 import threading
 import time
 
+from socket import AF_INET,AF_INET6
 from minigraph import parse_device_desc_xml
 from portconfig import get_child_ports
 from sonic_py_common import device_info, multi_asic
@@ -1777,7 +1778,15 @@ def vrf_add_management_vrf(config_db):
     config_db.mod_entry('MGMT_VRF_CONFIG', "vrf_global", {"mgmtVrfEnabled": "true"})
     mvrf_restart_services()
 
-def vrf_delete_management_vrf(config_db):
+    cmd = "cat /proc/net/route | grep -E \"eth0\s+00000000\s+[0-9A-Z]+\s+[0-9]+\s+[0-9]+\s+[0-9]+\s+202\" | wc -l"
+    proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+    output = proc.communicate()
+    #print "output: {}".format(int(output[0]))
+    if int(output[0]) >= 1:
+        cmd="ip -4 route del default dev eth0 metric 202"
+        os.system(cmd)
+
+def vrf_delete_management_vrf():
     """Disable management vrf in config DB"""
 
     entry = config_db.get_entry('MGMT_VRF_CONFIG', "vrf_global")
@@ -1795,6 +1804,8 @@ def snmpagentaddress(ctx):
     config_db.connect()
     ctx.obj = {'db': config_db}
 
+ip_family = {4: AF_INET, 6: AF_INET6}
+
 @snmpagentaddress.command('add')
 @click.argument('agentip', metavar='<SNMP AGENT LISTENING IP Address>', required=True)
 @click.option('-p', '--port', help="SNMP AGENT LISTENING PORT")
@@ -1804,13 +1815,43 @@ def add_snmp_agent_address(ctx, agentip, port, vrf):
     """Add the SNMP agent listening IP:Port%Vrf configuration"""
 
     #Construct SNMP_AGENT_ADDRESS_CONFIG table key in the format ip|<port>|<vrf>
+    if not clicommon.is_ipaddress(agentip):
+        click.echo("Invalid IP address")
+        return False
+    config_db = ctx.obj['db']
+    if not vrf:
+        entry = config_db.get_entry('MGMT_VRF_CONFIG', "vrf_global")
+        if entry and entry['mgmtVrfEnabled'] == 'true' :
+            click.echo("ManagementVRF is Enabled. Provide vrf.")
+            return
+    found = 0
+    ip = ipaddress.ip_address(agentip)
+    for intf in netifaces.interfaces():
+        ipaddresses = netifaces.ifaddresses(intf)
+        if ip_family[ip.version] in ipaddresses:
+            for ipaddr in ipaddresses[ip_family[ip.version]]:
+                if agentip == ipaddr['addr']:
+                    found = 1
+                    break;
+        if found == 1:
+            break;
+    if found == 0:
+        click.echo(" IP addfress is not available")
+        return
+
     key = agentip+'|'
     if port:
         key = key+port
+    #snmpd does not start if we have two entries with same ip and port.
+    key1 = "SNMP_AGENT_ADDRESS_CONFIG|" + key + '*'
+    entry = config_db.get_keys(key1)
+    if entry:
+        ip_port = agentip + ":" + port
+        click.echo("entry with {} already exist ". format(ip_port))
+        return
     key = key+'|'
     if vrf:
         key = key+vrf
-    config_db = ctx.obj['db']
     config_db.set_entry('SNMP_AGENT_ADDRESS_CONFIG', key, {})
 
     #Restarting the SNMP service will regenerate snmpd.conf and rerun snmpd

--- a/config/main.py
+++ b/config/main.py
@@ -1789,7 +1789,7 @@ def vrf_add_management_vrf(config_db):
     if int(output[0]) >= 1:
         cmd="ip -4 route del default dev eth0 metric 202"
         proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
-        (out, err) = proc.communicate()
+        output = proc.communicate()
         if proc.returncode != 0:
             click.echo("Could not delete eth0 route")
 

--- a/config/main.py
+++ b/config/main.py
@@ -1789,7 +1789,7 @@ def vrf_add_management_vrf(config_db):
     if int(output[0]) >= 1:
         cmd="ip -4 route del default dev eth0 metric 202"
         proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
-        output = proc.communicate()
+        proc.communicate()
         if proc.returncode != 0:
             click.echo("Could not delete eth0 route")
 

--- a/show/main.py
+++ b/show/main.py
@@ -279,7 +279,7 @@ def is_mgmt_vrf_enabled(ctx):
 #
 
 @cli.group('mgmt-vrf', invoke_without_command=True)
-@click.argument('routes', required=False)
+@click.argument('routes', required=False, type=click.Choice(["routes"]))
 @click.pass_context
 def mgmt_vrf(ctx,routes):
     """Show management VRF attributes"""


### PR DESCRIPTION
**- What I did**
1. added ip address validation for add_snmp_agent_address in config/main.py
2. Added click choice for routes in show/main.py 
3. Default kernel route via eth0 interface is still being show in the output 'show ip route' even after creating 'mgmt' VRF
   Added Fix for it .
**- How I did it**

-   Added different validation checks in add_snmp_agent_address for the following cases : -

a.  Invalid ip check for snmpagentaddress click cmd
b.  Error case when vrf is not provided for snmpagentaddress click cmd
c.  Error case when a different ip is used for snmpagentaddress click cmd.
d.  If ip and port exists throw a msg notifying the same

-   click choice for routes in show/main.py was added .

-   Default kernel route via eth0 interface is still being show in the output 'show ip route' even after creating 'mgmt' VRF
     Explicitly issuing del in vrf_add_management_vrf() in config/main.py 
**- How to verify it**
Verifications Tests done

- Various error case handling wrt mgmt vrf for "snmpagentaddress add <ip> -p <port> -v <vrf>" 

a. Error case validation for invalid ip
admin@sonic:  sudo config snmpagentaddress add 260.59.133.20 -p 161 -v mgmt
Invalid IP address
admin@sonic:
b. Error case when vrf is not provided for "snmpagentaddress add <ip> -p <port> -v <vrf>"
admin@sonic: sudo config snmpagentaddress add 10.59.133.20 -p 161
ManagementVRF is Enabled. Provide vrf.
admin@sonic:
c. Error case when a different ip is used for "snmpagentaddress add <ip> -p <port> -v <vrf>"
admin@sonic: sudo config snmpagentaddress add 10.59.133.27 -p 161 -v mgmt
 IP addfress is not available
admin@sonic:
d. If ip and port exists throw a msg notifying the same
admin@sonic: sudo config snmpagentaddress add 10.59.133.20 -p 161 -v mgmt
entry with 10.59.133.20:161 already exist
admin@sonic:

-  Config passing without error

admin@sonic: sudo config snmpagentaddress add 10.59.133.20 -p 161 -v mgmt
admin@sonic:
admin@sonic: sudo config snmpagentaddress del 10.59.133.20 -p 161 -v mgmt
admin@sonic:

-  Testing show cmd

admin@sonic: sudo show mgmt routes
Routes in Management VRF Routing Table:
broadcast 10.59.128.0 dev eth0 proto kernel scope link src 10.59.133.20
10.59.128.0/20 dev eth0 proto kernel scope link src 10.59.133.20
local 10.59.133.20 dev eth0 proto kernel scope host src 10.59.133.20
broadcast 10.59.143.255 dev eth0 proto kernel scope link src 10.59.133.20
broadcast 127.0.0.0 dev lo-m proto kernel scope link src 127.0.0.1
127.0.0.0/16 dev lo-m proto kernel scope link src 127.0.0.1
local 127.0.0.1 dev lo-m proto kernel scope host src 127.0.0.1
broadcast 127.0.255.255 dev lo-m proto kernel scope link src 127.0.0.1
admin@sonic: 

-  Test for default kernal route via eth0 not being shown

admin@sonic: cat /proc/net/route | grep eth
eth0    00000000        01803B0A        0003    0       0       0       00000000        0       0       0                                                    
eth0    00803B0A        00000000        0001    0       0       0       00F0FFFF        0       0       0                                                    
admin@sonic:
admin@sonic:
admin@sonic: sudo config vrf add mgmt

admin@sonic:
admin@sonic: cat /proc/net/route | grep eth
admin@sonic:
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

