### PR TITLE
[vnet] Add "vnet_route_check" script

### DIFF
--- a/scripts/vnet_route_check.py
+++ b/scripts/vnet_route_check.py
@@ -6,7 +6,6 @@ import json
 import syslog
 from swsssdk import ConfigDBConnector
 from swsssdk import SonicV2Connector
-from collections import defaultdict
 
 
 ''' vnet_route_check.py: tool that verifies VNET routes consistancy between SONiC and vendor SDK DBs.

--- a/scripts/vnet_route_check.py
+++ b/scripts/vnet_route_check.py
@@ -8,6 +8,10 @@ from swsssdk import SonicV2Connector
 from collections import defaultdict
 
 
+RC_OK = 0
+RC_ERR = -1
+
+
 ''' vnet_route_check.py: tool that verifies VNET routes consistancy between SONiC and vendor SDK DBs.
 
 Logically VNET route verification logic consists of 3 parts:
@@ -16,7 +20,7 @@ Logically VNET route verification logic consists of 3 parts:
 3. Get VNET routes entries that are missed in SDK but present in ASIC_DB.
 
 Returns 0 if there is no inconsistancy found and all VNET routes are aligned in all DBs.
-Returns -1 and prints differences between DBs in JSON format to standart output.
+Returns -1 if there is incosistancy found and prints differences between DBs in JSON format to standart output.
 
 Format of differences output:
 {
@@ -44,12 +48,11 @@ Format of differences output:
         }
     }
 }
-
 '''
 
 
 def get_vnet_intfs():
-    ''' Returns dictionary VNETs and related VNET interfaces.
+    ''' Returns dictionary of VNETs and related VNET interfaces.
     Format: { <vnet_name>: [ <vnet_rif_name> ] }
     '''
     config_db = ConfigDBConnector()
@@ -59,21 +62,22 @@ def get_vnet_intfs():
     vlan_intfs_data = config_db.get_table('VLAN_INTERFACE')
 
     vnet_intfs = {}
-    for k, v in intfs_data.items():
-        if 'vnet_name' in v:
-            vnet_name = v['vnet_name']
-            if vnet_name in vnet_intfs:
-                vnet_intfs[vnet_name].append(k)
-            else:
-                vnet_intfs[vnet_name] = [k]
 
-    for k, v in vlan_intfs_data.items():
-        if 'vnet_name' in v:
-            vnet_name = v['vnet_name']
+    for intf_name, intf_attrs in intfs_data.items():
+        if 'vnet_name' in intf_attrs:
+            vnet_name = intf_attrs['vnet_name']
             if vnet_name in vnet_intfs:
-                vnet_intfs[vnet_name].append(k)
+                vnet_intfs[vnet_name].append(intf_name)
             else:
-                vnet_intfs[vnet_name] = [k]
+                vnet_intfs[vnet_name] = [intf_name]
+
+    for intf_name, intf_attrs in vlan_intfs_data.items():
+        if 'vnet_name' in intf_attrs:
+            vnet_name = intf_attrs['vnet_name']
+            if vnet_name in vnet_intfs:
+                vnet_intfs[vnet_name].append(intf_name)
+            else:
+                vnet_intfs[vnet_name] = [intf_name]
 
     return vnet_intfs
 
@@ -85,7 +89,7 @@ def get_all_rifs_oids():
     db = SonicV2Connector(host='127.0.0.1')
     db.connect(db.COUNTERS_DB)
 
-    rif_name_oid_map = db.get_all(db.COUNTERS_DB, 'COUNTERS_RIF_NAME_MAP');
+    rif_name_oid_map = db.get_all(db.COUNTERS_DB, 'COUNTERS_RIF_NAME_MAP')
 
     return rif_name_oid_map
 
@@ -102,7 +106,7 @@ def get_vnet_rifs_oids():
 
     vnet_rifs_oids_map = {}
 
-    for intf_name in intfs_oids:
+    for intf_name in intfs_oids or {}:
         if intf_name in vnet_intfs:
             vnet_rifs_oids_map[intf_name] = intfs_oids[intf_name]
 
@@ -119,11 +123,46 @@ def get_vrf_entries():
     vnet_rifs_oids = get_vnet_rifs_oids()
 
     rif_vrf_map = {}
-    for k in vnet_rifs_oids:
-        keys = db.get_all(db.ASIC_DB, 'ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE:{}'.format(vnet_rifs_oids[k]))
-        rif_vrf_map[k] = keys['SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID']
+    for vnet_rif_name in vnet_rifs_oids:
+        rif_attrs = db.get_all(db.ASIC_DB, 'ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE:{}'.format(vnet_rifs_oids[vnet_rif_name]))
+        rif_vrf_map[vnet_rif_name] = rif_attrs['SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID']
 
     return rif_vrf_map
+
+
+def filter_out_vnet_ip2me_routes(vnet_routes):
+    ''' Filters out IP2ME routes from the provided dictionary with VNET routes
+    Format: { <vnet_name>: { 'routes': [ <pfx/pfx_len> ], 'vrf_oid': <oid> } }
+    '''
+    db = ConfigDBConnector()
+    db.db_connect('APPL_DB')
+
+    vnet_intfs = get_vnet_intfs()
+    all_rifs_db_keys = db.get_keys('INTF_TABLE')
+
+    vnet_intfs = [vnet_intfs[k] for k in vnet_intfs]
+    vnet_intfs = [val for sublist in vnet_intfs for val in sublist]
+
+    vnet_ip2me_routes = []
+    for rif in all_rifs_db_keys:
+        rif_attrs = rif.split(':')
+        # Skip RIF entries without IP prefix and prefix length (they have only one attribute - RIF name)
+        if len(rif_attrs) == 1:
+            continue
+
+        # rif_attrs[0] - RIF name
+        # rif_attrs[1] - IP prefix and prefix legth
+        # IP2ME routes have '/32' prefix length so replace it and add to the list
+        if rif_attrs[0] in vnet_intfs:
+            vnet_ip2me_routes.append(rif_attrs[1].replace('/24', '/32'))
+
+    for vnet, vnet_attrs in vnet_routes.items():
+        for route in vnet_attrs['routes']:
+            if route in vnet_ip2me_routes:
+                vnet_attrs['routes'].remove(route)
+
+        if not vnet_attrs['routes']:
+            vnet_routes.pop(vnet)
 
 
 def get_vnet_routes_from_app_db():
@@ -133,26 +172,28 @@ def get_vnet_routes_from_app_db():
     db = ConfigDBConnector()
     db.db_connect('APPL_DB')
 
-    intfs = get_vnet_intfs()
-    vrfs = get_vrf_entries()
+    vnet_intfs = get_vnet_intfs()
+    vnet_vrfs = get_vrf_entries()
 
     vnet_routes_db_keys = db.get_keys('VNET_ROUTE_TABLE') + db.get_keys('VNET_ROUTE_TUNNEL_TABLE')
 
-    routes = {}
+    vnet_routes = {}
 
     for vnet_route_db_key in vnet_routes_db_keys:
-        kv = vnet_route_db_key.split(':')
+        vnet_route_list = vnet_route_db_key.split(':')
+        vnet_name = vnet_route_list[0]
+        vnet_route = vnet_route_list[1]
 
