### PR TITLE
[route_check]: ignore routes pointing to Loopback interface

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -166,7 +166,7 @@ def get_interfaces():
 
 def filter_out_local_interfaces(keys):
     rt = []
-    local_if = set(['eth0', 'lo', 'docker0'])
+    local_if_re = ['eth0', 'lo', 'docker0', 'Loopback\d+']
 
     db = ConfigDBConnector()
     db.db_connect('APPL_DB')
@@ -176,7 +176,7 @@ def filter_out_local_interfaces(keys):
         if not e:
             # Prefix might have been added. So try w/o it.
             e = db.get_entry('ROUTE_TABLE', k.split("/")[0])
-        if not e or (e['ifname'] not in local_if):
+        if not e or all([not re.match(x, e['ifname']) for x in local_if_re]):
             rt.append(k)
 
     return rt


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
orchagent ignore all routes pointing to Loopback interfaces.
add this skip logic in route check.

https://github.com/Azure/sonic-swss/pull/1570

Signed-off-by: Guohan Lu <lguohan@gmail.com>

**- How I did it**
use regex to match the interface name

**- How to verify it**
tested on kvm switch

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

