### PR TITLE
[show] Run fwutil with sudo

### DIFF
--- a/show/platform.py
+++ b/show/platform.py
@@ -133,7 +133,7 @@ def temperature():
 @click.argument('args', nargs=-1, type=click.UNPROCESSED)
 def firmware(args):
     """Show firmware information"""
-    cmd = "fwutil show {}".format(" ".join(args))
+    cmd = "sudo fwutil show {}".format(" ".join(args))
 
     try:
         subprocess.check_call(cmd, shell=True)


### PR DESCRIPTION
Signed-off-by: Volodymyr Boyko <volodymyrx.boiko@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Added ability to run `show platform firmware` commands without `sudo`, as described in the [design document](https://github.com/Azure/sonic-utilities/blob/master/doc/Command-Reference.md#platform-component-firmware-show-commands):

**- How I did it**
Made `show platform firmware` implementation run `fwutil` with `sudo` 
**- How to verify it**
Run `show platform firmware status` 

**- Previous command output (if the output of a command-line utility has changed)**
```
$ show platform firmware status 
Error: Root privileges are required. Aborting...
Aborted!
```

**- New command output (if the output of a command-line utility has changed)**
```
$ show platform firmware status 
Chassis    Module    Component    Version    Description
---------  --------  -----------  ---------  -------------
```


