### PR TITLE
Use platform read_eeprom API if it doesn't support DB update.

### DIFF
--- a/show/platform.py
+++ b/show/platform.py
@@ -5,6 +5,7 @@ import sys
 import click
 import utilities_common.cli as clicommon
 from sonic_py_common import device_info, multi_asic
+from swsscommon.swsscommon import SonicV2Connector
 
 
 def get_hw_info_dict():
@@ -62,7 +63,16 @@ def summary(json):
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def syseeprom(verbose):
     """Show system EEPROM information"""
-    cmd = "sudo decode-syseeprom -d"
+
+    # Check if EEPROM info is present in DB. If yes, use the '-d' option.
+    # TODO, Remove this check when all platforms support EEPROM info in DB.
+    db = SonicV2Connector()
+    db.connect(db.STATE_DB)
+    if db.keys(db.STATE_DB, 'EEPROM_INFO|*'):
+        cmd = "sudo decode-syseeprom -d"
+    else:
+        cmd = "sudo decode-syseeprom"
+
     clicommon.run_command(cmd, display_cmd=verbose)
 
 


### PR DESCRIPTION

**- What I did**
Use the platform API to read eeprom, if the specific platform don't support populating EEPROM info in DB

**- How I did it**
Check if the STATE_DB has the EEPROM_INFO populated. If the EEPROM info is populated pass the "-d" option to decode-syseeprom, which retrieves and displays data from DB. Else use the read eeprom API's provided by vendor.

**- How to verify it**
Verified with platforms that the o/p is correct. 

1. Platforms where STATE DB was populated with EEPROM_INFO 

```
admin@str--acs-2:~$ show platform syseeprom 
TlvInfo Header:
   Id String:    TlvInfo
   Version:      1
   Total Length: 170
TLV Name             Code Len Value
-------------------- ---- --- -----
Base MAC Address     0x24   6 0C:29:EF:CF:AC:A0
Service Tag          0x2F   7 F3CD9Z2
Product Name         0x21   8 S6100-ON
Part Number          0x22   6 0F6N2R
Serial Number        0x23  20 TH0F6N2RCET0007600NG
Manufacture Date     0x25  19 07/07/2020 15:05:34
Device Version       0x26   1 1
Label Revision       0x27   3 A08
Platform Name        0x28  26 x86_64-dell_s6100_c2538-r0
ONIE Version         0x29   8 3.15.1.0
MAC Addresses        0x2A   2 384
Manufacturer         0x2B   5 CET00
Manufacture Country  0x2C   2 TH
Vendor Name          0x2D   4 DELL
Diag Version         0x2E   8 3.25.4.1
Vendor Extension     0xFD   7 
CRC-32               0xFE   4 0xAC518FB3
(checksum valid)
```
 
2. Platforms where STATE DB is not populated with EEPROM_INFO 

```
admin@str--acs-1:~$ show platform syseeprom 
    Name                   Value    
--------------------  ---------------
Part Revision         N0
MAC Addresses         264
Hardware Change Bit   10
Hardware Revision     1.6
(checksum valid)
```

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

