### PR TITLE
[dpb|config] Fix the validation logic of breakout mode

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -110,10 +110,8 @@ def _get_breakout_options(ctx, args, incomplete):
     else:
         breakout_file_input = readJsonFile(breakout_cfg_file)
         if interface_name in breakout_file_input[INTF_KEY]:
-            breakout_mode_list = [v["breakout_modes"] for i, v in breakout_file_input[INTF_KEY].items() if i == interface_name][0]
-            breakout_mode_options = []
-            for i in breakout_mode_list.split(','):
-                    breakout_mode_options.append(i)
+            breakout_mode_options = [mode for i, v in breakout_file_input[INTF_KEY].items() if i == interface_name \
+                                          for mode in v["breakout_modes"].keys()]
             all_mode_options = [str(c) for c in breakout_mode_options if incomplete in c]
         return all_mode_options
 
@@ -152,7 +150,7 @@ def _validate_interface_mode(ctx, breakout_cfg_file, interface_name, target_brko
         return False
 
     # Check whether target breakout mode is available for the user-selected interface or not
-    if target_brkout_mode not in breakout_file_input[interface_name]["breakout_modes"]:
+    if target_brkout_mode not in breakout_file_input[interface_name]["breakout_modes"].keys():
         click.secho('[ERROR] Target mode {} is not available for the port {}'. format(target_brkout_mode, interface_name), fg='red')
         return False
 

--- a/tests/config_dpb_test.py
+++ b/tests/config_dpb_test.py
@@ -21,26 +21,41 @@ breakout_cfg_file_json = {
         "Ethernet0": {
             "index": "1,1,1,1",
             "lanes": "65,66,67,68",
-            "alias_at_lanes": "Eth1/1, Eth1/2, Eth1/3, Eth1/4",
-            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+            "breakout_modes": {
+                "1x100G[40G]": ["Eth1"],
+                "2x50G": ["Eth1/1", "Eth1/2"],
+                "4x25G[10G]": ["Eth1/1", "Eth1/2", "Eth1/3", "Eth1/4"]
+            }
         },
         "Ethernet4": {
             "index": "2,2,2,2",
             "lanes": "69,70,71,72",
-            "alias_at_lanes": "Eth2/1, Eth2/2, Eth2/3, Eth2/4",
-            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],1x50G(2)+2x25G(2)"
+            "breakout_modes": {
+                "1x100G[40G]": ["Eth2"],
+                "2x50G": ["Eth2/1", "Eth2/2"],
+                "4x25G[10G]": ["Eth2/1", "Eth2/2", "Eth2/3", "Eth2/4"],
+                "1x50G(2)+2x25G(2)": ["Eth2/1", "Eth2/2", "Eth2/3"]
+            }
         },
         "Ethernet8": {
             "index": "3,3,3,3",
             "lanes": "73,74,75,76",
             "alias_at_lanes": "Eth3/1, Eth3/2, Eth3/3, Eth3/4",
-            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],1x50G(2)+2x25G(2)"
+            "breakout_modes": {
+                "1x100G[40G]": ["Eth3"],
+                "2x50G": ["Eth3/1", "Eth3/2"],
+                "4x25G[10G]": ["Eth3/1", "Eth3/2", "Eth3/3", "Eth3/4"],
+                "1x50G(2)+2x25G(2)": ["Eth3/1", "Eth3/2", "Eth3/3"]
+            }
         },
         "Ethernet12": {
             "index": "4,4,4,4",
             "lanes": "77,78,79,80",
-            "alias_at_lanes": "Eth4/1, Eth4/2, Eth4/3, Eth4/4",
-            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+            "breakout_modes": {
+                "1x100G[40G]": ["Eth4"],
+                "2x50G": ["Eth4/1", "Eth4/2"],
+                "4x25G[10G]": ["Eth4/1", "Eth1/2", "Eth4/3", "Eth4/4"]
+            }
         }
     }
 }

