### PR TITLE
Fast-reboot: add a new flag to ignore ASIC checksum verification failure

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -9,6 +9,7 @@ REBOOT_SCRIPT_NAME=$(basename $0)
 REBOOT_TYPE="${REBOOT_SCRIPT_NAME}"
 VERBOSE=no
 FORCE=no
+IGNORE_ASIC=no
 STRICT=no
 REBOOT_METHOD="/sbin/kexec -e"
 ASSISTANT_IP_LIST=""
@@ -55,6 +56,7 @@ function showHelpAndExit()
     echo "    -h,-? : get this help"
     echo "    -v    : turn on verbose"
     echo "    -f    : force execution"
+    echo "    -i    : ignore MD5-checksum-verification of ASIC configuration files"
     echo "    -r    : reboot with /sbin/reboot"
     echo "    -k    : reboot with /sbin/kexec -e [default]"
     echo "    -x    : execute script with -x flag"
@@ -67,7 +69,7 @@ function showHelpAndExit()
 
 function parseOptions()
 {
-    while getopts "vfh?rkxc:s" opt; do
+    while getopts "vfih?rkxc:s" opt; do
         case ${opt} in
             h|\? )
                 showHelpAndExit
@@ -77,6 +79,9 @@ function parseOptions()
                 ;;
             f )
                 FORCE=yes
+                ;;
+            i )
+                IGNORE_ASIC=yes
                 ;;
             r )
                 REBOOT_METHOD="/sbin/reboot"
@@ -335,7 +340,7 @@ function reboot_pre_check()
         ${ASIC_CONFIG_CHECK_SCRIPT} || ASIC_CONFIG_CHECK_EXIT_CODE=$?
 
         if [[ "${ASIC_CONFIG_CHECK_EXIT_CODE}" != "${ASIC_CONFIG_CHECK_SUCCESS}" ]]; then
-            if [[ x"${FORCE}" == x"yes" ]]; then
+            if [[ x"${IGNORE_ASIC}" == x"yes" ]]; then
                 debug "Ignoring ASIC config checksum failure..."
             else
                 error "ASIC config may have changed: errno=${ASIC_CONFIG_CHECK_EXIT_CODE}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
This is to fix/enhance the issue https://github.com/Azure/sonic-buildimage/issues/5972

`warm-reboot` with force flag ignores ASIC config checksum mismatch along with orchagent RESTARTCHECK failure.
There can be a use case when checksum-verification should be ignored but orchagent pause check should not be ignored.

**- How I did it**
Added a new `option` in fast-reboot script to ignore ASIC checksum verification failures.

**- How to verify it**

Reproduced the issue locally:
```
root@sonic:~# warm-reboot -vvv
Sat 05 Dec 2020 02:14:38 AM UTC Saving counters folder before warmboot...
ASIC config may have changed: errno=1
Sat 05 Dec 2020 02:14:40 AM UTC warm-reboot failure (1) cleanup ...
Sat 05 Dec 2020 02:14:41 AM UTC Cancel warm-reboot: code (1)
root@sonic:~# 
```

With the local change ASIC configuration checksum verification is ignored.
```
root@sonic:~# warm-reboot -h
Usage: warm-reboot [options]
    -h,-? : get this help
    -v    : turn on verbose
    -f    : force execution
    -i    : ignore MD5-checksum-verification of ASIC configuration files
    -r    : reboot with /sbin/reboot
    -k    : reboot with /sbin/kexec -e [default]
    -x    : execute script with -x flag
    -c    : specify control plane assistant IP list
    -s    : strict mode: do not proceed without:
            - control plane assistant IP list.
root@sonic:~# 
```
```
root@sonic:~# warm-reboot -vvvi
Sat 05 Dec 2020 02:14:46 AM UTC Saving counters folder before warmboot...
Sat 05 Dec 2020 02:14:47 AM UTC Ignoring ASIC config checksum failure...
Sat 05 Dec 2020 02:14:48 AM UTC Pausing orchagent ...
Sat 05 Dec 2020 02:14:48 AM UTC Collecting logs to check ssd health before warm-reboot...
Sat 05 Dec 2020 02:14:49 AM UTC Stopping nat ...
Dumping conntrack entries failed
Error response from daemon: Cannot kill container: nat: No such container: nat
Sat 05 Dec 2020 02:14:49 AM UTC Stopped nat ...
Sat 05 Dec 2020 02:14:49 AM UTC Stopping radv service...
Sat 05 Dec 2020 02:14:50 AM UTC Stopped radv service...
Sat 05 Dec 2020 02:14:50 AM UTC Stopping bgp ...
Sat 05 Dec 2020 02:14:52 AM UTC Stopped bgp ...
Sat 05 Dec 2020 02:14:54 AM UTC Stopping swss service ...
Sat 05 Dec 2020 02:15:03 AM UTC Stopped swss service ...
Sat 05 Dec 2020 02:15:03 AM UTC Initialize pre-shutdown ...
Sat 05 Dec 2020 02:15:04 AM UTC Requesting pre-shutdown ...
Sat 05 Dec 2020 02:15:04 AM UTC Waiting for pre-shutdown ...
Sat 05 Dec 2020 02:15:05 AM UTC Pre-shutdown succeeded ...
Sat 05 Dec 2020 02:15:05 AM UTC Backing up database ...
Sat 05 Dec 2020 02:15:07 AM UTC Stopping teamd ...
Sat 05 Dec 2020 02:15:08 AM UTC Stopped teamd ...
Sat 05 Dec 2020 02:15:08 AM UTC Stopping syncd ...
Sat 05 Dec 2020 02:15:20 AM UTC Stopped syncd ...
Sat 05 Dec 2020 02:15:20 AM UTC Stopping all remaining containers ...
Warning: Stopping mgmt-framework.service, but it can still be activated by:
  mgmt-framework.timer
Sat 05 Dec 2020 02:15:22 AM UTC Stopped all remaining containers ...
Sat 05 Dec 2020 02:15:24 AM UTC updating ssd fw forwarm-reboot
Sat 05 Dec 2020 02:15:24 AM UTC Enabling Watchdog before warm-reboot
Watchdog armed for 180 seconds
Sat 05 Dec 2020 02:15:25 AM UTC Running x86_64-dell_s6100_c2538-r0 specific plugin...
Sat 05 Dec 2020 02:15:25 AM UTC Rebooting with /sbin/kexec -e to SONiC-OS-20181130.85 ...
```



**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

