### PR TITLE
Update fast-reboot-dump.py to handle invalid parsing of genetlink type hostif object id attribute

### DIFF
--- a/scripts/fast-reboot-dump.py
+++ b/scripts/fast-reboot-dump.py
@@ -86,6 +86,8 @@ def get_map_port_id_2_iface_name(db):
     keys = [] if keys is None else keys
     for key in keys:
         value = db.get_all(db.ASIC_DB, key)
+        if 'SAI_HOSTIF_ATTR_OBJ_ID' not in value:	
+        continue
         port_id = value['SAI_HOSTIF_ATTR_OBJ_ID']
         iface_name = value['SAI_HOSTIF_ATTR_NAME']
         port_id_2_iface[port_id] = iface_name

--- a/scripts/fast-reboot-dump.py
+++ b/scripts/fast-reboot-dump.py
@@ -86,7 +86,7 @@ def get_map_port_id_2_iface_name(db):
     keys = [] if keys is None else keys
     for key in keys:
         value = db.get_all(db.ASIC_DB, key)
-        if 'SAI_HOSTIF_ATTR_OBJ_ID' not in value:	
+        if value['SAI_HOSTIF_ATTR_TYPE'] != 'SAI_HOSTIF_TYPE_NETDEV':
             continue
         port_id = value['SAI_HOSTIF_ATTR_OBJ_ID']
         iface_name = value['SAI_HOSTIF_ATTR_NAME']

--- a/scripts/fast-reboot-dump.py
+++ b/scripts/fast-reboot-dump.py
@@ -87,7 +87,7 @@ def get_map_port_id_2_iface_name(db):
     for key in keys:
         value = db.get_all(db.ASIC_DB, key)
         if 'SAI_HOSTIF_ATTR_OBJ_ID' not in value:	
-        continue
+            continue
         port_id = value['SAI_HOSTIF_ATTR_OBJ_ID']
         iface_name = value['SAI_HOSTIF_ATTR_NAME']
         port_id_2_iface[port_id] = iface_name


### PR DESCRIPTION
Fix fast reboot failure due to invalid parsing of genetlink type hostif object id attribute. Genetlink type hostif does NOT have object ID attribute.
SAI_HOSTIF_ATTR_OBJ_ID (SAI_HOSTIF_ATTR_TYPE == SAI_HOSTIF_TYPE_GENETLINK)


<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

