### PR TITLE
[fast-reboot-dump] Fix exception in struct.pack

### DIFF
--- a/scripts/fast-reboot-dump.py
+++ b/scripts/fast-reboot-dump.py
@@ -182,7 +182,7 @@ def generate_fdb_entries(filename):
 
 def get_if(iff, cmd):
     s = socket.socket()
-    ifreq = ioctl(s, cmd, struct.pack("16s16x",iff))
+    ifreq = ioctl(s, cmd, struct.pack("16s16x",bytes(iff.encode())))
     s.close()
     return ifreq
 


### PR DESCRIPTION


Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
This commit fix the exception thrown by struct.pack when attempting to pack a unicode string.
The script ```fast-reboot-dump.py``` will throw an exception in python3 because ```struct.pack``` requires ```bytes``` for ```s```.
```
Traceback: Traceback (most recent call last):
#012  File "/usr/local/bin/fast-reboot-dump.py", line 299, in <module>
#012    res = main()
#012  File "/usr/local/bin/fast-reboot-dump.py", line 292, in main
#012    send_garp_nd(neighbor_entries, map_mac_ip_per_vlan)
#012  File "/usr/local/bin/fast-reboot-dump.py", line 221, in send_garp_nd
#012    src_ip_addrs = {vlan_name:get_iface_ip_addr(vlan_name) for vlan_name,_,_ in neighbor_entries}
#012  File "/usr/local/bin/fast-reboot-dump.py", line 221, in <dictcomp>
#012    src_ip_addrs = {vlan_name:get_iface_ip_addr(vlan_name) for vlan_name,_,_ in neighbor_entries}
#012  File "/usr/local/bin/fast-reboot-dump.py", line 195, in get_iface_ip_addr
#012    return get_if(iff, SIOCGIFADDR)[20:24]
#012  File "/usr/local/bin/fast-reboot-dump.py", line 185, in get_if
#012    ifreq = ioctl(s, cmd, struct.pack("16s16x",iff))
#012  struct.error: argument for 's' must be a bytes object
```
**- How I did it**
Convert the input string to bytes.

**- How to verify it**
Verified by running ```test_fast_reboot```.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

