### PR TITLE
DHCP Relay support for Physical and PO L3 interfaces

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2745,6 +2745,10 @@ def dhcp_relay(ctx):
 @click.argument('ip_addr4', metavar='<ip_addr4>', required=False)
 @click.pass_context
 def dhcp_relay_add(ctx, interface_name, ip_addr1, ip_addr2, ip_addr3, ip_addr4):
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    ctx.obj = {}
+    ctx.obj['config_db'] = config_db
     db = ctx.obj["config_db"]
     intf = None
 
@@ -2839,6 +2843,10 @@ def dhcp_relay_add(ctx, interface_name, ip_addr1, ip_addr2, ip_addr3, ip_addr4):
 @click.argument('ip_addr4', metavar='<ip_addr4>', required=False)
 @click.pass_context
 def dhcp_relay_remove(ctx, interface_name, ip_addr1, ip_addr2, ip_addr3, ip_addr4):
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    ctx.obj = {}
+    ctx.obj['config_db'] = config_db
     db = ctx.obj["config_db"]
     intf = None
 

--- a/config/main.py
+++ b/config/main.py
@@ -2782,6 +2782,10 @@ def dhcp_relay(ctx):
 @click.option('-link-select', metavar='<link_select>', required=False, type=click.Choice(['enable', 'disable']), help="Enable/Disable link selection option")
 @click.pass_context
 def dhcp_relay_add(ctx, interface_name, ip_addr1, ip_addr2, ip_addr3, ip_addr4, src_intf, link_select):
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    ctx.obj = {}
+    ctx.obj['config_db'] = config_db
     db = ctx.obj["config_db"]
     intf = None
 
