### PR TITLE
[storyteller] allow storyteller to work on downloaded logs

### DIFF
--- a/scripts/storyteller
+++ b/scripts/storyteller
@@ -14,7 +14,7 @@ regex_dict = {
                 'crash'     : 'what\|unexpected exception\|notify_OA_about_syncd_exception\|SIG\|not expected',
                 'interface' : 'updatePortOperStatus\|Configure .* to',
                 'lag'       : 'link becomes\|addLag',
-                'reboot'    : 'BOOT\|rc.local\|old_config\|minigraph.xml\|Rebooting\|reboot\|executeOperationsOnAsic\|getAsicView\|dumpVidToAsicOperatioId',
+                'reboot'    : 'BOOT\|rc.local\|old_config\|minigraph.xml\|Rebooting\|reboot\|executeOperationsOnAsic\|getAsicView\|dumpVidToAsicOperatioId\|neighbor_adv\|Pausing\|shutdown\|warm',
                 'service'   : 'Starting\|Stopping\|Started\|Stopped',
              }
 
@@ -37,9 +37,9 @@ def build_options(after=0, before=0, context=0):
     return ' '.join(x for x in options)
 
 
-def find_log(log, regex, after=0, before=0, context=0):
+def find_log(logpath, log, regex, after=0, before=0, context=0):
     options = build_options(after, before, context)
-    cmd = 'ls -rt /var/log/{}* | xargs zgrep -a {} "{}"'.format(log, options, regex)
+    cmd = 'ls -rt {}/{}* | xargs zgrep -a {} "{}"'.format(logpath, log, options, regex)
     _, out, _ = exec_cmd(cmd)
     '''
         Opportunity to improve:
@@ -66,6 +66,8 @@ def main():
                         type=str, required=False, default='syslog')
     parser.add_argument('-c', '--category', help='Categories: bgp, crash, interface, lag, reboot, service Specify multiple categories as c1,c2,c3; default: reboot',
                         type=str, required=False, default='reboot')
+    parser.add_argument('-p', '--logpath', help='log file path, e.g. /var/log; default: /var/log',
+                        type=str, required=False, default='/var/log')
     parser.add_argument('-A', '--after', help='Show N lines after match',
                         type=int, required=False, default=0)
     parser.add_argument('-B', '--before', help='Show N lines before match',
@@ -78,7 +80,8 @@ def main():
     log = args.log
     reg = build_regex(args.category)
 
-    find_log(log, reg, args.after, args.before, args.context)
+
+    find_log(args.logpath, log, reg, args.after, args.before, args.context)
 
 
 if __name__ == '__main__':

--- a/scripts/storyteller
+++ b/scripts/storyteller
@@ -20,7 +20,8 @@ regex_dict = {
 
 
 def exec_cmd(cmd):
-    out = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True, text=True)
+    # Use universal_newlines (instead of text) so that this tool can work with any python versions.
+    out = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True, universal_newlines=True)
     stdout, stderr = out.communicate()
     return out.returncode, stdout, stderr
 

--- a/scripts/storyteller
+++ b/scripts/storyteller
@@ -80,7 +80,6 @@ def main():
     log = args.log
     reg = build_regex(args.category)
 
-
     find_log(args.logpath, log, reg, args.after, args.before, args.context)
 
 


### PR DESCRIPTION
**- What I did**

- Add log path parameter to allow storyteller to work on  logs downloaded from sonic devices.
- Improve reboot regex to capture more warm reboot related logs.

**- How to verify it**
Use storyteller against a sonic dump.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
