### PR TITLE
[storyteller] sort output by time and improve lag support

### DIFF
--- a/scripts/storyteller
+++ b/scripts/storyteller
@@ -17,7 +17,7 @@ regex_dict = {
                 'bgp'       : 'bgpcfgd',
                 'crash'     : r'what\|unexpected exception\|notify_OA_about_syncd_exception\|SIG\|not expected',
                 'interface' : r'updatePortOperStatus\|Configure .* to',
-                'lag'       : r'link becomes\|addLag',
+                'lag'       : r'link becomes\|addLag\|PortChannel.*oper state',
                 'reboot'    : r'BOOT\|rc.local\|old_config\|minigraph.xml\|Rebooting\|reboot\|executeOperationsOnAsic\|getAsicView\|dumpVidToAsicOperatioId\|neighbor_adv\|Pausing\|shutdown\|warm',
                 'service'   : r'Starting\|Stopping\|Started\|Stopped',
              }
@@ -46,7 +46,7 @@ def build_options(after=0, before=0, context=0):
 
 def find_log(logpath, log, regex, after=0, before=0, context=0):
     options = build_options(after, before, context)
-    cmd = 'find -L {}/{}* -newer {} | xargs zgrep -a {} "{}"'.format(logpath, log, reference_file, options, regex)
+    cmd = 'find -L {}/{}* -newer {} | xargs ls -rt | xargs zgrep -a {} "{}"'.format(logpath, log, reference_file, options, regex)
     _, out, _ = exec_cmd(cmd)
     '''
         Opportunity to improve:

--- a/scripts/storyteller
+++ b/scripts/storyteller
@@ -44,9 +44,13 @@ def build_options(after=0, before=0, context=0):
     return ' '.join(x for x in options)
 
 
-def find_log(logpath, log, regex, after=0, before=0, context=0):
+def find_log(logpath, log, regex, after=0, before=0, context=0, field=0):
     options = build_options(after, before, context)
-    cmd = 'find -L {}/{}* -newer {} | xargs ls -rt | xargs zgrep -a {} "{}"'.format(logpath, log, reference_file, options, regex)
+    if field <= 0:
+        cmd = 'find -L {}/{}* -newer {} | xargs ls -rt | xargs zgrep -a {} "{}"'.format(logpath, log, reference_file, options, regex)
+    else:
+        cmd = 'find -L {0}/{1}* -newer {2} | sort -rn -t . -k {3},{3} | xargs zgrep -a {4} "{5}"'.format(logpath, log, reference_file, field, options, regex)
+
     _, out, _ = exec_cmd(cmd)
     '''
         Opportunity to improve:
@@ -92,8 +96,10 @@ def main():
                         type=int, required=False, default=0)
     parser.add_argument('-C', '--context', help='Show N lines before and after match',
                         type=int, required=False, default=0)
-    parser.add_argument('-S', '--since', help='Filter logs since the given date',
+    parser.add_argument('-s', '--since', help='Filter logs since the given date',
                         type=str, required=False, default="@0")
+    parser.add_argument('-f', '--sortfield', help='Use Nth field separted by "." in file name to sort. e.g. syslog.1.gz: -f 2, swss.rec.2.gz: -f 3, default 0: sort by timestamp',
+                        type=int, required=False, default=0)
 
     args = parser.parse_args()
 
@@ -106,7 +112,7 @@ def main():
     reg = build_regex(category)
     configure_time_filter(since)
 
-    find_log(log_path, log, reg, args.after, args.before, args.context)
+    find_log(log_path, log, reg, args.after, args.before, args.context, args.sortfield)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### What I did
- sort output by time
- improve lag support according to event format changes
- add an option to sort the log files by a field of file name (after log files got moved or copied, sorting by timestamp is no longer reliable).

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How to verify it
run 'sudo storyteller --since "2021-2-10" -c lag' on a dut