### PR TITLE
[201911] show ip int changes

### DIFF
--- a/scripts/ipintutil
+++ b/scripts/ipintutil
@@ -1,0 +1,273 @@
+#!/usr/bin/env python
+
+import os
+import subprocess
+import sys
+
+import netaddr
+import netifaces
+from natsort import natsorted
+from tabulate import tabulate
+
+from sonic_py_common import multi_asic
+from swsssdk import ConfigDBConnector, SonicDBConfig
+from utilities_common import constants
+from utilities_common import multi_asic as multi_asic_util
+
+
+try:
+    if os.environ["UTILITIES_UNIT_TESTING"] == "2":
+
+        modules_path = os.path.join(os.path.dirname(__file__), "..")
+        tests_path = os.path.join(modules_path, "tests")
+        sys.path.insert(0, modules_path)
+        sys.path.insert(0, tests_path)
+        import mock_tables.dbconnector
+        if os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] == "multi_asic":
+            import mock_tables.mock_multi_asic
+            mock_tables.dbconnector.load_namespace_config()
+        else:
+            import mock_tables.mock_single_asic
+except KeyError:
+    pass
+
+
+def get_bgp_peer(namespace=None):
+    """
+    collects local and bgp neighbor ip along with device name in below format
+    {
+        'local_addr1':['neighbor_device1_name', 'neighbor_device1_ip'],
+        'local_addr2':['neighbor_device2_name', 'neighbor_device2_ip']
+    }
+    """
+    tables = ['BGP_NEIGHBOR', 'BGP_INTERNAL_NEIGHBOR']
+    bgp_peer = {}
+    config_db = ConfigDBConnector(namespace=namespace)
+    config_db.connect()
+    for table in tables:
+        data = config_db.get_table(table)
+
+        for neighbor_ip in data.keys():
+            local_addr = data[neighbor_ip]['local_addr']
+            neighbor_name = data[neighbor_ip]['name']
+            bgp_peer.setdefault(local_addr, [neighbor_name, neighbor_ip])
+    return bgp_peer
+
+
+def skip_ip_intf_display(interface, display_option):
+    if display_option != constants.DISPLAY_ALL:
+        if interface.startswith('Ethernet') and multi_asic.is_port_internal(interface):
+            return True
+        elif interface.startswith('PortChannel') and multi_asic.is_port_channel_internal(interface):
+            return True
+        elif interface.startswith('Loopback4096'):
+            return True
+        elif interface.startswith('eth0'):
+            return True
+        elif interface.startswith('veth'):
+            return True
+    return False
+
+
+def get_if_admin_state(iface, namespace):
+    """
+    Given an interface name, return its admin state reported by the kernel
+    """
+    cmd = "cat /sys/class/net/{0}/flags".format(iface)
+    if namespace != constants.DEFAULT_NAMESPACE:
+        cmd = "sudo ip netns exec {} {}".format(namespace, cmd)
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            shell=True,
+            stderr=subprocess.STDOUT,
+            stdout=subprocess.PIPE)
+        state_file = proc.communicate()[0]
+        proc.wait()
+
+    except OSError:
+        print("Error: unable to get admin state for {}".format(iface))
+        return "error"
+
+    try:
+        content = state_file.rstrip()
+        flags = int(content, 16)
+    except ValueError:
+        return "error"
+
+    if flags & 0x1:
+        return "up"
+    else:
+        return "down"
+
+
+def get_if_oper_state(iface, namespace):
+    """
+    Given an interface name, return its oper state reported by the kernel.
+    """
+    cmd = "cat /sys/class/net/{0}/carrier".format(iface)
+    if namespace != constants.DEFAULT_NAMESPACE:
+        cmd = "sudo ip netns exec {} {}".format(namespace, cmd)
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            shell=True,
+            stderr=subprocess.STDOUT,
+            stdout=subprocess.PIPE)
+        state_file = proc.communicate()[0]
+        proc.wait()
+
+    except OSError:
+        print("Error: unable to get oper state for {}".format(iface))
+        return "error"
+
+    oper_state = state_file.rstrip()
+    if oper_state == "1":
+        return "up"
+    else:
+        return "down"
+
+
+def get_if_master(iface):
+    """
+    Given an interface name, return its master reported by the kernel.
+    """
+    oper_file = "/sys/class/net/{0}/master"
+    if os.path.exists(oper_file.format(iface)):
+        real_path = os.path.realpath(oper_file.format(iface))
+        return os.path.basename(real_path)
+    else:
+        return ""
+
+
+def get_ip_intfs_in_namespace(af, namespace, display):
+    """
+    Get all the ip intefaces from the kernel for the given namespace
+    """
+    ip_intfs = {}
+    interfaces = multi_asic_util.multi_asic_get_ip_intf_from_ns(namespace)
+    bgp_peer = get_bgp_peer(namespace)
+    for iface in interfaces:
+        ip_intf_attr = []
+        if namespace != constants.DEFAULT_NAMESPACE and skip_ip_intf_display(iface, display):
+            continue
+        ipaddresses = multi_asic_util.multi_asic_get_ip_intf_addr_from_ns(namespace, iface)
+        if af in ipaddresses:
+            ifaddresses = []
+            bgp_neighs = {}
+            ip_intf_attr = []
+            for ipaddr in ipaddresses[af]:
+                neighbor_name = 'N/A'
+                neighbor_ip = 'N/A'
+                local_ip = str(ipaddr['addr'])
+                if af == netifaces.AF_INET:
+                    netmask = netaddr.IPAddress(ipaddr['netmask']).netmask_bits()
+                else:
+                    netmask = ipaddr['netmask'].split('/', 1)[-1]
+                local_ip_with_mask = "{}/{}".format(local_ip, str(netmask))
+                ifaddresses.append(["", local_ip_with_mask])
+                try:
+                    neighbor_name = bgp_peer[local_ip][0]
+                    neighbor_ip = bgp_peer[local_ip][1]
+                except KeyError:
+                    pass
+
+                bgp_neighs.update({local_ip_with_mask: [neighbor_name, neighbor_ip]})
+
+            if len(ifaddresses) > 0:
+                admin = get_if_admin_state(iface, namespace)
+                oper = get_if_oper_state(iface, namespace)
+                master = get_if_master(iface)
+
+            ip_intf_attr = {
+                "vrf": master,
+                "ipaddr": natsorted(ifaddresses),
+                "admin": admin,
+                "oper": oper,
+                "bgp_neighs": bgp_neighs,
+                "ns": namespace
+            }
+
+            ip_intfs[iface] = ip_intf_attr
+    return ip_intfs
+
+
+def display_ip_intfs(ip_intfs):
+    header = ['Interface', 'Master', 'IPv4 address/mask',
+              'Admin/Oper', 'BGP Neighbor', 'Neighbor IP']
+    data = []
+    for ip_intf, v in natsorted(ip_intfs.items()):
+        ip_address = v['ipaddr'][0][1]
+        neighbour_name = v['bgp_neighs'][ip_address][0]
+        neighbour_ip = v['bgp_neighs'][ip_address][1]
+        data.append([ip_intf, v['vrf'], v['ipaddr'][0][1], v['admin'] + "/" + v['oper'],  neighbour_name,  neighbour_ip])
+        for ifaddr in v['ipaddr'][1:]:
+            neighbour_name = v['bgp_neighs'][ifaddr[1]][0]
+            neighbour_ip = v['bgp_neighs'][ifaddr[1]][1]
+            data.append(["", "", ifaddr[1], "", neighbour_name, neighbour_ip])
+    print(tabulate(data, header, tablefmt="simple", stralign='left', missingval=""))
+
+
+def get_ip_intfs(af, namespace, display):
+    '''
+    Get all the ip interface present on the device.
+    This include ip interfaces on the host as well as ip
+    interfaces in each network namespace
+    '''
+    device = multi_asic_util.MultiAsic(namespace_option=namespace,
+                                       display_option=display)
+    namespace_list = device.get_ns_list_based_on_options()
+
+    # for single asic devices there is one namespace DEFAULT_NAMESPACE
+    # for multi asic devices, there is one network namespace
+    # for each asic and one on the host
+    if device.is_multi_asic:
+        namespace_list.append(constants.DEFAULT_NAMESPACE)
+
+    ip_intfs = {}
+    for namespace in namespace_list:
+        ip_intfs_in_ns = get_ip_intfs_in_namespace(af, namespace, display)
+        # multi asic device can have same ip interface in different namespace
+        # so remove the duplicates
+        if device.is_multi_asic:
+            for ip_intf, v in ip_intfs_in_ns.items():
+                if ip_intf in ip_intfs:
+                    if v['ipaddr'] != ip_intfs[ip_intf]['ipaddr']:
+                        ip_intfs[ip_intf]['ipaddr'] += (v['ipaddr'])
+                        ip_intfs[ip_intf]['bgp_neighs'].update(v['bgp_neighs'])
+                    continue
+                else:
+                    ip_intfs[ip_intf] = v
+        else:
+            ip_intfs.update(ip_intfs_in_ns)
+    return ip_intfs
+
+
+def main():
+    # This script gets the ip interfaces from different linux
+    # network namespaces. This can be only done from root user.
+    if os.geteuid() != 0 and os.environ.get("UTILITIES_UNIT_TESTING", "0") != "2":
+        sys.exit("Root privileges required for this operation")
+    
+    parser = multi_asic_util.multi_asic_args()
+    parser.add_argument('-a', '--address_family', type=str, help='ipv4 or ipv6 interfaces', default="ipv4")
+    args = parser.parse_args()
+    namespace = args.namespace
+    display = args.display
+
+    if args.address_family == "ipv4":
+        af = netifaces.AF_INET
+    elif args.address_family == "ipv6":
+        af = netifaces.AF_INET6
+    else:
+        sys.exit("Invalid argument -a {}".format(args.address_family))
+
+    SonicDBConfig.load_sonic_global_db_config()
+    ip_intfs = get_ip_intfs(af, namespace, display)
+    display_ip_intfs(ip_intfs)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ipintutil
+++ b/scripts/ipintutil
@@ -19,7 +19,7 @@ try:
     if os.environ["UTILITIES_UNIT_TESTING"] == "2":
 
         modules_path = os.path.join(os.path.dirname(__file__), "..")
