### PR TITLE
Add vlan_intf_object only if there are ipv4 or ipv6 mappings

### DIFF
--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -302,17 +302,18 @@ def construct_neighbor_advertiser_slice():
             ipv6_mappings.append(mapping)
             ctr += 1
 
-        vlan_interface_obj = {
-            'vlanId': vlan_id,
-            'vxlanId': vxlan_id,
-            'ipv4AddrMappings': ipv4_mappings,
-            'ipv6AddrMappings': ipv6_mappings
-        }
+        if len(ipv4_mappings) > 0 or len(ipv6_mappings) > 0:
+            vlan_interface_obj = {
+                'vlanId': vlan_id,
+                'vxlanId': vxlan_id,
+                'ipv4AddrMappings': ipv4_mappings,
+                'ipv6AddrMappings': ipv6_mappings
+            }
 
-        if vxlanPort:
-            vlan_interface_obj['vxlanPort'] = vxlanPort
+            if vxlanPort:
+                vlan_interface_obj['vxlanPort'] = vxlanPort
 
-        vlan_interfaces_obj.append(vlan_interface_obj)
+            vlan_interfaces_obj.append(vlan_interface_obj)
 
     slice_obj = {
         'switchInfo': switch_info_obj,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Add vlan_interface_object based on the presence of ipv4 or ipv6 mappings
**- How I did it**
Introduce a check for the count of ipv4 and ipv6 before adding vlan_interface_object and add it only if either of the mappings are present
**- How to verify it**
Look for the slice object and see that it contains no empty ipv4 and ipv6 mappings.
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

