### PR TITLE
[show mux]: Sort output by intf name

### DIFF
--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -4,6 +4,7 @@ import sys
 
 import click
 import utilities_common.cli as clicommon
+from natsort import natsorted
 from sonic_py_common import multi_asic
 from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
 from tabulate import tabulate
@@ -189,7 +190,7 @@ def status(port, json_output):
             port_status_dict["MUX_CABLE"] = {}
             for namespace in namespaces:
                 asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-                for key in sorted(port_table_keys[asic_id], key=lambda x: int(x.split("|")[1].replace("Ethernet", ""))):
+                for key in natsorted(port_table_keys[asic_id]):
                     port = key.split("|")[1]
                     muxcable_info_dict[asic_id] = per_npu_statedb[asic_id].get_all(
                         per_npu_statedb[asic_id].STATE_DB, 'MUX_CABLE_TABLE|{}'.format(port))
@@ -200,7 +201,7 @@ def status(port, json_output):
             print_data = []
             for namespace in namespaces:
                 asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-                for key in sorted(port_table_keys[asic_id], key=lambda x: int(x.split("|")[1].replace("Ethernet", ""))):
+                for key in natsorted(port_table_keys[asic_id]):
                     port = key.split("|")[1]
                     muxcable_info_dict[asic_id] = per_npu_statedb[asic_id].get_all(
                         per_npu_statedb[asic_id].STATE_DB, 'MUX_CABLE_TABLE|{}'.format(port))
@@ -316,7 +317,7 @@ def config(port, json_output):
             port_status_dict["MUX_CABLE"]["PORTS"] = {}
             for namespace in namespaces:
                 asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-                for port in sorted(port_mux_tbl_keys[asic_id], key=lambda x: int(x.replace("Ethernet", ""))):
+                for port in natsorted(port_mux_tbl_keys[asic_id]):
                     create_json_dump_per_port_config(port_status_dict, per_npu_configdb, asic_id, port)
 
             click.echo("{}".format(json.dumps(port_status_dict, indent=4)))
@@ -325,7 +326,7 @@ def config(port, json_output):
             print_peer_tor = []
             for namespace in namespaces:
                 asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-                for port in sorted(port_mux_tbl_keys[asic_id], key=lambda x: int(x.replace("Ethernet", ""))):
+                for port in natsorted(port_mux_tbl_keys[asic_id]):
                     create_table_dump_per_port_config(print_data, per_npu_configdb, asic_id, port)
 
             headers = ['SWITCH_NAME', 'PEER_TOR']

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -189,7 +189,7 @@ def status(port, json_output):
             port_status_dict["MUX_CABLE"] = {}
             for namespace in namespaces:
                 asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-                for key in port_table_keys[asic_id]:
+                for key in sorted(port_table_keys[asic_id], key=lambda x: int(x.split("|")[1].replace("Ethernet", ""))):
                     port = key.split("|")[1]
                     muxcable_info_dict[asic_id] = per_npu_statedb[asic_id].get_all(
                         per_npu_statedb[asic_id].STATE_DB, 'MUX_CABLE_TABLE|{}'.format(port))
@@ -200,7 +200,7 @@ def status(port, json_output):
             print_data = []
             for namespace in namespaces:
                 asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-                for key in port_table_keys[asic_id]:
+                for key in sorted(port_table_keys[asic_id], key=lambda x: int(x.split("|")[1].replace("Ethernet", ""))):
                     port = key.split("|")[1]
                     muxcable_info_dict[asic_id] = per_npu_statedb[asic_id].get_all(
                         per_npu_statedb[asic_id].STATE_DB, 'MUX_CABLE_TABLE|{}'.format(port))
@@ -316,7 +316,7 @@ def config(port, json_output):
             port_status_dict["MUX_CABLE"]["PORTS"] = {}
             for namespace in namespaces:
                 asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-                for port in port_mux_tbl_keys[asic_id]:
+                for port in sorted(port_mux_tbl_keys[asic_id], key=lambda x: int(x.replace("Ethernet", ""))):
                     create_json_dump_per_port_config(port_status_dict, per_npu_configdb, asic_id, port)
 
             click.echo("{}".format(json.dumps(port_status_dict, indent=4)))
@@ -325,7 +325,7 @@ def config(port, json_output):
             print_peer_tor = []
             for namespace in namespaces:
                 asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-                for port in port_mux_tbl_keys[asic_id]:
+                for port in sorted(port_mux_tbl_keys[asic_id], key=lambda x: int(x.replace("Ethernet", ""))):
                     create_table_dump_per_port_config(print_data, per_npu_configdb, asic_id, port)
 
             headers = ['SWITCH_NAME', 'PEER_TOR']

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -23,11 +23,11 @@ import show.main as show
 tabular_data_status_output_expected = """\
 PORT        STATUS    HEALTH
 ----------  --------  --------
-Ethernet32  active    HEALTHY
 Ethernet0   active    HEALTHY
 Ethernet4   standby   HEALTHY
 Ethernet8   standby   HEALTHY
 Ethernet12  unknown   HEALTHY
+Ethernet32  active    HEALTHY
 """
 
 json_data_status_output_expected = """\

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -33,10 +33,6 @@ Ethernet12  unknown   HEALTHY
 json_data_status_output_expected = """\
 {
     "MUX_CABLE": {
-        "Ethernet32": {
-            "STATUS": "active",
-            "HEALTH": "HEALTHY"
-        },
         "Ethernet0": {
             "STATUS": "active",
             "HEALTH": "HEALTHY"
@@ -52,6 +48,10 @@ json_data_status_output_expected = """\
         "Ethernet12": {
             "STATUS": "unknown",
             "HEALTH": "HEALTHY"
+        },
+        "Ethernet32": {
+            "STATUS": "active",
+            "HEALTH": "HEALTHY"
         }
     }
 }
@@ -64,11 +64,11 @@ SWITCH_NAME    PEER_TOR
 sonic-switch   10.2.2.2
 port        state    ipv4      ipv6
 ----------  -------  --------  --------
-Ethernet32  auto     10.1.1.1  fc00::75
 Ethernet0   active   10.2.1.1  e800::46
 Ethernet4   auto     10.3.1.1  e801::46
 Ethernet8   active   10.4.1.1  e802::46
 Ethernet12  active   10.4.1.1  e802::46
+Ethernet32  auto     10.1.1.1  fc00::75
 """
 
 json_data_status_config_output_expected = """\
@@ -76,13 +76,6 @@ json_data_status_config_output_expected = """\
     "MUX_CABLE": {
         "PEER_TOR": "10.2.2.2",
         "PORTS": {
-            "Ethernet32": {
-                "STATE": "auto",
-                "SERVER": {
-                    "IPv4": "10.1.1.1",
-                    "IPv6": "fc00::75"
-                }
-            },
             "Ethernet0": {
                 "STATE": "active",
                 "SERVER": {
@@ -109,6 +102,13 @@ json_data_status_config_output_expected = """\
                 "SERVER": {
                     "IPv4": "10.4.1.1",
                     "IPv6": "e802::46"
+                }
+            },
+            "Ethernet32": {
+                "STATE": "auto",
+                "SERVER": {
+                    "IPv4": "10.1.1.1",
+                    "IPv6": "fc00::75"
                 }
             }
         }


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Sort the output of `show mux status` and `show mux config` for easier comparison between devices
**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