-        tests_path = os.path.join(modules_path, "tests")
+        tests_path = os.path.join(modules_path, "sonic-utilities-tests")
         sys.path.insert(0, modules_path)
         sys.path.insert(0, tests_path)
         import mock_tables.dbconnector

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ setup(
         'scripts/generate_dump',
         'scripts/intfutil',
         'scripts/intfstat',
+        'scripts/ipintutil',
         'scripts/lldpshow',
         'scripts/mellanox_buffer_migrator.py',
         'scripts/mmuconfig',

--- a/show/main.py
+++ b/show/main.py
@@ -1198,65 +1198,6 @@ def ip():
 
 
 #
-# get_if_admin_state
-#
-# Given an interface name, return its admin state reported by the kernel.
-#
-def get_if_admin_state(iface):
-    admin_file = "/sys/class/net/{0}/flags"
-
-    try:
-        state_file = open(admin_file.format(iface), "r")
-    except IOError as e:
-        print "Error: unable to open file: %s" % str(e)
-        return "error"
-
-    content = state_file.readline().rstrip()
-    flags = int(content, 16)
-
-    if flags & 0x1:
-        return "up"
-    else:
-        return "down"
-
-
-#
-# get_if_oper_state
-#
-# Given an interface name, return its oper state reported by the kernel.
-#
-def get_if_oper_state(iface):
-    oper_file = "/sys/class/net/{0}/carrier"
-
-    try:
-        state_file = open(oper_file.format(iface), "r")
-    except IOError as e:
-        print "Error: unable to open file: %s" % str(e)
-        return "error"
-
-    oper_state = state_file.readline().rstrip()
-    if oper_state == "1":
-        return "up"
-    else:
-        return "down"
-
-
-#
-# get_if_master
-#
-# Given an interface name, return its master reported by the kernel.
-#
-def get_if_master(iface):
-    oper_file = "/sys/class/net/{0}/master"
-
-    if os.path.exists(oper_file.format(iface)):
-        real_path = os.path.realpath(oper_file.format(iface))
-        return os.path.basename(real_path)
-    else:
-        return ""
-
-
-#
 # 'show ip interfaces' command
 #
 # Display all interfaces with master, an IPv4 address, admin/oper states, their BGP neighbor name and peer ip.
@@ -1264,71 +1205,14 @@ def get_if_master(iface):
 # excluded.
 #
 @ip.command()
-def interfaces():
-    """Show interfaces IPv4 address"""
-    header = ['Interface', 'Master', 'IPv4 address/mask', 'Admin/Oper', 'BGP Neighbor', 'Neighbor IP']
-    data = []
-    bgp_peer = get_bgp_peer()
+@multi_asic_util.multi_asic_click_options
+def interfaces(namespace, display):
+    cmd = "sudo ipintutil -a ipv4"
+    if namespace is not None:
+        cmd += " -n {}".format(namespace)
 
-    interfaces = natsorted(netifaces.interfaces())
-
-    for iface in interfaces:
-        ipaddresses = netifaces.ifaddresses(iface)
-
-        if netifaces.AF_INET in ipaddresses:
-            ifaddresses = []
-            for ipaddr in ipaddresses[netifaces.AF_INET]:
-                neighbor_name = 'N/A'
-                neighbor_ip = 'N/A'
-                local_ip = str(ipaddr['addr'])
-                netmask = netaddr.IPAddress(ipaddr['netmask']).netmask_bits()
-                ifaddresses.append(["", local_ip + "/" + str(netmask)])
-                try:
-                    neighbor_name = bgp_peer[local_ip][0]
-                    neighbor_ip = bgp_peer[local_ip][1]
-                except:
-                    pass
-
-            if len(ifaddresses) > 0:
-                admin = get_if_admin_state(iface)
-                if admin == "up":
-                    oper = get_if_oper_state(iface)
-                else:
-                    oper = "down"
-                master = get_if_master(iface)
-                if get_interface_mode() == "alias":
-                    iface = iface_alias_converter.name_to_alias(iface)
-
-                data.append([iface, master, ifaddresses[0][1], admin + "/" + oper, neighbor_name, neighbor_ip])
-
-            for ifaddr in ifaddresses[1:]:
-                data.append(["", "", ifaddr[1], ""])
-
-    print tabulate(data, header, tablefmt="simple", stralign='left', missingval="")
-
-# get bgp peering info
-def get_bgp_peer():
-    """
-    collects local and bgp neighbor ip along with device name in below format
-    {
-     'local_addr1':['neighbor_device1_name', 'neighbor_device1_ip'],
-     'local_addr2':['neighbor_device2_name', 'neighbor_device2_ip']
-     }
-    """
-    config_db = ConfigDBConnector()
-    config_db.connect()
-    bgp_peer = {}
-    bgp_neighbor_tables = ['BGP_NEIGHBOR', 'BGP_INTERNAL_NEIGHBOR']
-
-    for table in bgp_neighbor_tables:
-        data = config_db.get_table(table)
-        for neighbor_ip in data.keys():
-            local_addr = data[neighbor_ip]['local_addr']
-            neighbor_name = data[neighbor_ip]['name']
-            bgp_peer.setdefault(local_addr, [neighbor_name, neighbor_ip])
-
-    return bgp_peer
-
+    cmd += " -d {}".format(display)
+    run_command(cmd)
 #
 # 'route' subcommand ("show ip route")
 #
@@ -1403,45 +1287,16 @@ def prefix_list(prefix_list_name, verbose):
 # excluded.
 #
 @ipv6.command()
-def interfaces():
-    """Show interfaces IPv6 address"""
-    header = ['Interface', 'Master', 'IPv6 address/mask', 'Admin/Oper', 'BGP Neighbor', 'Neighbor IP']
-    data = []
-    bgp_peer = get_bgp_peer()
+@multi_asic_util.multi_asic_click_options
+def interfaces(namespace, display):
+    cmd = "sudo ipintutil -a ipv6"
 
-    interfaces = natsorted(netifaces.interfaces())
+    if namespace is not None:
+        cmd += " -n {}".format(namespace)
 
-    for iface in interfaces:
-        ipaddresses = netifaces.ifaddresses(iface)
+    cmd += " -d {}".format(display)
 
-        if netifaces.AF_INET6 in ipaddresses:
-            ifaddresses = []
-            for ipaddr in ipaddresses[netifaces.AF_INET6]:
-                neighbor_name = 'N/A'
-                neighbor_ip = 'N/A'
-                local_ip = str(ipaddr['addr'])
-                netmask = ipaddr['netmask'].split('/', 1)[-1]
-                ifaddresses.append(["", local_ip + "/" + str(netmask)])
-                try:
-                    neighbor_name = bgp_peer[local_ip][0]
-                    neighbor_ip = bgp_peer[local_ip][1]
-                except:
-                    pass
-
-            if len(ifaddresses) > 0:
-                admin = get_if_admin_state(iface)
-                if admin == "up":
-                    oper = get_if_oper_state(iface)
-                else:
-                    oper = "down"
-                master = get_if_master(iface)
-                if get_interface_mode() == "alias":
-                    iface = iface_alias_converter.name_to_alias(iface)
-                data.append([iface, master, ifaddresses[0][1], admin + "/" + oper, neighbor_name, neighbor_ip])
-            for ifaddr in ifaddresses[1:]:
-                data.append(["", "", ifaddr[1], ""])
-
-    print tabulate(data, header, tablefmt="simple", stralign='left', missingval="")
+    run_command(cmd)
 
 
 #

--- a/show/main.py
+++ b/show/main.py
@@ -2,8 +2,6 @@
 
 import errno
 import json
-import netaddr
-import netifaces
 import os
 import re
 import subprocess

--- a/sonic-utilities-tests/mock_tables/asic0/config_db.json
+++ b/sonic-utilities-tests/mock_tables/asic0/config_db.json
@@ -154,5 +154,16 @@
         "state": "enabled",
         "auto_restart": "enabled",
         "high_mem_alert": "disabled"
+    },
+    "BGP_NEIGHBOR|20.1.1.5": {
+        "rrclient": "0",
+        "name": "T2-Peer",
+        "local_addr": "20.1.1.1",
+        "nhopself": "0",
+        "admin_status": "up", 
+        "holdtime": "10", 
+        "asn": "65200", 
+        "keepalive": "3"
     }
