### PR TITLE
[config] Prevent deleting VLAN with IP addresses.

### DIFF
--- a/config/vlan.py
+++ b/config/vlan.py
@@ -48,10 +48,9 @@ def del_vlan(db, vid):
 
     intf_table = db.cfgdb.get_table('VLAN_INTERFACE')
     for intf_key in intf_table:
-        if type(intf_key) is str and intf_key == 'Vlan{}'.format(vid):
-            db.cfgdb.set_entry('VLAN_INTERFACE', intf_key, None)
-        if type(intf_key) is tuple and intf_key[0] == 'Vlan{}'.format(vid):
-            db.cfgdb.set_entry('VLAN_INTERFACE', intf_key, None)
+        if ((type(intf_key) is str and intf_key == 'Vlan{}'.format(vid)) or
+            (type(intf_key) is tuple and intf_key[0] == 'Vlan{}'.format(vid))):
+            ctx.fail("{} can not be removed. First remove IP addresses assigned to this VLAN".format(vlan))
 
     keys = [ (k, v) for k, v in db.cfgdb.get_table('VLAN_MEMBER') if k == 'Vlan{}'.format(vid) ]
     for k in keys:

--- a/config/vlan.py
+++ b/config/vlan.py
@@ -46,6 +46,13 @@ def del_vlan(db, vid):
     if clicommon.check_if_vlanid_exist(db.cfgdb, vlan) == False:
         ctx.fail("{} does not exist".format(vlan))
 
+    intf_table = db.cfgdb.get_table('VLAN_INTERFACE')
+    for intf_key in intf_table:
+        if type(intf_key) is str and intf_key == 'Vlan{}'.format(vid):
+            db.cfgdb.set_entry('VLAN_INTERFACE', intf_key, None)
+        if type(intf_key) is tuple and intf_key[0] == 'Vlan{}'.format(vid):
+            db.cfgdb.set_entry('VLAN_INTERFACE', intf_key, None)
+
     keys = [ (k, v) for k, v in db.cfgdb.get_table('VLAN_MEMBER') if k == 'Vlan{}'.format(vid) ]
     for k in keys:
         db.cfgdb.set_entry('VLAN_MEMBER', k, None)

--- a/tests/vlan_test.py
+++ b/tests/vlan_test.py
@@ -330,8 +330,16 @@ class TestVlan(object):
         runner = CliRunner()
         db = Db()
 
-        runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Vlan1000", "192.168.0.1/21"], obj=db)
-        runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Vlan1000", "fc02:1000::1/64"], obj=db)
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Vlan1000", "192.168.0.1/21"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Vlan1000", "fc02:1000::1/64"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+
         result = runner.invoke(config.config.commands["vlan"].commands["del"], ["1000"], obj=db)
         print(result.exit_code)
         print(result.output)

--- a/tests/vlan_test.py
+++ b/tests/vlan_test.py
@@ -330,8 +330,8 @@ class TestVlan(object):
         runner = CliRunner()
         db = Db()
 
-        runner.invoke(config.config.commands["interface"].commands["ip"].commands["del"], ["Vlan1000", "192.168.0.1/21"], obj=db)
-        runner.invoke(config.config.commands["interface"].commands["ip"].commands["del"], ["Vlan1000", "fc02:1000::1/64"], obj=db)
+        runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Vlan1000", "192.168.0.1/21"], obj=db)
+        runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Vlan1000", "fc02:1000::1/64"], obj=db)
         result = runner.invoke(config.config.commands["vlan"].commands["del"], ["1000"], obj=db)
         print(result.exit_code)
         print(result.output)

--- a/tests/vlan_test.py
+++ b/tests/vlan_test.py
@@ -316,10 +316,22 @@ class TestVlan(object):
         assert result.exit_code != 0
         assert "Error: PortChannel0001 is a router interface!" in result.output
 
