### PR TITLE
[config][show] cli support for retrieving ber, eye-info and configuring prbs, loopback on Y-cable 

### DIFF
--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -217,4 +217,4 @@ def loopback(port, target, lane_map):
         click.echo("loopback config unsuccesful")
         sys.exit(CONFIG_FAIL)
     click.echo("loopback config sucessful")
-    sys.exit(0)
+    sys.exit(CONFIG_SUCCESSFUL)

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -189,13 +189,17 @@ def mode(state, port, json_output):
 
         sys.exit(CONFIG_SUCCESSFUL)
 
+@muxcable.group(cls=clicommon.AbbreviationGroup)
+def prbs():
+    """Enable prbs on a port"""
+    pass
 
-@muxcable.command()
+@prbs.command()
 @click.argument('port', required=True, default=None, type=click.INT)
 @click.argument('target', required=True, default=None, type=click.INT)
 @click.argument('mode_value', required=True, default=None, type=click.INT)
 @click.argument('lane_map', required=True, default=None, type=click.INT)
-def enable_prbs(port, target, mode_value, lane_map):
+def enable(port, target, mode_value, lane_map):
 
     import sonic_y_cable.y_cable
     res = sonic_y_cable.y_cable.enable_prbs_mode(port, target, mode_value, lane_map)
@@ -205,10 +209,10 @@ def enable_prbs(port, target, mode_value, lane_map):
     click.echo("PRBS config sucessful")
     sys.exit(CONFIG_SUCCESSFUL)
 
-@muxcable.command()
+@prbs.command()
 @click.argument('port', required=True, default=None, type=click.INT)
 @click.argument('target', required=True, default=None, type=click.INT)
-def disable_prbs(port, target):
+def disable(port, target):
 
     import sonic_y_cable.y_cable
     res = sonic_y_cable.y_cable.disable_prbs_mode(port, target)
@@ -218,12 +222,17 @@ def disable_prbs(port, target):
     click.echo("PRBS disbale sucessful")
     sys.exit(CONFIG_SUCCESSFUL)
 
+@muxcable.group(cls=clicommon.AbbreviationGroup)
+def loopback():
+    """Enable loopback on a port"""
+    pass
 
-@muxcable.command()
+
+@loopback.command()
 @click.argument('port', required=True, default=None, type=click.INT)
 @click.argument('target', required=True, default=None, type=click.INT)
 @click.argument('lane_map', required=True, default=None, type=click.INT)
-def enable_loopback(port, target, lane_map):
+def enable(port, target, lane_map):
 
     import sonic_y_cable.y_cable
     res = sonic_y_cable.y_cable.enable_loopback_mode(port, target, lane_map)
@@ -233,10 +242,10 @@ def enable_loopback(port, target, lane_map):
     click.echo("loopback config sucessful")
     sys.exit(CONFIG_SUCCESSFUL)
 
-@muxcable.command()
+@loopback.command()
 @click.argument('port', required=True, default=None, type=click.INT)
 @click.argument('target', required=True, default=None, type=click.INT)
-def disable_loopback(port, target):
+def disable(port, target):
 
     import sonic_y_cable.y_cable
     res = sonic_y_cable.y_cable.disable_loopback_mode(port, target)

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -191,7 +191,7 @@ def mode(state, port, json_output):
 
 @muxcable.group(cls=clicommon.AbbreviationGroup)
 def prbs():
-    """Enable prbs on a port"""
+    """Enable/disable PRBS mode on a port"""
     pass
 
 @prbs.command()
@@ -200,6 +200,7 @@ def prbs():
 @click.argument('mode_value', required=True, default=None, type=click.INT)
 @click.argument('lane_map', required=True, default=None, type=click.INT)
 def enable(port, target, mode_value, lane_map):
+    """Enable PRBS mode on a port"""
 
     import sonic_y_cable.y_cable
     res = sonic_y_cable.y_cable.enable_prbs_mode(port, target, mode_value, lane_map)
@@ -213,18 +214,19 @@ def enable(port, target, mode_value, lane_map):
 @click.argument('port', required=True, default=None, type=click.INT)
 @click.argument('target', required=True, default=None, type=click.INT)
 def disable(port, target):
+    """Disable PRBS mode on a port"""
 
     import sonic_y_cable.y_cable
     res = sonic_y_cable.y_cable.disable_prbs_mode(port, target)
     if res != True:
         click.echo("PRBS disable unsuccesful")
         sys.exit(CONFIG_FAIL)
-    click.echo("PRBS disbale sucessful")
+    click.echo("PRBS disable sucessful")
     sys.exit(CONFIG_SUCCESSFUL)
 
 @muxcable.group(cls=clicommon.AbbreviationGroup)
 def loopback():
-    """Enable loopback on a port"""
+    """Enable/disable loopback mode on a port"""
     pass
 
 
@@ -233,6 +235,7 @@ def loopback():
 @click.argument('target', required=True, default=None, type=click.INT)
 @click.argument('lane_map', required=True, default=None, type=click.INT)
 def enable(port, target, lane_map):
+    """Enable loopback mode on a port"""
 
     import sonic_y_cable.y_cable
     res = sonic_y_cable.y_cable.enable_loopback_mode(port, target, lane_map)
@@ -246,6 +249,7 @@ def enable(port, target, lane_map):
 @click.argument('port', required=True, default=None, type=click.INT)
 @click.argument('target', required=True, default=None, type=click.INT)
 def disable(port, target):