+
 }

--- a/sonic-utilities-tests/mock_tables/asic1/config_db.json
+++ b/sonic-utilities-tests/mock_tables/asic1/config_db.json
@@ -123,5 +123,15 @@
         "state": "enabled",
         "auto_restart": "enabled",
         "high_mem_alert": "disabled"
+    },
+    "BGP_INTERNAL_NEIGHBOR|30.1.1.5": {
+        "rrclient": "0",
+        "name": "T0-Peer",
+        "local_addr": "30.1.1.1",
+        "nhopself": "0",
+        "admin_status": "up", 
+        "holdtime": "10", 
+        "asn": "65200", 
+        "keepalive": "3"
     }
 }

--- a/sonic-utilities-tests/mock_tables/config_db.json
+++ b/sonic-utilities-tests/mock_tables/config_db.json
@@ -722,6 +722,26 @@
         "acl_entry_high_threshold": "85",
         "fdb_entry_low_threshold": "70",
         "ipv6_nexthop_high_threshold": "85"
+    },
+    "BGP_NEIGHBOR|20.1.1.5": {
+        "rrclient": "0",
+        "name": "T2-Peer",
+        "local_addr": "20.1.1.1",
+        "nhopself": "0",
+        "admin_status": "up", 
+        "holdtime": "10", 
+        "asn": "65200", 
+        "keepalive": "3"
+    },
+    "BGP_INTERNAL_NEIGHBOR|30.1.1.5": {
+        "rrclient": "0",
+        "name": "T0-Peer",
+        "local_addr": "30.1.1.1",
+        "nhopself": "0",
+        "admin_status": "up", 
+        "holdtime": "10", 
+        "asn": "65200", 
+        "keepalive": "3"
     }
 }
 

