### PR TITLE
[show] Fix 'show mac' output, when FDB entry with Vlan 1 is present

### DIFF
--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -87,6 +87,10 @@ class FdbShow(object):
             elif 'bvid' in fdb:
                 try:
                     vlan_id = port_util.get_vlan_id_from_bvid(self.db, fdb["bvid"])
+                    if vlan_id is None:
+                        # the situation could be faced if the system has an FDB entries,
+                        # which are linked to default Vlan(caused by untagged trafic)
+                        continue
                 except Exception:
                     vlan_id = fdb["bvid"]
                     print("Failed to get Vlan id for bvid {}\n".format(fdb["bvid"]))


### PR DESCRIPTION
* Skip records of FDB entries, which are linked to default Vlan 1,
  to prevent exception throwing while performing
  command 'show mac' or 'fdbshow'.

Signed-off-by: Maksym Belei <Maksym_Belei@jabil.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Resolves https://github.com/Azure/sonic-utilities/issues/894
Fixed "show mac" command execution failure in case, when the system has an FDB entry, which is linked to default Vlan 1.
The failure is caused by throwing exception, while trying to get int from None type object.
**- How I did it**
The condition has added to src/sonic-utilities/scripts/fdbshow script to handle and skip FDB entries, for which the system can not get Vlan ID.

**- How to verify it**
Configure your system to receive both tagged and untagged traffic. For example, you could use the next steps:
1. Do configuration on DUT
sudo config portchannel add PortChannel0002
sudo config portchannel member add PortChannel0002 Ethernet68
sudo config vlan add 40
sudo config vlan member add 40 PortChannel0002
sudo config interface ip add Vlan40 40.0.0.1/24
2. Do configuration on Linux host
sudo ip link add bond0 type bond
sudo ip link set dev bond0 type bond mode 4
sudo ip link set enp5s0f1 down
sudo ip link set enp5s0f1 master bond0
sudo ip link set enp5s0f1 up
sudo ip link set bond0 up
sudo ip link add link bond0 name bond0.40 type vlan id 40
sudo ip link set bond0.40 up
sudo ip addr add 40.0.0.3/24 dev bond0.40
3. Do ping from linux host to DUT IP 40.0.0.1
4. Do command "show mac" on DUT
"show mac" command should not be finished with the next message: `int() argument must be a string, a bytes-like object or a number, not 'NoneType'`. Instead, the normal output of the command should be shown.