### PR TITLE
[consutil] Look for udevprefix.conf file under platform dir, not plugins

### DIFF
--- a/consutil/lib.py
+++ b/consutil/lib.py
@@ -4,16 +4,14 @@
 # Helper code for CLI for interacting with switches via console device
 #
 
-try:
-    import click
-    import re
-    import subprocess
-    import pexpect
-    import sys
-    import os
-    from sonic_py_common import device_info
-except ImportError as e:
-    raise ImportError("%s - required module not found" % str(e))
+import os
+import pexpect
+import re
+import subprocess
+import sys
+
+import click
+from sonic_py_common import device_info
 
 ERR_DISABLE = 1
 ERR_CMD = 2
@@ -46,7 +44,7 @@ IDLE_FLAG = "idle"
 PICOCOM_READY = "Terminal ready"
 PICOCOM_BUSY = "Resource temporarily unavailable"
 
-FILENAME = "udevprefix.conf"
+UDEV_PREFIX_CONF_FILENAME = "udevprefix.conf"
 
 TIMEOUT_SEC = 0.2
 
@@ -266,10 +264,10 @@ class SysInfoProvider(object):
     @staticmethod
     def init_device_prefix():
         platform_path, _ = device_info.get_paths_to_platform_and_hwsku_dirs()
-        PLUGIN_PATH = "/".join([platform_path, "plugins", FILENAME])
+        UDEV_PREFIX_CONF_FILE_PATH = os.path.join(platform_path, UDEV_PREFIX_CONF_FILENAME)
 
-        if os.path.exists(PLUGIN_PATH):
-            fp = open(PLUGIN_PATH, 'r')
+        if os.path.exists(UDEV_PREFIX_CONF_FILE_PATH):
+            fp = open(UDEV_PREFIX_CONF_FILE_PATH, 'r')
             lines = fp.readlines()
             SysInfoProvider.DEVICE_PREFIX = "/dev/" + lines[0].rstrip()
 


### PR DESCRIPTION
#### What I did

Config files do not belong under `<platform>/plugins/` directory. That directory is intended for (now-deprecated) platform-related Python plugins. The directory will be removed in the near future.

#### How I did it

Look for udevprefix.conf file directly under the respective platform directory instead.
Also clean up and reorganize imports

NOTE: When this submodule is updated in sonic-buildimage, related files will need to be updated. Currently only platform/broadcom/sonic-platform-modules-cel/haliburton/script/udev_prefix.sh
