### PR TITLE
[config vlan]: Remove `-t` flag from docker exec command

### DIFF
--- a/config/vlan.py
+++ b/config/vlan.py
@@ -53,7 +53,7 @@ def del_vlan(db, vid):
 
 def restart_ndppd():
     verify_swss_running_cmd = "docker container inspect -f '{{.State.Status}}' swss"
-    docker_exec_cmd = "docker exec -it swss {}"
+    docker_exec_cmd = "docker exec -i swss {}"
     ndppd_config_gen_cmd = "sonic-cfggen -d -t /usr/share/sonic/templates/ndppd.conf.j2,/etc/ndppd.conf"
     ndppd_restart_cmd = "supervisorctl restart ndppd"
 


### PR DESCRIPTION

Signed-off-by: Lawrence Lee <lawlee@microsoft.com><!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Remove `-t` flag from the `docker exec` command used to restart SWSS after updating the proxy ARP config. Currently with the flag, this command cannot be executed as part of a script (e.g. during a unit test in sonic-mgmt) since Docker is expecting the input device to be a TTY. 
**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