--- a/sonic-utilities-tests/mock_tables/mock_multi_asic.py
+++ b/sonic-utilities-tests/mock_tables/mock_multi_asic.py
@@ -1,7 +1,56 @@
 # MONKEY PATCH!!!
 import mock
 from sonic_py_common import multi_asic
+from utilities_common import multi_asic as multi_asic_util
 
+mock_intf_table = {
+    '': {
+        'eth0': {
+            2: [{'addr': '10.1.1.1', 'netmask': '255.255.255.0', 'broadcast': '10.1.1.1'}],
+            10: [{'addr': '3100::1', 'netmask': 'ffff:ffff:ffff:ffff::/64'}]
+        },
+        'lo': {
+            2: [{'addr': '127.0.0.1', 'netmask': '255.0.0.0', 'broadcast': '127.255.255.255'}],
+            10: [{'addr': '::1', 'netmask':'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128'}]
+        }
+    },
+    'asic0': {
+        'Loopback0': {
+            17: [{'addr': '62:a5:9d:f4:16:96', 'broadcast': 'ff:ff:ff:ff:ff:ff'}], 
+            2: [{'addr': '40.1.1.1', 'netmask': '255.255.255.255', 'broadcast': '40.1.1.1'}], 
+            10: [{'addr': 'fe80::60a5:9dff:fef4:1696%Loopback0', 'netmask': 'ffff:ffff:ffff:ffff::/64'}]
+        },
+        'PortChannel0001': {
+            17: [{'addr': '82:fd:d1:5b:45:2f', 'broadcast': 'ff:ff:ff:ff:ff:ff'}], 
+            2: [{'addr': '20.1.1.1', 'netmask': '255.255.255.0', 'broadcast': '20.1.1.1'}], 
+            10: [{'addr': 'aa00::1', 'netmask': 'ffff:ffff:ffff:ffff::/64'}, {'addr': 'fe80::80fd:d1ff:fe5b:452f', 'netmask': 'ffff:ffff:ffff:ffff::/64'}]
+        },
+        'Loopback4096': {
+            2: [{'addr': '1.1.1.1', 'netmask': '255.255.255.0', 'broadcast': '1.1.1.1'}]
+        },
+        'veth@eth1': {
+            2: [{'addr': '192.1.1.1', 'netmask': '255.255.255.0', 'broadcast': '192.1.1.1'}]
+        }
+    },
+    'asic1': {
+        'Loopback0': {
+            17: [{'addr': '62:a5:9d:f4:16:96', 'broadcast': 'ff:ff:ff:ff:ff:ff'}], 
+            2: [{'addr': '40.1.1.1', 'netmask': '255.255.255.255', 'broadcast': '40.1.1.1'}], 
+            10: [{'addr': 'fe80::60a5:9dff:fef4:1696%Loopback0', 'netmask': 'ffff:ffff:ffff:ffff::/64'}]
+        },
+        'PortChannel0002': {
+            17: [{'addr': '82:fd:d1:5b:45:2f', 'broadcast': 'ff:ff:ff:ff:ff:ff'}], 
+            2: [{'addr': '30.1.1.1', 'netmask': '255.255.255.0', 'broadcast': '30.1.1.1'}], 
+            10: [{'addr': 'bb00::1', 'netmask': 'ffff:ffff:ffff:ffff::/64'}, {'addr': 'fe80::80fd:abff:fe5b:452f', 'netmask': 'ffff:ffff:ffff:ffff::/64'}]
+        },
+        'Loopback4096': {
+            2: [{'addr': '2.1.1.1', 'netmask': '255.255.255.0', 'broadcast': '2.1.1.1'}]
+        },
+        'veth@eth2': {
+            2: [{'addr': '193.1.1.1', 'netmask': '255.255.255.0', 'broadcast': '193.1.1.1'}]
+        }
+    }
+}
 
 def mock_get_num_asics():
     return 2
