### PR TITLE
[show ] Issue in CLI output alignment with shorter alias names in intf naming mode "alias" #1397

### DIFF
--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -351,6 +351,8 @@ def print_output_in_alias_mode(output, index):
     if output.startswith("---"):
         word = output.split()
         dword = word[index]
+        if(len(dword) > iface_alias_converter.alias_max_length):
+            dword = dword[:len(dword) - iface_alias_converter.alias_max_length]
         underline = dword.rjust(iface_alias_converter.alias_max_length,
                                 '-')
         word[index] = underline


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->
Fix #1397 
**- What I did**
      Added fix for Issue in CLI output alignment with shorter alias names in intf naming mode "alias"
**- How I did it**
      Added code to remove last few extra characters from string (-------…) using Slicing & Positive Indexing in python, to match the width to alias's name(not interface)
**- How to verify it**
     Steps to reproduce:
    1. Change the naming mode to alias instead of port names
        admin@sonic-svk169-dut:~$ config interface_naming_mode alias
    2. Update config_db.json for port section to change alias to shorter names like below
    3. Reload and run following command
**- Previous command output (if the output of a command-line utility has changed)**
   For shorter alias names like P0, P1, etc..
```
admin@sonic-svk169-dut:~$ show interfaces  counters
    IFACE    STATE    RX_OK    RX_BPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR     TX_OK    TX_BPS    TX_UTIL    TX_ERR    TX_DRP    TX_OVR
    -----------  -------  -------  --------  ---------  --------  --------  --------  --------  --------  ---------  --------  --------  --------
      P0        X        0       N/A        N/A         0         0         0         0       N/A        N/A         0         0         0
     P4        X        0       N/A        N/A         0         0         0         0       N/A        N/A         0         0         0
```

**- New command output (if the output of a command-line utility has changed)**

For shorter alias names like P0, P1, etc..
 ```
admin@sonic-svk169-dut:~$ show interfaces  counters
IFACE    STATE    RX_OK    RX_BPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR     TX_OK    TX_BPS    TX_UTIL    TX_ERR    TX_DRP    TX_OVR
-------  -------  -------  --------  ---------  --------  --------  --------  --------  --------  ---------  --------  --------  --------
  P0        X        0       N/A        N/A         0         0         0         0       N/A        N/A         0         0         0
  P4        X        0       N/A        N/A         0         0         0         0       N/A        N/A         0         0         0
  P8        U        2       N/A        N/A         0         0         0     15890       N/A        N/A         0         0         0
P12        U        2       N/A        N/A         0         0         0     15890       N/A        N/A         0         0         0
P16        U        2       N/A        N/A         0         0         0     15889       N/A        N/A         0         0         0
P20        U        2       N/A        N/A         0         0         0     15890       N/A        N/A         0         0         0
P24        U        2       N/A        N/A         0         0         0     15890       N/A        N/A         0         0         0
```

For bigger alias names:
```
admin@sonic-svk169-dut:~$ show interfaces  counters
                   IFACE    STATE    RX_OK    RX_BPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR    TX_OK    TX_BPS    TX_UTIL    TX_ERR    TX_DRP    TX_OVR
------------------------  -------  -------  --------  ---------  --------  --------  --------  -------  --------  ---------  --------  --------  --------
P00000000000000000000000        X        0       N/A        N/A         0         0         0        0       N/A        N/A         0         0         0
       P0000000000000004        X        0       N/A        N/A         0         0         0        0       N/A        N/A         0         0         0
                      P8        U        2       N/A        N/A         0         0         0       16       N/A        N/A         0         0         0
```