### PR TITLE
Validations checks while creating and deleting a Portchannel

### DIFF
--- a/tests/portchannel_test.py
+++ b/tests/portchannel_test.py
@@ -1,0 +1,67 @@
+import os
+import traceback
+
+from click.testing import CliRunner
+
+import config.main as config
+import show.main as show
+from utilities_common.db import Db
+
+class TestPortChannel(object):
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "1"
+        print("SETUP")
+
+    def test_add_portchannel_with_invalid_name(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+
+        # add a portchannel with invalid name
+        result = runner.invoke(config.config.commands["portchannel"].commands["add"], ["PortChan005"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Error: PortChan005 is invalid!, name should have prefix 'PortChannel' and suffix '<0-9999>'" in result.output
+
+    def test_delete_portchannel_with_invalid_name(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+
+        # delete a portchannel with invalid name
+        result = runner.invoke(config.config.commands["portchannel"].commands["del"], ["PortChan005"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Error: PortChan005 is invalid!, name should have prefix 'PortChannel' and suffix '<0-9999>'" in result.output
+
+    def test_add_existing_portchannel_again(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+
+        # add a portchannel which is already created
+        result = runner.invoke(config.config.commands["portchannel"].commands["add"], ["PortChannel0001"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Error: PortChannel0001 already exists!" in result.output
+
+    def test_delete_non_existing_portchannel(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+
+        # delete a portchannel which is not present
+        result = runner.invoke(config.config.commands["portchannel"].commands["del"], ["PortChannel0005"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Error: PortChannel0005 is not present." in result.output
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        print("TEARDOWN")


### PR DESCRIPTION
Added below validation checks when a portchannel is created by the user:
    1 if a given portchannel name is valid or not
    2 if a given portchannel name is already created by user (exists in CONFIG_DB)

Added below validation checks when a portchannel is attempted for deletion by the user:
    1 if a given portchannel name is valid or not
    2 if a given portchannel name exists in exists in CONFIG_DB or not (throw an error if it does not exist)

More details : 
Issue 1 : Creating a invalid Portchannel name

If we create a portchannel with invalid name, it gets added to CONFIG_DB, like below
root@sonic:/home/admin# config portchannel add PortChan001
root@sonic:/home/admin#
root@sonic:/home/admin# sonic-db-cli CONFIG_DB keys \*PORTCHANNEL\*
PORTCHANNEL|PortChan001
root@sonic:/home/admin#

Fix: Added a PortChannel name validation check, like below

root@sonic:/home/admin# config portchannel add PortChan001
Usage: config portchannel add [OPTIONS] <portchannel_name>

Error: PortChan001 is invalid!, name should have prefix 'PortChannel' and suffix '<0-9999>'
root@sonic:/home/admin#

Issue 2 : Creating a same PortChannel again and deleting the portchannel which is not exists

If we create a same portchannel again, it is allowing, like below
root@sonic:/home/admin# config portchannel add PortChannel0001
root@sonic:/home/admin#
root@sonic:/home/admin# sonic-db-cli CONFIG_DB keys \*PORTCHANNEL\*
PORTCHANNEL|PortChannel0001
root@sonic:/home/admin#
root@sonic:/home/admin# config portchannel add PortChannel0001
root@sonic:/home/admin#
root@sonic:/home/admin# sonic-db-cli CONFIG_DB keys \*PORTCHANNEL\*
PORTCHANNEL|PortChannel0001
root@sonic:/home/admin#

If we delete a portchannel which is not exists, it is allowing
root@sonic:/home/admin# sonic-db-cli CONFIG_DB keys \*PORTCHANNEL\*
PORTCHANNEL|PortChannel0001
root@sonic:/home/admin#
root@sonic:/home/admin# config portchannel del PortChannel0002
root@sonic:/home/admin#

Fix : Added a validation check like given portchannel exists in CONFIG_DB or not

While creating a portchannel
root@sonic:/home/admin# config portchannel add PortChannel0001
root@sonic:/home/admin#
root@sonic:/home/admin# sonic-db-cli CONFIG_DB keys \*PORTCHANNEL\*
PORTCHANNEL|PortChannel0001
root@sonic:/home/admin#
root@sonic:/home/admin# config portchannel add PortChannel0001
Usage: config portchannel add [OPTIONS] <portchannel_name>

Error: PortChannel0001 already exists!
root@sonic:/home/admin#

While deleting a portchannel
root@sonic:/home/admin# sonic-db-cli CONFIG_DB keys \*PORTCHANNEL\*
PORTCHANNEL|PortChannel0001
root@sonic:/home/admin#
root@sonic:/home/admin# config portchannel del PortChannel0002
Usage: config portchannel del [OPTIONS] <portchannel_name>

Error: PortChannel0002 is not present.
root@sonic:/home/admin#

Signed-off-by: Akhilesh Samineni <akhilesh.samineni@broadcom.com>