-        if kv[0] not in routes:
-            routes[kv[0]] = {}
-            routes[kv[0]]['routes'] = []
+        if vnet_name not in vnet_routes:
+            vnet_routes[vnet_name] = {}
+            vnet_routes[vnet_name]['routes'] = []
 
-            intf = intfs[kv[0]][0]
-            routes[kv[0]]['vrf_oid'] = vrfs.get(intf, 'None')
+            intf = vnet_intfs[vnet_name][0]
+            vnet_routes[vnet_name]['vrf_oid'] = vnet_vrfs.get(intf, 'None')
 
-        routes[kv[0]]['routes'].append(kv[1])
+        vnet_routes[vnet_name]['routes'].append(vnet_route)
 
-    return routes
+    return vnet_routes
 
 
 def get_vnet_routes_from_asic_db():
@@ -162,53 +203,60 @@ def get_vnet_routes_from_asic_db():
     db = ConfigDBConnector()
     db.db_connect('ASIC_DB')
 
-    vrfs = get_vrf_entries()
-    list = [vrfs[k] for k in vrfs]
-    intfs = get_vnet_intfs()
+    vnet_vrfs = get_vrf_entries()
+    vnet_vrfs_oids = [vnet_vrfs[k] for k in vnet_vrfs]
+    
+    vnet_intfs = get_vnet_intfs()
 
-    vr_to_vnet = {}
+    vrf_oid_to_vnet_map = {}
 
-    for k, v in intfs.items():
-        for k1, v1 in vrfs.items():
-            if k1 == v[0]:
-                vr_to_vnet[v1] = k
+    for vnet_name, vnet_rifs in vnet_intfs.items():
+        for vnet_rif, vrf_oid in vnet_vrfs.items():
+            if vnet_rif in vnet_rifs:
+                vrf_oid_to_vnet_map[vrf_oid] = vnet_name
 
-    keys = db.get_keys('ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY', False)   
+    routes_db_keys = db.get_keys('ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY', False)   
+    vnet_routes = {}
 
-    routes = {}
+    for route_db_key in routes_db_keys:
+        route_attrs = route_db_key.lower().split('\"', -1)
+        # route_attrs[11] - VRF OID for the VNET route
+        # route_attrs[3] - VNET route IP subnet
+        vrf_oid = route_attrs[11]
+        ip_addr = route_attrs[3]
 
-    for k in keys:
-        vr = k.lower().split('\"', -1)[11]
-        ip = k.lower().split('\"', -1)[3]
-        if vr in list:
-            if vr_to_vnet[vr] not in routes:
-                routes[vr_to_vnet[vr]] = {}
-                routes[vr_to_vnet[vr]]['routes'] = []
-                routes[vr_to_vnet[vr]]['vrf_oid'] = vr
+        if vrf_oid in vnet_vrfs_oids:
+            if vrf_oid_to_vnet_map[vrf_oid] not in vnet_routes:
+                vnet_name = vrf_oid_to_vnet_map[vrf_oid]
 
-            routes[vr_to_vnet[vr]]['routes'].append(ip)
+                vnet_routes[vnet_name] = {}
+                vnet_routes[vnet_name]['routes'] = []
+                vnet_routes[vnet_name]['vrf_oid'] = vrf_oid
 
-    return routes
+            vnet_routes[vnet_name]['routes'].append(ip_addr)
+
+    filter_out_vnet_ip2me_routes(vnet_routes)
+
+    return vnet_routes
 
 
 def get_vnet_routes_diff(routes_1, routes_2):
     ''' Returns all routes present in routes_2 dictionary but missed in routes_1
-    Format: { <vnet_name>: { 'routes': [ <pfx/pfx_len> ], 'vrf_oid': <oid> } }
+    Format: { <vnet_name>: { 'routes': [ <pfx/pfx_len> ] } }
     '''
 
     routes = {}
 
-    for k, v in routes_2.items():
-        if k not in routes_1:
-            routes[k] = v
+    for vnet_name, vnet_attrs in routes_2.items():
+        if vnet_name not in routes_1:
+            routes[vnet_name] = routes
         else:
-            for rt in v['routes']:
-                if rt not in routes_1[k]['routes']:
-                    if k not in routes:
-                        routes[k] = {}
-                        routes[k]['routes'] = []
-                    routes[k]['routes'].append(rt)
-                    routes[k]['vrf_oid'] = routes_1[k]['vrf_oid']
+            for vnet_route in vnet_attrs['routes']:
+                if vnet_route not in routes_1[vnet_name]['routes']:
+                    if vnet_name not in routes:
+                        routes[vnet_name] = {}
+                        routes[vnet_name]['routes'] = []
+                    routes[vnet_name]['routes'].append(vnet_route)
 
     return routes
 
@@ -223,19 +271,22 @@ def get_sdk_vnet_routes_diff(routes):
     if res != 0:
         return routes_diff
 
-    for k, v in routes.items():
-        res = os.system('docker exec syncd "/usr/bin/vnet_route_check.py {} {}"'.format(routes[k]["routes"], routes[k]["vrf_oid"]))
+    for vnet_name, vnet_routes in routes.items():
+        vnet_routes = routes[vnet_name]["routes"]
+        vnet_vrf_oid = routes[vnet_name]["vrf_oid"]
+
+        res = os.system('docker exec syncd "/usr/bin/vnet_route_check.py {} {}"'.format(vnet_vrf_oid, vnet_routes))
         if res:
-            routes[k] = {}
-            routes[k]['routes'] = res
+            routes_diff[vnet_name] = {}
+            routes_diff[vnet_name]['routes'] = res
 
     return routes_diff
 
 
 def main():
 
-    app_db_vnet_routes = get_vnet_routes_from_asic_db()
-    asic_db_vnet_routes = get_vnet_routes_from_app_db()
+    app_db_vnet_routes = get_vnet_routes_from_app_db()
+    asic_db_vnet_routes = get_vnet_routes_from_asic_db()
 
     missed_in_asic_db_routes = get_vnet_routes_diff(asic_db_vnet_routes, app_db_vnet_routes)
     missed_in_app_db_routes = get_vnet_routes_diff(app_db_vnet_routes, asic_db_vnet_routes)
@@ -243,7 +294,7 @@ def main():
 
     res = {}
     res['results'] = {}
-    rc = 0
+    rc = RC_OK
 
     if missed_in_asic_db_routes:
         res['results']['missed_in_asic_db_routes'] = missed_in_asic_db_routes
@@ -255,7 +306,7 @@ def main():
         res['results']['missed_in_sdk_routes'] = missed_in_sdk_routes
 
     if res['results']:
-        rc = -1
+        rc = RC_ERR
         print(json.dumps(res, indent=4))
 
     sys.exit(rc)
