### PR TITLE
[show] Fix int status when portchannel is in the system

### DIFF
--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -248,8 +248,8 @@ def po_speed_dict(po_int_dict, appl_db):
             if len(value) == 1:
                 interface_speed = appl_db.get(appl_db.APPL_DB, "PORT_TABLE:" + value[0], "speed")
                 if interface_speed is None:
-                    # If no speed was returned, set the value as N/A
-                    po_list.append("N/A")
+                    # If no speed was returned, append None without format
+                    po_list.append(None)
                 else:
                     interface_speed = '{}G'.format(interface_speed[:-3])
                     po_list.append(interface_speed)
@@ -277,6 +277,8 @@ def appl_db_portchannel_status_get(appl_db, config_db, po_name, status_type, por
     #print(full_table_id)
     if status_type == "speed":
         status = portchannel_speed_dict[po_name]
+        if status is None:
+            return "N/A"
         return status
     if status_type == "vlan":
         if combined_int_to_vlan_po_dict and po_name in combined_int_to_vlan_po_dict.keys():

--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -247,8 +247,12 @@ def po_speed_dict(po_int_dict, appl_db):
             po_list.append(key)
             if len(value) == 1:
                 interface_speed = appl_db.get(appl_db.APPL_DB, "PORT_TABLE:" + value[0], "speed")
-                interface_speed = '{}G'.format(interface_speed[:-3])
-                po_list.append(interface_speed)
+                if interface_speed is None:
+                    # If no speed was returned, set the value as N/A
+                    po_list.append("N/A")
+                else:
+                    interface_speed = '{}G'.format(interface_speed[:-3])
+                    po_list.append(interface_speed)
             elif len(value) > 1:
                 for intf in value:
                     temp_speed = appl_db.get(appl_db.APPL_DB, "PORT_TABLE:" + intf, "speed")


### PR DESCRIPTION
**- What I did**
Fixed crash of "show int status" command when there are portchannels in system.
```
Traceback (most recent call last):
  File "/usr/local/bin/intfutil", line 521, in <module>
    main()
  File "/usr/local/bin/intfutil", line 513, in main
    interface_stat.display_intf_status()
  File "/usr/local/bin/intfutil", line 354, in display_intf_status
    self.get_intf_status()
  File "/usr/local/lib/python3.7/dist-packages/utilities_common/multi_asic.py", line 137, in wrapped_run_on_all_asics
    func(self,  *args, **kwargs)
  File "/usr/local/bin/intfutil", line 435, in get_intf_status
    self.portchannel_speed_dict = po_speed_dict(self.po_int_dict, self.db)
  File "/usr/local/bin/intfutil", line 249, in po_speed_dict
    interface_speed = '{}G'.format(interface_speed[:-3])
TypeError: 'NoneType' object is not subscriptable
```
fixes https://github.com/Azure/sonic-buildimage/issues/6520
Also this might fix this issue:
fixes https://github.com/Azure/sonic-utilities/issues/1082

**- How I did it**
Added check of return value from db in inftutil.
If value is None, append N/A to the output instead of formatting incorrect type.

**- How to verify it**
1. Create portchannel
	$ sudo config portchannel add PortChannel0011
2. Execute interface status command
	$ show int status

Signed-off-by: d-dashkov <Dmytro_Dashkov@Jabil.com>