@@ -15,6 +64,27 @@ def mock_get_namespace_list(namespace=None):
     return ['asic0', 'asic1']
 
 
+def mock_multi_asic_get_ip_intf_from_ns(namespace):
+    interfaces = []
+    try:
+        interfaces = list(mock_intf_table[namespace].keys())
+    except KeyError:
+        pass
+    return interfaces
+
+
+def mock_multi_asic_get_ip_intf_addr_from_ns(namespace, iface):
+    ipaddresses = []
+    try:
+        ipaddresses = mock_intf_table[namespace][iface]
+    except KeyError:
+        pass
+    return ipaddresses
+
+
 multi_asic.get_num_asics = mock_get_num_asics
 multi_asic.is_multi_asic = mock_is_multi_asic
 multi_asic.get_namespace_list = mock_get_namespace_list
+multi_asic_util.multi_asic_get_ip_intf_from_ns = mock_multi_asic_get_ip_intf_from_ns
+multi_asic_util.multi_asic_get_ip_intf_addr_from_ns = mock_multi_asic_get_ip_intf_addr_from_ns
+

--- a/sonic-utilities-tests/mock_tables/mock_single_asic.py
+++ b/sonic-utilities-tests/mock_tables/mock_single_asic.py
@@ -1,5 +1,47 @@
 # MONKEY PATCH!!!
 from sonic_py_common import multi_asic
+from utilities_common import multi_asic as multi_asic_util
+
+mock_intf_table = {
+    '': {
+        'eth0': {
+            2: [{'addr': '10.1.1.1', 'netmask': '255.255.255.0', 'broadcast': '10.1.1.1'}],
+            10: [{'addr': '3100::1', 'netmask': 'ffff:ffff:ffff:ffff::/64'}]
+        },
+        'Ethernet0': {
+            17: [{'addr': '82:fd:d1:5b:45:2f', 'broadcast': 'ff:ff:ff:ff:ff:ff'}],
+            2: [
+                    {'addr': '20.1.1.1', 'netmask': '255.255.255.0', 'broadcast': '20.1.1.1'},
+                    {'addr': '21.1.1.1', 'netmask': '255.255.255.0', 'broadcast': '21.1.1.1'}
+                ],
+            10: [
+                    {'addr': 'aa00::1', 'netmask': 'ffff:ffff:ffff:ffff::/64'},
+                    {'addr': '2100::1', 'netmask': 'ffff:ffff:ffff:ffff::/64'},
+                    {'addr': 'fe80::64be:a1ff:fe85:c6c4%Ethernet0', 'netmask': 'ffff:ffff:ffff:ffff::/64'}
+                ]
+        },
+        'PortChannel0001': {
+            17: [{'addr': '82:fd:d1:5b:45:2f', 'broadcast': 'ff:ff:ff:ff:ff:ff'}], 
+            2: [{'addr': '30.1.1.1', 'netmask': '255.255.255.0', 'broadcast': '30.1.1.1'}],
+            10: [
+                    {'addr': 'ab00::1', 'netmask': 'ffff:ffff:ffff:ffff::/64'},
+                    {'addr': 'fe80::cc8d:60ff:fe08:139f%PortChannel0001', 'netmask': 'ffff:ffff:ffff:ffff::/64'}
+                ]
+        },
+        'Vlan100': {
+            17: [{'addr': '82:fd:d1:5b:45:2f', 'broadcast': 'ff:ff:ff:ff:ff:ff'}], 
+            2: [{'addr': '40.1.1.1', 'netmask': '255.255.255.0', 'broadcast': '30.1.1.1'}],
+            10: [
+                    {'addr': 'cc00::1', 'netmask': 'ffff:ffff:ffff:ffff::/64'},
+                    {'addr': 'fe80::c029:3fff:fe41:cf56%Vlan100', 'netmask': 'ffff:ffff:ffff:ffff::/64'}
+                ]
+        },
+        'lo': {
+            2: [{'addr': '127.0.0.1', 'netmask': '255.0.0.0', 'broadcast': '127.255.255.255'}],
+            10: [{'addr': '::1', 'netmask':'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128'}]
+        }
+    }
+}
 
 def mock_get_num_asics():
     return 1
