### PR TITLE
Fix deprecation warnings

### DIFF
--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -582,8 +582,7 @@ class ConfigMgmtDPB(ConfigMgmt):
                 for skey in skeys:
                     # pattern is very specific to current primary keys in
                     # config DB, may need to be updated later.
-                    pattern = '^' + skey + '\|' + '|' + skey + '$' + \
-                        '|' + '^' + skey + '$'
+                    pattern = r'^{0}\||{0}$|^{0}$'.format(skey)
                     reg = re.compile(pattern)
                     if reg.search(key):
                         # In primary key, only 1 match can be found, so return

--- a/config/main.py
+++ b/config/main.py
@@ -640,7 +640,7 @@ def _change_hostname(hostname):
     if current_hostname != hostname:
         clicommon.run_command('echo {} > /etc/hostname'.format(hostname), display_cmd=True)
         clicommon.run_command('hostname -F /etc/hostname', display_cmd=True)
-        clicommon.run_command('sed -i "/\s{}$/d" /etc/hosts'.format(current_hostname), display_cmd=True)
+        clicommon.run_command(r'sed -i "/\s{}$/d" /etc/hosts'.format(current_hostname), display_cmd=True)
         clicommon.run_command('echo "127.0.0.1 {}" >> /etc/hosts'.format(hostname), display_cmd=True)
 
 def _clear_qos():
@@ -1990,7 +1990,7 @@ def vrf_add_management_vrf(config_db):
         Iface   Destination     Gateway         Flags   RefCnt  Use     Metric  Mask            MTU     Window  IRTT
          eth0    00000000        01803B0A        0003    0       0       202     00000000        0       0       0
     """
-    cmd = "cat /proc/net/route | grep -E \"eth0\s+00000000\s+[0-9A-Z]+\s+[0-9]+\s+[0-9]+\s+[0-9]+\s+202\" | wc -l"
+    cmd = r"cat /proc/net/route | grep -E \"eth0\s+00000000\s+[0-9A-Z]+\s+[0-9]+\s+[0-9]+\s+[0-9]+\s+202\" | wc -l"
     proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
     output = proc.communicate()
     if int(output[0]) >= 1:

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -320,7 +320,7 @@ def filter_out_local_interfaces(keys):
     :return keys filtered out of local
     """
     rt = []
-    local_if_re = ['eth0', 'lo', 'docker0', 'tun0', 'Loopback\d+']
+    local_if_re = [r'eth0', r'lo', r'docker0', r'tun0', r'Loopback\d+']
 
     db = swsscommon.DBConnector(APPL_DB_NAME, 0)
     tbl = swsscommon.Table(db, 'ROUTE_TABLE')

--- a/tests/sku_create_test.py
+++ b/tests/sku_create_test.py
@@ -36,8 +36,8 @@ class TestSkuCreate(object):
 
         #Loop if either fname1 or fname2 has not reached EOF
         while f1_line!='' or f2_line!='':
-            f1_line = re.sub('[\s+]','',f1_line)
-            f2_line = re.sub('[\s+]','',f2_line)
+            f1_line = re.sub(r'[\s+]', '', f1_line)
+            f2_line = re.sub(r'[\s+]', '', f2_line)
 
             if f1_line!=f2_line:
                 f1.close()


### PR DESCRIPTION
#### What I did

Fix Python deprecation warnings as reported by pytest

#### How I did it

Convert strings which include escape sequences into raw strings

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

