### PR TITLE
Improve robustness of consutil plugin loading

### DIFF
--- a/consutil/lib.py
+++ b/consutil/lib.py
@@ -270,8 +270,8 @@ class SysInfoProvider(object):
 
         if os.path.exists(PLUGIN_PATH):
             fp = open(PLUGIN_PATH, 'r')
-            line = fp.readlines()
-            SysInfoProvider.DEVICE_PREFIX = "/dev/" + line[0]
+            lines = fp.readlines()
+            SysInfoProvider.DEVICE_PREFIX = "/dev/" + lines[0].rstrip()
 
     @staticmethod
     def list_console_ttys():


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

The configuration file of consulit did not tolerate a trailing new line.
Enhance the plugin mechanism by allowing trailing chars.

**- How I did it**

Removed trailing chars on the 1st line read from `udevprefix.conf`

**- How to verify it**

Run this fixed version with the following scenarios.

Backward compatibility: `echo -n ttyUSB > udevprefix.conf`
Support of trailing whitespaces `echo ttyUSB > udevprefix.conf`
Futureproof case where we might want to handle multiple prefixes `echo "ttyUSB \nttySMTH" > udevprefix.conf`