@@ -263,4 +314,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/scripts/vnet_route_check.py
+++ b/scripts/vnet_route_check.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+import json
+from swsssdk import ConfigDBConnector
+from swsssdk import SonicV2Connector
+
+
+def get_vnet_intfs():
+    config_db = ConfigDBConnector()
+    config_db.connect('CONFIG_DB')
+
+    intfs_data = config_db.get_table("INTERFACE")
+    vlan_intfs_data = config_db.get_table("VLAN_INTERFACE")
+
+    vnet_intfs = {}
+    for k, v in intfs_data.items():
+        if 'vnet_name' in v:
+            vnet_name = v['vnet_name']
+            if vnet_name in vnet_intfs:
+                vnet_intfs[vnet_name].append(k)
+            else:
+                vnet_intfs[vnet_name] = [k]
+
+    for k, v in vlan_intfs_data.items():
+        if 'vnet_name' in v:
+            vnet_name = v['vnet_name']
+            if vnet_name in vnet_intfs:
+                vnet_intfs[vnet_name].append(k)
+            else:
+                vnet_intfs[vnet_name] = [k]
+
+    return vnet_intfs
+
+
+def get_rifs_oid():
+    db = SonicV2Connector(host='127.0.0.1')
+    db.connect(db.COUNTERS_DB)
+
+    keys = db.get_all(db.COUNTERS_DB, 'COUNTERS_RIF_NAME_MAP');
+
+    return keys
+
+
+def get_vnet_rifs_oid():
+    intfs = get_vnet_intfs()
+    intfs_oids = get_rifs_oid()
+
+    list = [intfs[k] for k in intfs]
+    flattened = [val for sublist in list for val in sublist]
+
+    oids = {}
+
+    for i in intfs_oids:
+        if i in flattened:
+            oids[i] = intfs_oids[i]
+
+    return oids
+
+
+def get_vrf_entries():
+    db = ConfigDBConnector()
+    db.db_connect('ASIC_DB')
+
+    oids = get_vnet_rifs_oid()
+
+    vrid = {}
+
+    for k in oids:
+        keys = db.get_all(db.ASIC_DB, 'ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE:{}'.format(oids[k]))
+        vrid[k] = keys['SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID']
+
+    return vrid
+
+
+def get_routes_from_app_db():
+    db = ConfigDBConnector()
+    db.db_connect('APPL_DB')
+
+    intfs = get_vnet_intfs()
+    vrfs = get_vrf_entries()
+
+    keys = db.get_keys('VNET_ROUTE_TABLE') + db.get_keys('VNET_ROUTE_TUNNEL_TABLE')
+
+    routes = {}
+
+    for k in keys:
+        kv = k.split(':')
+
+        if kv[0] not in routes:
+            routes[kv[0]] = {}
+            routes[kv[0]]['routes'] = []
+
+            intf = intfs[kv[0]][0]
+            routes[kv[0]]['vrf_oid'] = vrfs.get(intf, 'None')
+
+        routes[kv[0]]['routes'].append(kv[1])
+
+    return routes
+
+
+def get_routes_from_asic_db():
+    db = ConfigDBConnector()
+    db.db_connect('ASIC_DB')
+
+    vrfs = get_vrf_entries()
+    list = [vrfs[k] for k in vrfs]
+    intfs = get_vnet_intfs()
+
+    vr_to_vnet = {}
+
+    for k, v in intfs.items():
+        for k1, v1 in vrfs.items():
+            if k1 == v[0]:
+                vr_to_vnet[v1] = k
+
+    keys = db.get_keys('ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY', False)   
+
+    routes = {}
+
+    for k in keys:
+        vr = k.lower().split("\"", -1)[11]
+        ip = k.lower().split("\"", -1)[3]
+        if vr in list:
+            if vr_to_vnet[vr] not in routes:
+                routes[vr_to_vnet[vr]] = {}
+                routes[vr_to_vnet[vr]]['routes'] = []
+                routes[vr_to_vnet[vr]]['vrf_oid'] = vr
+
+            routes[vr_to_vnet[vr]]['routes'].append(ip)
+
+    return routes
+
+
+def get_routes_diff(routes_1, routes_2):
+    routes = {}
+
+    for k, v in routes_2.items():
+        if k not in routes_1:
+            routes[k] = v
+        else:
+            for rt in v["routes"]:
+                if rt not in routes_1[k]["routes"]:
+                    if k not in routes:
+                        routes[k] = {}
+                        routes[k]["routes"] = []
+                    routes[k]["routes"].append(rt)
+                    routes[k]["vrf_oid"] = routes_1[k]["vrf_oid"]
+
+    return routes
+
+
+def get_sdk_routes_diff(routes):
+    routes_diff = {}
+    for k, v in routes.items():
+        res = os.system('docker exec syncd "/usr/bin/vnet_route_check.py {} {}"'.format(routes[k], routes[k]["vrf_oid"]))
+        if res:
+            routes[k] = {}
+            routes[k]["routes"] = res
+
+    return routes_diff
+
+
+def main():
+
+    app_routes = get_routes_from_asic_db()
+    asic_routes = get_routes_from_app_db()
+
+    missed_in_asic_db_routes = get_routes_diff(asic_routes, app_routes)
+    missed_in_app_db_routes = get_routes_diff(app_routes, asic_routes)
+    missed_in_sdk_routes = get_sdk_routes_diff(asic_routes)
+
+    res = {}
+    res["results"] = {}
+    rc = 0
+
+    if missed_in_asic_db_routes:
+        res["results"]["missed_in_asic_db_routes"] = missed_in_asic_db_routes
+
+    if missed_in_app_db_routes:
+        res["results"]["missed_in_app_db_routes"] = missed_in_app_db_routes
+
+    if missed_in_sdk_routes:
+        res["results"]["missed_in_sdk_routes"] = missed_in_sdk_routes
+
+    if res["results"]:
+        rc = -1
+        print(json.dumps(res, indent=4))
+
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/vnet_route_check.py
+++ b/scripts/vnet_route_check.py
@@ -1,19 +1,62 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python
 
 import os
 import sys
 import json
 from swsssdk import ConfigDBConnector
 from swsssdk import SonicV2Connector
+from collections import defaultdict
+
+
+''' vnet_route_check.py: tool that verifies VNET routes consistancy between SONiC and vendor SDK DBs.
+
+Logically VNET route verification logic consists of 3 parts:
+1. Get VNET routes entries that are missed in ASIC_DB but present in APP_DB.
+2. Get VNET routes entries that are missed in APP_DB but present in ASIC_DB.
+3. Get VNET routes entries that are missed in SDK but present in ASIC_DB.
+
+Returns 0 if there is no inconsistancy found and all VNET routes are aligned in all DBs.
+Returns -1 and prints differences between DBs in JSON format to standart output.
+
+Format of differences output:
+{
+    "results": {
+        "missed_in_asic_db_routes": {
+            "<vnet_name>": {
+                "routes": [
+                    "<pfx>/<pfx_len>"
+                ]
+            }
+        },
+        "missed_in_app_db_routes": {
+            "<vnet_name>": {
+                "routes": [
+                    "<pfx>/<pfx_len>"
+                ]
+            }
+        },
+        "missed_in_sdk_routes": {
+            "<vnet_name>": {
+                "routes": [
+                    "<pfx>/<pfx_len>"
+                ]
+            }
+        }
+    }
+}
+
+'''
 
 
 def get_vnet_intfs():
+    ''' Returns dictionary VNETs and related VNET interfaces.
+    Format: { <vnet_name>: [ <vnet_rif_name> ] }
+    '''
     config_db = ConfigDBConnector()
     config_db.connect('CONFIG_DB')
 
