### PR TITLE
Prevent configuring IP interface on a port which is a member of VLAN

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2474,6 +2474,13 @@ def add(ctx, interface_name, ip_addr, gw):
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
+    #add ad validation to check this interface is not a member in vlan before 
+    #changing it to router port 
+    vlan_member_table = config_db.get_table('VLAN_MEMBER')
+    if (interface_is_in_vlan(vlan_member_table, interface_name)):
+            click.echo("Interface {} is a member of vlan\nAborting!".format(interface_name))
+            return
+
     try:
         net = ipaddress.ip_network(ip_addr, strict=False)
         if '/' not in ip_addr:

--- a/config/main.py
+++ b/config/main.py
@@ -2474,8 +2474,8 @@ def add(ctx, interface_name, ip_addr, gw):
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
-    #add ad validation to check this interface is not a member in vlan before 
-    #changing it to router port 
+    # Add a validation to check this interface is not a member in vlan before 
+    # changing it to a router port 
     vlan_member_table = config_db.get_table('VLAN_MEMBER')
     if (interface_is_in_vlan(vlan_member_table, interface_name)):
             click.echo("Interface {} is a member of vlan\nAborting!".format(interface_name))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->
**- What I did**
Fixed bug https://github.com/Azure/sonic-buildimage/issues/6426
Added a validation in config/main.py to prevent configuring IP interface on a port which is a member of VLAN

**- How I did it**
Change config/main.py

**- How to verify it**
Add interface as member in vlan
Try to configure IP address on same interface

**- Previous command output (if the output of a command-line utility has changed)**
Success in the above scenario. 

**- New command output (if the output of a command-line utility has changed)**
prevent configuration:
"Interface Ethernet0 is a member of vlan
Aborting!"
