### PR TITLE
[show]: Use TCP Connection For Muxcable Commands

### DIFF
--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -131,7 +131,7 @@ def status(port, json_output):
     namespaces = multi_asic.get_front_end_namespaces()
     for namespace in namespaces:
         asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-        per_npu_statedb[asic_id] = swsscommon.SonicV2Connector(use_unix_socket_path=True, namespace=namespace)
+        per_npu_statedb[asic_id] = swsscommon.SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
         per_npu_statedb[asic_id].connect(per_npu_statedb[asic_id].STATE_DB)
 
         port_table_keys[asic_id] = per_npu_statedb[asic_id].keys(

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -233,7 +233,7 @@ def config(port, json_output):
         # TO-DO replace the macros with correct swsscommon names
         #config_db[asic_id] = swsscommon.DBConnector("CONFIG_DB", REDIS_TIMEOUT_MSECS, True, namespace)
         #mux_tbl_cfg_db[asic_id] = swsscommon.Table(config_db[asic_id], swsscommon.CFG_MUX_CABLE_TABLE_NAME)
-        per_npu_configdb[asic_id] = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+        per_npu_configdb[asic_id] = ConfigDBConnector(use_unix_socket_path=False, namespace=namespace)
         per_npu_configdb[asic_id].connect()
         mux_tbl_cfg_db[asic_id] = per_npu_configdb[asic_id].get_table("MUX_CABLE")
         peer_switch_tbl_cfg_db[asic_id] = per_npu_configdb[asic_id].get_table("PEER_SWITCH")


### PR DESCRIPTION
Unix domain sockets require privileged access while show command
could be run by ro user. Switch muxcable show command to use TCP
connection to work with ro user.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

fixes Azure/sonic-buildimage#6456
resolves Azure/sonic-buildimage#6456

**- What I did**
Fix show command for ro users

**- How I did it**
Change use_unix_socket attribute to False

**- How to verify it**
run `show muxcable config` from ro user account

**- Previous command output (if the output of a command-line utility has changed)**
N/A

**- New command output (if the output of a command-line utility has changed)**
N/A (same)
