### PR TITLE
[voq/inbandif] Voq inbandif port

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -354,6 +354,36 @@ def filter_out_local_interfaces(keys):
     return rt
 
 
+def filter_out_voq_neigh_routes(keys):
+    """
+    helper to filter out voq neigh routes. These are the
+    routes statically added for the voq neighbors. We skip
+    writing route entries in asic db for these. We filter
+    out reporting error on all the host routes written on
+    inband interface prefixed with "Ethernte-IB"
+    :param keys: APPL-DB:ROUTE_TABLE Routes to check.
+    :return keys filtered out for voq neigh routes
+    """
+    rt = []
+    local_if_re = [r'Ethernet-IB\d+']
+
+    db = swsscommon.DBConnector(APPL_DB_NAME, 0)
+    tbl = swsscommon.Table(db, 'ROUTE_TABLE')
+
+    for k in keys:
+        prefix = k.split("/")
+        e = dict(tbl.get(k)[1])
+        if not e:
+            # Prefix might have been added. So try w/o it.
+            e = dict(tbl.get(prefix[0])[1])
+        if not e or all([not (re.match(x, e['ifname']) and
+            ((prefix[1] == "32" and e['nexthop'] == "0.0.0.0") or
+                (prefix[1] == "128" and e['nexthop'] == "::"))) for x in local_if_re]):
+            rt.append(k)
+
+    return rt
+
+
 def filter_out_default_routes(lst):
     """
     helper to filter out default routes
@@ -408,6 +438,9 @@ def check_routes():
 
     if rt_appl_miss:
         rt_appl_miss = filter_out_local_interfaces(rt_appl_miss)
+
+    if rt_appl_miss:
+        rt_appl_miss = filter_out_voq_neigh_routes(rt_appl_miss)
 
     if rt_appl_miss or rt_asic_miss:
         # Look for subscribe updates for a second

--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -12,7 +12,7 @@ import sys
 
 import click
 from natsort import natsorted
-from sonic_py_common.interface import front_panel_prefix, backplane_prefix
+from sonic_py_common.interface import front_panel_prefix, backplane_prefix, inband_prefix
 from sonic_py_common import multi_asic
 from tabulate import tabulate
 from utilities_common import multi_asic as multi_asic_util
@@ -411,7 +411,7 @@ class SFPShow(object):
             sorted_table_keys = natsorted(port_table_keys)
             for i in sorted_table_keys:
                 interface = re.split(':', i, maxsplit=1)[-1].strip()
-                if interface and interface.startswith(front_panel_prefix()) and not interface.startswith(backplane_prefix()):
+                if interface and interface.startswith(front_panel_prefix()) and not interface.startswith(backplane_prefix()) and not interface.startswith(inband_prefix()):
                     presence = self.db.exists(self.db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(interface))
                     if presence:
                         self.output += self.convert_interface_sfp_info_to_cli_output_string(
@@ -435,7 +435,7 @@ class SFPShow(object):
             port_table_keys = self.db.keys(self.db.APPL_DB, "PORT_TABLE:*")
             for i in port_table_keys:
                 key = re.split(':', i, maxsplit=1)[-1].strip()
-                if key and key.startswith(front_panel_prefix()) and not key.startswith(backplane_prefix()):
+                if key and key.startswith(front_panel_prefix()) and not key.startswith(backplane_prefix()) and not key.startswith(inband_prefix()):
                     presence = self.db.exists(self.db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(key))
                     if presence:
                         port_table.append((key, 'Present'))

--- a/tests/mock_tables/appl_db.json
+++ b/tests/mock_tables/appl_db.json
@@ -108,6 +108,18 @@
         "pfc_asym": "off",
         "admin_status": "up"
     },
+    "PORT_TABLE:Ethernet-IB0": {
+        "admin_status": "up",
+        "alias": "Ethernet-IB0",
+        "asic_port_name": "Rcy-ASIC0",
+        "description": "",
+        "index": "148",
+        "lanes": "109,0,0,0,0,0,0,0",
+        "mtu": "9100",
+        "oper_status": "up",
+        "role": "Int",
+        "speed": "100000"
+    },
     "INTF_TABLE:Ethernet0.10": {
         "admin_status": "up"
     },

--- a/tests/mock_tables/asic0/appl_db.json
+++ b/tests/mock_tables/asic0/appl_db.json
@@ -47,6 +47,18 @@
         "speed": "40000",
         "asic_port_name": "Eth17-ASIC0"
     },
+    "PORT_TABLE:Ethernet-IB0": {
+        "admin_status": "up",
+        "alias": "Ethernet-IB0",
+        "asic_port_name": "Rcy-ASIC0",
+        "description": "",
+        "index": "148",
+        "lanes": "109,0,0,0,0,0,0,0",
+        "mtu": "9100",
+        "oper_status": "up",
+        "role": "Int",
+        "speed": "100000"
+    },
     "LAG_MEMBER_TABLE:PortChannel1002:Ethernet0": {
         "status": "disabled"
     },

--- a/tests/mock_tables/asic1/appl_db.json
+++ b/tests/mock_tables/asic1/appl_db.json
@@ -33,6 +33,18 @@
         "speed": "40000",
         "asic_port_name": "Eth1-ASIC1"
     },
+    "PORT_TABLE:Ethernet-IB1": {
+        "admin_status": "up",
+        "alias": "Ethernet-IB1",
+        "asic_port_name": "Rcy-ASIC1",
+        "description": "",
+        "index": "152",
+        "lanes": "109,0,0,0,0,0,0,0",
+        "mtu": "9100",
+        "oper_status": "up",
+        "role": "Int",
+        "speed": "100000"
+    },
     "LAG_TABLE:PortChannel4009": {
         "admin_status": "up",
         "oper_status": "up",

--- a/tests/mock_tables/asic2/appl_db.json
+++ b/tests/mock_tables/asic2/appl_db.json
@@ -47,6 +47,18 @@
         "speed": "40000",
         "asic_port_name": "Eth17-ASIC2"
     },
+    "PORT_TABLE:Ethernet-IB2": {
+        "admin_status": "up",
+        "alias": "Ethernet-IB2",
+        "asic_port_name": "Rcy-ASIC2",
+        "description": "",
+        "index": "156",
+        "lanes": "109,0,0,0,0,0,0,0",
+        "mtu": "9100",
+        "oper_status": "up",
+        "role": "Int",
+        "speed": "100000"
+    },
     "LAG_MEMBER_TABLE:PortChannel1015:Ethernet20": {
         "status": "enabled"
     },

--- a/tests/route_check_test.py
+++ b/tests/route_check_test.py
@@ -180,6 +180,44 @@ test_data = {
                 }
             }
         }
+    },
+    "4": {
+        DESCR: "Good one with routes on voq inband interface",
+        ARGS: "route_check",
+        PRE: {
+            APPL_DB: {
+                ROUTE_TABLE: {
+                    "0.0.0.0/0" : { "ifname": "portchannel0" },
+                    "10.10.196.12/31" : { "ifname": "portchannel0" },
+                    "10.10.196.20/31" : { "ifname": "portchannel0" },
+                    "10.10.196.30/31" : { "ifname": "lo" },
+                    "10.10.197.1" : { "ifname": "Ethernet-IB0", "nexthop": "0.0.0.0"},
+                    "2603:10b0:503:df5::1" : { "ifname": "Ethernet-IB0", "nexthop": "::"},
+                    "100.0.0.2/32" : { "ifname": "Ethernet-IB0", "nexthop": "0.0.0.0" },
+                    "2064:100::2/128" : { "ifname": "Ethernet-IB0", "nexthop": "::" },
+                    "101.0.0.0/24" : { "ifname": "Ethernet-IB0", "nexthop": "100.0.0.2"}
+                },
+                INTF_TABLE: {
+                    "PortChannel1013:10.10.196.24/31": {},
+                    "PortChannel1023:2603:10b0:503:df4::5d/126": {},
+                    "PortChannel1024": {},
+                    "Ethernet-IB0:10.10.197.1/24": {},
+                    "Ethernet-IB0:2603:10b0:503:df5::1/64": {}
+                }
+            },
+            ASIC_DB: {
+                RT_ENTRY_TABLE: {
+                    RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
+                    RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + RT_ENTRY_KEY_SUFFIX: {},
+                    RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
+                    RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
+                    RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {},
+                    RT_ENTRY_KEY_PREFIX + "10.10.197.1/32" + RT_ENTRY_KEY_SUFFIX: {},
+                    RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df5::1/128" + RT_ENTRY_KEY_SUFFIX: {},
+                    RT_ENTRY_KEY_PREFIX + "101.0.0.0/24" + RT_ENTRY_KEY_SUFFIX: {}
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

Inband port can be made available in PORT table. But regular port handlngs are
not applicable for Inband port. This PR has change to avoid regular port handling for inband port

Ref: VOQ HLD https://github.com/Azure/SONiC/blob/master/doc/voq/voq_hld.md

**- How I did it**

The inband port is considered similar to back plane port. An inband_prefix = "Ethernet-IB" and this is checked in all places to avoid regular port handling.

**- How to verify it**

- Expose a port with name prefixed with "Ethernet-IB" to SONiC via port_config.ini
- Have an entry in the PORT table for this port with name prefixed with "Ethernet-IB"
- When the system is booted, there should not be errors related to Inband interface

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

Note: This PR depends on sonic-buildimage PR https://github.com/Azure/sonic-buildimage/pull/6477

