### PR TITLE
[VLAN] Do not allow to delete a VLAN with members

### DIFF
--- a/config/vlan.py
+++ b/config/vlan.py
@@ -53,8 +53,10 @@ def del_vlan(db, vid):
             ctx.fail("{} can not be removed. First remove IP addresses assigned to this VLAN".format(vlan))
 
     keys = [ (k, v) for k, v in db.cfgdb.get_table('VLAN_MEMBER') if k == 'Vlan{}'.format(vid) ]
-    for k in keys:
-        db.cfgdb.set_entry('VLAN_MEMBER', k, None)
+    
+    if keys:
+        ctx.fail("VLAN ID {} can not be removed. First remove all members assigned to this VLAN.".format(vid))
+        
     db.cfgdb.set_entry('VLAN', 'Vlan{}'.format(vid), None)
 
 def restart_ndppd():

--- a/tests/vlan_test.py
+++ b/tests/vlan_test.py
@@ -337,6 +337,21 @@ class TestVlan(object):
         print(result.exit_code, result.output)
         assert result.exit_code != 0
 
+        # del vlan with IP
+        result = runner.invoke(config.config.commands["vlan"].commands["del"], ["1000"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Error: VLAN ID 1000 can not be removed. First remove all members assigned to this VLAN." in result.output
+
+        vlan_member = db.cfgdb.get_table('VLAN_MEMBER')
+        keys = [ (k, v) for k, v in vlan_member if k == 'Vlan{}'.format(1000) ]
+        for k,v in keys:    
+            result = runner.invoke(config.config.commands["vlan"].commands["member"].commands["del"], ["1000", v], obj=db)
+            print(result.exit_code)
+            print(result.output)
+            assert result.exit_code == 0
+
         result = runner.invoke(config.config.commands["vlan"].commands["del"], ["1000"], obj=db)
         print(result.exit_code)
         print(result.output)


### PR DESCRIPTION
Signed-off-by: allas <allas@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
In vlan.py , function del_vlan added validation if there is no members assigned to this VLAN. If there are members - the execution of this command is failed with error on the screen.

#### How I did it
Added validation of the VLAN_MEMBER_CFG_TABLE with the key VLAN_ID. If there are entries with this VLAN_ID - print error:
VLAN ID {} can not be removed. First remove all members assigned to this VLAN.
User should remove all members assigned to this VLAN, and after that he can delete vlan.
#### How to verify it
sudo config vlan add 200
sudo config vlan member add 200 Ethernet0
sudo config vlan del 200
In this case - you will see error as there are members assigned to this VLAN

sudo config vlan member del 200 Ethernet0
sudo config vlan del 200
Will pass.
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