@@ -10,6 +52,29 @@ def mock_is_multi_asic():
 def mock_get_namespace_list(namespace=None):
     return ['']
 
+
+def mock_single_asic_get_ip_intf_from_ns(namespace):
+    interfaces = []
+    try:
+        interfaces = list(mock_intf_table[namespace].keys())
+    except KeyError:
+        pass
+    return interfaces
+
+
+def mock_single_asic_get_ip_intf_addr_from_ns(namespace, iface):
+    ipaddresses = []
+    try:
+        ipaddresses = mock_intf_table[namespace][iface]
+    except KeyError:
+        pass
+    return ipaddresses
+
+
 multi_asic.is_multi_asic = mock_is_multi_asic
 multi_asic.get_num_asics = mock_get_num_asics
 multi_asic.get_namespace_list = mock_get_namespace_list
+multi_asic_util.multi_asic_get_ip_intf_from_ns = mock_single_asic_get_ip_intf_from_ns
+multi_asic_util.multi_asic_get_ip_intf_addr_from_ns = mock_single_asic_get_ip_intf_addr_from_ns
+
+

--- a/sonic-utilities-tests/show_ip_int_test.py
+++ b/sonic-utilities-tests/show_ip_int_test.py
@@ -1,0 +1,156 @@
+import os
+import pytest
+import subprocess
+from click.testing import CliRunner
+
+import show.main as show
+from utils import get_result_and_return_code
+
+root_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(root_path)
+scripts_path = os.path.join(modules_path, "scripts")
+
+show_ipv4_intf_with_multple_ips = """\
+Interface        Master    IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
+---------------  --------  -------------------  ------------  --------------  -------------
+Ethernet0                  20.1.1.1/24          error/down    T2-Peer         20.1.1.5
+                           21.1.1.1/24                        N/A             N/A
+PortChannel0001            30.1.1.1/24          error/down    T0-Peer         30.1.1.5
+Vlan100                    40.1.1.1/24          error/down    N/A             N/A"""
+
+show_ipv6_intf_with_multiple_ips = """\
+Interface        Master    IPv4 address/mask                             Admin/Oper    BGP Neighbor    Neighbor IP
+---------------  --------  --------------------------------------------  ------------  --------------  -------------
+Ethernet0                  2100::1/64                                    error/down    N/A             N/A
+                           aa00::1/64                                                  N/A             N/A
+                           fe80::64be:a1ff:fe85:c6c4%Ethernet0/64                      N/A             N/A
+PortChannel0001            ab00::1/64                                    error/down    N/A             N/A
+                           fe80::cc8d:60ff:fe08:139f%PortChannel0001/64                N/A             N/A
+Vlan100                    cc00::1/64                                    error/down    N/A             N/A
+                           fe80::c029:3fff:fe41:cf56%Vlan100/64                        N/A             N/A"""
+
+show_multi_asic_ip_intf = """\
+Interface        Master    IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
+---------------  --------  -------------------  ------------  --------------  -------------
+Loopback0                  40.1.1.1/32          error/down    N/A             N/A
+PortChannel0001            20.1.1.1/24          error/down    T2-Peer         20.1.1.5"""
+
+show_multi_asic_ipv6_intf = """\
+Interface        Master    IPv4 address/mask                       Admin/Oper    BGP Neighbor    Neighbor IP
+---------------  --------  --------------------------------------  ------------  --------------  -------------
+Loopback0                  fe80::60a5:9dff:fef4:1696%Loopback0/64  error/down    N/A             N/A
+PortChannel0001            aa00::1/64                              error/down    N/A             N/A
+                           fe80::80fd:d1ff:fe5b:452f/64                          N/A             N/A"""
+
+show_multi_asic_ip_intf_all = """\
+Interface        Master    IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
+---------------  --------  -------------------  ------------  --------------  -------------
+Loopback0                  40.1.1.1/32          error/down    N/A             N/A
+Loopback4096               1.1.1.1/24           error/down    N/A             N/A
+                           2.1.1.1/24                         N/A             N/A
+PortChannel0001            20.1.1.1/24          error/down    T2-Peer         20.1.1.5
+PortChannel0002            30.1.1.1/24          error/down    T0-Peer         30.1.1.5
+veth@eth1                  192.1.1.1/24         error/down    N/A             N/A
+veth@eth2                  193.1.1.1/24         error/down    N/A             N/A"""
+
+show_multi_asic_ipv6_intf_all = """\
+Interface        Master    IPv4 address/mask                       Admin/Oper    BGP Neighbor    Neighbor IP
+---------------  --------  --------------------------------------  ------------  --------------  -------------
+Loopback0                  fe80::60a5:9dff:fef4:1696%Loopback0/64  error/down    N/A             N/A
+PortChannel0001            aa00::1/64                              error/down    N/A             N/A
+                           fe80::80fd:d1ff:fe5b:452f/64                          N/A             N/A
+PortChannel0002            bb00::1/64                              error/down    N/A             N/A
+                           fe80::80fd:abff:fe5b:452f/64                          N/A             N/A"""
+
+show_error_invalid_af = """Invalid argument -a ipv5"""
+
+
+@pytest.fixture(scope="class")
+def setup_teardown_single_asic():
+    os.environ["PATH"] += os.pathsep + scripts_path
+    os.environ["UTILITIES_UNIT_TESTING"] = "2"
+    os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = ""
+    yield
+
+    os.environ["UTILITIES_UNIT_TESTING"] = "0"
+
+
+@pytest.fixture(scope="class")
+def setup_teardown_multi_asic():
+    os.environ["PATH"] += os.pathsep + scripts_path
+    os.environ["UTILITIES_UNIT_TESTING"] = "2"
+    os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = "multi_asic"
+    yield
+    os.environ["UTILITIES_UNIT_TESTING"] = "0"
+    os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = ""
+
+
+def verify_output(output, expected_output):
+    lines = output.splitlines()
+    ignored_intfs = ['eth0', 'lo']
+    for intf in ignored_intfs:
+        # the output should have line to display the ip address of eth0 and lo
+        assert len([line for line in lines if line.startswith(intf)]) == 1
+
+    new_output = '\n'.join([line for line in lines if not any(i in line for i in ignored_intfs)])
+    print(new_output)
+    assert new_output == expected_output
+
+
+@pytest.mark.usefixtures('setup_teardown_single_asic')
+class TestShowIpInt(object):
+
+    def test_show_ip_intf_v4(self):
+        return_code, result = get_result_and_return_code(" ipintutil")
+        assert return_code == 0
+        verify_output(result, show_ipv4_intf_with_multple_ips)
+
+    def test_show_ip_intf_v6(self):
+        return_code, result = get_result_and_return_code(" ipintutil -a ipv6")
+
+        assert return_code == 0
+        verify_output(result, show_ipv6_intf_with_multiple_ips)
+
+    def test_show_intf_invalid_af_option(self):
+        return_code, result = get_result_and_return_code(" ipintutil -a ipv5")
+        assert return_code == 1
+        assert result == show_error_invalid_af
+
+
+@pytest.mark.usefixtures('setup_teardown_multi_asic')
+class TestMultiAsicShowIpInt(object):
+
+    def test_show_ip_intf_v4(self):
+        return_code, result = get_result_and_return_code("ipintutil")
+        assert return_code == 0
+        verify_output(result, show_multi_asic_ip_intf)
+
+    def test_show_ip_intf_v4_asic0(self):
+        return_code, result = get_result_and_return_code("ipintutil -n asic0")
+        assert return_code == 0
+        verify_output(result, show_multi_asic_ip_intf)
+
+    def test_show_ip_intf_v4_all(self):
+        return_code, result = get_result_and_return_code("ipintutil -d all")
+        assert return_code == 0
+        verify_output(result, show_multi_asic_ip_intf_all)
+
+    def test_show_ip_intf_v6(self):
+        return_code, result = get_result_and_return_code("ipintutil  -a ipv6")
+        assert return_code == 0
+        verify_output(result, show_multi_asic_ipv6_intf)
+
+    def test_show_ip_intf_v6_asic0(self):
+        return_code, result = get_result_and_return_code("ipintutil -a ipv6 -n asic0")
+        assert return_code == 0
+        verify_output(result, show_multi_asic_ipv6_intf)
+
+    def test_show_ip_intf_v6_all(self):
+        return_code, result = get_result_and_return_code("ipintutil -a ipv6 -d all")
+        assert return_code == 0
+        verify_output(result, show_multi_asic_ipv6_intf_all)
+
+    def test_show_intf_invalid_af_option(self):
+        return_code, result = get_result_and_return_code(" ipintutil -a ipv5")
+        assert return_code == 1
+        assert result == show_error_invalid_af

