### PR TITLE
[PFCWD] Fix 'start' pfcwd command

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1555,10 +1555,10 @@ def start(action, restoration_time, ports, detection_time, verbose):
 
     if ports:
         ports = set(ports) - set(['ports', 'detection-time'])
-        cmd += " ports {}".format(' '.join(ports))
+        cmd += " {}".format(' '.join(ports))
 
     if detection_time:
-        cmd += " detection-time {}".format(detection_time)
+        cmd += " {}".format(detection_time)
 
     if restoration_time:
         cmd += " --restoration-time {}".format(restoration_time)

--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -167,6 +167,9 @@ class PfcwdCli(object):
         port_set = set(ports)
         # "all" is a valid option, remove before performing set diff
         port_set.discard("all")
+        # "detection-time" and "ports" are part of the arg tuple, remove before performing set diff
+        port_set.discard("detection-time")
+        port_set.discard("ports")
         return port_set - set(self.all_ports)
 
     @multi_asic_util.run_on_multi_asic

--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -167,9 +167,6 @@ class PfcwdCli(object):
         port_set = set(ports)
         # "all" is a valid option, remove before performing set diff
         port_set.discard("all")
-        # "detection-time" and "ports" are part of the arg tuple, remove before performing set diff
-        port_set.discard("detection-time")
-        port_set.discard("ports")
         return port_set - set(self.all_ports)
 
     @multi_asic_util.run_on_multi_asic


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
The 'config' method is getting arguments from the user CLI and build a proper command for the pfcwd script in a wrong way, causing this issue.

**- How I did it**
Fix the command structure to align with pfcwd.main script.

**- How to verify it**
Run "config pfcwd start --action drop ports all detection-time 400 --restoration-time 400"

**- Previous command output (if the output of a command-line utility has changed)**
config pfcwd start --action drop ports all detection-time 400 --restoration-time 400
Failed to run command, invalid options:
ports
detection-time

**- New command output (if the output of a command-line utility has changed)**
Command succeeded.
