### PR TITLE
Fix: initialize SonicDBConfig differently for single or multi_asic (continued)

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -9,7 +9,7 @@ import openconfig_acl
 import tabulate
 import pyangbind.lib.pybindJSON as pybindJSON
 from natsort import natsorted
-from sonic_py_common import device_info
+from sonic_py_common import device_info, multi_asic
 from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector, SonicDBConfig
 
 

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -114,8 +114,13 @@ class AclLoader(object):
         self.tables_db_info = {}
         self.rules_db_info = {}
         self.rules_info = {}
-        # Load global db config. This call is no-op in single npu platforms
-        SonicDBConfig.load_sonic_global_db_config()
+        num_asic = multi_asic.get_num_asics()
+        if num_asic > 1:
+            # Load global db config
+            SonicDBConfig.load_sonic_global_db_config()
+        else:
+            SonicDBConfig.initialize()
+
         self.sessions_db_info = {}
         self.configdb = ConfigDBConnector()
         self.configdb.connect()

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -114,8 +114,8 @@ class AclLoader(object):
         self.tables_db_info = {}
         self.rules_db_info = {}
         self.rules_info = {}
-        num_asic = multi_asic.get_num_asics()
-        if num_asic > 1:
+
+        if multi_asic.is_multi_asic():
             # Load global db config
             SonicDBConfig.load_sonic_global_db_config()
         else:

--- a/crm/main.py
+++ b/crm/main.py
@@ -217,8 +217,12 @@ def cli(ctx):
 
     ctx.obj = context
 
-    # Load the global config file database_global.json once.
-    SonicDBConfig.load_sonic_global_db_config()
+    num_asic = multi_asic.get_num_asics()
+    if num_asic > 1:
+        # Load the global config file database_global.json once.
+        SonicDBConfig.load_sonic_global_db_config()
+    else:
+        SonicDBConfig.initialize()
 
 @cli.group()
 @click.pass_context

--- a/crm/main.py
+++ b/crm/main.py
@@ -217,12 +217,14 @@ def cli(ctx):
 
     ctx.obj = context
 
-    num_asic = multi_asic.get_num_asics()
-    if num_asic > 1:
-        # Load the global config file database_global.json once.
-        SonicDBConfig.load_sonic_global_db_config()
-    else:
-        SonicDBConfig.initialize()
+    # Note: SonicDBConfig may be already initialized in unit test, then skip
+    if not SonicDBConfig.isInit():
+        num_asic = multi_asic.get_num_asics()
+        if num_asic > 1:
+            # Load the global config file database_global.json once.
+            SonicDBConfig.load_sonic_global_db_config()
+        else:
+            SonicDBConfig.initialize()
 
 @cli.group()
 @click.pass_context

--- a/crm/main.py
+++ b/crm/main.py
@@ -211,20 +211,19 @@ def cli(ctx):
     # Use the db object if given as input.
     db = None if ctx.obj is None else ctx.obj.cfgdb
 
+    # Note: SonicDBConfig may be already initialized in unit test, then skip
+    if not SonicDBConfig.isInit():
+        if multi_asic.is_multi_asic():
+            # Load the global config file database_global.json once.
+            SonicDBConfig.load_sonic_global_db_config()
+        else:
+            SonicDBConfig.initialize()
+
     context = {
         "crm": Crm(db)
     }
 
     ctx.obj = context
-
-    # Note: SonicDBConfig may be already initialized in unit test, then skip
-    if not SonicDBConfig.isInit():
-        num_asic = multi_asic.get_num_asics()
-        if num_asic > 1:
-            # Load the global config file database_global.json once.
-            SonicDBConfig.load_sonic_global_db_config()
-        else:
-            SonicDBConfig.initialize()
 
 @cli.group()
 @click.pass_context

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -555,6 +555,8 @@ def main():
 
         if args.namespace is not None:
             SonicDBConfig.load_sonic_global_db_config(namespace=args.namespace)
+        else:
+            SonicDBConfig.initialize()
 
         if socket_path:
             dbmgtr = DBMigrator(namespace, socket=socket_path)

--- a/scripts/lldpshow
+++ b/scripts/lldpshow
@@ -47,8 +47,8 @@ class Lldpshow(object):
         # So far only find Router and Bridge two capabilities in lldpctl, so any other capacility types will be read as Other
         # if further capability type is supported like WLAN, can just add the tag definition here
         self.ctags = {'Router': 'R', 'Bridge': 'B'}
-        num_asic = multi_asic.get_num_asics()
-        if num_asic > 1:
+
+        if multi_asic.is_multi_asic():
             SonicDBConfig.load_sonic_global_db_config()
         else:
             SonicDBConfig.initialize()

--- a/scripts/lldpshow
+++ b/scripts/lldpshow
@@ -25,7 +25,7 @@ import subprocess
 import sys
 import xml.etree.ElementTree as ET
 
-from sonic_py_common import device_info
+from sonic_py_common import device_info, multi_asic
 from swsscommon.swsscommon import ConfigDBConnector, SonicDBConfig
 from tabulate import tabulate
 
@@ -47,7 +47,11 @@ class Lldpshow(object):
         # So far only find Router and Bridge two capabilities in lldpctl, so any other capacility types will be read as Other
         # if further capability type is supported like WLAN, can just add the tag definition here
         self.ctags = {'Router': 'R', 'Bridge': 'B'}
-        SonicDBConfig.load_sonic_global_db_config()
+        num_asic = multi_asic.get_num_asics()
+        if num_asic > 1:
+            SonicDBConfig.load_sonic_global_db_config()
+        else:
+            SonicDBConfig.initialize()
 
         # For multi-asic platforms we will get only front-panel interface to display
         namespaces = device_info.get_all_namespaces()

--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -82,6 +82,8 @@ def main():
 
     if args.namespace is not None:
         SonicDBConfig.load_sonic_global_db_config(namespace=args.namespace)
+    else:
+        SonicDBConfig.initialize()
 
     try:
         port = portconfig(args.verbose, args.port, args.namespace)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
This bug is exposed by https://github.com/Azure/sonic-utilities/pull/1392. Previously the `config` command will call `SonicDBConfig.load_sonic_global_db_config()` even on a single ASIC platform, and it will silently failed. After exposed, it will fail with error syslog message:
```
Feb  9 05:04:46.462361 vlab-01 ERR python3: :- initializeGlobalConfig: Sonic database config global file doesn't exist at /var/run/redis/sonic-db/database_global.json
```

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

