### PR TITLE
[show] Fix warnings, related to gearbox, while show commands execution

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -2,6 +2,7 @@ import json
 import os
 import subprocess
 import sys
+import re
 
 import click
 import netifaces
@@ -44,6 +45,8 @@ HWSKU_JSON = 'hwsku.json'
 PORT_STR = "Ethernet"
 
 VLAN_SUB_INTERFACE_SEPARATOR = '.'
+
+GEARBOX_TABLE_PHY_PATTERN = r"_GEARBOX_TABLE:phy:*"
 
 # To be enhanced. Routing-stack information should be collected from a global
 # location (configdb?), so that we prevent the continous execution of this
@@ -119,7 +122,20 @@ def connect_config_db():
     config_db.connect()
     return config_db
 
+def is_gearbox_configured():
+    """
+    Checks whether Gearbox is configured or not
+    """
+    app_db = SonicV2Connector()
+    app_db.connect(app_db.APPL_DB)
 
+    keys = app_db.keys(app_db.APPL_DB, '*')
+
+    # If any _GEARBOX_TABLE:phy:* records present in APPL_DB, then the gearbox is configured
+    if any(re.match(GEARBOX_TABLE_PHY_PATTERN, key) for key in keys):
+        return True
+    else:
+        return False
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help', '-?'])
 
@@ -160,10 +176,7 @@ cli.add_command(system_health.system_health)
 cli.add_command(warm_restart.warm_restart)
 
 # Add greabox commands only if GEARBOX is configured
-# TODO: Find a cleaner way to do this
-app_db = SonicV2Connector(host='127.0.0.1')
-app_db.connect(app_db.APPL_DB)
-if app_db.keys(app_db.APPL_DB, '_GEARBOX_TABLE:phy:*'):
+if is_gearbox_configured():
     cli.add_command(gearbox.gearbox)
 
 


### PR DESCRIPTION
* Performing getting from APPL_DB of all the keys while checking readiness
  status of the gearbox to prevent warnings sending to syslog if there no 
  records of PHYs of a gearbox in APPL_DB.
* Moving of the gearbox readiness status checking procedure to separated
  function.

Signed-off-by: Maksym Belei <Maksym_Belei@jabil.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
1. Resolves https://github.com/Azure/sonic-buildimage/issues/6311.
Occurrence of the next warnings while performing show commands has fixed:
`Jan 29 15:05:50.705534 sonic WARNING python3: :- operator(): DB '{APPL_DB}' is empty with pattern '_GEARBOX_TABLE:phy:*'!`;

**- How I did it**
The issue has fixed by getting of all the keys from APPL_DB, before checking of presence of _GEARBOX_TABLE:phy:* records in the DB.

**- How to verify it**
1. open two terminal sessions with the DUT;
2. perform command "sudo tail -f /var/log/syslog | grep operator" in the first session;
3. perform command "show interface counters" or "show interface status" in the second session;
4. verify the the warning, described above is not occurred in the first CLI session.