-    intfs_data = config_db.get_table("INTERFACE")
-    vlan_intfs_data = config_db.get_table("VLAN_INTERFACE")
+    intfs_data = config_db.get_table('INTERFACE')
+    vlan_intfs_data = config_db.get_table('VLAN_INTERFACE')
 
     vnet_intfs = {}
     for k, v in intfs_data.items():
@@ -35,59 +78,70 @@ def get_vnet_intfs():
     return vnet_intfs
 
 
-def get_rifs_oid():
+def get_all_rifs_oids():
+    ''' Returns dictionary of all router interfaces and their OIDs.
+    Format: { <rif_name>: <rif_oid> }
+    '''
     db = SonicV2Connector(host='127.0.0.1')
     db.connect(db.COUNTERS_DB)
 
-    keys = db.get_all(db.COUNTERS_DB, 'COUNTERS_RIF_NAME_MAP');
+    rif_name_oid_map = db.get_all(db.COUNTERS_DB, 'COUNTERS_RIF_NAME_MAP');
 
-    return keys
+    return rif_name_oid_map
 
 
-def get_vnet_rifs_oid():
-    intfs = get_vnet_intfs()
-    intfs_oids = get_rifs_oid()
+def get_vnet_rifs_oids():
+    ''' Returns dictionary of VNET interfaces and their OIDs.
+    Format: { <vnet_rif_name>: <vnet_rif_oid> }
+    '''
+    vnet_intfs = get_vnet_intfs()
+    intfs_oids = get_all_rifs_oids()
 
-    list = [intfs[k] for k in intfs]
-    flattened = [val for sublist in list for val in sublist]
+    vnet_intfs = [vnet_intfs[k] for k in vnet_intfs]
+    vnet_intfs = [val for sublist in vnet_intfs for val in sublist]
 
-    oids = {}
+    vnet_rifs_oids_map = {}
 
-    for i in intfs_oids:
-        if i in flattened:
-            oids[i] = intfs_oids[i]
+    for intf_name in intfs_oids:
+        if intf_name in vnet_intfs:
+            vnet_rifs_oids_map[intf_name] = intfs_oids[intf_name]
 
-    return oids
+    return vnet_rifs_oids_map
 
 
 def get_vrf_entries():
+    ''' Returns dictionary of VNET interfaces and corresponding VRF OIDs.
+    Format: { <vnet_rif_name>: <vrf_oid> }
+    '''
     db = ConfigDBConnector()
     db.db_connect('ASIC_DB')
 
-    oids = get_vnet_rifs_oid()
+    vnet_rifs_oids = get_vnet_rifs_oids()
 
-    vrid = {}
+    rif_vrf_map = {}
+    for k in vnet_rifs_oids:
+        keys = db.get_all(db.ASIC_DB, 'ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE:{}'.format(vnet_rifs_oids[k]))
+        rif_vrf_map[k] = keys['SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID']
 
-    for k in oids:
-        keys = db.get_all(db.ASIC_DB, 'ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE:{}'.format(oids[k]))
-        vrid[k] = keys['SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID']
-
-    return vrid
+    return rif_vrf_map
 
 
-def get_routes_from_app_db():
+def get_vnet_routes_from_app_db():
+    ''' Returns dictionary of VNET routes configured per each VNET in APP_DB.
+    Format: { <vnet_name>: { 'routes': [ <pfx/pfx_len> ], 'vrf_oid': <oid> } }
+    '''
     db = ConfigDBConnector()
     db.db_connect('APPL_DB')
 
     intfs = get_vnet_intfs()
     vrfs = get_vrf_entries()
 
-    keys = db.get_keys('VNET_ROUTE_TABLE') + db.get_keys('VNET_ROUTE_TUNNEL_TABLE')
+    vnet_routes_db_keys = db.get_keys('VNET_ROUTE_TABLE') + db.get_keys('VNET_ROUTE_TUNNEL_TABLE')
 
     routes = {}
 
-    for k in keys:
-        kv = k.split(':')
+    for vnet_route_db_key in vnet_routes_db_keys:
+        kv = vnet_route_db_key.split(':')
 
         if kv[0] not in routes:
             routes[kv[0]] = {}
@@ -101,7 +155,10 @@ def get_routes_from_app_db():
     return routes
 
 
-def get_routes_from_asic_db():
+def get_vnet_routes_from_asic_db():
+    ''' Returns dictionary of VNET routes configured per each VNET in ASIC_DB.
+    Format: { <vnet_name>: { 'routes': [ <pfx/pfx_len> ], 'vrf_oid': <oid> } }
+    '''
     db = ConfigDBConnector()
     db.db_connect('ASIC_DB')
 
@@ -121,8 +178,8 @@ def get_routes_from_asic_db():
     routes = {}
 
     for k in keys:
-        vr = k.lower().split("\"", -1)[11]
-        ip = k.lower().split("\"", -1)[3]
+        vr = k.lower().split('\"', -1)[11]
+        ip = k.lower().split('\"', -1)[3]
         if vr in list:
             if vr_to_vnet[vr] not in routes:
                 routes[vr_to_vnet[vr]] = {}
@@ -134,58 +191,70 @@ def get_routes_from_asic_db():
     return routes
 
 
-def get_routes_diff(routes_1, routes_2):
+def get_vnet_routes_diff(routes_1, routes_2):
+    ''' Returns all routes present in routes_2 dictionary but missed in routes_1
+    Format: { <vnet_name>: { 'routes': [ <pfx/pfx_len> ], 'vrf_oid': <oid> } }
+    '''
+
     routes = {}
 
     for k, v in routes_2.items():
         if k not in routes_1:
             routes[k] = v
         else:
-            for rt in v["routes"]:
-                if rt not in routes_1[k]["routes"]:
+            for rt in v['routes']:
+                if rt not in routes_1[k]['routes']:
                     if k not in routes:
                         routes[k] = {}
-                        routes[k]["routes"] = []
-                    routes[k]["routes"].append(rt)
-                    routes[k]["vrf_oid"] = routes_1[k]["vrf_oid"]
+                        routes[k]['routes'] = []
+                    routes[k]['routes'].append(rt)
+                    routes[k]['vrf_oid'] = routes_1[k]['vrf_oid']
 
     return routes
 
 
-def get_sdk_routes_diff(routes):
+def get_sdk_vnet_routes_diff(routes):
+    ''' Returns all routes present in routes dictionary but missed in SAI/SDK
+    Format: { <vnet_name>: { 'routes': [ <pfx/pfx_len> ], 'vrf_oid': <oid> } }
+    '''
     routes_diff = {}
+
+    res = os.system('docker exec syncd test -f /usr/bin/vnet_route_check.py')
+    if res != 0:
+        return routes_diff
+
     for k, v in routes.items():
-        res = os.system('docker exec syncd "/usr/bin/vnet_route_check.py {} {}"'.format(routes[k], routes[k]["vrf_oid"]))
+        res = os.system('docker exec syncd "/usr/bin/vnet_route_check.py {} {}"'.format(routes[k]["routes"], routes[k]["vrf_oid"]))
         if res:
             routes[k] = {}
-            routes[k]["routes"] = res
+            routes[k]['routes'] = res
 
     return routes_diff
 
 
 def main():
 
-    app_routes = get_routes_from_asic_db()
-    asic_routes = get_routes_from_app_db()
+    app_db_vnet_routes = get_vnet_routes_from_asic_db()
+    asic_db_vnet_routes = get_vnet_routes_from_app_db()
 
