### PR TITLE
Added show ip/v6 route summary support for multi-asic platform

### DIFF
--- a/show/bgp_common.py
+++ b/show/bgp_common.py
@@ -331,6 +331,7 @@ def show_routes(args, namespace, display, verbose, ipver):
     arg_strg = ""
     found_json = 0
     found_tables = 0
+    found_summary = 0
     ns_l = []
     print_ns_str = False
     filter_by_ip = False
@@ -353,25 +354,29 @@ def show_routes(args, namespace, display, verbose, ipver):
     else:
         back_end_intf_set = None
     # get all the other arguments except json that needs to be the last argument of the cmd if present
+    # Handling of multi-asic show ip/v6 route summary will print directly FRR result of each namespace
+    check_summary_set = set(["sum", "summ", "summa", "summar", "summary"])
     for arg in args:
         arg_strg += str(arg) + " "
         if str(arg) == "json":
             found_json = 1
         elif str(arg) == "tables":
             found_tables = 1
+        elif set([str(arg)]).issubset(check_summary_set):
+            found_summary = 1
         else:
             try:
                 filter_by_ip = ipaddress.ip_network(arg)
             except ValueError:
                 # Not ip address just ignore it
                 pass
-    # Due to options such as "summary" and "tables" are not yet supported in multi-asic platform
+    # Due to option such as "tables" is not yet supported in multi-asic platform
     # we will let FRR handle all the processing instead of handling it here for non multi-asic platform
     if multi_asic.is_multi_asic():
         if found_tables:
             print("% Unknown command: show {} route {}".format(ipver, arg_strg))
             return
-        if not found_json:
+        if not found_json and not found_summary:
             arg_strg += "json"
     combined_route = {}
     for ns in ns_l:
@@ -398,6 +403,13 @@ def show_routes(args, namespace, display, verbose, ipver):
                 error_msg = output
             print(error_msg)
             return
+
+        # Multi-asic show ip route summary is handled by going to FRR directly and get those outputs from each namespace
+        if multi_asic.is_multi_asic() and found_summary:
+            print("{}:".format(ns))
+            print(output)
+            continue
+
         route_info = json.loads(output)
         if filter_back_end or print_ns_str:
             # clean up the dictionary to remove all the nexthops that are back-end interface

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,8 +141,10 @@ def setup_multi_asic_bgp_instance(request):
         m_asic_json_file = 'ip_empty_route.json'
     elif request.param == 'ip_specific_route_on_1_asic':
         m_asic_json_file = 'ip_special_route_asic0_only.json'
+    elif request.param == 'ip_route_summary':
+        m_asic_json_file = 'ip_route_summary.txt'
     else:
-        bgp_mocked_json = os.path.join(
+        m_asic_json_file = os.path.join(
             test_path, 'mock_tables', 'dummy.json')
 
     def mock_run_bgp_command(vtysh_cmd, bgp_namespace):

--- a/tests/ip_show_routes_multi_asic_test.py
+++ b/tests/ip_show_routes_multi_asic_test.py
@@ -220,6 +220,20 @@ class TestMultiAiscShowIpRouteDisplayAllCommands(object):
         assert result.exit_code == 0
         assert result.output == "" 
 
+    @pytest.mark.parametrize('setup_multi_asic_bgp_instance',
+                             ['ip_route_summary'], indirect=['setup_multi_asic_bgp_instance'])
+    def test_show_multi_asic_ip_route_summay(
+            self,
+            setup_ip_route_commands,
+            setup_multi_asic_bgp_instance):
+        show = setup_ip_route_commands
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["ip"].commands["route"], ["summary"])
+        print("{}".format(result.output))
+        assert result.exit_code == 0
+        assert result.output == show_ip_route_common.show_ip_route_summary_expected_output
+
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")

--- a/tests/ip_show_routes_multi_asic_test.py
+++ b/tests/ip_show_routes_multi_asic_test.py
@@ -91,20 +91,6 @@ class TestMultiAiscShowIpRouteDisplayAllCommands(object):
         assert result.exit_code == 0
         assert result.output == show_ip_route_common.show_ipv6_route_multi_asic_specific_route_output
 
-    @pytest.mark.parametrize('setup_multi_asic_bgp_instance',
-                             ['ip_route'], indirect=['setup_multi_asic_bgp_instance'])
-    def test_show_multi_asic_ip_route_tables_option_err(
-            self,
-            setup_ip_route_commands,
-            setup_multi_asic_bgp_instance):
-        show = setup_ip_route_commands
-        runner = CliRunner()
-        result = runner.invoke(
-            show.cli.commands["ip"].commands["route"], ["tables"])
-        print("{}".format(result.output))
-        assert result.exit_code == 0
-        assert result.output == show_ip_route_common.show_ip_route_multi_asic_invalid_tables_cmd_err_output
-
     # note that we purposely use the single bgp instance setup to cause trigger a param error bad 
     # just bail out while executing in multi-asic show ipv6 route handling.
     # This is to test out the error parm handling code path

--- a/tests/mock_tables/asic0/ip_route_summary.txt
+++ b/tests/mock_tables/asic0/ip_route_summary.txt
@@ -1,0 +1,8 @@
+Route Source         Routes               FIB  (vrf default)
+kernel               1                    1
+connected            6                    6
+static               1                    0
+ebgp                 6371                 6371
+ibgp                 88                   88
+------
+Totals               6467                 6466

--- a/tests/mock_tables/asic1/ip_route_summary.txt
+++ b/tests/mock_tables/asic1/ip_route_summary.txt
@@ -1,0 +1,8 @@
+Route Source         Routes               FIB  (vrf default)
+kernel               1                    1
+connected            6                    6
+static               1                    0
+ebgp                 6371                 6371
+ibgp                 88                   88
+------
+Totals               6467                 6466

