### PR TITLE
[show] Use proper variable to avoid exception in natshow script

### DIFF
--- a/scripts/natshow
+++ b/scripts/natshow
@@ -134,7 +134,7 @@ class NatShow(object):
             translated_dst = "---"
             translated_src = "---"
 
-            ent = self.asic_db.get_all('ASIC_DB', s, blocking=True)
+            ent = self.asic_db.get_all('ASIC_DB', nat_entry, blocking=True)
 
             nat_type = nat['nat_type']
 


### PR DESCRIPTION
* Substituting nat_entry variable, instead of s inside fetch_translations
  function to avoid exception throwing inside the function due to undefined
  variable.

Signed-off-by: Maksym Belei <Maksym_Belei@jabil.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Resolves https://github.com/Azure/sonic-buildimage/issues/6391
Fix exception throwing during fetching translations inside `natshow `scripts.

**- How I did it**
The issue has introduced in be63918d, while migrating to Python 3.
Variable `s` has replaced with `nat_entry`.

**- How to verify it**
Execute:
`natshow -t`
or
`show nat translations`

