### PR TITLE
[vrf]: Fix freezing during interface binding (#6209)

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2901,7 +2901,7 @@ def bind(ctx, interface_name, vrf_name):
         state_db = SonicV2Connector(use_unix_socket_path=True, namespace=ctx.obj['namespace'])
     state_db.connect(state_db.STATE_DB, False)
     _hash = '{}{}'.format('INTERFACE_TABLE|', interface_name)
-    while state_db.get_all(state_db.STATE_DB, _hash) != None:
+    while state_db.exists(state_db.STATE_DB, _hash):
         time.sleep(0.01)
     state_db.close(state_db.STATE_DB)
     config_db.set_entry(table_name, interface_name, {"vrf_name": vrf_name})


### PR DESCRIPTION
* Replacing using 'get_all' with 'exists' in port state checking
  procedure inside bind function to avoid freezing in the while loop,
  what caused by absence of related record in STATE_DB.

Signed-off-by: Maksym Belei <Maksym_Belei@jabil.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Resolves https://github.com/Azure/sonic-buildimage/issues/6209
Freezing of "sudo config interface vrf bind EthernetXX Vrf_XX" operation has resolved.

**- How I did it**
As currently the system completely deletes "INTERFACE_TABLE|EthernetXX" record in STATE_DB on unbinding or on preparing stage of bind, there is not need to check presence of any keys of the record.
Checking of keys of "INTERFACE_TABLE|EthernetXX" record in STATE_DB, what caused freezing due to absence of the record, has changed to checking for existence of entire record.

**- How to verify it**
Perform the next steps:
1. sudo config vrf add Vrf_custom
2. sudo config interface vrf bind Ethernet36 Vrf_custom

After the steps above command "show vrf" should display Ethernet36 is bound to Vrf_custom.