--- a/tests/mock_tables/asic2/ip_route_summary.txt
+++ b/tests/mock_tables/asic2/ip_route_summary.txt
@@ -1,0 +1,8 @@
+Route Source         Routes               FIB  (vrf default)
+kernel               1                    1
+connected            14                   14
+static               1                    0
+ebgp                 42                   42
+ibgp                 6409                 6409
+------
+Totals               6467                 6466

--- a/tests/show_ip_route_common.py
+++ b/tests/show_ip_route_common.py
@@ -584,10 +584,6 @@ show_ip_route_multi_asic_invalid_display_err_output = """\
 dislay option 'everything' is not a valid option.
 """
 
-show_ip_route_multi_asic_invalid_tables_cmd_err_output = """\
-% Unknown command: show ip route tables 
-"""
-
 show_ip_route_multi_asic_specific_route_output = """\
 Routing entry for 10.0.0.4/31
   Known via "connected", distance 0, metric 0, best

--- a/tests/show_ip_route_common.py
+++ b/tests/show_ip_route_common.py
@@ -644,3 +644,25 @@ show_ipv6_route_multi_asic_json_output = """\
 }
 """
 
+show_ip_route_summary_expected_output = """\
+asic0:
+Route Source         Routes               FIB  (vrf default)
+kernel               1                    1
+connected            6                    6
+static               1                    0
+ebgp                 6371                 6371
+ibgp                 88                   88
+------
+Totals               6467                 6466
+
+asic2:
+Route Source         Routes               FIB  (vrf default)
+kernel               1                    1
+connected            14                   14
+static               1                    0
+ebgp                 42                   42
+ibgp                 6409                 6409
+------
+Totals               6467                 6466
+
+"""


### PR DESCRIPTION
**- What I did**
Added Multi-ASIC support of handling "show ip/v6 route summary"
This was not supported for multi-ASIC platform previously.
When running this cmd under multi-ASIC platform the following output are expected:
```
admin@SONiC:$ show ip route summary -d all
asic0:
Route Source         Routes               FIB  (vrf default)
kernel               1                    1
connected            6                    6
static               1                    0
ebgp                 6371                 6371
ibgp                 88                   88
------
Totals               6467                 6466


asic1:
Route Source         Routes               FIB  (vrf default)
kernel               1                    1
connected            6                    6
static               1                    0
ebgp                 6371                 6371
ibgp                 88                   88
------
Totals               6467                 6466


asic2:
Route Source         Routes               FIB  (vrf default)
kernel               1                    1
connected            14                   14
static               1                    0
ebgp                 43                   43
ibgp                 6408                 6408
------
Totals               6467                 6466


asic3:
Route Source         Routes               FIB  (vrf default)
kernel               1                    1
connected            14                   14
static               1                    0
ebgp                 42                   42
ibgp                 6409                 6409
------
Totals               6467                 6466


asic4:
Route Source         Routes               FIB  (vrf default)
kernel               1                    1
connected            6                    6
static               1                    0
ebgp                 0                    0
ibgp                 6462                 6458
------
Totals               6470                 6465


asic5:
Route Source         Routes               FIB  (vrf default)
kernel               1                    1
connected            6                    6
static               1                    0
ebgp                 0                    0
ibgp                 6462                 6458
------
Totals               6470                 6465


admin@SONiC:$ show ip route summary -n asic2
asic2:
Route Source         Routes               FIB  (vrf default)
kernel               1                    1
connected            14                   14
static               1                    0
ebgp                 43                   43
ibgp                 6408                 6408
------
Totals               6467                 6466


admin@SONiC:$ show ip route summary
asic0:
Route Source         Routes               FIB  (vrf default)
kernel               1                    1
connected            6                    6
static               1                    0
ebgp                 6371                 6371
ibgp                 88                   88
------
Totals               6467                 6466


asic1:
Route Source         Routes               FIB  (vrf default)
kernel               1                    1
connected            6                    6
static               1                    0
ebgp                 6371                 6371
ibgp                 88                   88
------
Totals               6467                 6466


asic2:
Route Source         Routes               FIB  (vrf default)
kernel               1                    1
connected            14                   14
static               1                    0
ebgp                 43                   43
ibgp                 6408                 6408
------
Totals               6467                 6466


asic3:
Route Source         Routes               FIB  (vrf default)
kernel               1                    1
connected            14                   14
static               1                    0
ebgp                 42                   42
ibgp                 6409                 6409
------
Totals               6467                 6466


admin@SONiC:$
 
```


**- How to verify it**
Perform "show ip/v6 route summary" on multi-asic platform to see that this option is now supported.
Before the change:
```
admin@SONiC:~$ show ip route summary
% Unknown command: show ip route sum 
```

After the added support:
```
admin@SONiC:~$ show ip route summary
asic0:
Route Source         Routes               FIB  (vrf default)
kernel               1                    1
connected            6                    6
static               1                    0
ebgp                 6371                 6371
ibgp                 88                   88
------
Totals               6467                 6466


asic1:
Route Source         Routes               FIB  (vrf default)
kernel               1                    1
connected            6                    6
static               1                    0
ebgp                 6371                 6371
ibgp                 88                   88
------
Totals               6467                 6466


asic2:
Route Source         Routes               FIB  (vrf default)
kernel               1                    1
connected            14                   14
static               1                    0
ebgp                 43                   43
ibgp                 6408                 6408
------
Totals               6467                 6466


asic3:
Route Source         Routes               FIB  (vrf default)
kernel               1                    1
connected            14                   14
static               1                    0
ebgp                 42                   42
ibgp                 6409                 6409
------
Totals               6467                 6466


admin@SONiC:$
```