### PR TITLE
[unit test][pfcwd] Fix tests that require sudo access

### DIFF
--- a/tests/pfcwd_test.py
+++ b/tests/pfcwd_test.py
@@ -3,6 +3,8 @@ import os
 import sys
 
 from click.testing import CliRunner
+from unittest.mock import patch
+
 from utilities_common.db import Db
 
 from .pfcwd_input.pfcwd_test_vectors import *
@@ -78,7 +80,8 @@ class TestPfcwd(object):
             if 'rc_output' in input:
                 assert result.output == input['rc_output']
 
-    def test_pfcwd_start_ports_valid(self):
+    @patch('pfcwd.main.os')
+    def test_pfcwd_start_ports_valid(self, mock_os):
         # pfcwd start --action drop --restoration-time 200 Ethernet0 200
         import pfcwd.main as pfcwd
         runner = CliRunner()
@@ -92,6 +95,7 @@ class TestPfcwd(object):
         print(result.output)
         assert result.output == pfcwd_show_config_output
 
+        mock_os.geteuid.return_value = 0
         result = runner.invoke(
             pfcwd.cli.commands["start"],
             [
@@ -112,7 +116,8 @@ class TestPfcwd(object):
         assert result.exit_code == 0
         assert result.output == pfcwd_show_start_config_output_pass
 
-    def test_pfcwd_start_actions(self):
+    @patch('pfcwd.main.os')
+    def test_pfcwd_start_actions(self, mock_os):
         # pfcwd start --action fwd --restoration-time 200 Ethernet0 200
         import pfcwd.main as pfcwd
         runner = CliRunner()
@@ -126,6 +131,7 @@ class TestPfcwd(object):
         print(result.output)
         assert result.output == pfcwd_show_config_output
 
+        mock_os.geteuid.return_value = 0
         result = runner.invoke(
             pfcwd.cli.commands["start"],
             [
@@ -267,7 +273,8 @@ class TestMultiAsicPfcwdShow(object):
         assert result.exit_code == 0
         assert result.output == show_pfcwd_config_with_ports
 
-    def test_pfcwd_start_ports_masic_valid(self):
+    @patch('pfcwd.main.os')
+    def test_pfcwd_start_ports_masic_valid(self, mock_os):
         # pfcwd start --action forward --restoration-time 200 Ethernet0 200
         import pfcwd.main as pfcwd
         runner = CliRunner()
@@ -280,6 +287,7 @@ class TestMultiAsicPfcwdShow(object):
         print(result.output)
         assert result.output == show_pfc_config_all
 
+        mock_os.geteuid.return_value = 0
         result = runner.invoke(
             pfcwd.cli.commands["start"],
             [
@@ -300,7 +308,8 @@ class TestMultiAsicPfcwdShow(object):
         assert result.exit_code == 0
         assert result.output == show_pfc_config_start_pass
 
-    def test_pfcwd_start_actions_masic(self):
+    @patch('pfcwd.main.os')
+    def test_pfcwd_start_actions_masic(self, mock_os):
         # pfcwd start --action drop --restoration-time 200 Ethernet0 200
         import pfcwd.main as pfcwd
         runner = CliRunner()
@@ -313,6 +322,7 @@ class TestMultiAsicPfcwdShow(object):
         print(result.output)
         assert result.output == show_pfc_config_all
 
+        mock_os.geteuid.return_value = 0
         result = runner.invoke(
             pfcwd.cli.commands["start"],
             [

--- a/tests/pfcwd_test.py
+++ b/tests/pfcwd_test.py
@@ -1,9 +1,9 @@
 import imp
 import os
 import sys
+from unittest.mock import patch
 
 from click.testing import CliRunner
-from unittest.mock import patch
 
 from utilities_common.db import Db
 


### PR DESCRIPTION
**- What I did**
The 'config' tests that require sudo access were failing. Fixed it by mocking os.geteuid.

**- How I did it**
Fixed it my mocking os.geteuid.

**- How to verify it**
Unit tests and manual verification

```
before:

samaddik@856d790db1d1:/sonic/src/sonic-utilities/tests$ pytest-3 pfcwd_test.py  -k test_pfcwd_start_actions_masic
>       assert result.exit_code == 0                                                                                                                                                                                                         |
E       AssertionError: assert 1 == 0                                                                                                                                                                                                        |
E        +  where 1 = <Result SystemExit('Root privileges are required for this operation')>.exit_code                                                                                                                                       |
                                                                                                                                                                                                                                             |
pfcwd_test.py:335: AssertionError                                                                                                                                                                                                            |
----------------------------------------------------------------------------------------------------------- Captured stdout setup -----------------------------------------------------------------------------------------------------------|
SETUP                                                                                                                                                                                                                                        |
----------------------------------------------------------------------------------------------------------- Captured stdout call ------------------------------------------------------------------------------------------------------------|
Changed polling interval to 199ms on asic0                                                                                                                                                                                                   |
BIG_RED_SWITCH status is enable on asic0                                                                                                                                                                                                     |
Changed polling interval to 199ms on asic1                                                                                                                                                                                                   |
BIG_RED_SWITCH status is enable on asic1                                                                                                                                                                                                     |
          PORT    ACTION    DETECTION TIME    RESTORATION TIME                                                                                                                                                                               |
--------------  --------  ----------------  ------------------                                                                                                                                                                               |
     Ethernet0      drop               200                 200                                                                                                                                                                               |
     Ethernet4      drop               200                 200                                                                                                                                                                               |
  Ethernet-BP0      drop               200                 200                                                                                                                                                                               |
  Ethernet-BP4      drop               200                 200                                                                                                                                                                               |
Ethernet-BP256      drop               200                 200                                                                                                                                                                               |
Ethernet-BP260      drop               200                 200                                                                                                                                                                               |
                                                                                                                                                                                                                                             |
Root privileges are required for this operation                                                                                                                                                                                              |
                                                                                                                                                                                                                                             |
--------------------------------------------------------------------------------------------------------- Captured stdout teardown ----------------------------------------------------------------------------------------------------------|
TEARDOWN                                                                                                                                                                                                                                     |
================================================================================================== 1 failed, 17 deselected in 0.18 seconds ==================================================================================================|

After:
============================================================================================================ test session starts ============================================================================================================|
platform linux -- Python 3.7.3, pytest-3.10.1, py-1.7.0, pluggy-0.8.0
rootdir: /sonic/src/sonic-utilities/tests, inifile: pytest.ini
plugins: cov-2.6.0
collected 18 items / 17 deselected                                                                                                                                                                                                          

pfcwd_test.py .                                                                                                                                                                                                                       [100%]

================================================================================================== 1 passed, 17 deselected in 0.22 seconds ==================================================================================================
```
samaddik@856d790db1d1:/sonic/src/sonic-utilities/tests$ pytest-3 pfcwd_test.py  -k test_pfcwd_start_actions_masic                                                                                                                            

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

