### PR TITLE
Fix: initialize SonicDBConfig differently for single or multi_asic

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -929,7 +929,11 @@ def config(ctx):
         platform.add_command(mlnx.mlnx)
 
     # Load the global config file database_global.json once.
-    SonicDBConfig.load_sonic_global_db_config()
+    num_asic = multi_asic.get_num_asics()
+    if num_asic > 1:
+        SonicDBConfig.load_sonic_global_db_config()
+    else:
+        SonicDBConfig.initialize()
 
     if os.geteuid() != 0:
         exit("Root privileges are required for this operation")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Fixes https://github.com/Azure/sonic-buildimage/issues/6708

This bug is exposed by https://github.com/Azure/sonic-utilities/pull/1392. Previously the `config` command will call `SonicDBConfig.load_sonic_global_db_config()` even on a single ASIC platform, and it will silently failed. After exposed, it will fail with error syslog message:
```
admin@sonic:~$ sudo config save
Existing files will be overwritten, continue? [y/N]: ^CAborted!

Feb  8 03:23:48.729434 sonic ERR sniffer: :- initializeGlobalConfig: Sonic database config global file doesn't exist at /var/run/redis/sonic-db/database_global.json
```
**- How I did it**

**- How to verify it**
Tested on DUT

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

