### PR TITLE
[sflow] Fix sample rate defaults for sflow in CLI reference

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -6257,13 +6257,13 @@ Enable/disable sflow at an interface level. By default, sflow is enabled on all 
 
 Configure the sample-rate for a specific interface.
 
-The default sample rate for any interface is (ifSpeed / 1e6) where ifSpeed is in bits/sec. So, the default sample rate based on interface speed is:
+The default sample rate for any interface is (ifSpeed / 1e7) where ifSpeed is in bits/sec. So, the default sample rate based on interface speed is:
 
-    1-in-1000 for a 1G link
-    1-in-10,000 for a 10G link
-    1-in-40,000 for a 40G link
-    1-in-50,000 for a 50G link
-    1-in-100,000 for a 100G link
+    1-in-100 for a 1G link
+    1-in-1,000 for a 10G link
+    1-in-4,000 for a 40G link
+    1-in-5,000 for a 50G link
+    1-in-10,000 for a 100G link
 
 It is recommended not to change the defaults. This CLI is to be used only in case of exceptions (e.g., to set the sample-rate to the nearest power-of-2 if there are hardware restrictions in using the defaults)
 


### PR DESCRIPTION
* Align sample rate default values for sflow in CLI reference
  with real defaults, defined in src/sonic-swss/cfgmgr

Signed-off-by: Maksym Belei <Maksym_Belei@jabil.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Resolves https://github.com/Azure/sonic-utilities/issues/1334
Default values of sample rate for sFlow have changed according to values, defined in sonic-buildimage/src/sonic-swss/cfgmgr/sflowmgr.h.

**- How I did it**
Command reference file has changed.

**- How to verify it**
The default sample rates have defined here:
https://github.com/Azure/sonic-swss/blob/321291aa7aca89a3ccef2bed36aff074eac1054f/cfgmgr/sflowmgr.h#L21