+    """Disable loopback mode on a port"""
 
     import sonic_y_cable.y_cable
     res = sonic_y_cable.y_cable.disable_loopback_mode(port, target)

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -72,7 +72,7 @@ def lookup_statedb_and_update_configdb(per_npu_statedb, config_db, port, state_c
     ipv6_value = get_value_for_key_in_config_tbl(config_db, port, "server_ipv6", "MUX_CABLE")
 
     state = get_value_for_key_in_dict(muxcable_statedb_dict, port, "state", "MUX_CABLE_TABLE")
-    if (state == "active" and configdb_state == "active") or (state == "standby" and configdb_state == "active") or (state == "unknown" and  configdb_state == "active") :
+    if (state == "active" and configdb_state == "active") or (state == "standby" and configdb_state == "active") or (state == "unknown" and configdb_state == "active"):
         if state_cfg_val == "active":
             # status is already active, so right back error
             port_status_dict[port] = 'OK'
@@ -91,7 +91,7 @@ def lookup_statedb_and_update_configdb(per_npu_statedb, config_db, port, state_c
             # dont write anything to db, write OK to user
             port_status_dict[port] = 'OK'
 
-    elif (state == "standby" and configdb_state == "auto") or (state == "unknown" and  configdb_state == "auto"):
+    elif (state == "standby" and configdb_state == "auto") or (state == "unknown" and configdb_state == "auto"):
         if state_cfg_val == "active":
             # make the state active
             config_db.set_entry("MUX_CABLE", port, {"state": "active",
@@ -190,11 +190,12 @@ def mode(state, port, json_output):
 
         sys.exit(CONFIG_SUCCESSFUL)
 
+
 @muxcable.command()
-@click.argument('port', required=True, default=None, type= click.INT)
-@click.argument('target', required=True, default=None, type = click.INT)
-@click.argument('mode_value', required=True, default=None, type= click.INT)
-@click.argument('lane_map', required=True, default=None, type = click.INT)
+@click.argument('port', required=True, default=None, type=click.INT)
+@click.argument('target', required=True, default=None, type=click.INT)
+@click.argument('mode_value', required=True, default=None, type=click.INT)
+@click.argument('lane_map', required=True, default=None, type=click.INT)
 def prbs(port, target, mode_value, lane_map):
 
     res = y_cable.enable_prbs_mode(port, target, mode_value, lane_map)
@@ -204,10 +205,11 @@ def prbs(port, target, mode_value, lane_map):
     click.echo("PRBS config sucessful")
     sys.exit(0)
 
+
 @muxcable.command()
-@click.argument('port', required=True, default=None, type= click.INT)
-@click.argument('target', required=True, default=None, type = click.INT)
-@click.argument('lane_map', required=True, default=None, type = click.INT)
+@click.argument('port', required=True, default=None, type=click.INT)
+@click.argument('target', required=True, default=None, type=click.INT)
+@click.argument('lane_map', required=True, default=None, type=click.INT)
 def loopback(port, target, lane_map):
 
     res = y_cable.enable_loopback_mode(port, target, lane_map)

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -203,7 +203,7 @@ def prbs(port, target, mode_value, lane_map):
         click.echo("PRBS config unsuccesful")
         sys.exit(CONFIG_FAIL)
     click.echo("PRBS config sucessful")
-    sys.exit(0)
+    sys.exit(CONFIG_SUCCESSFUL)
 
 
 @muxcable.command()

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -5,6 +5,7 @@ import sys
 import click
 import utilities_common.cli as clicommon
 from sonic_py_common import multi_asic
+from sonic_y_cable import y_cable
 from swsssdk import ConfigDBConnector
 from swsscommon import swsscommon
 from tabulate import tabulate
@@ -188,3 +189,30 @@ def mode(state, port, json_output):
                 click.echo(tabulate(data, headers=headers))
 
         sys.exit(CONFIG_SUCCESSFUL)
+
+@muxcable.command()
+@click.argument('port', required=True, default=None, type= click.INT)
+@click.argument('target', required=True, default=None, type = click.INT)
+@click.argument('mode_value', required=True, default=None, type= click.INT)
+@click.argument('lane_map', required=True, default=None, type = click.INT)
+def prbs(port, target, mode_value, lane_map):
+
+    res = y_cable.enable_prbs_mode(port, target, mode_value, lane_map)
+    if res != True:
+        click.echo("PRBS config unsuccesful")
+        sys.exit(CONFIG_FAIL)
+    click.echo("PRBS config sucessful")
+    sys.exit(0)
+
+@muxcable.command()
+@click.argument('port', required=True, default=None, type= click.INT)
+@click.argument('target', required=True, default=None, type = click.INT)
+@click.argument('lane_map', required=True, default=None, type = click.INT)
+def loopback(port, target, lane_map):
+
+    res = y_cable.enable_loopback_mode(port, target, lane_map)
+    if res != True:
+        click.echo("loopback config unsuccesful")
+        sys.exit(CONFIG_FAIL)
+    click.echo("loopback config sucessful")
+    sys.exit(0)

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -5,7 +5,6 @@ import sys
 import click
 import utilities_common.cli as clicommon
 from sonic_py_common import multi_asic
-from sonic_y_cable import y_cable
 from swsssdk import ConfigDBConnector
 from swsscommon import swsscommon
 from tabulate import tabulate
@@ -196,13 +195,27 @@ def mode(state, port, json_output):
 @click.argument('target', required=True, default=None, type=click.INT)
 @click.argument('mode_value', required=True, default=None, type=click.INT)
 @click.argument('lane_map', required=True, default=None, type=click.INT)
-def prbs(port, target, mode_value, lane_map):
+def enable_prbs(port, target, mode_value, lane_map):
 
-    res = y_cable.enable_prbs_mode(port, target, mode_value, lane_map)
+    import sonic_y_cable.y_cable
+    res = sonic_y_cable.y_cable.enable_prbs_mode(port, target, mode_value, lane_map)
     if res != True:
         click.echo("PRBS config unsuccesful")
         sys.exit(CONFIG_FAIL)
     click.echo("PRBS config sucessful")
+    sys.exit(CONFIG_SUCCESSFUL)
+
+@muxcable.command()
+@click.argument('port', required=True, default=None, type=click.INT)
+@click.argument('target', required=True, default=None, type=click.INT)
+def disable_prbs(port, target):
+
+    import sonic_y_cable.y_cable
+    res = sonic_y_cable.y_cable.disable_prbs_mode(port, target)
+    if res != True:
+        click.echo("PRBS disable unsuccesful")
+        sys.exit(CONFIG_FAIL)
+    click.echo("PRBS disbale sucessful")
     sys.exit(CONFIG_SUCCESSFUL)
 
 
@@ -210,11 +223,25 @@ def prbs(port, target, mode_value, lane_map):
 @click.argument('port', required=True, default=None, type=click.INT)
 @click.argument('target', required=True, default=None, type=click.INT)
 @click.argument('lane_map', required=True, default=None, type=click.INT)
-def loopback(port, target, lane_map):
+def enable_loopback(port, target, lane_map):
 
-    res = y_cable.enable_loopback_mode(port, target, lane_map)
+    import sonic_y_cable.y_cable
+    res = sonic_y_cable.y_cable.enable_loopback_mode(port, target, lane_map)
     if res != True:
         click.echo("loopback config unsuccesful")
         sys.exit(CONFIG_FAIL)
     click.echo("loopback config sucessful")
+    sys.exit(CONFIG_SUCCESSFUL)
+
+@muxcable.command()
+@click.argument('port', required=True, default=None, type=click.INT)
+@click.argument('target', required=True, default=None, type=click.INT)
+def disable_loopback(port, target):
+
+    import sonic_y_cable.y_cable
+    res = sonic_y_cable.y_cable.disable_loopback_mode(port, target)
+    if res != True:
+        click.echo("loopback disable unsuccesful")
+        sys.exit(CONFIG_FAIL)
+    click.echo("loopback disable sucessful")
     sys.exit(CONFIG_SUCCESSFUL)

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -4734,6 +4734,54 @@ While displaying the muxcable configuration, users can configure the following f
           }
     ```
 
+**show muxcable ber-info**
+
+This command displays the ber(Bit error rate) of the port user provides on the target user provides. The target provided as an integer corresponds to actual target as.
+0 -> local
+1 -> tor 1
+2 -> tor 2
+3 -> nic
+
+- Usage:
+  ```
+  Usage: show muxcable ber-info [OPTIONS] PORT TARGET
+  ```
+
+
+- PORT   required - Port number should be a valid port
+- TARGET required - the actual target to get the ber info of.
+
+- Example:
+    ```
+        admin@sonic:~$ show muxcable ber-info 1 1
+        Lane1    Lane2
+        -------  -------
+        0       0
+    ```
+
+**show muxcable ber-info**
+
+This command displays the eye info in mv(milli volts) of the port user provides on the target user provides. The target provided as an integer corresponds to actual target as.
+0 -> local
+1 -> tor 1
+2 -> tor 2
+3 -> nic
+
+- Usage:
+  ```
+  Usage: show muxcable eye-info [OPTIONS] PORT TARGET
+  ```
+
+- PORT   required - Port number should be a valid port
+- TARGET required - the actual target to get the eye info of.
+
+- Example:
+    ```
+        admin@sonic:~$ show muxcable ber-info 1 1
+        Lane1    Lane2
+        -------  -------
+        632      622
+    ```
 
 ### Muxcable Config commands
 
@@ -4769,7 +4817,6 @@ While configuring the muxcable, users needs to configure the following fields fo
                "Ethernet0": "OK"  
            }
     ```    
-  
     ```
         admin@sonic:~$ sudo config muxcable  mode active all  
         port        state  
@@ -4785,8 +4832,65 @@ While configuring the muxcable, users needs to configure the following fields fo
                 "Ethernet32": "INPROGRESS",  
                 "Ethernet0": "OK"
            }
-    ```    
+    ```
+**config muxcable prbs**
 
+This command is used for setting the configuration of prbs on a port user provides. In addition to port the user also needs to provides the target, prbs mode and lane map on which the user intends to run prbs on.
+
+- Usage:
+  ```
+  config muxcable prbs [OPTIONS] PORT TARGET MODE_VALUE LANE_MAP
+  ```
+
+While configuring the muxcable, users needs to configure the following fields for the operation
+
+- PORT   required - Port number should be a valid port
+- TARGET  required - the actual target to run the prbs on
+                         0 -> local side,
+                         1 -> TOR 1
+                         2 -> TOR 2
+                         3 -> NIC
+- MODE_VALUE  required - the mode/type for configuring the PRBS mode.
+             0x00 = PRBS 9, 0x01 = PRBS 15, 0x02 = PRBS 23, 0x03 = PRBS 31
+- LANE_MAP  required - an integer representing the lane_map to be run PRBS on
+             0bit for lane 0, 1bit for lane1 and so on.
+             for example 3 -> 0b'0011 , means running on lane0 and lane1
+- Example:
+    ```
+        admin@sonic:~$ sudo config muxcable prbs 1 1 3 3
+	PRBS config sucessful
+    ```
+
+**config muxcable loopback**
+
+This command is used for setting the configuration of loopback on a port user provides. In addition to port the user also needs to provides the target and lane map on which the user intends to run loopback on.
+
+- Usage:
+  ```
+  config muxcable loopback [OPTIONS] PORT TARGET LANE_MAP
+  ```
+
+While configuring the muxcable, users needs to configure the following fields for the operation
+
+- PORT   required - Port number should be a valid port
+- TARGET  required - the actual target to run the loopback on
+                         0 -> local side,
+                         1 -> TOR 1
+                         2 -> TOR 2
+                         3 -> NIC
+- LANE_MAP  required - an integer representing the lane_map to be run loopback on
+             0bit for lane 0, 1bit for lane1 and so on.
+             for example 3 -> 0b'0011 , means running on lane0 and lane1
+
+- Example:
+    ```
+        admin@sonic:~$ sudo config muxcable loopback 1 1 3
+	loopback config sucessful
+    ```
+
+Go Back To [Beginning of the document](#) or [Beginning of this section](#muxcable)
+
+## Mirroring
 Go Back To [Beginning of the document](#) or [Beginning of this section](#muxcable)
 
 ## Mirroring

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -4891,9 +4891,6 @@ While configuring the muxcable, users needs to configure the following fields fo
 Go Back To [Beginning of the document](#) or [Beginning of this section](#muxcable)
 
 ## Mirroring
-Go Back To [Beginning of the document](#) or [Beginning of this section](#muxcable)
-
-## Mirroring
 
 ### Mirroring Show commands
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -4859,7 +4859,7 @@ While configuring the muxcable, users needs to configure the following fields fo
 - Example:
     ```
         admin@sonic:~$ sudo config muxcable prbs enable 1 1 3 3
-	PRBS config sucessful
+        PRBS config sucessful
         admin@sonic:~$  sudo config muxcable prbs disable 1 0
         PRBS disable sucessful
     ```
@@ -4889,7 +4889,7 @@ While configuring the muxcable, users needs to configure the following fields fo
 - Example:
     ```
         admin@sonic:~$ sudo config muxcable loopback enable 1 1 3
-	loopback config sucessful
+        loopback config sucessful
         admin@sonic:~$  sudo config muxcable loopback disable 1 0
         loopback disable sucessfull
     ```

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -4833,13 +4833,14 @@ While configuring the muxcable, users needs to configure the following fields fo
                 "Ethernet0": "OK"
            }
     ```
-**config muxcable prbs**
+**config muxcable prbs enable/disable**
 
-This command is used for setting the configuration of prbs on a port user provides. In addition to port the user also needs to provides the target, prbs mode and lane map on which the user intends to run prbs on.
+This command is used for setting the configuration and enable/diable of prbs on a port user provides. While enabling in addition to port the user also needs to provides the target, prbs mode and lane map on which the user intends to run prbs on. The target reflects where the enable/dsiable will happen.
 
 - Usage:
   ```
-  config muxcable prbs [OPTIONS] PORT TARGET MODE_VALUE LANE_MAP
+  config muxcable prbs enable [OPTIONS] PORT TARGET MODE_VALUE LANE_MAP
+  config muxcable prbs disable [OPTIONS] PORT TARGET
   ```
 
 While configuring the muxcable, users needs to configure the following fields for the operation
@@ -4857,17 +4858,20 @@ While configuring the muxcable, users needs to configure the following fields fo
              for example 3 -> 0b'0011 , means running on lane0 and lane1
 - Example:
     ```
-        admin@sonic:~$ sudo config muxcable prbs 1 1 3 3
+        admin@sonic:~$ sudo config muxcable prbs enable 1 1 3 3
 	PRBS config sucessful
+        admin@sonic:~$  sudo config muxcable prbs disable 1 0
+        PRBS disable sucessful
     ```
 
-**config muxcable loopback**
+**config muxcable loopback enable/disable**
 
-This command is used for setting the configuration of loopback on a port user provides. In addition to port the user also needs to provides the target and lane map on which the user intends to run loopback on.
+This command is used for setting the configuration and enable/disable of loopback on a port user provides. While enabling in addition to port the user also needs to provides the target and lane map on which the user intends to run loopback on. The target reflects where the enable/dsiable will happen.
 
 - Usage:
   ```
-  config muxcable loopback [OPTIONS] PORT TARGET LANE_MAP
+  config muxcable loopback enable [OPTIONS] PORT TARGET LANE_MAP
+  config muxcable loopback disable [OPTIONS] PORT TARGET
   ```
 
 While configuring the muxcable, users needs to configure the following fields for the operation
@@ -4884,8 +4888,10 @@ While configuring the muxcable, users needs to configure the following fields fo
 
 - Example:
     ```
-        admin@sonic:~$ sudo config muxcable loopback 1 1 3
+        admin@sonic:~$ sudo config muxcable loopback enable 1 1 3
 	loopback config sucessful
+        admin@sonic:~$  sudo config muxcable loopback disable 1 0
+        loopback disable sucessfull
     ```
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#muxcable)

--- a/setup.py
+++ b/setup.py
@@ -155,6 +155,7 @@ setup(
         'netifaces==0.10.7',
         'pexpect==4.8.0',
         'requests==2.25.0',
+        'sonic-platform-common',
         'sonic-py-common',
         'sonic-yang-mgmt',
         'swsssdk>=2.0.1',

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -339,9 +339,10 @@ def config(port, json_output):
 
         sys.exit(CONFIG_SUCCESSFUL)
 
+
 @muxcable.command()
-@click.argument('port', required=True, default=None, type= click.INT)
-@click.argument('target', required=True, default=None, type = click.INT)
+@click.argument('port', required=True, default=None, type=click.INT)
+@click.argument('target', required=True, default=None, type=click.INT)
 def berinfo(port, target):
 
     if os.geteuid() != 0:
@@ -357,9 +358,10 @@ def berinfo(port, target):
     lane_data.append(res)
     click.echo(tabulate(lane_data, headers=headers))
 
+
 @muxcable.command()
-@click.argument('port', required=True, default=None, type= click.INT)
-@click.argument('target', required=True, default=None, type = click.INT)
+@click.argument('port', required=True, default=None, type=click.INT)
+@click.argument('target', required=True, default=None, type=click.INT)
 def eyeinfo(port, target):
 
     if os.geteuid() != 0:

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -345,7 +345,7 @@ def config(port, json_output):
 @click.argument('port', required=True, default=None, type=click.INT)
 @click.argument('target', required=True, default=None, type=click.INT)
 def berinfo(port, target):
-    """Show muxcable ber (bit error rate) information"""
+    """Show muxcable BER (bit error rate) information"""
 
     if os.geteuid() != 0:
         click.echo("Root privileges are required for this operation")
@@ -366,7 +366,7 @@ def berinfo(port, target):
 @click.argument('port', required=True, default=None, type=click.INT)
 @click.argument('target', required=True, default=None, type=click.INT)
 def eyeinfo(port, target):
-    """Show muxcable eye information"""
+    """Show muxcable eye information in mv"""
 
     if os.geteuid() != 0:
         click.echo("Root privileges are required for this operation")

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -355,7 +355,7 @@ def berinfo(port, target):
     if res == False or res == -1:
         click.echo("Unable to fetch ber info")
         sys.exit(EXIT_FAIL)
-    headers = ['Lane1', 'Lane2']
+    headers = ['Lane1', 'Lane2', 'Lane3', 'Lane4']
     lane_data = []
     lane_data.append(res)
     click.echo(tabulate(lane_data, headers=headers))
@@ -376,7 +376,7 @@ def eyeinfo(port, target):
     if res == False or res == -1:
         click.echo("Unable to fetch eye info")
         sys.exit(EXIT_FAIL)
-    headers = ['Lane1', 'Lane2']
+    headers = ['Lane1', 'Lane2', 'Lane3', 'Lane4']
     lane_data = []
     lane_data.append(res)
     click.echo(tabulate(lane_data, headers=headers))

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -1,9 +1,11 @@
 import json
+import os
 import sys
 
 import click
 import utilities_common.cli as clicommon
 from sonic_py_common import multi_asic
+from sonic_y_cable import y_cable
 from swsscommon import swsscommon
 from swsssdk import ConfigDBConnector
 from tabulate import tabulate
@@ -336,3 +338,38 @@ def config(port, json_output):
             click.echo(tabulate(print_data, headers=headers))
 
         sys.exit(CONFIG_SUCCESSFUL)
+
+@muxcable.command()
+@click.argument('port', required=True, default=None, type= click.INT)
+@click.argument('target', required=True, default=None, type = click.INT)
+def berinfo(port, target):
+
+    if os.geteuid() != 0:
+        click.echo("Root privileges are required for this operation")
+        sys.exit(CONFIG_FAIL)
+    res = y_cable.get_ber_info(port, target)
+    if res == False or res == -1:
+        click.echo("Unable to fetch ber info")
+        sys.exit(CONFIG_FAIL)
+    #res1 = y_cable.get_eye_info(port, target)
+    headers = ['Lane1', 'Lane2']
+    lane_data = []
+    lane_data.append(res)
+    click.echo(tabulate(lane_data, headers=headers))
+
+@muxcable.command()
+@click.argument('port', required=True, default=None, type= click.INT)
+@click.argument('target', required=True, default=None, type = click.INT)
+def eyeinfo(port, target):
+
+    if os.geteuid() != 0:
+        click.echo("Root privileges are required for this operation")
+        sys.exit(CONFIG_FAIL)
+    res = y_cable.get_eye_info(port, target)
+    if res == False or res == -1:
+        click.echo("Unable to fetch eye info")
+        sys.exit(CONFIG_FAIL)
+    headers = ['Lane1', 'Lane2']
+    lane_data = []
+    lane_data.append(res)
+    click.echo(tabulate(lane_data, headers=headers))

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -17,6 +17,8 @@ REDIS_TIMEOUT_MSECS = 0
 
 CONFIG_SUCCESSFUL = 101
 CONFIG_FAIL = 1
+BER_CONFIG_FAIL = 1
+EYE_CONFIG_FAIL = 1
 STATUS_FAIL = 1
 STATUS_SUCCESSFUL = 102
 
@@ -347,11 +349,11 @@ def berinfo(port, target):
 
     if os.geteuid() != 0:
         click.echo("Root privileges are required for this operation")
-        sys.exit(CONFIG_FAIL)
+        sys.exit(BER_CONFIG_FAIL)
     res = y_cable.get_ber_info(port, target)
     if res == False or res == -1:
         click.echo("Unable to fetch ber info")
-        sys.exit(CONFIG_FAIL)
+        sys.exit(BER_CONFIG_FAIL)
     headers = ['Lane1', 'Lane2']
     lane_data = []
     lane_data.append(res)
@@ -365,11 +367,11 @@ def eyeinfo(port, target):
 
     if os.geteuid() != 0:
         click.echo("Root privileges are required for this operation")
-        sys.exit(CONFIG_FAIL)
+        sys.exit(EYE_CONFIG_FAIL)
     res = y_cable.get_eye_info(port, target)
     if res == False or res == -1:
         click.echo("Unable to fetch eye info")
-        sys.exit(CONFIG_FAIL)
+        sys.exit(EYE_CONFIG_FAIL)
     headers = ['Lane1', 'Lane2']
     lane_data = []
     lane_data.append(res)

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -345,6 +345,7 @@ def config(port, json_output):
 @click.argument('port', required=True, default=None, type=click.INT)
 @click.argument('target', required=True, default=None, type=click.INT)
 def berinfo(port, target):
+    """Show muxcable ber (bit error rate) information"""
 
     if os.geteuid() != 0:
         click.echo("Root privileges are required for this operation")
@@ -365,6 +366,7 @@ def berinfo(port, target):
 @click.argument('port', required=True, default=None, type=click.INT)
 @click.argument('target', required=True, default=None, type=click.INT)
 def eyeinfo(port, target):
+    """Show muxcable eye information"""
 
     if os.geteuid() != 0:
         click.echo("Root privileges are required for this operation")

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -352,7 +352,6 @@ def berinfo(port, target):
     if res == False or res == -1:
         click.echo("Unable to fetch ber info")
         sys.exit(CONFIG_FAIL)
-    #res1 = y_cable.get_eye_info(port, target)
     headers = ['Lane1', 'Lane2']
     lane_data = []
     lane_data.append(res)

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -5,7 +5,6 @@ import sys
 import click
 import utilities_common.cli as clicommon
 from sonic_py_common import multi_asic
-from sonic_y_cable import y_cable
 from swsscommon import swsscommon
 from swsssdk import ConfigDBConnector
 from tabulate import tabulate
@@ -350,7 +349,8 @@ def berinfo(port, target):
     if os.geteuid() != 0:
         click.echo("Root privileges are required for this operation")
         sys.exit(EXIT_FAIL)
-    res = y_cable.get_ber_info(port, target)
+    import sonic_y_cable.y_cable
+    res = sonic_y_cable.y_cable.get_ber_info(port, target)
     if res == False or res == -1:
         click.echo("Unable to fetch ber info")
         sys.exit(EXIT_FAIL)
@@ -358,6 +358,7 @@ def berinfo(port, target):
     lane_data = []
     lane_data.append(res)
     click.echo(tabulate(lane_data, headers=headers))
+    sys.exit(EXIT_SUCCESS)
 
 
 @muxcable.command()
@@ -368,7 +369,8 @@ def eyeinfo(port, target):
     if os.geteuid() != 0:
         click.echo("Root privileges are required for this operation")
         sys.exit(EXIT_FAIL)
-    res = y_cable.get_eye_info(port, target)
+    import sonic_y_cable.y_cable
+    res = sonic_y_cable.y_cable.get_eye_info(port, target)
     if res == False or res == -1:
         click.echo("Unable to fetch eye info")
         sys.exit(EXIT_FAIL)
@@ -376,3 +378,4 @@ def eyeinfo(port, target):
     lane_data = []
     lane_data.append(res)
     click.echo(tabulate(lane_data, headers=headers))
+    sys.exit(EXIT_SUCCESS)

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -17,8 +17,8 @@ REDIS_TIMEOUT_MSECS = 0
 
 CONFIG_SUCCESSFUL = 101
 CONFIG_FAIL = 1
-BER_CONFIG_FAIL = 1
-EYE_CONFIG_FAIL = 1
+EXIT_FAIL = 1
+EXIT_SUCCESS = 0
 STATUS_FAIL = 1
 STATUS_SUCCESSFUL = 102
 
@@ -349,11 +349,11 @@ def berinfo(port, target):
 
     if os.geteuid() != 0:
         click.echo("Root privileges are required for this operation")
-        sys.exit(BER_CONFIG_FAIL)
+        sys.exit(EXIT_FAIL)
     res = y_cable.get_ber_info(port, target)
     if res == False or res == -1:
         click.echo("Unable to fetch ber info")
-        sys.exit(BER_CONFIG_FAIL)
+        sys.exit(EXIT_FAIL)
     headers = ['Lane1', 'Lane2']
     lane_data = []
     lane_data.append(res)
@@ -367,11 +367,11 @@ def eyeinfo(port, target):
 
     if os.geteuid() != 0:
         click.echo("Root privileges are required for this operation")
-        sys.exit(EYE_CONFIG_FAIL)
+        sys.exit(EXIT_FAIL)
     res = y_cable.get_eye_info(port, target)
     if res == False or res == -1:
         click.echo("Unable to fetch eye info")
-        sys.exit(EYE_CONFIG_FAIL)
+        sys.exit(EXIT_FAIL)
     headers = ['Lane1', 'Lane2']
     lane_data = []
     lane_data.append(res)

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -421,81 +421,69 @@ class TestMuxcable(object):
 
         assert(result.exit_code == 1)
 
+    @mock.patch('os.geteuid', mock.MagicMock(return_value=0))
+    @mock.patch('sonic_y_cable.y_cable.get_eye_info', mock.MagicMock(return_value=[0, 0]))
     def test_show_muxcable_eye_info(self):
         runner = CliRunner()
         db = Db()
 
-        with mock.patch('os.geteuid') as patched_util_outer:
-            os.geteuid.return_value = 0
-            with mock.patch('sonic_y_cable.y_cable') as patched_util:
-                patched_util.get_eye_info.return_value = [0, 0]
-                result = runner.invoke(show.cli.commands["muxcable"].commands["eyeinfo"], [
-                                       "0", "0"], obj=db)
+        result = runner.invoke(show.cli.commands["muxcable"].commands["eyeinfo"], [
+                               "0", "0"], obj=db)
 
         assert(result.exit_code == 0)
 
+    @mock.patch('os.geteuid', mock.MagicMock(return_value=0))
+    @mock.patch('sonic_y_cable.y_cable.get_ber_info', mock.MagicMock(return_value=[0, 0]))
     def test_show_muxcable_ber_info(self):
         runner = CliRunner()
         db = Db()
 
-        with mock.patch('os.geteuid') as patched_util_outer:
-            os.geteuid.return_value = 0
-            with mock.patch('sonic_y_cable.y_cable') as patched_util:
-                patched_util.get_ber_info.return_value = [0, 0]
-                result = runner.invoke(show.cli.commands["muxcable"].commands["berinfo"], [
-                                       "0", "0"], obj=db)
+        result = runner.invoke(show.cli.commands["muxcable"].commands["berinfo"], [
+                               "0", "0"], obj=db)
 
         assert(result.exit_code == 0)
 
+    @mock.patch('os.geteuid', mock.MagicMock(return_value=0))
+    @mock.patch('sonic_y_cable.y_cable.enable_prbs_mode', mock.MagicMock(return_value=1))
     def test_config_muxcable_enable_prbs(self):
         runner = CliRunner()
         db = Db()
 
-        with mock.patch('os.geteuid') as patched_util_outer:
-            os.geteuid.return_value = 0
-            with mock.patch('sonic_y_cable.y_cable') as patched_util:
-                patched_util.enable_prbs_mode.return_value = 1
-                result = runner.invoke(config.config.commands["muxcable"].commands["prbs"].commands["enable"], [
-                                       "0", "0", "0", "0"], obj=db)
+        result = runner.invoke(config.config.commands["muxcable"].commands["prbs"].commands["enable"], [
+                               "0", "0", "0", "0"], obj=db)
 
         assert(result.exit_code == 100)
 
+    @mock.patch('os.geteuid', mock.MagicMock(return_value=0))
+    @mock.patch('sonic_y_cable.y_cable.enable_loopback_mode', mock.MagicMock(return_value=1))
     def test_config_muxcable_enable_loopback(self):
         runner = CliRunner()
         db = Db()
 
-        with mock.patch('os.geteuid') as patched_util_outer:
-            os.geteuid.return_value = 0
-            with mock.patch('sonic_y_cable.y_cable') as patched_util:
-                patched_util.enable_loopback_mode.return_value = 1
-                result = runner.invoke(config.config.commands["muxcable"].commands["loopback"].commands["enable"], [
-                                       "0", "0", "0"], obj=db)
+        result = runner.invoke(config.config.commands["muxcable"].commands["loopback"].commands["enable"], [
+                               "0", "0", "0"], obj=db)
 
         assert(result.exit_code == 100)
 
+    @mock.patch('os.geteuid', mock.MagicMock(return_value=0))
+    @mock.patch('sonic_y_cable.y_cable.disable_prbs_mode', mock.MagicMock(return_value=1))
     def test_config_muxcable_disble_prbs(self):
         runner = CliRunner()
         db = Db()
 
-        with mock.patch('os.geteuid') as patched_util_outer:
-            os.geteuid.return_value = 0
-            with mock.patch('sonic_y_cable.y_cable') as patched_util:
-                patched_util.disable_prbs_mode.return_value = 1
-                result = runner.invoke(config.config.commands["muxcable"].commands["prbs"].commands["disable"], [
-                                       "0", "0"], obj=db)
+        result = runner.invoke(config.config.commands["muxcable"].commands["prbs"].commands["disable"], [
+                               "0", "0"], obj=db)
 
         assert(result.exit_code == 100)
 
+    @mock.patch('os.geteuid', mock.MagicMock(return_value=0))
+    @mock.patch('sonic_y_cable.y_cable.disable_loopback_mode', mock.MagicMock(return_value=1))
     def test_config_muxcable_disable_loopback(self):
         runner = CliRunner()
         db = Db()
 
-        with mock.patch('os.geteuid') as patched_util_outer:
-            os.geteuid.return_value = 0
-            with mock.patch('sonic_y_cable.y_cable') as patched_util:
-                patched_util.disable_loopback_mode.return_value = 1
-                result = runner.invoke(config.config.commands["muxcable"].commands["loopback"].commands["disable"], [
-                                       "0", "0"], obj=db)
+        result = runner.invoke(config.config.commands["muxcable"].commands["loopback"].commands["disable"], [
+                               "0", "0"], obj=db)
 
         assert(result.exit_code == 100)
 

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -10,6 +10,11 @@ from utilities_common.db import Db
 sys.modules['sonic_platform_base'] = mock.Mock()
 sys.modules['sonic_platform_base.sonic_sfp'] = mock.Mock()
 sys.modules['sonic_platform_base.sonic_sfp.sfputilhelper'] = mock.Mock()
+sys.modules['sonic_y_cable'] = mock.Mock()
+sys.modules['y_cable'] = mock.Mock()
+sys.modules['sonic_y_cable.y_cable'] = mock.Mock()
+#sys.modules['os'] = mock.Mock()
+#sys.modules['os.geteuid'] = mock.Mock()
 #sys.modules['platform_sfputil'] = mock.Mock()
 import config.main as config
 import show.main as show
@@ -415,6 +420,84 @@ class TestMuxcable(object):
                                    "active", "Ethernet33"], obj=db)
 
         assert(result.exit_code == 1)
+
+    def test_show_muxcable_eye_info(self):
+        runner = CliRunner()
+        db = Db()
+
+        with mock.patch('os.geteuid') as patched_util_outer:
+            os.geteuid.return_value = 0
+            with mock.patch('sonic_y_cable.y_cable') as patched_util:
+                patched_util.get_eye_info.return_value = [0, 0]
+                result = runner.invoke(show.cli.commands["muxcable"].commands["eyeinfo"], [
+                                       "0", "0"], obj=db)
+
+        assert(result.exit_code == 0)
+
+    def test_show_muxcable_ber_info(self):
+        runner = CliRunner()
+        db = Db()
+
+        with mock.patch('os.geteuid') as patched_util_outer:
+            os.geteuid.return_value = 0
+            with mock.patch('sonic_y_cable.y_cable') as patched_util:
+                patched_util.get_ber_info.return_value = [0, 0]
+                result = runner.invoke(show.cli.commands["muxcable"].commands["berinfo"], [
+                                       "0", "0"], obj=db)
+
+        assert(result.exit_code == 0)
+
+    def test_config_muxcable_enable_prbs(self):
+        runner = CliRunner()
+        db = Db()
+
+        with mock.patch('os.geteuid') as patched_util_outer:
+            os.geteuid.return_value = 0
+            with mock.patch('sonic_y_cable.y_cable') as patched_util:
+                patched_util.enable_prbs_mode.return_value = 1
+                result = runner.invoke(config.config.commands["muxcable"].commands["enable-prbs"], [
+                                       "0", "0", "0", "0"], obj=db)
+
+        assert(result.exit_code == 100)
+
+    def test_config_muxcable_enable_loopback(self):
+        runner = CliRunner()
+        db = Db()
+
+        with mock.patch('os.geteuid') as patched_util_outer:
+            os.geteuid.return_value = 0
+            with mock.patch('sonic_y_cable.y_cable') as patched_util:
+                patched_util.enable_loopback_mode.return_value = 1
+                result = runner.invoke(config.config.commands["muxcable"].commands["enable-loopback"], [
+                                       "0", "0", "0"], obj=db)
+
+        assert(result.exit_code == 100)
+
+    def test_config_muxcable_disble_prbs(self):
+        runner = CliRunner()
+        db = Db()
+
+        with mock.patch('os.geteuid') as patched_util_outer:
+            os.geteuid.return_value = 0
+            with mock.patch('sonic_y_cable.y_cable') as patched_util:
+                patched_util.disable_prbs_mode.return_value = 1
+                result = runner.invoke(config.config.commands["muxcable"].commands["disable-prbs"], [
+                                       "0", "0"], obj=db)
+
+        assert(result.exit_code == 100)
+
+    def test_config_muxcable_disable_loopback(self):
+        runner = CliRunner()
+        db = Db()
+
+        with mock.patch('os.geteuid') as patched_util_outer:
+            os.geteuid.return_value = 0
+            with mock.patch('sonic_y_cable.y_cable') as patched_util:
+                patched_util.disable_loopback_mode.return_value = 1
+                result = runner.invoke(config.config.commands["muxcable"].commands["disable-loopback"], [
+                                       "0", "0"], obj=db)
+
+        assert(result.exit_code == 100)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -455,7 +455,7 @@ class TestMuxcable(object):
             os.geteuid.return_value = 0
             with mock.patch('sonic_y_cable.y_cable') as patched_util:
                 patched_util.enable_prbs_mode.return_value = 1
-                result = runner.invoke(config.config.commands["muxcable"].commands["enable-prbs"], [
+                result = runner.invoke(config.config.commands["muxcable"].commands["prbs"].commands["enable"], [
                                        "0", "0", "0", "0"], obj=db)
 
         assert(result.exit_code == 100)
@@ -468,7 +468,7 @@ class TestMuxcable(object):
             os.geteuid.return_value = 0
             with mock.patch('sonic_y_cable.y_cable') as patched_util:
                 patched_util.enable_loopback_mode.return_value = 1
-                result = runner.invoke(config.config.commands["muxcable"].commands["enable-loopback"], [
+                result = runner.invoke(config.config.commands["muxcable"].commands["loopback"].commands["enable"], [
                                        "0", "0", "0"], obj=db)
 
         assert(result.exit_code == 100)
@@ -481,7 +481,7 @@ class TestMuxcable(object):
             os.geteuid.return_value = 0
             with mock.patch('sonic_y_cable.y_cable') as patched_util:
                 patched_util.disable_prbs_mode.return_value = 1
-                result = runner.invoke(config.config.commands["muxcable"].commands["disable-prbs"], [
+                result = runner.invoke(config.config.commands["muxcable"].commands["prbs"].commands["enable"], [
                                        "0", "0"], obj=db)
 
         assert(result.exit_code == 100)
@@ -494,7 +494,7 @@ class TestMuxcable(object):
             os.geteuid.return_value = 0
             with mock.patch('sonic_y_cable.y_cable') as patched_util:
                 patched_util.disable_loopback_mode.return_value = 1
-                result = runner.invoke(config.config.commands["muxcable"].commands["disable-loopback"], [
+                result = runner.invoke(config.config.commands["muxcable"].commands["prbs"].commands["disbale"], [
                                        "0", "0"], obj=db)
 
         assert(result.exit_code == 100)

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -165,8 +165,8 @@ class TestMuxcable(object):
         db = Db()
         result = runner.invoke(show.cli.commands["muxcable"].commands["status"], obj=db)
 
-        assert(result.exit_code == 102)
-        assert(result.output == tabular_data_status_output_expected)
+        assert result.exit_code == 102
+        assert result.output == tabular_data_status_output_expected
 
     def test_muxcable_status_json(self):
         runner = CliRunner()
@@ -174,8 +174,8 @@ class TestMuxcable(object):
 
         result = runner.invoke(show.cli.commands["muxcable"].commands["status"], ["--json"], obj=db)
 
-        assert(result.exit_code == 102)
-        assert(result.output == json_data_status_output_expected)
+        assert result.exit_code == 102
+        assert result.output == json_data_status_output_expected
 
     def test_muxcable_status_config(self):
         runner = CliRunner()
@@ -183,8 +183,8 @@ class TestMuxcable(object):
 
         result = runner.invoke(show.cli.commands["muxcable"].commands["config"], obj=db)
 
-        assert(result.exit_code == 101)
-        assert(result.output == tabular_data_config_output_expected)
+        assert result.exit_code == 101
+        assert result.output == tabular_data_config_output_expected
 
     def test_muxcable_status_config_json(self):
         runner = CliRunner()
@@ -192,8 +192,8 @@ class TestMuxcable(object):
 
         result = runner.invoke(show.cli.commands["muxcable"].commands["config"], ["--json"], obj=db)
 
-        assert(result.exit_code == 101)
-        assert(result.output == json_data_status_config_output_expected)
+        assert result.exit_code == 101
+        assert result.output == json_data_status_config_output_expected
 
     def test_muxcable_config_json_with_incorrect_port(self):
         runner = CliRunner()
@@ -201,7 +201,7 @@ class TestMuxcable(object):
 
         result = runner.invoke(show.cli.commands["muxcable"].commands["config"], ["Ethernet33", "--json"], obj=db)
 
-        assert(result.exit_code == 1)
+        assert result.exit_code == 1
 
     def test_muxcable_status_json_with_correct_port(self):
         runner = CliRunner()
@@ -210,7 +210,7 @@ class TestMuxcable(object):
             patched_util.SfpUtilHelper.return_value.get_asic_id_for_logical_port.return_value = 0
             result = runner.invoke(show.cli.commands["muxcable"].commands["status"], ["Ethernet0", "--json"], obj=db)
 
-        assert(result.exit_code == 102)
+        assert result.exit_code == 102
 
     def test_muxcable_status_json_port_incorrect_index(self):
         runner = CliRunner()
@@ -219,7 +219,7 @@ class TestMuxcable(object):
             patched_util.SfpUtilHelper.return_value.get_asic_id_for_logical_port.return_value = 1
             result = runner.invoke(show.cli.commands["muxcable"].commands["status"], ["Ethernet0", "--json"], obj=db)
 
-        assert(result.exit_code == 1)
+        assert result.exit_code == 1
 
     def test_muxcable_status_with_patch(self):
         runner = CliRunner()
@@ -234,7 +234,7 @@ class TestMuxcable(object):
             patched_util.SfpUtilHelper.return_value.get_asic_id_for_logical_port.return_value = 0
             result = runner.invoke(show.cli.commands["muxcable"].commands["status"], ["Ethernet33", "--json"], obj=db)
 
-        assert(result.exit_code == 1)
+        assert result.exit_code == 1
 
     def test_muxcable_config_with_correct_port(self):
         runner = CliRunner()
@@ -243,7 +243,7 @@ class TestMuxcable(object):
             patched_util.SfpUtilHelper.return_value.get_asic_id_for_logical_port.return_value = 0
             result = runner.invoke(show.cli.commands["muxcable"].commands["config"], ["Ethernet0"], obj=db)
 
-        assert(result.exit_code == 101)
+        assert result.exit_code == 101
 
     def test_muxcable_config_json_with_correct_port(self):
         runner = CliRunner()
@@ -252,7 +252,7 @@ class TestMuxcable(object):
             patched_util.SfpUtilHelper.return_value.get_asic_id_for_logical_port.return_value = 0
             result = runner.invoke(show.cli.commands["muxcable"].commands["config"], ["Ethernet0", "--json"], obj=db)
 
-        assert(result.exit_code == 101)
+        assert result.exit_code == 101
 
     def test_muxcable_config_json_port_with_incorrect_index(self):
         runner = CliRunner()
@@ -261,7 +261,7 @@ class TestMuxcable(object):
             patched_util.SfpUtilHelper.return_value.get_asic_id_for_logical_port.return_value = 1
             result = runner.invoke(show.cli.commands["muxcable"].commands["config"], ["Ethernet0", "--json"], obj=db)
 
-        assert(result.exit_code == 101)
+        assert result.exit_code == 101
 
     def test_muxcable_config_json_with_incorrect_port_patch(self):
         runner = CliRunner()
@@ -270,7 +270,7 @@ class TestMuxcable(object):
             patched_util.SfpUtilHelper.return_value.get_asic_id_for_logical_port.return_value = 0
             result = runner.invoke(show.cli.commands["muxcable"].commands["config"], ["Ethernet33", "--json"], obj=db)
 
-        assert(result.exit_code == 1)
+        assert result.exit_code == 1
 
     def test_muxcable_status_json_port_eth0(self):
         runner = CliRunner()
@@ -279,7 +279,7 @@ class TestMuxcable(object):
             patched_util.SfpUtilHelper.return_value.get_asic_id_for_logical_port.return_value = 0
             result = runner.invoke(show.cli.commands["muxcable"].commands["status"], ["Ethernet0"], obj=db)
 
-        assert(result.exit_code == 102)
+        assert result.exit_code == 102
 
     def test_config_muxcable_tabular_port_Ethernet8_active(self):
         runner = CliRunner()
@@ -289,7 +289,7 @@ class TestMuxcable(object):
             patched_util.SfpUtilHelper.return_value.get_asic_id_for_logical_port.return_value = 0
             result = runner.invoke(config.config.commands["muxcable"].commands["mode"], ["active", "Ethernet8"], obj=db)
 
-        assert(result.exit_code == 100)
+        assert result.exit_code == 100
 
     def test_config_muxcable_tabular_port_Ethernet8_auto(self):
         runner = CliRunner()
@@ -299,7 +299,7 @@ class TestMuxcable(object):
             patched_util.SfpUtilHelper.return_value.get_asic_id_for_logical_port.return_value = 0
             result = runner.invoke(config.config.commands["muxcable"].commands["mode"], ["auto", "Ethernet8"], obj=db)
 
-        assert(result.exit_code == 100)
+        assert result.exit_code == 100
 
     def test_config_muxcable_mode_auto_json(self):
         runner = CliRunner()
@@ -307,8 +307,8 @@ class TestMuxcable(object):
 
         result = runner.invoke(config.config.commands["muxcable"].commands["mode"], ["auto", "all", "--json"], obj=db)
 
-        assert(result.exit_code == 100)
-        assert(result.output == json_data_config_output_auto_expected)
+        assert result.exit_code == 100
+        assert result.output == json_data_config_output_auto_expected
 
     def test_config_muxcable_mode_active_json(self):
         runner = CliRunner()
@@ -318,8 +318,8 @@ class TestMuxcable(object):
         f = open("newfile1", "w")
         f.write(result.output)
 
-        assert(result.exit_code == 100)
-        assert(result.output == json_data_config_output_active_expected)
+        assert result.exit_code == 100
+        assert result.output == json_data_config_output_active_expected
 
     def test_config_muxcable_json_port_auto_Ethernet0(self):
         runner = CliRunner()
@@ -330,7 +330,7 @@ class TestMuxcable(object):
             result = runner.invoke(config.config.commands["muxcable"].commands["mode"], [
                                    "auto", "Ethernet0", "--json"], obj=db)
 
-        assert(result.exit_code == 100)
+        assert result.exit_code == 100
 
     def test_config_muxcable_json_port_active_Ethernet0(self):
         runner = CliRunner()
@@ -341,13 +341,13 @@ class TestMuxcable(object):
             result = runner.invoke(config.config.commands["muxcable"].commands["mode"], [
                                    "active", "Ethernet0", "--json"], obj=db)
 
-        assert(result.exit_code == 100)
+        assert result.exit_code == 100
 
     def test_config_muxcable_mode_auto_tabular(self):
         runner = CliRunner()
         db = Db()
         result = runner.invoke(config.config.commands["muxcable"].commands["mode"], ["auto", "all"], obj=db)
-        assert(result.exit_code == 100)
+        assert result.exit_code == 100
 
     def test_config_muxcable_mode_active_tabular(self):
         runner = CliRunner()
@@ -357,7 +357,7 @@ class TestMuxcable(object):
         f = open("newfile", "w")
         f.write(result.output)
 
-        assert(result.exit_code == 100)
+        assert result.exit_code == 100
 
     def test_config_muxcable_tabular_port(self):
         runner = CliRunner()
@@ -367,7 +367,7 @@ class TestMuxcable(object):
             patched_util.SfpUtilHelper.return_value.get_asic_id_for_logical_port.return_value = 0
             result = runner.invoke(config.config.commands["muxcable"].commands["mode"], ["active", "Ethernet0"], obj=db)
 
-        assert(result.exit_code == 100)
+        assert result.exit_code == 100
 
     def test_config_muxcable_tabular_port_Ethernet4_active(self):
         runner = CliRunner()
@@ -377,7 +377,7 @@ class TestMuxcable(object):
             patched_util.SfpUtilHelper.return_value.get_asic_id_for_logical_port.return_value = 0
             result = runner.invoke(config.config.commands["muxcable"].commands["mode"], ["active", "Ethernet4"], obj=db)
 
-        assert(result.exit_code == 100)
+        assert result.exit_code == 100
 
     def test_config_muxcable_tabular_port_Ethernet4_auto(self):
         runner = CliRunner()
@@ -387,7 +387,7 @@ class TestMuxcable(object):
             patched_util.SfpUtilHelper.return_value.get_asic_id_for_logical_port.return_value = 0
             result = runner.invoke(config.config.commands["muxcable"].commands["mode"], ["auto", "Ethernet4"], obj=db)
 
-        assert(result.exit_code == 100)
+        assert result.exit_code == 100
 
     def test_config_muxcable_tabular_port_with_incorrect_index(self):
         runner = CliRunner()
@@ -397,7 +397,7 @@ class TestMuxcable(object):
             patched_util.SfpUtilHelper.return_value.get_asic_id_for_logical_port.return_value = 2
             result = runner.invoke(config.config.commands["muxcable"].commands["mode"], ["active", "Ethernet0"], obj=db)
 
-        assert(result.exit_code == 1)
+        assert result.exit_code == 1
 
     def test_config_muxcable_tabular_port_with_incorrect_port_index(self):
         runner = CliRunner()
@@ -408,7 +408,7 @@ class TestMuxcable(object):
             result = runner.invoke(config.config.commands["muxcable"].commands["mode"], [
                                    "active", "Ethernet33"], obj=db)
 
-        assert(result.exit_code == 1)
+        assert result.exit_code == 1
 
     def test_config_muxcable_tabular_port_with_incorrect_port(self):
         runner = CliRunner()
@@ -419,7 +419,7 @@ class TestMuxcable(object):
             result = runner.invoke(config.config.commands["muxcable"].commands["mode"], [
                                    "active", "Ethernet33"], obj=db)
 
-        assert(result.exit_code == 1)
+        assert result.exit_code == 1
 
     @mock.patch('os.geteuid', mock.MagicMock(return_value=0))
     @mock.patch('sonic_y_cable.y_cable.get_eye_info', mock.MagicMock(return_value=[0, 0]))
@@ -430,7 +430,7 @@ class TestMuxcable(object):
         result = runner.invoke(show.cli.commands["muxcable"].commands["eyeinfo"],
                                ["0", "0"], obj=db)
 
-        assert(result.exit_code == 0)
+        assert result.exit_code == 0
 
     @mock.patch('os.geteuid', mock.MagicMock(return_value=0))
     @mock.patch('sonic_y_cable.y_cable.get_ber_info', mock.MagicMock(return_value=[0, 0]))
@@ -441,7 +441,7 @@ class TestMuxcable(object):
         result = runner.invoke(show.cli.commands["muxcable"].commands["berinfo"],
                                ["0", "0"], obj=db)
 
-        assert(result.exit_code == 0)
+        assert result.exit_code == 0
 
     @mock.patch('os.geteuid', mock.MagicMock(return_value=0))
     @mock.patch('sonic_y_cable.y_cable.enable_prbs_mode', mock.MagicMock(return_value=1))
@@ -452,7 +452,7 @@ class TestMuxcable(object):
         result = runner.invoke(config.config.commands["muxcable"].commands["prbs"].commands["enable"],
                                ["0", "0", "0", "0"], obj=db)
 
-        assert(result.exit_code == 100)
+        assert result.exit_code == 100
 
     @mock.patch('os.geteuid', mock.MagicMock(return_value=0))
     @mock.patch('sonic_y_cable.y_cable.enable_loopback_mode', mock.MagicMock(return_value=1))
@@ -463,7 +463,7 @@ class TestMuxcable(object):
         result = runner.invoke(config.config.commands["muxcable"].commands["loopback"].commands["enable"],
                                ["0", "0", "0"], obj=db)
 
-        assert(result.exit_code == 100)
+        assert result.exit_code == 100
 
     @mock.patch('os.geteuid', mock.MagicMock(return_value=0))
     @mock.patch('sonic_y_cable.y_cable.disable_prbs_mode', mock.MagicMock(return_value=1))
@@ -474,7 +474,7 @@ class TestMuxcable(object):
         result = runner.invoke(config.config.commands["muxcable"].commands["prbs"].commands["disable"],
                                ["0", "0"], obj=db)
 
-        assert(result.exit_code == 100)
+        assert result.exit_code == 100
 
     @mock.patch('os.geteuid', mock.MagicMock(return_value=0))
     @mock.patch('sonic_y_cable.y_cable.disable_loopback_mode', mock.MagicMock(return_value=1))
@@ -485,7 +485,7 @@ class TestMuxcable(object):
         result = runner.invoke(config.config.commands["muxcable"].commands["loopback"].commands["disable"],
                                ["0", "0"], obj=db)
 
-        assert(result.exit_code == 100)
+        assert result.exit_code == 100
 
     @classmethod
     def teardown_class(cls):

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -427,8 +427,8 @@ class TestMuxcable(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(show.cli.commands["muxcable"].commands["eyeinfo"], [
-                               "0", "0"], obj=db)
+        result = runner.invoke(show.cli.commands["muxcable"].commands["eyeinfo"],
+                               ["0", "0"], obj=db)
 
         assert(result.exit_code == 0)
 
@@ -438,8 +438,8 @@ class TestMuxcable(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(show.cli.commands["muxcable"].commands["berinfo"], [
-                               "0", "0"], obj=db)
+        result = runner.invoke(show.cli.commands["muxcable"].commands["berinfo"],
+                               ["0", "0"], obj=db)
 
         assert(result.exit_code == 0)
 
@@ -449,8 +449,8 @@ class TestMuxcable(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["muxcable"].commands["prbs"].commands["enable"], [
-                               "0", "0", "0", "0"], obj=db)
+        result = runner.invoke(config.config.commands["muxcable"].commands["prbs"].commands["enable"],
+                               ["0", "0", "0", "0"], obj=db)
 
         assert(result.exit_code == 100)
 
@@ -460,8 +460,8 @@ class TestMuxcable(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["muxcable"].commands["loopback"].commands["enable"], [
-                               "0", "0", "0"], obj=db)
+        result = runner.invoke(config.config.commands["muxcable"].commands["loopback"].commands["enable"],
+                               ["0", "0", "0"], obj=db)
 
         assert(result.exit_code == 100)
 
@@ -471,8 +471,8 @@ class TestMuxcable(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["muxcable"].commands["prbs"].commands["disable"], [
-                               "0", "0"], obj=db)
+        result = runner.invoke(config.config.commands["muxcable"].commands["prbs"].commands["disable"],
+                               ["0", "0"], obj=db)
 
         assert(result.exit_code == 100)
 
@@ -482,8 +482,8 @@ class TestMuxcable(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["muxcable"].commands["loopback"].commands["disable"], [
-                               "0", "0"], obj=db)
+        result = runner.invoke(config.config.commands["muxcable"].commands["loopback"].commands["disable"],
+                               ["0", "0"], obj=db)
 
         assert(result.exit_code == 100)
 

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -481,7 +481,7 @@ class TestMuxcable(object):
             os.geteuid.return_value = 0
             with mock.patch('sonic_y_cable.y_cable') as patched_util:
                 patched_util.disable_prbs_mode.return_value = 1
-                result = runner.invoke(config.config.commands["muxcable"].commands["prbs"].commands["enable"], [
+                result = runner.invoke(config.config.commands["muxcable"].commands["prbs"].commands["disable"], [
                                        "0", "0"], obj=db)
 
         assert(result.exit_code == 100)
@@ -494,7 +494,7 @@ class TestMuxcable(object):
             os.geteuid.return_value = 0
             with mock.patch('sonic_y_cable.y_cable') as patched_util:
                 patched_util.disable_loopback_mode.return_value = 1
-                result = runner.invoke(config.config.commands["muxcable"].commands["prbs"].commands["disbale"], [
+                result = runner.invoke(config.config.commands["muxcable"].commands["loopback"].commands["disable"], [
                                        "0", "0"], obj=db)
 
         assert(result.exit_code == 100)


### PR DESCRIPTION
Summary:
This PR provides the support for adding CLI commands for configuring prbs, loopback and showing the BER and Eye info of the muxcable.
In particular these Cli commands are supported:
` show muxcable eyeinfo <portnumber><target>`
` show muxcable berinfo <portnumber> <target>`

`config muxcable prbs <portnumber> <target> <mode> <lanemap>`
`config muxcable loopback <portnumber> <target> <lanemap>`

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
added the changes in sonic-utilities/show and sonic-utilities/config by changing the muxcable.py 

#### What is the motivation for this PR?

To add the support for Cli for muxcable to be utilized for configuring prbs, loopback modes and showing the ber, eye info of all the Port/Ports on a muxcable.

#### How did you do it?
Added the changes inside sonic-utilities and tested it on the testbed

#### How did you verify/test it?
Ran the cli commands on an Arista7260cx3 testbed with Gemini cable

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>


