### PR TITLE
Add new CLI for PG drop counters part of counterpoll utility

### DIFF
--- a/tests/counterpoll_test.py
+++ b/tests/counterpoll_test.py
@@ -7,6 +7,7 @@ import sys
 import time
 from click.testing import CliRunner
 from shutil import copyfile
+from utilities_common.db import Db
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
@@ -25,6 +26,7 @@ PORT_STAT                           1000  enable
 PORT_BUFFER_DROP                   60000  enable
 QUEUE_WATERMARK_STAT               10000  enable
 PG_WATERMARK_STAT                  10000  enable
+PG_DROP_STAT                       10000  enable
 """
 
 class TestCounterpoll(object):
@@ -54,6 +56,14 @@ class TestCounterpoll(object):
         assert result.exit_code == 2
         assert expected in result.output
 
+    def test_pg_drop_interval_too_long(self):
+        runner = CliRunner()
+        result = runner.invoke(counterpoll.cli.commands["pg-drop"].commands["interval"], ["50000"])
+        print(result.output)
+        expected = "Invalid value for \"POLL_INTERVAL\": 50000 is not in the valid range of 1000 to 30000."
+        assert result.exit_code == 2
+        assert expected in result.output
+
     @pytest.fixture(scope='class')
     def _get_config_db_file(self):
         sample_config_db_file = os.path.join(test_path, "counterpoll_input", "config_db.json")
@@ -75,6 +85,30 @@ class TestCounterpoll(object):
         if "FLEX_COUNTER_TABLE" in config_db:
             for counter, counter_config in config_db["FLEX_COUNTER_TABLE"].items():
                 assert counter_config["FLEX_COUNTER_STATUS"] == status
+
+    @pytest.mark.parametrize("status", ["disable", "enable"])
+    def test_update_pg_drop_status(self, status):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(counterpoll.cli.commands["pg-drop"].commands[status], [], obj=db.cfgdb)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
+        table = db.cfgdb.get_table('FLEX_COUNTER_TABLE')
+        assert status == table["PG_DROP"]["FLEX_COUNTER_STATUS"]
+
+    def test_update_pg_drop_interval(self):
+        runner = CliRunner()
+        db = Db()
+        test_interval = "20000"
+
+        result = runner.invoke(counterpoll.cli.commands["pg-drop"].commands["interval"], [test_interval], obj=db.cfgdb)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
+        table = db.cfgdb.get_table('FLEX_COUNTER_TABLE')
+        assert test_interval == table["PG_DROP"]["POLL_INTERVAL"]
 
     @classmethod
     def teardown_class(cls):

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -1262,6 +1262,10 @@
         "POLL_INTERVAL": "10000",
         "FLEX_COUNTER_STATUS": "enable"
     },
+    "FLEX_COUNTER_TABLE|PG_DROP": {
+        "POLL_INTERVAL": "10000",
+        "FLEX_COUNTER_STATUS": "enable"
+    },
     "PFC_WD|Ethernet0": {
         "action": "drop",
         "detection_time": "600",


### PR DESCRIPTION
Enhance counterpoll utility to support PG drop counters. 
Add new CLI to enable/disable it.

Signed-off-by: Andriy Yurkiv <ayurkiv@nvidia.com>

**depends on:**
https://github.com/Azure/sonic-buildimage/pull/6444
https://github.com/Azure/sonic-swss/pull/1600

**merge priority:**
https://github.com/Azure/sonic-swss/pull/1600
https://github.com/Azure/sonic-utilities/pull/1355
https://github.com/Azure/sonic-buildimage/pull/6444

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Added new option for "counterpoll" utility

**- How I did it**
Enhance counterpoll utility for SAI_INGRESS_PRIORITY_GROUP_STAT_DROPPED_PACKETS 
Add new CLI command and extend the show command.

**- How to verify it**
To test it use QoS test. run the pfcxontest and Pfcxofftest, drop can be triggered in either of the test.
It runs in ptf32 topo and requires RPC image.
```
admin@arc-switch1041:~$ counterpoll pg-drop enable  --> to enable the new counter
admin@arc-switch1041:~$ counterpoll show  --> check new INGRESS_PG_STAT_DROP counter status
```
Check counters
```
admin@arc-switch1041:~$ redis-cli -n 2
127.0.0.1:6379[2]> HGETALL COUNTERS:oid:0x1a000000000062
1) "SAI_INGRESS_PRIORITY_GROUP_STAT_XOFF_ROOM_WATERMARK_BYTES"
2) "0"
3) "SAI_INGRESS_PRIORITY_GROUP_STAT_SHARED_WATERMARK_BYTES"
4) "0"
5) "SAI_INGRESS_PRIORITY_GROUP_STAT_DROPPED_PACKETS"
6) "0"

```

**- Previous command output (if the output of a command-line utility has changed)**

```
admin@arc-switch1041:~$ counterpoll show
Type                        Interval (in ms)    Status
--------------------------  ------------------  --------
QUEUE_STAT                  default (10000)     enable
PORT_STAT                   default (1000)      enable
PORT_BUFFER_DROP            default (60000)     enable
RIF_STAT                    default (1000)      enable
QUEUE_WATERMARK_STAT        default (10000)     enable
PG_WATERMARK_STAT           default (10000)     enable
BUFFER_POOL_WATERMARK_STAT  default (10000)     enable
```

```
admin@arc-switch1041:~$ counterpoll
.......
Commands:
  config-db         Config DB counter commands
  port              Queue counter commands
  port-buffer-drop  Port buffer drop counter commands
  queue             Queue counter commands
  rif               RIF counter commands
  show              Show the counter configuration
  watermark         Watermark counter commands
```




**- New command output (if the output of a command-line utility has changed)**
```

admin@arc-switch1041:~$ counterpoll show
Type                        Interval (in ms)    Status
--------------------------  ------------------  --------
QUEUE_STAT                  default (10000)     enable
PORT_STAT                   default (1000)      enable
PORT_BUFFER_DROP            default (60000)     enable
RIF_STAT                    default (1000)      enable
QUEUE_WATERMARK_STAT        default (10000)     enable
PG_WATERMARK_STAT           default (10000)     enable
PG_DROP_STAT                default (10000)     enable         <--- new line
BUFFER_POOL_WATERMARK_STAT  default (10000)     enable

```


```
admin@arc-switch1041:~$ counterpoll
Usage: counterpoll [OPTIONS] COMMAND [ARGS]...
...............
Commands:
  config-db         Config DB counter commands
  pg-drop           Ingress PG drop counter commands     <--- new command
  port              Queue counter commands
  port-buffer-drop  Port buffer drop counter commands
  queue             Queue counter commands
  rif               RIF counter commands
  show              Show the counter configuration
  watermark         Watermark counter commands
```