-    missed_in_asic_db_routes = get_routes_diff(asic_routes, app_routes)
-    missed_in_app_db_routes = get_routes_diff(app_routes, asic_routes)
-    missed_in_sdk_routes = get_sdk_routes_diff(asic_routes)
+    missed_in_asic_db_routes = get_vnet_routes_diff(asic_db_vnet_routes, app_db_vnet_routes)
+    missed_in_app_db_routes = get_vnet_routes_diff(app_db_vnet_routes, asic_db_vnet_routes)
+    missed_in_sdk_routes = get_sdk_vnet_routes_diff(asic_db_vnet_routes)
 
     res = {}
-    res["results"] = {}
+    res['results'] = {}
     rc = 0
 
     if missed_in_asic_db_routes:
-        res["results"]["missed_in_asic_db_routes"] = missed_in_asic_db_routes
+        res['results']['missed_in_asic_db_routes'] = missed_in_asic_db_routes
 
     if missed_in_app_db_routes:
-        res["results"]["missed_in_app_db_routes"] = missed_in_app_db_routes
+        res['results']['missed_in_app_db_routes'] = missed_in_app_db_routes
 
     if missed_in_sdk_routes:
-        res["results"]["missed_in_sdk_routes"] = missed_in_sdk_routes
+        res['results']['missed_in_sdk_routes'] = missed_in_sdk_routes
 
-    if res["results"]:
+    if res['results']:
         rc = -1
         print(json.dumps(res, indent=4))
 

