### PR TITLE
[ci]: download from sonic-buildimage.vs artifact

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ steps:
     source: specific
     project: build
     pipeline: 1
-    artifact: sonic-buildimage.kvm
+    artifact: sonic-buildimage.vs
     runVersion: 'latestFromBranch'
     runBranch: 'refs/heads/master'
   displayName: "Download artifacts from latest sonic-buildimage build"


### PR DESCRIPTION
https://github.com/Azure/sonic-buildimage/pull/6768/ change
the kvm artifact name from kvm to vs

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
https://github.com/Azure/sonic-buildimage/pull/6768/ change
the kvm artifact name from kvm to vs

#### How I did it
download from sonic-buildimage.vs artifact

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

