### PR TITLE
[Dynamic Port Breakout]validate breakout mode exactly

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -130,7 +130,7 @@ def _validate_interface_mode(ctx, breakout_cfg_file, interface_name, target_brko
         return False
 
     # Check whether target breakout mode is available for the user-selected interface or not
-    if target_brkout_mode not in breakout_file_input[interface_name]["breakout_modes"]:
+    if target_brkout_mode not in breakout_file_input[interface_name]["breakout_modes"].replace(" ","").split(','):
         click.secho('[ERROR] Target mode {} is not available for the port {}'. format(target_brkout_mode, interface_name), fg='red')
         return False
 


### PR DESCRIPTION
The supported breakout mode is 1x100G(4), but it can accept 1x100G.
1x100G => the numbers of hw lanes is default
1x100G(4) => the numbers of hw lanes should be 4

If the default numbers of hw lanes is not 4, the 1x100G and 1x100G(4) are different.

Signed-off-by: chiourung_huang <chiourung_huang@edge-core.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
validate breakout mode exactly

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**
root@as7816-64x:/# config interface breakout Ethernet0 1x100G -f -y

Running Breakout Mode : 4x25G
Target Breakout Mode : 1x100G

Ports to be deleted :
 {
    "Ethernet2": "25000",
    "Ethernet3": "25000",
    "Ethernet0": "25000",
    "Ethernet1": "25000"
}
Ports to be added :
 {
    "Ethernet0": "100000"
}

After running Logic to limit the impact

Final list of ports to be deleted :
 {
    "Ethernet2": "25000",
    "Ethernet3": "25000",
    "Ethernet0": "25000",
    "Ethernet1": "25000"
}
Final list of ports to be added :
 {
    "Ethernet0": "100000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-extension', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-types', 'sonic-vlan']
Note: Below table(s) have no YANG models:
TACPLUS_SERVER, DEVICE_METADATA, BGP_PEER_RANGE, PORTCHANNEL_MEMBER, FLEX_COUNTER_TABLE, SYSLOG_SERVER, CRM, CONTAINER_FEATURE, BGP_NEIGHBOR, PORTCHANNEL_INTERFACE, MGMT_INTERFACE, NTP_SERVER, DEVICE_NEIGHBOR_METADATA, TELEMETRY, DEVICE_NEIGHBOR, FEATURE, BREAKOUT_CFG, DHCP_SERVER, MGMT_PORT, RESTAPI, VERSIONS, BUFFER_POOL, BUFFER_PROFILE,
Breakout process got successfully completed.
Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`.
root@as7816-64x:/# redis-cli -n 4 hgetall "BREAKOUT_CFG|Ethernet0"
1) "brkout_mode"
2) "1x100G"

**- New command output (if the output of a command-line utility has changed)**
root@as7816-64x:/# config interface breakout Ethernet0 1x100G -f -y
[ERROR] Target mode 1x100G is not available for the port Ethernet0
Aborted!
