### PR TITLE
[show]fix for show muxcable status by replacing "hostname" to "peer_switch" for deriving tor ipv4_address

### DIFF
--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -63,7 +63,7 @@ def get_switch_name(config_db):
     info_dict = config_db.get_entry("DEVICE_METADATA", "localhost")
     #click.echo("{} ".format(info_dict))
 
-    switch_name = get_value_for_key_in_dict(info_dict, "localhost", "hostname", "DEVICE_METADATA")
+    switch_name = get_value_for_key_in_dict(info_dict, "localhost", "peer_switch", "DEVICE_METADATA")
     if switch_name is not None:
         return switch_name
     else:

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -666,6 +666,7 @@
         "hwsku": "Mellanox-SN3800-D112C8",
         "mac": "1d:34:db:16:a6:00",
         "platform": "x86_64-mlnx_msn3800-r0",
+        "peer_switch": "sonic-switch",
         "type": "ToRRouter"
     },
     "DEVICE_NEIGHBOR|Ethernet4": {


### PR DESCRIPTION
Summary:
This PR provides the support for fixing the show muxcable config. 
There was a change in the Config_DB schema where there was an addition of key-value pair
"peer_switch:tor_name" in DEVICE_METADATA|localhost  table which actually gives the other TOR's name (hostname).
This TOR name is then utilized in PEER_SWITCH|switchname table which has "address_ipv4: IPv4 address" key-value pair,
which correctly gives the ip address for displaying on the show mux config           

` show muxcable config <portname>`
`

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
added the changes in sonic-utilities/show muxcable.py

#### What is the motivation for this PR?

To add the fix the working for show muxcable config

#### How did you do it?
Added the changes inside sonic-utilities and tested it on the testbed

#### How did you verify/test it?
Ran the cli commands on an Arista7050cx3 testbed with Gemini cable

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>