+    def test_config_vlan_del_vlan_with_ip(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["vlan"].commands["del"], ["1000"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Error: Vlan1000 can not be removed. First remove IP addresses assigned to this VLAN" in result.output
+
     def test_config_vlan_del_vlan(self):
         runner = CliRunner()
         db = Db()
 
+        runner.invoke(config.config.commands["interface"].commands["ip"].commands["del"], ["Vlan1000", "192.168.0.1/21"], obj=db)
+        runner.invoke(config.config.commands["interface"].commands["ip"].commands["del"], ["Vlan1000", "fc02:1000::1/64"], obj=db)
         result = runner.invoke(config.config.commands["vlan"].commands["del"], ["1000"], obj=db)
         print(result.exit_code)
         print(result.output)

--- a/tests/vlan_test.py
+++ b/tests/vlan_test.py
@@ -337,9 +337,6 @@ class TestVlan(object):
         print(result.exit_code, result.output)
         assert result.exit_code != 0
 
-        vlan_member = db.cfgdb.get_table('VLAN_INTERFACE')
-        print(vlan_member)
-
         result = runner.invoke(config.config.commands["vlan"].commands["del"], ["1000"], obj=db)
         print(result.exit_code)
         print(result.output)

--- a/tests/vlan_test.py
+++ b/tests/vlan_test.py
@@ -316,29 +316,29 @@ class TestVlan(object):
         assert result.exit_code != 0
         assert "Error: PortChannel0001 is a router interface!" in result.output
 
-    def test_config_vlan_del_vlan_with_ip(self):
+    def test_config_vlan_del_vlan(self):
         runner = CliRunner()
         db = Db()
+        obj = {'config_db':db.cfgdb}
 
+        # del vlan with IP
         result = runner.invoke(config.config.commands["vlan"].commands["del"], ["1000"], obj=db)
         print(result.exit_code)
         print(result.output)
         assert result.exit_code != 0
         assert "Error: Vlan1000 can not be removed. First remove IP addresses assigned to this VLAN" in result.output
 
-    def test_config_vlan_del_vlan(self):
-        runner = CliRunner()
-        db = Db()
+        # remove vlan IP`s
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Vlan1000", "192.168.0.1/21"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code != 0
 
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Vlan1000", "192.168.0.1/21"], obj=db)
-        print(result.exit_code)
-        print(result.output)
-        assert result.exit_code == 0
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Vlan1000", "fc02:1000::1/64"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code != 0
 
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["remove"], ["Vlan1000", "fc02:1000::1/64"], obj=db)
-        print(result.exit_code)
-        print(result.output)
-        assert result.exit_code == 0
+        vlan_member = db.cfgdb.get_table('VLAN_INTERFACE')
+        print(vlan_member)
 
         result = runner.invoke(config.config.commands["vlan"].commands["del"], ["1000"], obj=db)
         print(result.exit_code)


### PR DESCRIPTION
#### What I did
Prevent deleting VLAN if it has IP addresses.
fixes: https://github.com/Azure/sonic-buildimage/issues/6769
Currently, if an IP was added to the vlan, it creates entries in the VLAN_INTERFACE table and increments the reference counter for the vlan:
```
VLAN_INTERFACE|Vlan22|100.0.0.20/24
VLAN_INTERFACE|Vlan22
```
But after deleting the vlan, they get stuck in the table and throw an error:
```
sonic ERR swss#orchagent: :- removeVlan: Failed to remove ref count 1 VLAN Vlan22
```
Therefore, to prevent this error, make sure that the entries do not exist before deleting the VLAN.

#### How I did it
Added check of the VLAN INTERFACE table and if there are records, the delete operation is not available and an error is displayed.

#### How to verify it
1. config vlan add 22
2. config int ip add Vlan22 10.0.0.51/24
3. config vlan del 22
```
Error: Vlan22 can not be removed. First remove IP addresses assigned to this VLAN
```

Signed-off-by: d-dashkov <Dmytro_Dashkov@Jabil.com>
