### PR TITLE
[pcieutil] Remove 'pcie-' prefix from subcommands

### DIFF
--- a/pcieutil/main.py
+++ b/pcieutil/main.py
@@ -91,7 +91,7 @@ def print_test_title(testname):
 
 
 @cli.command()
-def pcie_show():
+def show():
     '''Display PCIe Device '''
     testname = "Display PCIe Device"
     print_test_title(testname)
@@ -107,7 +107,7 @@ def pcie_show():
 
 #  Show PCIE Vender ID and Device ID
 @cli.command()
-def pcie_check():
+def check():
     '''Check PCIe Device '''
     testname = "PCIe Device Check"
     err = 0
@@ -128,7 +128,7 @@ def pcie_check():
 
 @cli.command()
 @click.confirmation_option(prompt="Are you sure to overwrite config file pcie.yaml with current pcie device info?")
-def pcie_generate():
+def generate():
     '''Generate config file with current pci device'''
     platform_pcieutil.dump_conf_yaml()
     click.echo("Generate config file pcie.yaml under path %s" % platform_plugins_path)

--- a/show/platform.py
+++ b/show/platform.py
@@ -100,9 +100,9 @@ def ssdhealth(device, verbose, vendor):
 @click.option('-c', '--check', is_flag=True, help="Check the platfome pcie device")
 def pcieinfo(check, verbose):
     """Show Device PCIe Info"""
-    cmd = "sudo pcieutil pcie-show"
+    cmd = "sudo pcieutil show"
     if check:
-        cmd = "sudo pcieutil pcie-check"
+        cmd = "sudo pcieutil check"
     clicommon.run_command(cmd, display_cmd=verbose)
 
 


### PR DESCRIPTION
**- What I did**

Remove redundant 'pcie-' prefix from subcommands

Note this will also require an update to files/image_config/pcie-check/pcie-check.sh in sonic-buildimage. Also, since these commands require sudo, they need to be added to the read-only commands in the sudoers file, which they have not yet been.

**- How to verify it**

Ensure the following commands work:

```
pcieutil show
pcieutil check
pcieutil generate
show pcieinfo
show pcieinfo -c
```

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