--- a/sonic-utilities-tests/show_ip_int_test.py
+++ b/sonic-utilities-tests/show_ip_int_test.py
@@ -101,18 +101,18 @@ def verify_output(output, expected_output):
 class TestShowIpInt(object):
 
     def test_show_ip_intf_v4(self):
-        return_code, result = get_result_and_return_code(" ipintutil")
+        return_code, result = get_result_and_return_code("ipintutil")
         assert return_code == 0
         verify_output(result, show_ipv4_intf_with_multple_ips)
 
     def test_show_ip_intf_v6(self):
-        return_code, result = get_result_and_return_code(" ipintutil -a ipv6")
+        return_code, result = get_result_and_return_code("ipintutil -a ipv6")
 
         assert return_code == 0
         verify_output(result, show_ipv6_intf_with_multiple_ips)
 
     def test_show_intf_invalid_af_option(self):
-        return_code, result = get_result_and_return_code(" ipintutil -a ipv5")
+        return_code, result = get_result_and_return_code("ipintutil -a ipv5")
         assert return_code == 1
         assert result == show_error_invalid_af
 
@@ -151,6 +151,6 @@ class TestMultiAsicShowIpInt(object):
         verify_output(result, show_multi_asic_ipv6_intf_all)
 
     def test_show_intf_invalid_af_option(self):
