### PR TITLE
[Mellanox] Add FW dump with new SAI implementation and remove mst dump

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -517,11 +517,12 @@ collect_mellanox() {
     ${CMD_PREFIX}docker exec syncd tar Ccf $(dirname $sai_dump_filename) - $(basename $sai_dump_filename) | tar Cxf /tmp/ -
     save_file $sai_dump_filename sai_sdk_dump true
 
-    local mst_dump_filename="/tmp/mstdump"
-    local max_dump_count="3"
-    for i in $(seq 1 $max_dump_count); do
-        ${CMD_PREFIX}/usr/bin/mstdump /dev/mst/mt*conf0 > "${mst_dump_filename}${i}"
-        save_file "${mst_dump_filename}${i}" mstdump true
+    file_list_string=$(${CMD_PREFIX}docker exec -it syncd ls -l /tmp | grep sdkdump | awk '{print $9}' | tr -d '\r')
+    file_list_array=( $file_list_string )
+    for element in "${file_list_array[@]}"
+    do
+        docker cp syncd:/tmp/$element /tmp
+        save_file /tmp/$element sai_sdk_dump true
     done
 }
 


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Mellanox SAI implementation of the sai dump is now extracting more information which previously provided by direct call to a Mellanox FW tool which is not longer required.

The new files created will be taken along with the new dump.
Remove MST dump as it is not required anymore.

**- How I did it**
Add commands to copy FW dump output into techsupport output file, inside "sai_sdk_dump" directory.
Remove commands for MST dump.

**- How to verify it**
Run "show techsupport" with MLNX SAI 1.18.0

**- Previous command output (if the output of a command-line utility has changed)**

├── mstdump
│   ├── mstdump1.gz
│   ├── mstdump2.gz
│   └── mstdump3.gz

**- New command output (if the output of a command-line utility has changed)**

└── sai_sdk_dump
    ├── sai_sdk_dump_12_09_2020_03_17_PM.gz
    ├── sdkdump_ext_cr_001-09_12_2020-15_17_57.udmp.gz
    ├── sdkdump_ext_cr_001-09_12_2020-15_17_58.udmp.gz
    ├── sdkdump_ext_cr_001-09_12_2020-15_18_00.udmp.gz
    ├── sdkdump_ext_meta_001-09_12_2020-15_17_57.gz
    ├── sdkdump_ext_meta_001-09_12_2020-15_17_58.gz
    └── sdkdump_ext_meta_001-09_12_2020-15_18_00.gz