@@ -2920,6 +2924,10 @@ def dhcp_relay_add(ctx, interface_name, ip_addr1, ip_addr2, ip_addr3, ip_addr4, 
 @click.argument('ip_addr4', metavar='<ip_addr4>', required=False)
 @click.pass_context
 def dhcp_relay_remove(ctx, interface_name, ip_addr1, ip_addr2, ip_addr3, ip_addr4):
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    ctx.obj = {}
+    ctx.obj['config_db'] = config_db
     db = ctx.obj["config_db"]
     intf = None
 
@@ -3005,6 +3013,10 @@ def dhcp_relay_src_intf(ctx):
 @click.pass_context
 def dhcp_relay_add_src_intf(ctx, interface_name, src_intf):
     """Set DHCP relay source interface"""
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    ctx.obj = {}
+    ctx.obj['config_db'] = config_db
     db = ctx.obj["config_db"]
     intf = None
 
@@ -3048,6 +3060,10 @@ def dhcp_relay_add_src_intf(ctx, interface_name, src_intf):
 @click.pass_context
 def dhcp_relay_remove_src_intf(ctx, interface_name):
     """Remove DHCP relay source interface"""
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    ctx.obj = {}
+    ctx.obj['config_db'] = config_db
     db = ctx.obj["config_db"]
     intf = None
 
@@ -3091,6 +3107,10 @@ def dhcp_relay_link_select(ctx):
 @click.pass_context
 def dhcp_relay_add_link_select(ctx, interface_name):
     """Enable DHCP relay link selection suboption"""
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    ctx.obj = {}
+    ctx.obj['config_db'] = config_db
     db = ctx.obj["config_db"]
     intf = None
 
@@ -3128,6 +3148,10 @@ def dhcp_relay_add_link_select(ctx, interface_name):
 @click.pass_context
 def dhcp_relay_remove_link_select(ctx, interface_name):
     """Disable DHCP relay link selection suboption"""
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    ctx.obj = {}
+    ctx.obj['config_db'] = config_db
     db = ctx.obj["config_db"]
     intf = None
 

--- a/config/main.py
+++ b/config/main.py
@@ -2673,9 +2673,9 @@ def remove(ctx, interface_name, ip_addr):
 # Use this method to validate unicast IPv4 address
 #
 def is_ip4_addr_valid(addr, display):
-    v4_invalid_list = [ipaddress.IPv4Address(unicode('0.0.0.0')), ipaddress.IPv4Address(unicode('255.255.255.255'))]
+    v4_invalid_list = [ipaddress.IPv4Address('0.0.0.0'), ipaddress.IPv4Address('255.255.255.255')]
     try:
-        ip = ipaddress.ip_address(unicode(addr))
+        ip = ipaddress.ip_address(addr)
         if (ip.version == 4):
             if (ip.is_reserved):
                 if display:

--- a/config/main.py
+++ b/config/main.py
@@ -3023,13 +3023,6 @@ def dhcp_relay_add_src_intf(ctx, interface_name, src_intf):
     if intf.has_key('dhcp_relay_src_intf') and intf['dhcp_relay_src_intf'] == src_intf:
         ctx.fail("Source interface is already configured")
 
-    if interface_type == 'VLAN':
-        intf_type = 'VLAN_INTERFACE'
-    else:
-        intf_type = interface_type
-
-    intf_db = db.get_entry(intf_type, interface_name)
-
     [intf_exists, addr_exists] = is_valid_dhcp_relay_src_intf(src_intf)
 
     if intf_exists is False:

--- a/show/main.py
+++ b/show/main.py
@@ -806,12 +806,11 @@ def show_dhcp_relay_detailed(intf):
     dhcp_servers_list = intf.get('dhcp_servers', [])
     dhcp_servers = ','.replace(',', ', ').join(dhcp_servers_list)
 
-    click.echo("\nServer Address: " + dhcp_servers)
+    click.echo("Server Address: " + dhcp_servers)
     if intf.has_key('dhcp_relay_src_intf'):
         click.echo("Source Interface: " + intf['dhcp_relay_src_intf'])
     if intf.has_key('dhcp_relay_link_select'):
         click.echo("Link Select: " + intf['dhcp_relay_link_select'])
-    click.echo("\n")
 
 #
 # 'dhcp_relay' subcommand ("show ip dhcp_relay ...")
@@ -845,7 +844,7 @@ def brief(ctx):
           for interface,value in dhcp_helper_dict.items():
              if 'dhcp_servers' in value:
                  dhcp_helper_data[interface] = dhcp_helper_dict[interface]['dhcp_servers']
-                 dhcp_servers = ','.replace(',', ' ').join(dhcp_helper_data[interface])
+                 dhcp_servers = ','.replace(',', '\n').join(dhcp_helper_data[interface])
                  if len(dhcp_servers) != 0:
                      body.append([interface, dhcp_servers])
 

--- a/show/main.py
+++ b/show/main.py
@@ -801,17 +801,6 @@ def get_dhcp_relay_intf_db(ctx, interface_name):
 
     return intf
 
-def show_dhcp_relay_detailed(intf):
-
-    dhcp_servers_list = intf.get('dhcp_servers', [])
-    dhcp_servers = ','.replace(',', ', ').join(dhcp_servers_list)
-
-    click.echo("Server Address: " + dhcp_servers)
-    if intf.has_key('dhcp_relay_src_intf'):
-        click.echo("Source Interface: " + intf['dhcp_relay_src_intf'])
-    if intf.has_key('dhcp_relay_link_select'):
-        click.echo("Link Select: " + intf['dhcp_relay_link_select'])
-
 #
 # 'dhcp_relay' subcommand ("show ip dhcp_relay ...")
 #
@@ -849,36 +838,6 @@ def brief(ctx):
                      body.append([interface, dhcp_servers])
 
     click.echo(tabulate(body, header, tablefmt="grid"))
-
-#
-# 'detailed' command ("show ip dhcp_relay detailed")
-#
-@dhcp_relay.command()
-@click.argument('interface_name', metavar='<interface_name>', required=False)
-@click.pass_context
-def detailed(ctx, interface_name):
-    """Show detailed DHCP Relay configuration"""
-
-    db = ConfigDBConnector()
-    db.connect()
-
-    if interface_name is not None:
-        intf = get_dhcp_relay_intf_db(ctx, interface_name)
-        show_dhcp_relay_detailed(intf)
-    else:
-        interfaces = ['INTERFACE', 'PORTCHANNEL_INTERFACE', 'VLAN']
-        intf = None
-
-        for i in interfaces:
-            interface_dict = db.get_table(i)
-
-            if interface_dict:
-                for interface, value in interface_dict.items():
-                    if 'dhcp_servers' in value:
-                        intf = interface_dict[interface]
-                        click.echo("\nRelay Interface: " + interface)
-                        show_dhcp_relay_detailed(intf)
-
 
 #
 # 'ipv6' group ("show ipv6 ...")

--- a/tests/dhcp_relay_test.py
+++ b/tests/dhcp_relay_test.py
@@ -11,7 +11,7 @@ show_dhcp_relay_brief_output="""\
 +------------------+-----------------------+
 | Interface Name   | DHCP Helper Address   |
 +==================+=======================+
-| Ethernet1        | 12.0.0.1              |
+| Ethernet0        | 12.0.0.1              |
 |                  | 12.0.0.2              |
 |                  | 12.0.0.3              |
 +------------------+-----------------------+
@@ -27,18 +27,6 @@ show_dhcp_relay_brief_output="""\
 +------------------+-----------------------+
 """
 
-show_dhcp_relay_detailed_output="""\
-
-Relay Interface: Ethernet1
-Server Address: 12.0.0.1, 12.0.0.2, 12.0.0.3
-
-Relay Interface: Vlan1000
-Server Address: 192.0.0.1, 192.0.0.2, 192.0.0.3, 192.0.0.4
-
-Relay Interface: Vlan2000
-Server Address: 192.0.0.1, 192.0.0.2, 192.0.0.3, 192.0.0.4
-"""
-
 config_vlan_add_dhcp_relay_output="""\
 Added DHCP relay address 192.0.0.4 to Vlan2000
 Restarting DHCP relay service...
@@ -50,12 +38,12 @@ Restarting DHCP relay service...
 """
 
 config_physical_add_dhcp_relay_output="""\
-Added DHCP relay address 12.0.0.4 to Ethernet1
+Added DHCP relay address 12.0.0.4 to Ethernet0
 Restarting DHCP relay service...
 """
 
 config_physical_rem_dhcp_relay_output="""\
-Removed DHCP relay address 12.0.0.3 from Ethernet1
+Removed DHCP relay address 12.0.0.3 from Ethernet0
 Restarting DHCP relay service...
 """
 
@@ -75,37 +63,27 @@ class TestDhcpRelay(object):
         print(result.output)
         assert result.output == show_dhcp_relay_brief_output
 
-    def test_show_dhcp_relay_detailed(self):
-        runner = CliRunner()
-        db = Db()
-        obj = {'db':db.cfgdb}
-
-        # show detailed output
-        result = runner.invoke(show.cli.commands["ip"].commands["dhcp-relay"].commands["detailed"], [], obj=obj)
-        print(result.output)
-        assert result.output == show_dhcp_relay_detailed_output
-
     def test_config_add_delete_dhcp_relay_physical_interface(self):
         runner = CliRunner()
         db = Db()
         obj = {'db':db.cfgdb}
 
-        # add a same dhcp relay server address to Ethernet1
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Ethernet1", "12.0.0.3"], obj=obj)
+        # add a same dhcp relay server address to Ethernet0
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Ethernet0", "12.0.0.3"], obj=obj)
         print(result.exit_code)
         print(result.output)
         assert result.exit_code != 0
         assert "Error: IP address 12.0.0.3 is already configured" in result.output
 
-        # remove dhcp relay server address from Ethernet1
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["remove"], ["Ethernet1", "12.0.0.3"], obj=obj)
+        # remove dhcp relay server address from Ethernet0
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["remove"], ["Ethernet0", "12.0.0.3"], obj=obj)
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
         assert result.output == config_physical_rem_dhcp_relay_output
 
-        # add a new dhcp relay server address to Ethernet1
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Ethernet1", "12.0.0.4"], obj=obj)
+        # add a new dhcp relay server address to Ethernet0
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Ethernet0", "12.0.0.4"], obj=obj)
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0

--- a/tests/dhcp_relay_test.py
+++ b/tests/dhcp_relay_test.py
@@ -68,41 +68,44 @@ class TestDhcpRelay(object):
     def test_show_dhcp_relay_brief(self):
         runner = CliRunner()
         db = Db()
+        obj = {'db':db.cfgdb}
 
         # show brief output
-        result = runner.invoke(show.cli.commands["ip"].commands["dhcp-relay"].commands["brief"], [], obj=db)
+        result = runner.invoke(show.cli.commands["ip"].commands["dhcp-relay"].commands["brief"], [], obj=obj)
         print(result.output)
         assert result.output == show_dhcp_relay_brief_output
 
     def test_show_dhcp_relay_detailed(self):
         runner = CliRunner()
         db = Db()
+        obj = {'db':db.cfgdb}
 
         # show detailed output
-        result = runner.invoke(show.cli.commands["ip"].commands["dhcp-relay"].commands["detailed"], [], obj=db)
+        result = runner.invoke(show.cli.commands["ip"].commands["dhcp-relay"].commands["detailed"], [], obj=obj)
         print(result.output)
         assert result.output == show_dhcp_relay_detailed_output
 
     def test_config_add_delete_dhcp_relay_physical_interface(self):
         runner = CliRunner()
         db = Db()
+        obj = {'db':db.cfgdb}
 
         # add a same dhcp relay server address to Ethernet1
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Ethernet1", "12.0.0.3"], obj=db)
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Ethernet1", "12.0.0.3"], obj=obj)
         print(result.exit_code)
         print(result.output)
         assert result.exit_code != 0
         assert "Error: IP address 12.0.0.3 is already configured" in result.output
 
         # remove dhcp relay server address from Ethernet1
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["remove"], ["Ethernet1", "12.0.0.3"], obj=db)
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["remove"], ["Ethernet1", "12.0.0.3"], obj=obj)
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
         assert result.output == config_physical_rem_dhcp_relay_output
 
         # add a new dhcp relay server address to Ethernet1
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Ethernet1", "12.0.0.4"], obj=db)
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Ethernet1", "12.0.0.4"], obj=obj)
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
@@ -111,16 +114,17 @@ class TestDhcpRelay(object):
     def test_config_add_delete_dhcp_relay_vlan_interface(self):
         runner = CliRunner()
         db = Db()
+        obj = {'db':db.cfgdb}
 
         # add a new dhcp relay server address to Vlan1000
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Vlan1000", "192.0.0.5"], obj=db)
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Vlan1000", "192.0.0.5"], obj=obj)
         print(result.exit_code)
         print(result.output)
         assert result.exit_code != 0
         assert "Error: Maximum number of Servers configured on the relay interface Vlan1000" in result.output
 
         # remove a existing dhcp relay server address from Vlan1000
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["remove"], ["Vlan1000", "192.0.0.4"], obj=db)
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["remove"], ["Vlan1000", "192.0.0.4"], obj=obj)
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0

--- a/tests/dhcp_relay_test.py
+++ b/tests/dhcp_relay_test.py
@@ -56,34 +56,34 @@ class TestDhcpRelay(object):
     def test_show_dhcp_relay_brief(self):
         runner = CliRunner()
         db = Db()
-        #obj = {'db':db.cfgdb}
+        obj = {'db':db.cfgdb}
 
         # show brief output
-        result = runner.invoke(show.cli.commands["ip"].commands["dhcp-relay"].commands["brief"], [], obj=db)
+        result = runner.invoke(show.cli.commands["ip"].commands["dhcp-relay"].commands["brief"], [], obj=obj)
         print(result.output)
         assert result.output == show_dhcp_relay_brief_output
 
     def test_config_add_delete_dhcp_relay_physical_interface(self):
         runner = CliRunner()
         db = Db()
-        #obj = {'db':db.cfgdb}
+        obj = {'db':db.cfgdb}
 
         # add a same dhcp relay server address to Ethernet0
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Ethernet0", "12.0.0.3"], obj=db)
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Ethernet0", "12.0.0.3"], obj=obj)
         print(result.exit_code)
         print(result.output)
         assert result.exit_code != 0
         assert "Error: IP address 12.0.0.3 is already configured" in result.output
 
         # remove dhcp relay server address from Ethernet0
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["remove"], ["Ethernet0", "12.0.0.3"], obj=db)
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["remove"], ["Ethernet0", "12.0.0.3"], obj=obj)
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
         assert result.output == config_physical_rem_dhcp_relay_output
 
         # add a new dhcp relay server address to Ethernet0
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Ethernet0", "12.0.0.4"], obj=db)
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Ethernet0", "12.0.0.4"], obj=obj)
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
@@ -92,17 +92,17 @@ class TestDhcpRelay(object):
     def test_config_add_delete_dhcp_relay_vlan_interface(self):
         runner = CliRunner()
         db = Db()
-        #obj = {'db':db.cfgdb}
+        obj = {'db':db.cfgdb}
 
         # add a new dhcp relay server address to Vlan1000
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Vlan1000", "192.0.0.5"], obj=db)
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Vlan1000", "192.0.0.5"], obj=obj)
         print(result.exit_code)
         print(result.output)
         assert result.exit_code != 0
         assert "Error: Maximum number of Servers configured on the relay interface Vlan1000" in result.output
 
         # remove a existing dhcp relay server address from Vlan1000
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["remove"], ["Vlan1000", "192.0.0.4"], obj=db)
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["remove"], ["Vlan1000", "192.0.0.4"], obj=obj)
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0

--- a/tests/dhcp_relay_test.py
+++ b/tests/dhcp_relay_test.py
@@ -1,0 +1,132 @@
+import os
+import traceback
+
+from click.testing import CliRunner
+
+import config.main as config
+import show.main as show
+from utilities_common.db import Db
+
+show_dhcp_relay_brief_output="""\
++------------------+-----------------------+
+| Interface Name   | DHCP Helper Address   |
++==================+=======================+
+| Ethernet1        | 12.0.0.1              |
+|                  | 12.0.0.2              |
+|                  | 12.0.0.3              |
++------------------+-----------------------+
+| Vlan1000         | 192.0.0.1             |
+|                  | 192.0.0.2             |
+|                  | 192.0.0.3             |
+|                  | 192.0.0.4             |
++------------------+-----------------------+
+| Vlan2000         | 192.0.0.1             |
+|                  | 192.0.0.2             |
+|                  | 192.0.0.3             |
+|                  | 192.0.0.4             |
++------------------+-----------------------+
+"""
+
+show_dhcp_relay_detailed_output="""\
+
+Relay Interface: Ethernet1
+Server Address: 12.0.0.1, 12.0.0.2, 12.0.0.3
+
+Relay Interface: Vlan1000
+Server Address: 192.0.0.1, 192.0.0.2, 192.0.0.3, 192.0.0.4
+
+Relay Interface: Vlan2000
+Server Address: 192.0.0.1, 192.0.0.2, 192.0.0.3, 192.0.0.4
+"""
+
+config_vlan_add_dhcp_relay_output="""\
+Added DHCP relay address 192.0.0.4 to Vlan2000
+Restarting DHCP relay service...
+"""
+
+config_vlan_rem_dhcp_relay_output="""\
+Removed DHCP relay address 192.0.0.4 from Vlan1000
+Restarting DHCP relay service...
+"""
+
+config_physical_add_dhcp_relay_output="""\
+Added DHCP relay address 12.0.0.4 to Ethernet1
+Restarting DHCP relay service...
+"""
+
+config_physical_rem_dhcp_relay_output="""\
+Removed DHCP relay address 12.0.0.3 from Ethernet1
+Restarting DHCP relay service...
+"""
+
+class TestDhcpRelay(object):
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "1"
+        print("SETUP")
+
+    def test_show_dhcp_relay_brief(self):
+        runner = CliRunner()
+        db = Db()
+
+        # show brief output
+        result = runner.invoke(show.cli.commands["ip"].commands["dhcp-relay"].commands["brief"], [], obj=db)
+        print(result.output)
+        assert result.output == show_dhcp_relay_brief_output
+
+    def test_show_dhcp_relay_detailed(self):
+        runner = CliRunner()
+        db = Db()
+
+        # show detailed output
+        result = runner.invoke(show.cli.commands["ip"].commands["dhcp-relay"].commands["detailed"], [], obj=db)
+        print(result.output)
+        assert result.output == show_dhcp_relay_detailed_output
+
+    def test_config_add_delete_dhcp_relay_physical_interface(self):
+        runner = CliRunner()
+        db = Db()
+
+        # add a same dhcp relay server address to Ethernet1
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Ethernet1", "12.0.0.3"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Error: IP address 12.0.0.3 is already configured" in result.output
+
+        # remove dhcp relay server address from Ethernet1
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["remove"], ["Ethernet1", "12.0.0.3"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == config_physical_rem_dhcp_relay_output
+
+        # add a new dhcp relay server address to Ethernet1
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Ethernet1", "12.0.0.4"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == config_physical_add_dhcp_relay_output
+
+    def test_config_add_delete_dhcp_relay_vlan_interface(self):
+        runner = CliRunner()
+        db = Db()
+
+        # add a new dhcp relay server address to Vlan1000
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Vlan1000", "192.0.0.5"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Error: Maximum number of Servers configured on the relay interface Vlan1000" in result.output
+
+        # remove a existing dhcp relay server address from Vlan1000
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["remove"], ["Vlan1000", "192.0.0.4"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == config_vlan_rem_dhcp_relay_output
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        print("TEARDOWN")

--- a/tests/dhcp_relay_test.py
+++ b/tests/dhcp_relay_test.py
@@ -56,34 +56,34 @@ class TestDhcpRelay(object):
     def test_show_dhcp_relay_brief(self):
         runner = CliRunner()
         db = Db()
-        obj = {'db':db.cfgdb}
+        #obj = {'db':db.cfgdb}
 
         # show brief output
-        result = runner.invoke(show.cli.commands["ip"].commands["dhcp-relay"].commands["brief"], [], obj=obj)
+        result = runner.invoke(show.cli.commands["ip"].commands["dhcp-relay"].commands["brief"], [], obj=db)
         print(result.output)
         assert result.output == show_dhcp_relay_brief_output
 
     def test_config_add_delete_dhcp_relay_physical_interface(self):
         runner = CliRunner()
         db = Db()
-        obj = {'db':db.cfgdb}
+        #obj = {'db':db.cfgdb}
 
         # add a same dhcp relay server address to Ethernet0
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Ethernet0", "12.0.0.3"], obj=obj)
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Ethernet0", "12.0.0.3"], obj=db)
         print(result.exit_code)
         print(result.output)
         assert result.exit_code != 0
         assert "Error: IP address 12.0.0.3 is already configured" in result.output
 
         # remove dhcp relay server address from Ethernet0
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["remove"], ["Ethernet0", "12.0.0.3"], obj=obj)
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["remove"], ["Ethernet0", "12.0.0.3"], obj=db)
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
         assert result.output == config_physical_rem_dhcp_relay_output
 
         # add a new dhcp relay server address to Ethernet0
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Ethernet0", "12.0.0.4"], obj=obj)
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Ethernet0", "12.0.0.4"], obj=db)
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
@@ -92,17 +92,17 @@ class TestDhcpRelay(object):
     def test_config_add_delete_dhcp_relay_vlan_interface(self):
         runner = CliRunner()
         db = Db()
-        obj = {'db':db.cfgdb}
+        #obj = {'db':db.cfgdb}
 
         # add a new dhcp relay server address to Vlan1000
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Vlan1000", "192.0.0.5"], obj=obj)
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Vlan1000", "192.0.0.5"], obj=db)
         print(result.exit_code)
         print(result.output)
         assert result.exit_code != 0
         assert "Error: Maximum number of Servers configured on the relay interface Vlan1000" in result.output
 
         # remove a existing dhcp relay server address from Vlan1000
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["remove"], ["Vlan1000", "192.0.0.4"], obj=obj)
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["remove"], ["Vlan1000", "192.0.0.4"], obj=db)
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0

--- a/tests/dhcp_relay_test.py
+++ b/tests/dhcp_relay_test.py
@@ -1,5 +1,6 @@
 import os
 import traceback
+from unittest import mock
 
 from click.testing import CliRunner
 
@@ -28,7 +29,7 @@ show_dhcp_relay_brief_output="""\
 """
 
 config_vlan_add_dhcp_relay_output="""\
-Added DHCP relay address 192.0.0.4 to Vlan2000
+Added DHCP relay address 192.0.0.4 to Vlan1000
 Restarting DHCP relay service...
 """
 
@@ -63,50 +64,55 @@ class TestDhcpRelay(object):
         print(result.output)
         assert result.output == show_dhcp_relay_brief_output
 
-    def test_config_add_delete_dhcp_relay_physical_interface(self):
+    def test_config_add_delete_dhcp_server_on_physical_interface(self):
         runner = CliRunner()
         db = Db()
         obj = {'db':db.cfgdb}
 
-        # add a same dhcp relay server address to Ethernet0
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Ethernet0", "12.0.0.3"], obj=obj)
-        print(result.exit_code)
-        print(result.output)
-        assert result.exit_code != 0
-        assert "Error: IP address 12.0.0.3 is already configured" in result.output
+        with mock.patch("utilities_common.cli.run_command") as mock_run_command:
+            # add a same dhcp relay server address to Ethernet0
+            result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Ethernet0", "12.0.0.3"], obj=obj)
+            print(result.exit_code)
+            print(result.output)
+            assert result.exit_code != 0
+            assert "Error: IP address 12.0.0.3 is already configured" in result.output
 
-        # remove dhcp relay server address from Ethernet0
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["remove"], ["Ethernet0", "12.0.0.3"], obj=obj)
-        print(result.exit_code)
-        print(result.output)
-        assert result.exit_code == 0
-        assert result.output == config_physical_rem_dhcp_relay_output
+            # remove dhcp relay server address from Ethernet0
+            result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["remove"], ["Ethernet0", "12.0.0.3"], obj=obj)
+            print(result.exit_code)
+            print(result.output)
+            assert result.exit_code == 0
+            assert result.output == config_physical_rem_dhcp_relay_output
+            assert mock_run_command.call_count == 3
 
-        # add a new dhcp relay server address to Ethernet0
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Ethernet0", "12.0.0.4"], obj=obj)
-        print(result.exit_code)
-        print(result.output)
-        assert result.exit_code == 0
-        assert result.output == config_physical_add_dhcp_relay_output
+            # add a new dhcp relay server address to Ethernet0
+            result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Ethernet0", "12.0.0.4"], obj=obj)
+            print(result.exit_code)
+            print(result.output)
+            assert result.exit_code == 0
+            assert result.output == config_physical_add_dhcp_relay_output
+            assert mock_run_command.call_count == 3
 
-    def test_config_add_delete_dhcp_relay_vlan_interface(self):
+    def test_config_add_delete_dhcp_server_on_vlan_interface(self):
         runner = CliRunner()
         db = Db()
         obj = {'db':db.cfgdb}
 
-        # add a new dhcp relay server address to Vlan1000
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Vlan1000", "192.0.0.5"], obj=obj)
-        print(result.exit_code)
-        print(result.output)
-        assert result.exit_code != 0
-        assert "Error: Maximum number of Servers configured on the relay interface Vlan1000" in result.output
+        with mock.patch("utilities_common.cli.run_command") as mock_run_command:
+            # add a new dhcp relay server address to Vlan1000
+            result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["add"], ["Vlan1000", "192.0.0.5"], obj=obj)
+            print(result.exit_code)
+            print(result.output)
+            assert result.exit_code != 0
+            assert "Error: Maximum number of Servers configured on the relay interface Vlan1000" in result.output
 
-        # remove a existing dhcp relay server address from Vlan1000
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["remove"], ["Vlan1000", "192.0.0.4"], obj=obj)
-        print(result.exit_code)
-        print(result.output)
-        assert result.exit_code == 0
-        assert result.output == config_vlan_rem_dhcp_relay_output
+            # remove a existing dhcp relay server address from Vlan1000
+            result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["dhcp-relay"].commands["remove"], ["Vlan1000", "192.0.0.4"], obj=obj)
+            print(result.exit_code)
+            print(result.output)
+            assert result.exit_code == 0
+            assert result.output == config_vlan_rem_dhcp_relay_output
+            assert mock_run_command.call_count == 3
 
     @classmethod
     def teardown_class(cls):

--- a/tests/dhcp_relay_test.py
+++ b/tests/dhcp_relay_test.py
@@ -91,7 +91,7 @@ class TestDhcpRelay(object):
             print(result.output)
             assert result.exit_code == 0
             assert result.output == config_physical_add_dhcp_relay_output
-            assert mock_run_command.call_count == 3
+            assert mock_run_command.call_count == 6
 
     def test_config_add_delete_dhcp_server_on_vlan_interface(self):
         runner = CliRunner()

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -556,11 +556,11 @@
         "NULL": "NULL"
     },
     "INTERFACE|Ethernet0": {
-        "NULL": "NULL"
-    },
-    "INTERFACE|Ethernet0|14.14.0.1/24": {
         "NULL": "NULL",
         "dhcp_servers@": "12.0.0.1,12.0.0.2,12.0.0.3"
+    },
+    "INTERFACE|Ethernet0|14.14.0.1/24": {
+        "NULL": "NULL"
     },
     "DEBUG_COUNTER|DEBUG_0": {
         "type": "PORT_INGRESS_DROPS"

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -519,7 +519,8 @@
         "NULL": "NULL"
     },
     "PORTCHANNEL_INTERFACE|PortChannel0001": {
-        "NULL": "NULL"
+        "NULL": "NULL",
+        "dhcp_servers@": "11.0.0.1,11.0.0.2,11.0.0.3",
     },
     "PORTCHANNEL_INTERFACE|PortChannel0002": {
         "NULL": "NULL"

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -558,7 +558,8 @@
         "NULL": "NULL"
     },
     "INTERFACE|Ethernet0|14.14.0.1/24": {
-        "NULL": "NULL"
+        "NULL": "NULL",
+        "dhcp_servers@": "12.0.0.1,12.0.0.2,12.0.0.3"
     },
     "DEBUG_COUNTER|DEBUG_0": {
         "type": "PORT_INGRESS_DROPS"

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -520,7 +520,7 @@
     },
     "PORTCHANNEL_INTERFACE|PortChannel0001": {
         "NULL": "NULL",
-        "dhcp_servers@": "11.0.0.1,11.0.0.2,11.0.0.3",
+        "dhcp_servers@": "11.0.0.1,11.0.0.2,11.0.0.3"
     },
     "PORTCHANNEL_INTERFACE|PortChannel0002": {
         "NULL": "NULL"


### PR DESCRIPTION
Currently DHCP Relay support is for Vlan interfaces only.
This PR, extending the DHCP Relay support to Physical and Port channels L3 interfaces.

Config Commands : 
```
**config interface ip dhcp-relay add <interface_name> <ip_addr1> <ip_addr2> <ip_addr3> <ip_addr4>**

This command enables user to configure IPv4 DHCP Server address on an interface. 
- One address is mandatory and a maximum of four addresses are allowed. 
- If the command is used multiple times with different addresses, the addresses are appended to the list of server addresses.

- Examples:

  admin@sonic:~$ sudo config interface ip dhcp-relay add Ethernet52 1.2.0.1 3.4.0.1 192.168.0.1
  admin@sonic:~$ sudo config interface ip dhcp-relay add Vlan206 1.2.0.1 3.4.0.1
  admin@sonic:~$ sudo config interface ip dhcp-relay add PortChannel007 192.168.0.1

**config interface ip dhcp-relay remove <interface_name> <ip_addr1> <ip_addr2> <ip_addr3> <ip_addr4>**

This command enables user to remove the configured DHCP Server address on an interface. 
- One address is mandatory and a maximum of four addresses are allowed. 
- A single server address can be deleted from the list of configured addresses by providing that address as argument.

- Examples:

  admin@sonic:~$ sudo config interface ip dhcp-relay remove Ethernet52 1.2.0.1 3.4.0.1 192.168.0.1 192.168.5.1
  admin@sonic:~$ sudo config interface ip dhcp-relay remove Vlan206 1.2.0.1 3.4.0.1 
  admin@sonic:~$ sudo config interface ip dhcp-relay remove PortChannel007 192.168.0.1 

These add/remove new commands are inline with the below existing command, which is used to configure the dhcp-relay on a VLAN.
  config vlan dhcp_relay add <vlan_id> <dhcp_relay_destination_ip>
  config vlan dhcp_relay del <vlan-id> <dhcp_relay_destination_ip>
```

Show Command :
```
**show ip dhcp-relay brief**

This command displays all the configured DHCP Server address configurations.

Sample Output:
admin@sonic:~$ sudo show ip dhcp-relay brief

+------------------+-------------------------+
| Interface Name   | DHCP Helper Address     |
+==========+=================================+
| Vlan10           | 20.20.1.2               |
|                  | 1.2.0.1                 |
+------------------+-------------------------+
| PortChannel10    | 40.20.1.2               |
+------------------+-------------------------+
| Ethernet52       | 10.10.1.2               |
+------------------+-------------------------+
```
Signed-off-by: Akhilesh Samineni <akhilesh.samineni@broadcom.com>