--- a/scripts/vnet_route_check.py
+++ b/scripts/vnet_route_check.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import os
-import re
 import sys
 import json
 import syslog

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ setup(
         'scripts/reboot',
         'scripts/route_check.py',
         'scripts/route_check_test.sh',
+        'scripts/vnet_route_check.py',
         'scripts/sfpshow',
         'scripts/syseeprom-to-json',
         'scripts/tempershow',

--- a/tests/vnet_route_check_test.py
+++ b/tests/vnet_route_check_test.py
@@ -1,0 +1,318 @@
+import copy
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.append("scripts")
+import vnet_route_check
+
+DESCR = "Description"
+ARGS = "args"
+RET = "return"
+APPL_DB = 0
+ASIC_DB = 1
+CNTR_DB = 2
+PRE = "pre-value"
+UPD = "update"
+RESULT = "res"
+
+OP_SET = "SET"
+OP_DEL = "DEL"
+
+ROUTE_TABLE = 'ROUTE_TABLE'
+INTF_TABLE = 'INTF_TABLE'
+RT_ENTRY_TABLE = 'ASIC_STATE'
+SEPARATOR = ":"
+
+RT_ENTRY_KEY_PREFIX = 'SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest":\"'
+RT_ENTRY_KEY_SUFFIX = '\",\"switch_id\":\"oid:0x21000000000000\",\"vr\":\"oid:0x3000000000d4b\"}'
+
+current_test_name = None
+current_test_no = None
+current_test_data = None
+
+tables_returned = {}
+
+selector_returned = None
+subscribers_returned = {}
+
+test_data = {
+    "0": {
+        DESCR: "basic good one",
+        ARGS: "vnet_route_check",
+        PRE: {
+            APPL_DB: {
+                "VXLAN_TUNNEL_TABLE": {
+                    "tunnel_v4": { "src_ip": "10.1.0.32" }
+                },
+                "VNET_TABLE": {
+                    "Vnet1": { "vxlan_tunnel": "tunnel_v4", "vni": "10001" }
+                },
+                "INTF_TABLE": {
+                    "Vlan3001": { "vnet_name": "Vnet1" },
+                    "Vlan3001:30.1.10.1/24": {}
+                },
+                "VNET_ROUTE_TABLE": {
+                    "Vnet1:30.1.10.0/24": { "ifname": "Vlan3001" },
+                    "Vnet1:50.1.1.0/24": { "ifname": "Vlan3001" },
+                    "Vnet1:50.2.2.0/24": { "ifname": "Vlan3001" }
+                }
+            },
+            ASIC_DB: {
+                RT_ENTRY_TABLE: {
+                    RT_ENTRY_KEY_PREFIX + "30.1.10.0/24" + RT_ENTRY_KEY_SUFFIX: {},
+                    RT_ENTRY_KEY_PREFIX + "50.1.1.0/24" + RT_ENTRY_KEY_SUFFIX: {},
+                    RT_ENTRY_KEY_PREFIX + "50.2.2.0/24" + RT_ENTRY_KEY_SUFFIX: {},
+                    "SAI_OBJECT_TYPE_ROUTER_INTERFACE:oid:0x6000000000d76": { "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": "oid:0x3000000000d4b" }
+                }
+            },
+            CNTR_DB: {
+                "COUNTERS_RIF_NAME_MAP": { "Vlan3001": "oid:0x6000000000d76" }
+            }
+        }
+    }
+}
+
+def do_start_test(tname, tno, ctdata):
+    global current_test_name, current_test_no, current_test_data
+    global tables_returned, selector_returned, subscribers_returned
+
+    current_test_name = tname
+    current_test_no = tno
+    current_test_data = ctdata
+    tables_returned = {}
+
+    selector_returned = None
+    subscribers_returned = {}
+
+    print("Starting test case {} number={}".format(tname, tno))
+
+
+def check_subset(d_sub, d_all):
+    if type(d_sub) != type(d_all):
+        return -1
+    if not type(d_sub) is dict:
+        ret = 0 if d_sub == d_all else -2
+        return ret
+
+    for (k, v) in d_sub.items():
+        if not k in d_all:
+            return -3
+        ret = check_subset(v, d_all[k])
+        if ret != 0:
+            return ret
+    return 0
+
+
+def recursive_update(d, t):
+    assert (type(t) is dict)
+    for k in t.keys():
+        if type(t[k]) is not dict:
+            d.update(t)
+            return
+
+        if k not in d:
+            d[k] = {}
+        recursive_update(d[k], t[k])
+
+
+class Table:
+
+    def __init__(self, db, tbl):
+        self.db = db
+        self.tbl = tbl
+        self.data = copy.deepcopy(self.get_val(current_test_data[PRE], [db, tbl]))
+
+
+    def update(self):
+        t = copy.deepcopy(self.get_val(current_test_data.get(UPD, {}),
+            [self.db, self.tbl, OP_SET]))
+        drop = copy.deepcopy(self.get_val(current_test_data.get(UPD, {}),
+                        [self.db, self.tbl, OP_DEL]))
+        if t:
+            recursive_update(self.data, t)
+
+        for k in drop:
+            self.data.pop(k, None)
+        return (list(t.keys()), list(drop.keys()))
+
+
+    def get_val(self, d, keys):
+        for k in keys:
+            d = d[k] if k in d else {}
+        return d
+
+
+    def getKeys(self):
+        return list(self.data.keys())
+
+
+    def get(self, key):
+        ret = copy.deepcopy(self.data.get(key, {}))
+        return (True, ret)
+
+
+db_conns = {"APPL_DB": APPL_DB, "ASIC_DB": ASIC_DB, "COUNTERS_DB": CNTR_DB}
+def conn_side_effect(arg, _):
+    return db_conns[arg]
+
+
+def table_side_effect(db, tbl):
+    if not db in tables_returned:
+        tables_returned[db] = {}
+    if not tbl in tables_returned[db]:
+        tables_returned[db][tbl] = Table(db, tbl)
+    return tables_returned[db][tbl]
+
+
+class mock_selector:
+    TIMEOUT = 1
+
+    def __init__(self):
+        self.select_state = 0
+        self.select_cnt = 0
+        self.subs = None
+        # print("Mock Selector constructed")
+
+
+    def addSelectable(self, subs):
+        self.subs = subs
+        return 0
+
+
+    def select(self, timeout):
+        # Toggle between good & timeout
+        #
+        state = self.select_state
+        self.subs.update()
+
+        if self.select_state == 0:
+            self.select_state = self.TIMEOUT
+        else:
+            time.sleep(timeout)
+
+        return (state, None)
+
+
+class mock_db_conn:
+    def __init__(self, db):
+        self.db_name = None
+        for (k, v) in db_conns.items():
+            if v == db:
+                self.db_name = k
+        assert self.db_name != None
+
+    def getDbName(self):
+        return self.db_name
+
+
+class mock_subscriber:
+    def __init__(self, db, tbl):
+        self.state = PRE
+        self.db = db
+        self.tbl = tbl
+        self.dbconn = mock_db_conn(db)
+        self.mock_tbl = table_side_effect(self.db, self.tbl)
+        self.set_keys = list(self.mock_tbl.data.keys())
+        self.del_keys = []
+
+
+    def update(self):
+        if self.state == PRE:
+            s_keys, d_keys = self.mock_tbl.update()
+            self.set_keys += s_keys
+            self.del_keys += d_keys
+            self.state = UPD
+
+
+    def pop(self):
+        v = None
+        if self.set_keys:
+            op = OP_SET
+            k = self.set_keys.pop(0)
+            v = self.mock_tbl.get(k)[1]
+        elif self.del_keys:
+            op = OP_DEL
+            k = self.del_keys.pop(0)
+        else:
+            k = ""
+            op = ""
+
+        print("state={} k={} op={} v={}".format(self.state, k, op, str(v)))
+        return (k, op, v)
+   
+
+    def getDbConnector(self):
+        return self.dbconn
+
+
+    def getTableName(self):
+        return self.tbl
+
+
+def subscriber_side_effect(db, tbl):
+    global subscribers_returned
+
+    key = "db_{}_tbl_{}".format(db, tbl)
+    if not key in subscribers_returned:
+        subscribers_returned[key] = mock_subscriber(db, tbl)
+    return subscribers_returned[key]
+
+
+def select_side_effect():
+    global selector_returned
+
+    if not selector_returned:
+        selector_returned = mock_selector()
+    return selector_returned
+
+
+def table_side_effect(db, tbl):
+    if not db in tables_returned:
+        tables_returned[db] = {}
+    if not tbl in tables_returned[db]:
+        tables_returned[db][tbl] = Table(db, tbl)
+    return tables_returned[db][tbl]
+
+
+def set_mock(mock_table, mock_conn, mock_sel, mock_subs):
+    mock_conn.side_effect = conn_side_effect
+    mock_table.side_effect = table_side_effect
+    mock_sel.side_effect = select_side_effect
+    mock_subs.side_effect = subscriber_side_effect
+
+
+class TestRouteCheck(object):
+    def setup(self):
+        pass
+
+    def init(self):
+        vnet_route_check.UNIT_TESTING = 1
+
+
+    @patch("route_check.swsscommon.DBConnector")
+    @patch("route_check.swsscommon.Table")
+    @patch("route_check.swsscommon.Select")
+    @patch("route_check.swsscommon.SubscriberStateTable")
+    def test_server(self, mock_subs, mock_sel, mock_table, mock_conn):
+        self.init()
+        ret = 0
+
+        set_mock(mock_table, mock_conn, mock_sel, mock_subs)
+        for (i, ct_data) in test_data.items():
+            do_start_test("route_test", i, ct_data)
+
+            with patch('sys.argv', ct_data[ARGS].split()):
+                ret, res = vnet_route_check.main()
+                expect_ret = ct_data[RET] if RET in ct_data else 0
+                expect_res = ct_data[RESULT] if RESULT in ct_data else None
+                if res:
+                    print("res={}".format(json.dumps(res, indent=4)))
+                if expect_res:
+                    print("expect_res={}".format(json.dumps(expect_res, indent=4)))
+                assert ret == expect_ret
+                assert res == expect_res
+

--- a/tests/vnet_route_check_test.py
+++ b/tests/vnet_route_check_test.py
@@ -22,10 +22,11 @@ RESULT = "res"
 OP_SET = "SET"
 OP_DEL = "DEL"
 
-ROUTE_TABLE = 'ROUTE_TABLE'
-INTF_TABLE = 'INTF_TABLE'
-RT_ENTRY_TABLE = 'ASIC_STATE'
-SEPARATOR = ":"
+VXLAN_TUNNEL_TABLE = "VXLAN_TUNNEL_TABLE"
+VNET_TABLE = "VNET_TABLE"
+VNET_ROUTE_TABLE = "VNET_ROUTE_TABLE"
+INTF_TABLE = "INTF_TABLE"
+ASIC_STATE = "ASIC_STATE"
 
 RT_ENTRY_KEY_PREFIX = 'SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest":\"'
 RT_ENTRY_KEY_SUFFIX = '\",\"switch_id\":\"oid:0x21000000000000\",\"vr\":\"oid:0x3000000000d4b\"}'
@@ -36,119 +37,221 @@ current_test_data = None
 
 tables_returned = {}
 
-selector_returned = None
-subscribers_returned = {}
-
 test_data = {
     "0": {
-        DESCR: "basic good one",
+        DESCR: "All VNET routes are configured in both APP and ASIC DBs",
         ARGS: "vnet_route_check",
         PRE: {
             APPL_DB: {
-                "VXLAN_TUNNEL_TABLE": {
+                VXLAN_TUNNEL_TABLE: {
                     "tunnel_v4": { "src_ip": "10.1.0.32" }
                 },
-                "VNET_TABLE": {
+                VNET_TABLE: {
                     "Vnet1": { "vxlan_tunnel": "tunnel_v4", "vni": "10001" }
                 },
-                "INTF_TABLE": {
+                INTF_TABLE: {
                     "Vlan3001": { "vnet_name": "Vnet1" },
                     "Vlan3001:30.1.10.1/24": {}
                 },
-                "VNET_ROUTE_TABLE": {
+                VNET_ROUTE_TABLE: {
                     "Vnet1:30.1.10.0/24": { "ifname": "Vlan3001" },
                     "Vnet1:50.1.1.0/24": { "ifname": "Vlan3001" },
                     "Vnet1:50.2.2.0/24": { "ifname": "Vlan3001" }
                 }
             },
             ASIC_DB: {
-                RT_ENTRY_TABLE: {
+                ASIC_STATE: {
                     RT_ENTRY_KEY_PREFIX + "30.1.10.0/24" + RT_ENTRY_KEY_SUFFIX: {},
                     RT_ENTRY_KEY_PREFIX + "50.1.1.0/24" + RT_ENTRY_KEY_SUFFIX: {},
                     RT_ENTRY_KEY_PREFIX + "50.2.2.0/24" + RT_ENTRY_KEY_SUFFIX: {},
-                    "SAI_OBJECT_TYPE_ROUTER_INTERFACE:oid:0x6000000000d76": { "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": "oid:0x3000000000d4b" }
+                    "SAI_OBJECT_TYPE_ROUTER_INTERFACE:oid:0x6000000000d76": {
+                        "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": "oid:0x3000000000d4b"
+                    }
                 }
             },
             CNTR_DB: {
                 "COUNTERS_RIF_NAME_MAP": { "Vlan3001": "oid:0x6000000000d76" }
             }
+        },
+        RESULT: {
+            "results": {}
+        }
+    },
+    "1": {
+        DESCR: "VNET route is missed in ASIC DB",
+        ARGS: "vnet_route_check",
+        RET: -1,
+        PRE: {
+            APPL_DB: {
+                VXLAN_TUNNEL_TABLE: {
+                    "tunnel_v4": { "src_ip": "10.1.0.32" }
+                },
+                VNET_TABLE: {
+                    "Vnet1": { "vxlan_tunnel": "tunnel_v4", "vni": "10001" }
+                },
+                INTF_TABLE: {
+                    "Vlan3001": { "vnet_name": "Vnet1" },
+                    "Vlan3001:30.1.10.1/24": {}
+                },
+                VNET_ROUTE_TABLE: {
+                    "Vnet1:30.1.10.0/24": { "ifname": "Vlan3001" },
+                    "Vnet1:50.1.1.0/24": { "ifname": "Vlan3001" },
+                    "Vnet1:50.2.2.0/24": { "ifname": "Vlan3001" }
+                }
+            },
+            ASIC_DB: {
+                ASIC_STATE: {
+                    RT_ENTRY_KEY_PREFIX + "30.1.10.0/24" + RT_ENTRY_KEY_SUFFIX: {},
+                    RT_ENTRY_KEY_PREFIX + "50.1.1.0/24" + RT_ENTRY_KEY_SUFFIX: {},
+                    "SAI_OBJECT_TYPE_ROUTER_INTERFACE:oid:0x6000000000d76": {
+                        "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": "oid:0x3000000000d4b"
+                    }
+                }
+            },
+            CNTR_DB: {
+                "COUNTERS_RIF_NAME_MAP": { "Vlan3001": "oid:0x6000000000d76" }
+            }
+        },
+        RESULT: {
+            "results": {
+                "missed_in_asic_db_routes": {
+                    "Vnet1": {
+                        "routes": [
+                            "50.2.2.0/24"
+                        ]
+                    }
+                }
+            }
+        }
+    },
+    "2": {
+        DESCR: "VNET route is missed in APP DB",
+        ARGS: "vnet_route_check",
+        RET: -1,
+        PRE: {
+            APPL_DB: {
+                VXLAN_TUNNEL_TABLE: {
+                    "tunnel_v4": { "src_ip": "10.1.0.32" }
+                },
+                VNET_TABLE: {
+                    "Vnet1": { "vxlan_tunnel": "tunnel_v4", "vni": "10001" }
+                },
+                INTF_TABLE: {
+                    "Vlan3001": { "vnet_name": "Vnet1" },
+                    "Vlan3001:30.1.10.1/24": {}
+                },
+                VNET_ROUTE_TABLE: {
+                    "Vnet1:30.1.10.0/24": { "ifname": "Vlan3001" },
+                    "Vnet1:50.1.1.0/24": { "ifname": "Vlan3001" },
+                }
+            },
+            ASIC_DB: {
+                ASIC_STATE: {
+                    RT_ENTRY_KEY_PREFIX + "30.1.10.0/24" + RT_ENTRY_KEY_SUFFIX: {},
+                    RT_ENTRY_KEY_PREFIX + "50.1.1.0/24" + RT_ENTRY_KEY_SUFFIX: {},
+                    RT_ENTRY_KEY_PREFIX + "50.2.2.0/24" + RT_ENTRY_KEY_SUFFIX: {},
+                    "SAI_OBJECT_TYPE_ROUTER_INTERFACE:oid:0x6000000000d76": {
+                        "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": "oid:0x3000000000d4b"
+                    }
+                }
+            },
+            CNTR_DB: {
+                "COUNTERS_RIF_NAME_MAP": { "Vlan3001": "oid:0x6000000000d76" }
+            }
+        },
+        RESULT: {
+            "results": {
+                "missed_in_app_db_routes": {
+                    "Vnet1": {
+                        "routes": [
+                            "50.2.2.0/24"
+                        ]
+                    }
+                }
+            }
+        }
+    },
+    "3": {
+        DESCR: "VNET routes are missed in both ASIC and APP DB",
+        ARGS: "vnet_route_check",
+        RET: -1,
+        PRE: {
+            APPL_DB: {
+                VXLAN_TUNNEL_TABLE: {
+                    "tunnel_v4": { "src_ip": "10.1.0.32" }
+                },
+                VNET_TABLE: {
+                    "Vnet1": { "vxlan_tunnel": "tunnel_v4", "vni": "10001" }
+                },
+                INTF_TABLE: {
+                    "Vlan3001": { "vnet_name": "Vnet1" },
+                    "Vlan3001:30.1.10.1/24": {}
+                },
+                VNET_ROUTE_TABLE: {
+                    "Vnet1:30.1.10.0/24": { "ifname": "Vlan3001" },
+                    "Vnet1:50.1.1.0/24": { "ifname": "Vlan3001" },
+                }
+            },
+            ASIC_DB: {
+                ASIC_STATE: {
+                    RT_ENTRY_KEY_PREFIX + "30.1.10.0/24" + RT_ENTRY_KEY_SUFFIX: {},
+                    RT_ENTRY_KEY_PREFIX + "50.2.2.0/24" + RT_ENTRY_KEY_SUFFIX: {},
+                    "SAI_OBJECT_TYPE_ROUTER_INTERFACE:oid:0x6000000000d76": {
+                        "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": "oid:0x3000000000d4b"
+                    }
+                }
+            },
+            CNTR_DB: {
+                "COUNTERS_RIF_NAME_MAP": { "Vlan3001": "oid:0x6000000000d76" }
+            }
+        },
+        RESULT: {
+            "results": {
+                "missed_in_app_db_routes": {
+                    "Vnet1": {
+                        "routes": [
+                            "50.2.2.0/24"
+                        ]
+                    }
+                },
+                "missed_in_asic_db_routes": {
+                    "Vnet1": {
+                        "routes": [
+                            "50.1.1.0/24"
+                        ]
+                    }
+                }
+            }
         }
     }
 }
 
+
 def do_start_test(tname, tno, ctdata):
     global current_test_name, current_test_no, current_test_data
-    global tables_returned, selector_returned, subscribers_returned
+    global tables_returned
 
     current_test_name = tname
     current_test_no = tno
     current_test_data = ctdata
     tables_returned = {}
 
-    selector_returned = None
-    subscribers_returned = {}
-
     print("Starting test case {} number={}".format(tname, tno))
 
 
-def check_subset(d_sub, d_all):
-    if type(d_sub) != type(d_all):
-        return -1
-    if not type(d_sub) is dict:
-        ret = 0 if d_sub == d_all else -2
-        return ret
-
-    for (k, v) in d_sub.items():
-        if not k in d_all:
-            return -3
-        ret = check_subset(v, d_all[k])
-        if ret != 0:
-            return ret
-    return 0
-
-
-def recursive_update(d, t):
-    assert (type(t) is dict)
-    for k in t.keys():
-        if type(t[k]) is not dict:
-            d.update(t)
-            return
-
-        if k not in d:
-            d[k] = {}
-        recursive_update(d[k], t[k])
-
-
 class Table:
-
     def __init__(self, db, tbl):
         self.db = db
         self.tbl = tbl
         self.data = copy.deepcopy(self.get_val(current_test_data[PRE], [db, tbl]))
-
-
-    def update(self):
-        t = copy.deepcopy(self.get_val(current_test_data.get(UPD, {}),
-            [self.db, self.tbl, OP_SET]))
-        drop = copy.deepcopy(self.get_val(current_test_data.get(UPD, {}),
-                        [self.db, self.tbl, OP_DEL]))
-        if t:
-            recursive_update(self.data, t)
-
-        for k in drop:
-            self.data.pop(k, None)
-        return (list(t.keys()), list(drop.keys()))
-
 
     def get_val(self, d, keys):
         for k in keys:
             d = d[k] if k in d else {}
         return d
 
-
     def getKeys(self):
         return list(self.data.keys())
-
 
     def get(self, key):
         ret = copy.deepcopy(self.data.get(key, {}))
@@ -168,35 +271,6 @@ def table_side_effect(db, tbl):
     return tables_returned[db][tbl]
 
 
-class mock_selector:
-    TIMEOUT = 1
-
-    def __init__(self):
-        self.select_state = 0
-        self.select_cnt = 0
-        self.subs = None
-        # print("Mock Selector constructed")
-
-
-    def addSelectable(self, subs):
-        self.subs = subs
-        return 0
-
-
-    def select(self, timeout):
-        # Toggle between good & timeout
-        #
-        state = self.select_state
-        self.subs.update()
-
-        if self.select_state == 0:
-            self.select_state = self.TIMEOUT
-        else:
-            time.sleep(timeout)
-
-        return (state, None)
-
-
 class mock_db_conn:
     def __init__(self, db):
         self.db_name = None
@@ -209,67 +283,6 @@ class mock_db_conn:
         return self.db_name
 
 
-class mock_subscriber:
-    def __init__(self, db, tbl):
-        self.state = PRE
-        self.db = db
-        self.tbl = tbl
-        self.dbconn = mock_db_conn(db)
-        self.mock_tbl = table_side_effect(self.db, self.tbl)
-        self.set_keys = list(self.mock_tbl.data.keys())
-        self.del_keys = []
-
-
-    def update(self):
-        if self.state == PRE:
-            s_keys, d_keys = self.mock_tbl.update()
-            self.set_keys += s_keys
-            self.del_keys += d_keys
-            self.state = UPD
-
-
-    def pop(self):
-        v = None
-        if self.set_keys:
-            op = OP_SET
-            k = self.set_keys.pop(0)
-            v = self.mock_tbl.get(k)[1]
-        elif self.del_keys:
-            op = OP_DEL
-            k = self.del_keys.pop(0)
-        else:
-            k = ""
-            op = ""
-
-        print("state={} k={} op={} v={}".format(self.state, k, op, str(v)))
-        return (k, op, v)
-   
-
-    def getDbConnector(self):
-        return self.dbconn
-
-
-    def getTableName(self):
-        return self.tbl
-
-
-def subscriber_side_effect(db, tbl):
-    global subscribers_returned
-
-    key = "db_{}_tbl_{}".format(db, tbl)
-    if not key in subscribers_returned:
-        subscribers_returned[key] = mock_subscriber(db, tbl)
-    return subscribers_returned[key]
-
-
-def select_side_effect():
-    global selector_returned
-
-    if not selector_returned:
-        selector_returned = mock_selector()
-    return selector_returned
-
-
 def table_side_effect(db, tbl):
     if not db in tables_returned:
         tables_returned[db] = {}
@@ -278,30 +291,25 @@ def table_side_effect(db, tbl):
     return tables_returned[db][tbl]
 
 
-def set_mock(mock_table, mock_conn, mock_sel, mock_subs):
+def set_mock(mock_table, mock_conn):
     mock_conn.side_effect = conn_side_effect
     mock_table.side_effect = table_side_effect
-    mock_sel.side_effect = select_side_effect
-    mock_subs.side_effect = subscriber_side_effect
 
 
-class TestRouteCheck(object):
+class TestVnetRouteCheck(object):
     def setup(self):
         pass
 
     def init(self):
         vnet_route_check.UNIT_TESTING = 1
 
-
-    @patch("route_check.swsscommon.DBConnector")
-    @patch("route_check.swsscommon.Table")
-    @patch("route_check.swsscommon.Select")
-    @patch("route_check.swsscommon.SubscriberStateTable")
-    def test_server(self, mock_subs, mock_sel, mock_table, mock_conn):
+    @patch("vnet_route_check.swsscommon.DBConnector")
+    @patch("vnet_route_check.swsscommon.Table")
+    def test_vnet_route_check(self, mock_table, mock_conn):
         self.init()
         ret = 0
 
-        set_mock(mock_table, mock_conn, mock_sel, mock_subs)
+        set_mock(mock_table, mock_conn)
         for (i, ct_data) in test_data.items():
             do_start_test("route_test", i, ct_data)
 
@@ -315,4 +323,3 @@ class TestRouteCheck(object):
                     print("expect_res={}".format(json.dumps(expect_res, indent=4)))
                 assert ret == expect_ret
                 assert res == expect_res
-


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Added "vnet_route_check" tool for check VNET route consistency.

vnet_route_check.py: tool that verifies VNET routes consistancy between SONiC and vendor SDK DBs.

Logically VNET route verification logic consists of 3 parts:
1. Get VNET routes entries that are missed in ASIC_DB but present in APP_DB.
2. Get VNET routes entries that are missed in APP_DB but present in ASIC_DB.
3. Get VNET routes entries that are missed in SDK but present in ASIC_DB.

Returns 0 if there is no inconsistancy found and all VNET routes are aligned in all DBs.
Returns -1 if there is incosistancy found and prints differences between DBs in JSON format to standart output.

**- How I did it**
Added "vnet_route_check" script with the relevant VNET route check logic

**- How to verify it**
Configure VNET routes then remove some in ASIC_DB or APP_DB and tun the script.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**
Output example:
```
{
    "results": {
        "missed_in_asic_db_routes": {
            "Vnet1": {
                "routes": [
                    "100.1.1.1/32",
                    "30.1.10.201/32",
                    "100.1.1.2/32"
                ]
            },
            "Vnet2": {
                "routes": [
                    "100.2.1.1/32",
                    "30.2.10.202/32"
                ]
            }
        },
        "missed_in_app_db_routes": {
            "Vnet1": {
                "routes": [
                    "30.1.10.1/32"
                ]
            },
            "Vnet2": {
                "routes": [
                    "30.2.10.1/32"
                ]
            }
        }
    }
}
```
