### PR TITLE
Shut down interface before dynamic port breakout

### DIFF
--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -376,9 +376,12 @@ class ConfigMgmtDPB(ConfigMgmt):
             if_name_map, if_oid_map = port_util.get_interface_oid_map(dataBase)
             self.sysLog(syslog.LOG_DEBUG, 'if_name_map {}'.format(if_name_map))
 
-            # If we are here, then get ready to update the Config DB, Update
-            # deletion of Config first, then verify in Asic DB for port deletion,
-            # then update addition of ports in config DB.
+            # If we are here, then get ready to update the Config DB as below:
+            # -- shutdown the ports,
+            # -- Update deletion of ports in Config DB,
+            # -- verify Asic DB for port deletion,
+            # -- then update addition of ports in config DB.
+            self._shutdownIntf(delPorts)
             self.writeConfigDB(delConfigToLoad)
             # Verify in Asic DB,
             self._verifyAsicDB(db=dataBase, ports=delPorts, portMap=if_name_map, \
@@ -513,6 +516,27 @@ class ConfigMgmtDPB(ConfigMgmt):
             return configToLoad, False
 
         return configToLoad, True
+
+    def _shutdownIntf(self, ports):
+        """
+        Based on the list of Ports, create a dict to shutdown port, update Config DB.
+        Shut down all the interfaces before deletion.
+
+        Parameters:
+            ports(list): list of ports, which are getting deleted due to DPB.
+
+        Returns:
+            void
+        """
+        shutDownConf = dict(); shutDownConf["PORT"] = dict()
+        for intf in ports:
+            shutDownConf["PORT"][intf] = {"admin_status": "down"}
+        self.sysLog(msg='shutdown Interfaces: {}'.format(shutDownConf))
+
+        if len(shutDownConf["PORT"]):
+            self.writeConfigDB(shutDownConf)
+
+        return
 
     def _mergeConfigs(self, D1, D2, uniqueKeys=True):
         '''

--- a/config/main.py
+++ b/config/main.py
@@ -2471,7 +2471,7 @@ def breakout(ctx, interface_name, mode, verbose, force_remove_dependencies, load
 
     # validate all del_ports before calling breakOutPort
     for intf in del_intf_dict.keys():
-        if not interface_name_is_valid(intf):
+        if not interface_name_is_valid(config_db, intf):
             click.secho("[ERROR] Interface name {} is invalid".format(intf))
             raise click.Abort()
 

--- a/config/main.py
+++ b/config/main.py
@@ -117,32 +117,6 @@ def _get_breakout_options(ctx, args, incomplete):
             all_mode_options = [str(c) for c in breakout_mode_options if incomplete in c]
         return all_mode_options
 
-def shutdown_interfaces(ctx, del_intf_dict):
-    """ shut down all the interfaces before deletion """
-    for intf in del_intf_dict:
-        config_db = ctx.obj['config_db']
-        if clicommon.get_interface_naming_mode() == "alias":
-            interface_name = interface_alias_to_name(config_db, intf)
-            if interface_name is None:
-                click.echo("[ERROR] interface name is None!")
-                return False
-
-        if interface_name_is_valid(config_db, intf) is False:
-            click.echo("[ERROR] Interface name is invalid. Please enter a valid interface name!!")
-            return False
-
-        port_dict = config_db.get_table('PORT')
-        if not port_dict:
-            click.echo("port_dict is None!")
-            return False
-
-        if intf in port_dict:
-            config_db.mod_entry("PORT", intf, {"admin_status": "down"})
-        else:
-            click.secho("[ERROR] Could not get the correct interface name, exiting", fg='red')
-            return False
-    return True
-
 def _validate_interface_mode(ctx, breakout_cfg_file, interface_name, target_brkout_mode, cur_brkout_mode):
     """ Validate Parent interface and user selected mode before starting deletion or addition process """
     breakout_file_input = readJsonFile(breakout_cfg_file)["interfaces"]
@@ -2468,12 +2442,7 @@ def breakout(ctx, interface_name, mode, verbose, force_remove_dependencies, load
     del_intf_dict = {intf: del_ports[intf]["speed"] for intf in del_ports}
 
     if del_intf_dict:
-        """ shut down all the interface before deletion """
-        ret = shutdown_interfaces(ctx, del_intf_dict)
-        if not ret:
-            raise click.Abort()
         click.echo("\nPorts to be deleted : \n {}".format(json.dumps(del_intf_dict, indent=4)))
-
     else:
         click.secho("[ERROR] del_intf_dict is None! No interfaces are there to be deleted", fg='red')
         raise click.Abort()
@@ -2499,6 +2468,11 @@ def breakout(ctx, interface_name, mode, verbose, force_remove_dependencies, load
     for item in matched_items:
         del_intf_dict.pop(item)
         add_intf_dict.pop(item)
+
+    # validate all del_ports before calling breakOutPort
+    for intf in del_intf_dict.keys():
+        if not interface_name_is_valid(intf):
+            raise Exception("Interface name {} is invalid")
 
     click.secho("\nFinal list of ports to be deleted : \n {} \nFinal list of ports to be added :  \n {}".format(json.dumps(del_intf_dict, indent=4), json.dumps(add_intf_dict, indent=4), fg='green', blink=True))
     if not add_intf_dict:

--- a/config/main.py
+++ b/config/main.py
@@ -2472,7 +2472,8 @@ def breakout(ctx, interface_name, mode, verbose, force_remove_dependencies, load
     # validate all del_ports before calling breakOutPort
     for intf in del_intf_dict.keys():
         if not interface_name_is_valid(intf):
-            raise Exception("Interface name {} is invalid")
+            click.secho("[ERROR] Interface name {} is invalid".format(intf))
+            raise click.Abort()
 
     click.secho("\nFinal list of ports to be deleted : \n {} \nFinal list of ports to be added :  \n {}".format(json.dumps(del_intf_dict, indent=4), json.dumps(add_intf_dict, indent=4), fg='green', blink=True))
     if not add_intf_dict:

--- a/tests/config_mgmt_test.py
+++ b/tests/config_mgmt_test.py
@@ -56,9 +56,9 @@ class TestConfigMgmt(TestCase):
             len(out['ACL_TABLE'][k]) == 1
         return
 
-	def test_shutdownIntf_call(self):
+    def test_shutdownIntf_call(self):
         '''
-        Verify that verifyAppDB() is called with deleted ports while calling
+        Verify that _shutdownIntf() is called with deleted ports while calling
         breakOutPort()
         '''
         conf = dict(configDbJson)

--- a/tests/config_mgmt_test.py
+++ b/tests/config_mgmt_test.py
@@ -83,8 +83,8 @@ class TestConfigMgmt(TestCase):
         Verify that _shutdownIntf() is called with deleted ports while calling
         breakOutPort()
         '''
-        conf = dict(configDbJson)
-        cmdpb = self.config_mgmt_dpb(conf)
+        curConfig = deepcopy(configDbJson)
+        cmdpb = self.config_mgmt_dpb(curConfig)
 
         # create ARGS
         dPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \

--- a/tests/config_mgmt_test.py
+++ b/tests/config_mgmt_test.py
@@ -252,7 +252,7 @@ class TestConfigMgmt(TestCase):
         Return:
             void
         '''
-        calls = [call(delConfig), call(addConfig)]
+        calls = [mock.call(delConfig), mock.call(addConfig)]
         assert cmdpb.writeConfigDB.call_count == 3
         cmdpb.writeConfigDB.assert_has_calls(calls, any_order=False)
         return


### PR DESCRIPTION
Changes:
-- Shutdown the interfaces after config validation while Dy Port Breakout.
-- Validate del ports before calling breakOutPorts API.

Signed-off-by: Praveen Chaudhary pchaudhary@linkedin.com

Fixes https://github.com/Azure/sonic-buildimage/issues/6646, https://github.com/Azure/sonic-buildimage/issues/6631, 

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Changes:
-- Shutdown the interfaces after config validation while Dy Port Breakout.

**- How I did it**
-- move shutdown part to config_mgmt.py, because we need to shutdown only when DPB is initiated.

**- How to verify it**
```
svc-lnos-user@server10:/home/svc-lnos-user/praveen/sonic-buildimage/src/sonic-swss/tests$ cat test_port_dpb_system.py | grep -A 4 -B 4 Uncomment

        # Verify port is removed from ACL table
        self.dvs_acl.verify_acl_table_count(1)

        #TBD: Uncomment this, or explain why Ethernet0 is being added back to ACL table
        # Also, string "None" is being added as port to ACL port list after the breakout
        self.dvs_acl.verify_acl_group_num(0)

        # Verify child ports are created.

svc-lnos-user@server10:/home/svc-lnos-user/praveen/sonic-buildimage/src/sonic-swss/tests$ sudo pytest --dvsname=vs-jk test_port_dpb_system.py -k test_port_breakout_with_acl --junitxml=report.xml | tee out
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-3.3.0, py-1.6.0, pluggy-0.6.0
rootdir: /home/svc-lnos-user/praveen/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 2 items

test_port_dpb_system.py .                                                [100%]

 generated xml file: /home/svc-lnos-user/praveen/sonic-buildimage/src/sonic-swss/tests/report.xml
============================== 1 tests deselected ==============================
=================== 1 passed, 1 deselected in 92.36 seconds ====================
```

```
Jun  5 06:16:37.007136 fec26aa9f1be INFO #sonic_yang: Try to load Data in the tree
Jun  5 06:16:37.007722 fec26aa9f1be INFO #configMgmt: Data Validation successful
Jun  5 06:16:37.031857 fec26aa9f1be INFO #configMgmt: shutdown Interfaces: {'PORT': {'Ethernet2': {'admin_status': 'down'}, 'Ethernet3': {'admin_status': 'down'}, 'Ethernet0': {'admin_status': 'down'}, 'Ethernet1': {'admin_status': 'down'}}}
Jun  5 06:16:37.032485 fec26aa9f1be INFO #configMgmt: Write in DB: {'PORT': OrderedDict([('Ethernet0', {'admin_status': 'down'}), ('Ethernet1', {'admin_status': 'down'}), ('Ethernet2', {'admin_status': 'down'}), ('Ethernet3', {'admin_status': 'down'})])}
Jun  5 06:16:37.033823 fec26aa9f1be NOTICE #orchagent: :- doPortTask: Set port Ethernet0 admin status to down
Jun  5 06:16:37.034270 fec26aa9f1be INFO #configMgmt: Write in DB: {u'PORT': OrderedDict([(u'Ethernet0', None), (u'Ethernet1', None), (u'Ethernet2', None), (u'Ethernet3', None)])}
Jun  5 06:16:37.034383 fec26aa9f1be NOTICE #orchagent: :- doPortTask: Set port Ethernet1 admin status to down
Jun  5 06:16:37.034486 fec26aa9f1be NOTICE #orchagent: :- doPortTask: Set port Ethernet2 admin status to down
Jun  5 06:16:37.034872 fec26aa9f1be NOTICE #portsyncd: :- onMsg: nlmsg type:16 key:Ethernet0 admin:0 oper:0 addr:02:42:ac:11:00:0c ifindex:1199 master:0 type:tun
Jun  5 06:16:37.035004 fec26aa9f1be NOTICE #orchagent: :- doPortTask: Set port Ethernet3 admin status to down
Jun  5 06:16:37.035166 fec26aa9f1be NOTICE #portsyncd: :- onMsg: Publish Ethernet0(ok) to state db
Jun  5 06:16:37.035317 fec26aa9f1be INFO #configMgmt: Verify Port Deletion from Asic DB, Wait...
```

——Test 06/09/2020
```
Jun  9 23:58:26.590188 fec26aa9f1be INFO #configMgmt: shutdown Interfaces: {'PORT': {'Ethernet2': {'admin_status': 'down'}, 'Ethernet0': {'admin_status': 'down'}}}
Jun  9 23:58:26.590828 fec26aa9f1be INFO #configMgmt: Write in DB: {'PORT': OrderedDict([('Ethernet0', {'admin_status': 'down'}), ('Ethernet2', {'admin_status': 'down'})])}
Jun  9 23:58:26.591800 fec26aa9f1be INFO #configMgmt: Write in DB: {u'PORT': OrderedDict([(u'Ethernet0', None), (u'Ethernet2', None)])}
Jun  9 23:58:26.592121 fec26aa9f1be INFO #configMgmt: Verify Port Deletion from Asic DB, Wait...

svc-lnos-user@server10:/home/svc-lnos-user/praveen/sonic-buildimage/src/sonic-swss/tests$ cat test_port_dpb_system.py | grep -A 4 -B 4 Uncomment

        # Verify port is removed from ACL table
        self.dvs_acl.verify_acl_table_count(1)

        #TBD: Uncomment this, or explain why Ethernet0 is being added back to ACL table
        # Also, string "None" is being added as port to ACL port list after the breakout
        self.dvs_acl.verify_acl_group_num(0)

        # Verify child ports are created.
svc-lnos-user@server10:/home/svc-lnos-user/praveen/sonic-buildimage/src/sonic-swss/tests$ sudo pytest --dvsname=vs-jk test_port_dpb_system.py -k test_port_breakout_with_acl --junitxml=report.xml | tee out
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-3.3.0, py-1.6.0, pluggy-0.6.0
rootdir: /home/svc-lnos-user/praveen/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 2 items

test_port_dpb_system.py .                                                [100%]

 generated xml file: /home/svc-lnos-user/praveen/sonic-buildimage/src/sonic-swss/tests/report.xml
============================== 1 tests deselected ==============================
=================== 1 passed, 1 deselected in 93.69 seconds ====================
```
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

