### PR TITLE
[ecnconfig] Handle Multi ASIC backend port names when extracting port I/F

### DIFF
--- a/scripts/ecnconfig
+++ b/scripts/ecnconfig
@@ -198,7 +198,11 @@ class EcnQ(object):
             port_table = self.config_db.get_table(DEVICE_NEIGHBOR_TABLE_NAME)
             self.ports_key = port_table.keys()
 
-            self.ports_key = sorted(self.ports_key, key = lambda k: int(k[8:]))
+            # In multi-ASIC platforms backend ethernet ports are identified as
+            # 'Ethernet-BPxy'. Add 1024 to sort backend ports to the end.
+            self.ports_key.sort(
+                key = lambda k: int(k[8:]) if "BP" not in k else int(k[11:]) + 1024
+            )
 
     def set(self, enable):
         if os.geteuid() != 0:


### PR DESCRIPTION
**- What I did**
On Multi ASIC platforms ports names for backend ports have the following convention: 'Ethernet-BPxy'

Port ID extraction was failing for these backend port names.

**- How I did it**

Fix the port ID extraction for backend port names.

**- How to verify it**

Manual:

```
before:
admin@str-sonic-acs-2:~$ sudo ip netns exec asic0 ecnconfig -q 3
Exception caught:  invalid literal for int() with base 10: '-BP48'

After:
admin@str-sonic-acs-2:~$ sudo ip netns exec asic0 ecnconfig -q 3
ECN status:
queue 3: on

```

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

