### PR TITLE
[QoS] clear function

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -598,6 +598,11 @@ def _clear_qos():
             'BUFFER_PROFILE',
             'BUFFER_PG',
             'BUFFER_QUEUE']
+         
+    TABLE_NAMES_CONTAIN_QOS = [
+            'BUFFER_PORT_EGRESS_PROFILE_LIST',
+            'BUFFER_PORT_INGRESS_PROFILE_LIST'
+    ]
 
     namespace_list = [DEFAULT_NAMESPACE]
     if multi_asic.get_num_asics() > 1:
@@ -613,6 +618,13 @@ def _clear_qos():
         config_db.connect()
         for qos_table in QOS_TABLE_NAMES:
             config_db.delete_table(qos_table)
+            
+        # Find and remove references to deleted BUFFER_PROFILE table
+        for table_with_qos in TABLE_NAMES_CONTAIN_QOS:
+            for key in config_db.get_keys(table_with_qos):
+                dictionary_value = config_db.get_entry(table_with_qos, key)['profile_list']
+                if dictionary_value.find('BUFFER_PROFILE'):
+                    config_db.mod_entry(table_with_qos, key, None)
 
 def _get_sonic_generated_services(num_asic):
     if not os.path.isfile(SONIC_GENERATED_SERVICE_PATH):

--- a/config/main.py
+++ b/config/main.py
@@ -619,12 +619,13 @@ def _clear_qos():
         for qos_table in QOS_TABLE_NAMES:
             config_db.delete_table(qos_table)
             
-        # Find and remove references to deleted BUFFER_PROFILE table
+        # Find and remove references to deleted tables
         for table_with_qos in TABLE_NAMES_CONTAIN_QOS:
             for key in config_db.get_keys(table_with_qos):
-                dictionary_value = config_db.get_entry(table_with_qos, key)['profile_list']
-                if dictionary_value.find('BUFFER_PROFILE'):
-                    config_db.mod_entry(table_with_qos, key, None)
+                for k,v in config_db.get_entry(table_with_qos, key).items():
+                    for qos_table in QOS_TABLE_NAMES:
+                        if v.find(qos_table):
+                            config_db.mod_entry(table_with_qos, key, None)
 
 def _get_sonic_generated_services(num_asic):
     if not os.path.isfile(SONIC_GENERATED_SERVICE_PATH):


### PR DESCRIPTION
**- What I did**
After executing "config qos clear", some references to the QoS table remain in the configuration file.
This modification of the cleanup function finds and removes records in the table that no longer exist.

**- How I did it**
Currently, the cleanup function just deletes the QoS tables by the list, but some references to those tables get stuck in config.
So, this was fixed by adding search and removing records with outdated links.

**- How to verify it**
admin@sonic: sudo config qos reload
admin@sonic: sudo config save -y
admin@sonic: sudo config qos clear
admin@sonic: sudo config save -y

Signed-off-by: dmytro_dashkov@Jabil.com
