### PR TITLE
Fix exception handling code in python3

### DIFF
--- a/scripts/aclshow
+++ b/scripts/aclshow
@@ -212,7 +212,7 @@ def main():
         acls.previous_counters()
         acls.display_acl_stat(args.all)
     except Exception as e:
-        print(e.message, file=sys.stderr)
+        print(str(e), file=sys.stderr)
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/scripts/ecnconfig
+++ b/scripts/ecnconfig
@@ -326,7 +326,7 @@ def main():
             sys.exit(1)
 
     except Exception as e:
-        print("Exception caught: ", e.message, file=sys.stderr)
+        print("Exception caught: ", str(e), file=sys.stderr)
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/scripts/fdbclear
+++ b/scripts/fdbclear
@@ -50,7 +50,7 @@ def main():
             fdb.send_notification("ALL", "ALL")
             print("FDB entries are cleared.")
     except Exception as e:
-        print(e.message)
+        print(str(e))
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -147,7 +147,7 @@ def main():
         fdb = FdbShow()
         fdb.display(args.vlan, args.port)
     except Exception as e:
-        print(e.message)
+        print(str(e))
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/scripts/lldpshow
+++ b/scripts/lldpshow
@@ -201,7 +201,7 @@ def main():
         lldp.parse_info(lldp_detail_info)
         lldp.display_sum(lldp_detail_info)
     except Exception as e:
-        print(e.message, file=sys.stderr)
+        print(str(e), file=sys.stderr)
         sys.exit(1)
 
 

--- a/scripts/mmuconfig
+++ b/scripts/mmuconfig
@@ -151,7 +151,7 @@ def main(config):
             sys.exit(1)
 
     except Exception as e:
-        print("Exception caught:", e.message, file=sys.stderr)
+        print("Exception caught:", str(e), file=sys.stderr)
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/scripts/natclear
+++ b/scripts/natclear
@@ -63,7 +63,7 @@ def main():
             nat.send_statistics_notification("STATISTICS", "ALL")
             print("\nNAT statistics are cleared.")
     except Exception as e:
-        print(e.message)
+        print(str(e))
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/scripts/natconfig
+++ b/scripts/natconfig
@@ -367,7 +367,7 @@ def main():
             nat.fetch_nat_zone()
             nat.display_nat_zone()
     except Exception as e:
-        print(e.message)
+        print(str(e))
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/scripts/natshow
+++ b/scripts/natshow
@@ -404,7 +404,7 @@ def main():
             nat.display_count()
 
     except Exception as e:
-        print(e.message)
+        print(str(e))
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/scripts/nbrshow
+++ b/scripts/nbrshow
@@ -261,7 +261,7 @@ def main():
             arp.display()
 
     except Exception as e:
-        print(e.message)
+        print(str(e))
         sys.exit(1)
 
 

--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -99,7 +99,7 @@ def main():
             sys.exit(1)
 
     except Exception as e:
-        print(e.message, file=sys.stderr)
+        print(str(e), file=sys.stderr)
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/scripts/sonic_sku_create.py
+++ b/scripts/sonic_sku_create.py
@@ -631,7 +631,7 @@ class SkuCreate(object):
         try:
             shutil.copytree(self.base_sku_dir, self.new_sku_dir)
         except OSError as e:
-            print(e.message, file=sys.stderr)
+            print(str(e), file=sys.stderr)
 
     def remove_sku_dir(self):
         # remove SKU directory 
@@ -653,7 +653,7 @@ class SkuCreate(object):
             else:
                 print("SKU directory: "+ self.new_sku_dir + " was NOT removed")
         except OSError as e:
-            print(e.message, file=sys.stderr) 
+            print(str(e), file=sys.stderr) 
 
     def platform_specific(self):
         # Function that checks for Platform specific restrictions


### PR DESCRIPTION

Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
In python3, message is not an attribute of Exception. As a result, another exception will be thrown in exception handling code. 
```
"Traceback (most recent call last):", 
        "  File \"/usr/local/bin/fdbshow\", line 154, in <module>", 
        "    main()", 
        "  File \"/usr/local/bin/fdbshow\", line 150, in main", 
        "    print(e.message)", 
        "AttributeError: 'RuntimeError' object has no attribute 'message'"
```
This commit addressed the issue.

**- How I did it**
Relpace ```e.message``` with ```str(e)```.

**- How to verify it**
Verified by a demo script.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

