### PR TITLE
[ecnconfig] Allow ecn unit test to run without sudo

### DIFF
--- a/scripts/ecnconfig
+++ b/scripts/ecnconfig
@@ -166,7 +166,7 @@ class EcnConfig(object):
         return result
 
     def set_wred_threshold(self, profile, threshold, value):
-        if os.geteuid() != 0:
+        if os.geteuid() != 0 and os.environ.get("UTILITIES_UNIT_TESTING", "0") != "2":
             sys.exit("Root privileges required for this operation")
 
         field = WRED_CONFIG_FIELDS[threshold]
@@ -179,7 +179,7 @@ class EcnConfig(object):
                 json.dump(prof_table, fd)
 
     def set_wred_prob(self, profile, drop_color, value):
-        if os.geteuid() != 0:
+        if os.geteuid() != 0 and os.environ.get("UTILITIES_UNIT_TESTING", "0") != "2":
             sys.exit("Root privileges required for this operation")
 
         field = WRED_CONFIG_FIELDS[drop_color]
@@ -227,7 +227,7 @@ class EcnQ(object):
             )
 
     def set(self, enable):
-        if os.geteuid() != 0:
+        if os.geteuid() != 0 and os.environ.get("UTILITIES_UNIT_TESTING", "0") != "2":
             sys.exit("Root privileges required for this operation")
         for queue in self.queues:
             if self.verbose:

--- a/scripts/ecnconfig
+++ b/scripts/ecnconfig
@@ -89,6 +89,10 @@ OFF                        = "[]"
 
 lossless_queues         = ['3', '4']
 
+def chk_exec_privilege():
+    if os.geteuid() != 0 and os.environ.get("UTILITIES_UNIT_TESTING", "0") != "2":
+        sys.exit("Root privileges required for this operation")
+
 class EcnConfig(object):
     """
     Process ecnconfig
@@ -166,8 +170,7 @@ class EcnConfig(object):
         return result
 
     def set_wred_threshold(self, profile, threshold, value):
-        if os.geteuid() != 0 and os.environ.get("UTILITIES_UNIT_TESTING", "0") != "2":
-            sys.exit("Root privileges required for this operation")
+        chk_exec_privilege()
 
         field = WRED_CONFIG_FIELDS[threshold]
         if self.verbose:
@@ -179,8 +182,7 @@ class EcnConfig(object):
                 json.dump(prof_table, fd)
 
     def set_wred_prob(self, profile, drop_color, value):
-        if os.geteuid() != 0 and os.environ.get("UTILITIES_UNIT_TESTING", "0") != "2":
-            sys.exit("Root privileges required for this operation")
+        chk_exec_privilege()
 
         field = WRED_CONFIG_FIELDS[drop_color]
         if self.verbose:
@@ -227,8 +229,8 @@ class EcnQ(object):
             )
 
     def set(self, enable):
-        if os.geteuid() != 0 and os.environ.get("UTILITIES_UNIT_TESTING", "0") != "2":
-            sys.exit("Root privileges required for this operation")
+        chk_exec_privilege()
+
         for queue in self.queues:
             if self.verbose:
                 print("%s ECN on %s queue %s" % ("Enable" if enable else "Disable", ','.join(self.ports_key), queue))


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->
Allow ecn unit tests to run without root privileges

**- How I did it**
Included the UTILITIES_UNIT_TESTING' env variable also as one of the conditions to determine if the command needs root privileges for execution

**- How to verify it**
Ran utilities test using the command "python3 setup.py test" and ecn_test.py passed. Prior to the fix, most of the testcases were failing with the error 'Root privileged required for this operation'
