### PR TITLE
Parse sonic_platform kernel command line parameter to read the platform identifier string

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -10,7 +10,7 @@ if [ -e $VMCORE_FILE -a -s $VMCORE_FILE ]; then
         echo "We have a /proc/vmcore, then we just kdump'ed"
         echo "User issued 'kdump' command [User: kdump, Time: ${REBOOT_TIME}]" > ${REBOOT_CAUSE_FILE}
         sync
-        PLATFORM=$(grep -oP 'platform=\K\S+' /proc/cmdline)
+        PLATFORM=$(grep -oP 'sonic_platform=\K\S+' /proc/cmdline)
         if [ ! -z "${PLATFORM}" -a -x ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT} ]; then
             exec ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT}
         fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
The platform identifier string is used in the reboot script to identify and execute any custom platform specific reboot script. 
sonic_platform is used as the kernel parameter to pass the platform identifier string.

**- How I did it**
In the reboot script, under the case where it is executed by the crash kernel, parse /proc/cmdline and parse sonic_platform value.

**- How to verify it**
Enable kdump and reboot to operationally enable it.
Using echo c /proc/sysrq-trigger, crash the kernel and observe that the crash kernel executes platform specific reboot script

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

