### PR TITLE
[CLI][techsupport] Add "no-op" option to 'show techsupport'

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -989,12 +989,17 @@ def users(verbose):
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 @click.option('--allow-process-stop', is_flag=True, help="Dump additional data which may require system interruption")
 @click.option('--silent', is_flag=True, help="Run techsupport in silent mode")
-def techsupport(since, global_timeout, cmd_timeout, verbose, allow_process_stop, silent):
+@click.option('-n', '--noop', default=False, is_flag=True, help="Show commands without executing them")
+def techsupport(since, global_timeout, cmd_timeout, verbose, allow_process_stop, silent, noop):
     """Gather information for troubleshooting"""
     cmd = "sudo timeout -s SIGTERM --foreground {}m".format(global_timeout)
 
     if allow_process_stop:
         cmd += " -a"
+
+    if noop:
+        cmd += " -n"
+        silent = False
 
     if silent:
         cmd += " generate_dump"

--- a/show/main.py
+++ b/show/main.py
@@ -997,15 +997,15 @@ def techsupport(since, global_timeout, cmd_timeout, verbose, allow_process_stop,
     if allow_process_stop:
         cmd += " -a"
 
-    if noop:
-        cmd += " -n"
-        silent = False
-
     if silent:
         cmd += " generate_dump"
         click.echo("Techsupport is running with silent option. This command might take a long time.")
     else:
         cmd += " generate_dump -v"
+
+    if noop:
+        cmd += " -n"
+        silent = False
 
     if since:
         cmd += " -s '{}'".format(since)

--- a/show/main.py
+++ b/show/main.py
@@ -1005,7 +1005,6 @@ def techsupport(since, global_timeout, cmd_timeout, verbose, allow_process_stop,
 
     if noop:
         cmd += " -n"
-        silent = False
 
     if since:
         cmd += " -s '{}'".format(since)


### PR DESCRIPTION


#### What I did
 Added "no-op" option to 'show techsupport'

The "no-op" option can be used during unit tests to collect the list of commands being run.

#### How I did it
Using Click option

#### How to verify it
```
admin@str-s6000-acs-8:~$ show techsupport --help                                                                                                                                      
Usage: show techsupport [OPTIONS]                                                                                                                                                     

  Gather information for troubleshooting

Options:
  --since TEXT                  Collect logs and core files since given date                                                                                                          
  -g, --global-timeout INTEGER  Global timeout in minutes. Default 30 mins
  -c, --cmd-timeout INTEGER     Individual command timeout in minutes. Default                                                                                                        
                                5 mins
  --verbose                     Enable verbose output
  --allow-process-stop          Dump additional data which may require system
                                interruption
  --silent                      Run techsupport in silent mode
  -n, --noop                    Show commands without executing them                                                                                                                  
  -?, -h, --help                Show this message and exit.                                                                                                                           
admin@str-s6000-acs-8:~$ show techsupport -n

main
mkdir -v -p /var/dump/sonic_dump_str-s6000-acs-8_20210218_004913
ln -v -s /usr/bin/generate_dump /var/dump/sonic_dump_str-s6000-acs-8_20210218_004913
tar -v -chf /var/dump/sonic_dump_str-s6000-acs-8_20210218_004913.tar -C /var/dump sonic_dump_str-s6000-acs-8_20210218_004913                                                          
rm -v -f /var/dump/sonic_dump_str-s6000-acs-8_20210218_004913/sonic_dump                                                                                                              
mkdir -v -p /var/dump/sonic_dump_str-s6000-acs-8_20210218_004913/proc
cp -v -r /proc/buddyinfo /proc/cmdline /proc/consoles /proc/cpuinfo /proc/devices /proc/diskstats /proc/dma /proc/interrupts /proc/iomem /proc/ioports /proc/kallsyms /proc/loadavg /proc/locks /proc/meminfo /proc/misc /proc/modules /proc/self/mounts /proc/self/net /proc/pagetypeinfo /proc/partitions /proc/sched_debug /proc/slabinfo /proc/softirqs /proc/stat /proc
/swaps /proc/sysvipc /proc/timer_list /proc/uptime /proc/version /proc/vmallocinfo /proc/vmstat /proc/zoneinfo /var/dump/sonic_dump_str-s6000-acs-8_20210218_004913/proc              
tar -v -rhf /var/dump/sonic_dump_str-s6000-acs-8_20210218_004913.tar -C /var/dump --mode=+rw sonic_dump_str-s6000-acs-8_20210218_004913/proc                                          
rm -v -rf /var/dump/sonic_dump_str-s6000-acs-8_20210218_004913/proc                                                                                                                   
mkdir -v -p /var/dump/sonic_dump_str-s6000-acs-8_20210218_004913/dump                                                                                                                 
eval systemd-analyze blame &> '/var/dump/sonic_dump_str-s6000-acs-8_20210218_004913/dump/systemd.analyze.blame'                                                                       
tar -v -rhf /var/dump/sonic_dump_str-s6000-acs-8_20210218_004913.tar -C /var/dump sonic_dump_str-s6000-acs-8_20210218_004913/dump/systemd.analyze.blame                               
rm -v -rf /var/dump/sonic_dump_str-s6000-acs-8_20210218_004913/dump/systemd.analyze.blame                                                                                             
mkdir -v -p /var/dump/sonic_dump_str-s6000-acs-8_20210218_004913/dump
eval systemd-analyze dump &> '/var/dump/sonic_dump_str-s6000-acs-8_20210218_004913/dump/systemd.analyze.dump'                                                                         
/usr/bin/generate_dump: line 389: /var/dump/sonic_dump_str-s6000-acs-8_20210218_004913/dump/platform: No such file or directory                                                       
tar -v -rhf /var/dump/sonic_dump_str-s6000-acs-8_20210218_004913.tar -C /var/dump sonic_dump_str-s6000-acs-8_20210218_004913/dump/systemd.analyze.dump                                
/usr/bin/generate_dump: line 390: /var/dump/sonic_dump_str-s6000-acs-8_20210218_004913/dump/platform: No such file or directory
rm -v -rf /var/dump/sonic_dump_str-s6000-acs-8_20210218_004913/dump/systemd.analyze.dump                                                                                              
mkdir -v -p /var/dump/sonic_dump_str-s6000-acs-8_20210218_004913/dump                                                                                                                 
eval systemd-analyze plot &> '/var/dump/sonic_dump_str-s6000-acs-8_20210218_004913/dump/systemd.analyze.plot.svg'
tar -v -rhf /var/dump/sonic_dump_str-s6000-acs-8_20210218_004913.tar -C /var/dump sonic_dump_str-s6000-acs-8_20210218_004913/dump/systemd.analyze.plot.svg                            
rm -v -rf /var/dump/sonic_dump_str-s6000-acs-8_20210218_004913/dump/systemd.analyze.plot.svg                                                                                          
mkdir -v -p /var/dump/sonic_dump_str-s6000-acs-8_20210218_004913/dump      
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

