### PR TITLE
[route_check.py] Skip route check for tun0 interfaces

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -320,7 +320,7 @@ def filter_out_local_interfaces(keys):
     :return keys filtered out of local
     """
     rt = []
-    local_if_re = ['eth0', 'lo', 'docker0', 'Loopback\d+']
+    local_if_re = ['eth0', 'lo', 'docker0', 'tun0', 'Loopback\d+']
 
     db = swsscommon.DBConnector(APPL_DB_NAME, 0)
     tbl = swsscommon.Table(db, 'ROUTE_TABLE')


### PR DESCRIPTION
**- What I did**
As part of dual-tor features, kernel tunnel interface (tun0) is being created. The routes over this is intended for kernel forwarding and not expected to be installed in ASIC. 

Ref PR - https://github.com/Azure/sonic-swss/pull/1615

**- How I did it**
Added to the list of 'skipped' interfaces

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

