### PR TITLE
Added CLI reference for buffer-pool watermark|persistent-watermark commands

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -110,6 +110,7 @@
   * [QoS Show commands](#qos-show-commands)
     * [PFC](#pfc)
     * [Queue And Priority-Group](#queue-and-priority-group)
+    * [Buffer Pool](#buffer-pool)
   * [QoS config commands](#qos-config-commands)
 * [sFlow](#sflow)
   * [sFlow Show commands](#sflow-show-commands)
@@ -340,6 +341,7 @@ This command displays the full list of show commands available in the software; 
     aaa                   Show AAA configuration
     acl                   Show ACL related information
     arp                   Show IP ARP table
+    buffer_pool           Show details of the Buffer-pools
     clock                 Show date and time
     ecn                   Show ECN configuration
     environment           Show environmentals (voltages, fans, temps)
@@ -6168,6 +6170,52 @@ This command displays the user persistet-watermark for the queues (Egress shared
 
   admin@sonic:~$ sonic-clear priority-group persistent-watermark headroom
   ```
+
+#### Buffer Pool
+
+This sub-section explains the following buffer-pool parameters that can be displayed using "show buffer_pool" command.
+1) buffer_pool watermark
+2) buffer_pool persistent-watermark
+
+**show buffer_pool watermark**
+
+This command displays the user watermark for all the buffer_pools(Total Buffer pool maximum occupancy per pool)
+
+- Usage:
+  ```
+  show buffer_pool watermark
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ show buffer_pool watermark
+  Shared pool maximum occupancy:
+                   Pool    Bytes
+  ---------------------  -------
+  ingress_lossless_pool        0
+             lossy_pool     2464
+  ```
+
+
+**show buffer_pool persistent-watermark**
+
+This command displays the user persistet-watermark for all the buffer_pools(Total Buffer pool maximum occupancy per pool)
+
+- Usage:
+  ```
+  show buffer_pool persistent-watermark
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ show buffer_pool persistent-watermark
+  Shared pool maximum occupancy:
+                   Pool    Bytes
+  ---------------------  -------
+  ingress_lossless_pool        0
+             lossy_pool     2464
+  ```
+
 
 
 ### QoS config commands

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -6173,13 +6173,13 @@ This command displays the user persistet-watermark for the queues (Egress shared
 
 #### Buffer Pool
 
-This sub-section explains the following buffer-pool parameters that can be displayed using "show buffer_pool" command.
-1) buffer_pool watermark
-2) buffer_pool persistent-watermark
+This sub-section explains the following buffer pool parameters that can be displayed using "show buffer_pool" command.
+1) buffer pool watermark
+2) buffer pool persistent-watermark
 
 **show buffer_pool watermark**
 
-This command displays the user watermark for all the buffer_pools(Total Buffer pool maximum occupancy per pool)
+This command displays the user watermark for all the buffer pools
 
 - Usage:
   ```
@@ -6199,7 +6199,7 @@ This command displays the user watermark for all the buffer_pools(Total Buffer p
 
 **show buffer_pool persistent-watermark**
 
-This command displays the user persistet-watermark for all the buffer_pools(Total Buffer pool maximum occupancy per pool)
+This command displays the user persistent-watermark for all the buffer pools
 
 - Usage:
   ```


### PR DESCRIPTION
Fix #1424
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added CLI reference for buffer-pool watermark|persistent-watermark commands
#### How I did it
Updated the Command-Reference.md file for following:
1. Added buffer_pool in "show" help
2. show description for buffer_pool watermark
3. show descritpion buffer_pool persistent-watermark
#### How to verify it
NA
#### Previous command output (if the output of a command-line utility has changed)
NA
#### New command output (if the output of a command-line utility has changed)
NA
