### PR TITLE
[show] Fix show arp in case with FDB entries, linked to default VLAN

### DIFF
--- a/scripts/nbrshow
+++ b/scripts/nbrshow
@@ -95,6 +95,10 @@ class NbrBase(object):
             elif 'bvid' in fdb:
                 try:
                     vlan_id = port_util.get_vlan_id_from_bvid(self.db, fdb["bvid"])
+                    if vlan_id is None:
+                        # the case could be happened if the FDB entry has created with linking to
+                        # default VLAN 1, which is not present in the system
+                        continue
                 except Exception:
                     vlan_id = fdb["bvid"]
                     print("Failed to get Vlan id for bvid {}\n".format(fdb["bvid"]))


### PR DESCRIPTION
* Adding condition to check result of getting of Vlan id, using bvid.
  If the vlan id is None, then skip the record to avoid exception
  raising on int(NoneType)

Signed-off-by: Maksym Belei <Maksym_Belei@jabil.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Resolves https://github.com/Azure/sonic-buildimage/issues/6367
Fix exception raising while executing "show arp" command in cases, when the system has an FDB entry, which is linked to default VLAN 1.

**- How I did it**
New condition has added to function "fetch_fdb_data" inside "nbrshow" script, which checks the result of getting "vlan_id" by using "bvid". If "vlan_id" is None, then just continue iterate "fdb_str", as a record inside "bridge_mac_list", which has not vlan_id, could not be using in any other places of "nbrshow" script.

**- How to verify it**
1. Assign IP address to the Ethernet interface:
   sudo config interface ip add Ethernet68 104.0.0.1/24
2. Perform Steps to reproduce from https://github.com/Azure/sonic-buildimage/issues/6367. Start pinging from Linux host device. After that we will get FDB entry of Linux host device
3. Remove IP address from the Ethernet interface:
   sudo config interface ip rem Ethernet68 104.0.0.1/24
   This will cause creation of a new FDB entry with the same MAC address, but with oid of the default VLAN(oid:0x26000000000013)
4. execute "show arp". The command should return normal output.