### PR TITLE
[Mellanox] Revert "Add FW dump with new SAI implementation (#1338)"

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -711,12 +711,11 @@ collect_mellanox() {
     ${CMD_PREFIX}docker exec syncd tar Ccf $(dirname $sai_dump_filename) - $(basename $sai_dump_filename) | tar Cxf /tmp/ -
     save_file $sai_dump_filename sai_sdk_dump true
 
-    file_list_string=$(${CMD_PREFIX}docker exec -it syncd ls -l /tmp | grep sdkdump | awk '{print $9}' | tr -d '\r')
-    file_list_array=( $file_list_string )
-    for element in "${file_list_array[@]}"
-    do
-        docker cp syncd:/tmp/$element /tmp
-        save_file /tmp/$element sai_sdk_dump true
+    local mst_dump_filename="/tmp/mstdump"
+    local max_dump_count="3"
+    for i in $(seq 1 $max_dump_count); do
+        ${CMD_PREFIX}/usr/bin/mstdump /dev/mst/mt*conf0 > "${mst_dump_filename}${i}"
+        save_file "${mst_dump_filename}${i}" mstdump true
     done
 }
 


### PR DESCRIPTION
This reverts commit b10622e08fd0a92dd22688b023f7dbbef498aceb.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
revert changes to call sdkdump and replace with old call to mstdump

**- How I did it**
reverting a previous commit [Mellanox] Add FW dump with new SAI implementation and remove mst dump Azure#1338

**- How to verify it**
run techsupport

**- Previous command output (if the output of a command-line utility has changed)**
N/A

**- New command output (if the output of a command-line utility has changed)**
N/A