-        return_code, result = get_result_and_return_code(" ipintutil -a ipv5")
+        return_code, result = get_result_and_return_code("ipintutil -a ipv5")
         assert return_code == 1
         assert result == show_error_invalid_af

--- a/sonic-utilities-tests/show_ip_int_test.py
+++ b/sonic-utilities-tests/show_ip_int_test.py
@@ -1,9 +1,5 @@
 import os
 import pytest
-import subprocess
-from click.testing import CliRunner
-
-import show.main as show
 from utils import get_result_and_return_code
 
 root_path = os.path.dirname(os.path.abspath(__file__))

--- a/utilities_common/multi_asic.py
+++ b/utilities_common/multi_asic.py
@@ -2,6 +2,9 @@ import argparse
 import functools
 
 import click
+import netifaces
+import pyroute2
+from natsort import natsorted
 from sonic_py_common import multi_asic
 from utilities_common import constants
 
@@ -145,3 +148,24 @@ def get_multi_asic_cfgdb():
             cfgdb[ns] = multi_asic.connect_config_db_for_ns(ns)
 
         return cfgdb
+
+def multi_asic_get_ip_intf_from_ns(namespace):
+    if namespace != constants.DEFAULT_NAMESPACE:
+        pyroute2.netns.pushns(namespace)
+    interfaces = natsorted(netifaces.interfaces())
+
+    if namespace != constants.DEFAULT_NAMESPACE:
+        pyroute2.netns.popns()
+
+    return interfaces
+
+
+def multi_asic_get_ip_intf_addr_from_ns(namespace, iface):
+    if namespace != constants.DEFAULT_NAMESPACE:
+        pyroute2.netns.pushns(namespace)
+    ipaddresses = netifaces.ifaddresses(iface)
+
+    if namespace != constants.DEFAULT_NAMESPACE:
+        pyroute2.netns.popns()
+
+    return ipaddresses


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->


**- What I did**
The PR has changes to support command `show ip interface` for multi asic platform.
Dependent on this PR: https://github.com/Azure/sonic-buildimage/pull/6792

**- How I did it**
 The following changes  are done in this PR
 - The code for `show ip interface` has been moved from `show/main.py` to `scripts\ipintutil`
 -  Modify the code to support both single and multi asic platform
    - To do this the library [pyroute2](https://pypi.org/project/pyroute2/) is used to get interface information in each namespace
   
 - Add the following options for multi asic
     -  [-n, --namespace] to allow user to display the information for given namespaces
         If this option is not present the information from all the namespaces will be displayed

      - [-d, --display] to allow user to display information related both internal and external interfaces
        If this option is not present only external interfaces/neighbors will be display
 - Add unit tests for single and multi asic 

**- How to verify it**
Verify on single and multi asic
```
admin@sonic:~$ show ip interface
Interface        Master    IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
---------------  --------  -------------------  ------------  --------------  -------------
Loopback0                  10.1.0.32/32         up/up         N/A             N/A
PortChannel0001            10.0.0.32/31         up/up         ARISTA01T0      10.0.0.33
PortChannel0002            10.0.0.0/31          up/up         ARISTA01T2      10.0.0.1
PortChannel0003            10.0.0.34/31         up/up         ARISTA02T0      10.0.0.35
PortChannel0004            10.0.0.36/31         up/up         ARISTA03T0      10.0.0.37
PortChannel0005            10.0.0.4/31          up/up         ARISTA03T2      10.0.0.5
PortChannel0006            10.0.0.38/31         up/up         ARISTA04T0      10.0.0.39
PortChannel0007            10.0.0.40/31         up/up         ARISTA05T0      10.0.0.41
PortChannel0008            10.0.0.8/31          up/up         ARISTA05T2      10.0.0.9
PortChannel0009            10.0.0.42/31         up/up         ARISTA06T0      10.0.0.43
PortChannel0010            10.0.0.44/31         up/up         ARISTA07T0      10.0.0.45
PortChannel0011            10.0.0.12/31         up/up         ARISTA07T2      10.0.0.13
PortChannel0012            10.0.0.46/31         up/up         ARISTA08T0      10.0.0.47
PortChannel0013            10.0.0.48/31         up/up         ARISTA09T0      10.0.0.49
PortChannel0014            10.0.0.50/31         up/up         ARISTA10T0      10.0.0.51
PortChannel0015            10.0.0.52/31         up/up         ARISTA11T0      10.0.0.53
PortChannel0016            10.0.0.54/31         up/up         ARISTA12T0      10.0.0.55
PortChannel0017            10.0.0.56/31         up/up         ARISTA13T0      10.0.0.57
PortChannel0018            10.0.0.58/31         up/up         ARISTA14T0      10.0.0.59
PortChannel0019            10.0.0.60/31         up/up         ARISTA15T0      10.0.0.61
PortChannel0020            10.0.0.62/31         up/up         ARISTA16T0      10.0.0.63
PortChannel0021            10.0.0.64/31         up/up         ARISTA17T0      10.0.0.65
PortChannel0022            10.0.0.66/31         up/up         ARISTA18T0      10.0.0.67
PortChannel0023            10.0.0.68/31         up/up         ARISTA19T0      10.0.0.69
PortChannel0024            10.0.0.70/31         up/up         ARISTA20T0      10.0.0.71
docker0                    240.127.1.1/24       up/up         N/A             N/A
eth0                       10.3.147.150/23      up/up         N/A             N/A
lo                         127.0.0.1/8          up/up         N/A             N/A
admin@sonic:~$ 


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