--- a/tests/config_dpb_test.py
+++ b/tests/config_dpb_test.py
@@ -40,7 +40,6 @@ breakout_cfg_file_json = {
         "Ethernet8": {
             "index": "3,3,3,3",
             "lanes": "73,74,75,76",
-            "alias_at_lanes": "Eth3/1, Eth3/2, Eth3/3, Eth3/4",
             "breakout_modes": {
                 "1x100G[40G]": ["Eth3"],
                 "2x50G": ["Eth3/1", "Eth3/2"],

--- a/tests/config_dpb_test.py
+++ b/tests/config_dpb_test.py
@@ -21,38 +21,42 @@ breakout_cfg_file_json = {
         "Ethernet0": {
             "index": "1,1,1,1",
             "lanes": "65,66,67,68",
+            "alias_at_lanes": "Eth1/1, Eth1/2, Eth1/3, Eth1/4",
             "breakout_modes": {
                 "1x100G[40G]": ["Eth1"],
-                "2x50G": ["Eth1/1", "Eth1/2"],
+                "2x50G": ["Eth1/1", "Eth1/3"],
                 "4x25G[10G]": ["Eth1/1", "Eth1/2", "Eth1/3", "Eth1/4"]
             }
         },
         "Ethernet4": {
             "index": "2,2,2,2",
             "lanes": "69,70,71,72",
+            "alias_at_lanes": "Eth2/1, Eth2/2, Eth2/3, Eth2/4",
             "breakout_modes": {
                 "1x100G[40G]": ["Eth2"],
-                "2x50G": ["Eth2/1", "Eth2/2"],
+                "2x50G": ["Eth2/1", "Eth2/3"],
                 "4x25G[10G]": ["Eth2/1", "Eth2/2", "Eth2/3", "Eth2/4"],
-                "1x50G(2)+2x25G(2)": ["Eth2/1", "Eth2/2", "Eth2/3"]
+                "1x50G(2)+2x25G(2)": ["Eth2/1", "Eth2/3", "Eth2/4"]
             }
         },
         "Ethernet8": {
             "index": "3,3,3,3",
             "lanes": "73,74,75,76",
+            "alias_at_lanes": "Eth3/1, Eth3/2, Eth3/3, Eth3/4",
             "breakout_modes": {
                 "1x100G[40G]": ["Eth3"],
-                "2x50G": ["Eth3/1", "Eth3/2"],
+                "2x50G": ["Eth3/1", "Eth3/3"],
                 "4x25G[10G]": ["Eth3/1", "Eth3/2", "Eth3/3", "Eth3/4"],
-                "1x50G(2)+2x25G(2)": ["Eth3/1", "Eth3/2", "Eth3/3"]
+                "1x50G(2)+2x25G(2)": ["Eth3/1", "Eth3/3", "Eth3/4"]
             }
         },
         "Ethernet12": {
             "index": "4,4,4,4",
             "lanes": "77,78,79,80",
+            "alias_at_lanes": "Eth4/1, Eth4/2, Eth4/3, Eth4/4",
             "breakout_modes": {
                 "1x100G[40G]": ["Eth4"],
-                "2x50G": ["Eth4/1", "Eth4/2"],
+                "2x50G": ["Eth4/1", "Eth4/3"],
                 "4x25G[10G]": ["Eth4/1", "Eth1/2", "Eth4/3", "Eth4/4"]
             }
         }

--- a/tests/config_dpb_test.py
+++ b/tests/config_dpb_test.py
@@ -57,7 +57,7 @@ breakout_cfg_file_json = {
             "breakout_modes": {
                 "1x100G[40G]": ["Eth4"],
                 "2x50G": ["Eth4/1", "Eth4/3"],
-                "4x25G[10G]": ["Eth4/1", "Eth1/2", "Eth4/3", "Eth4/4"]
+                "4x25G[10G]": ["Eth4/1", "Eth4/2", "Eth4/3", "Eth4/4"]
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: Sangita Maity <samaity@linkedin.com>


#### What I did
As per latest update in DPB [DOC](https://github.com/Azure/SONiC/pull/749), fixed this [bug](https://github.com/Azure/sonic-buildimage/issues/6645)

previously we had string value in "breakout_modes" key so it was not matching the whole string, But after the update via, now "breakout_modes" contain a dictionary where `key` is the `breakout_mode` and value is the `alias`. So we can easily check whether the key is present or not.

> DEPENDENCY on [Update Dynamic Port Breakout Logic for flexible alias support](https://github.com/Azure/sonic-buildimage/pull/6831) which fixes the [issue](https://github.com/Azure/sonic-buildimage/issues/6024)

#### How I did it
checked whether the user-specified breakout mode key is present under "breakout_modes" in`platform.json`.

#### How to verify it
If you only have 1x100G[50G,40G,25G,10G], the below CLI command should fail:
`config interface breakout Ethernet96 1x100G` as it matches the whole key.


```
admin@lnos-x1-a-csw05:~$ sudo config interface breakout Ethernet40
1x100G[40G]  2x50G        4x25G[10G]

admin@lnos-x1-a-csw05:~$ sudo config interface breakout Ethernet40 2x50G -v -y

Running Breakout Mode : 2x50G
Target Breakout Mode : 2x50G
[WARNING] No action will be taken as current and desired Breakout Mode are same.
```
 **it matches the whole key.**

```
admin@lnos-x1-a-csw05:~$ sudo config interface breakout Ethernet40 4x25G -v -y
[ERROR] Target mode 4x25G is not available for the port Ethernet40
Aborted!
```