### PR TITLE
[CLI][techsupport] Add NOOP option for commands that did not have that option

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -921,9 +921,9 @@ save_warmboot_files() {
             $BASE/warmboot \
             || abort "${ERROR_TAR_FAILED}" "Tar append operation failed. Aborting for safety.") \
             && $RM $V -rf $TARDIR
-        end_t=$(date +%s%3N)
-        echo "[ Warm-boot Files ] : $(($end_t-$start_t)) msec" >> $TECHSUPPORT_TIME_INFO
     fi
+    end_t=$(date +%s%3N)
+    echo "[ Warm-boot Files ] : $(($end_t-$start_t)) msec" >> $TECHSUPPORT_TIME_INFO
 }
 
 ###############################################################################

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -215,6 +215,71 @@ save_cmd_all_ns() {
 }
 
 ###############################################################################
+# Copies a given file from a specified docker to the given target location
+# default (host) namespace in single ASIC platform
+# Globals:
+#  None
+# Arguments:
+#  docker: docker name
+#  filename: the filename to copy
+#  destination: destination filename
+# Returns:
+#  None
+###############################################################################
+copy_from_docker() {
+    local start_t=$(date +%s%3N)
+    local end_t=0
+    local docker=$1
+    local filename=$2
+    local dstpath=$3
+    local timeout_cmd="timeout --foreground ${TIMEOUT_MIN}m"
+
+    if $NOOP; then
+        echo "${timeout_cmd} sudo docker exec -i ${docker} touch ${filename}"
+        echo "${timeout_cmd} sudo docker cp ${docker}:${filename} ${dstpath}"
+    else
+        eval "${timeout_cmd} sudo docker exec -i ${docker} touch ${filename}"
+        if [ $? -ne 0 ]; then
+            echo "Command: $cmd timedout after ${TIMEOUT_MIN} minutes."
+        fi
+        eval "${timeout_cmd} sudo docker cp ${docker}:${filename} ${dstpath}"
+        if [ $? -ne 0 ]; then
+            echo "Command: $cmd timedout after ${TIMEOUT_MIN} minutes."
+        fi
+    fi
+    end_t=$(date +%s%3N)
+    echo "[ copy_from_docker:${docker}:${filename} ] : $(($end_t-$start_t)) msec" \
+        >> $TECHSUPPORT_TIME_INFO
+}
+
+###############################################################################
+# Copies a given file from a specified docker to the given target location
+# default (host) namespace in single ASIC platform
+# Globals:
+#  NUM_ASICS
+# Arguments:
+#  docker: docker name
+#  filename: the filename to copy
+#  destination: destination filename
+# Returns:
+#  None
+###############################################################################
+copy_from_masic_docker() {
+    local docker=$1
+    local filename=$2
+    local dstpath=$3
+
+    if [[ ("$NUM_ASICS" > 1) ]]; then
+        for (( i=0; i<$NUM_ASICS; i++ ))
+        do
+            copy_from_docker "$docker$i" "$filename" "$dstpath.$i"
+        done
+    else
+        copy_from_docker "$docker" "$filename" "$dstpath"
+    fi
+}
+
+###############################################################################
 # Returns namespace option to be used with vtysh commmand, based on the ASIC ID.
 # Returns empty string if no ASIC ID is provided
 # Globals:
@@ -493,6 +558,7 @@ save_redis_info() {
 #  RM
 #  BASE
 #  TARFILE
+#  NOOP
 # Arguments:
 #  *procfiles: variable-length list of proc file paths to save
 # Returns:
@@ -500,10 +566,20 @@ save_redis_info() {
 ###############################################################################
 save_proc() {
     local procfiles="$@"
-    $MKDIR $V -p $TARDIR/proc \
-        && (for f in $procfiles; do ( [ -e $f ] && $CP $V -r $f $TARDIR/proc ) || echo "$f not found" > $TARDIR/$f; done) \
-        && $TAR $V -rhf $TARFILE -C $DUMPDIR --mode=+rw $BASE/proc \
-        && $RM $V -rf $TARDIR/proc
+    $MKDIR $V -p $TARDIR/proc
+    for f in $procfiles
+    do
+        if $NOOP; then
+            if [ -e $f ]
+            then
+                echo "$CP $V -r $f $TARDIR/proc"
+            fi
+        else
+            ( [ -e $f ] && $CP $V -r $f $TARDIR/proc ) || echo "$f not found" > $TARDIR/$f
+        fi
+    done
+    $TAR $V -rhf $TARFILE -C $DUMPDIR --mode=+rw $BASE/proc
+    $RM $V -rf $TARDIR/proc
 }
 
 ###############################################################################
@@ -800,6 +876,9 @@ collect_broadcom() {
     save_bcmcmd_all_ns "\"mirror dest show\"" "mirror.dest.summary"
     save_bcmcmd_all_ns "\"port *\"" "port.summary"
     save_bcmcmd_all_ns "\"d chg my_station_tcam\"" "mystation.tcam.summary"
+
+    copy_from_masic_docker "syncd" "/var/log/diagrun.log" "/var/log/diagrun.log"
+    copy_from_masic_docker "syncd" "/var/log/bcm_diag_post" "/var/log/bcm_diag_post"
 }
 
 ###############################################################################
@@ -859,7 +938,7 @@ save_log_files() {
 ###############################################################################
 # Save warmboot files
 # Globals:
-#  TARDIR, TARFILE, TAR, DUMPDIR, TECHSUPPORT_TIME_INFO
+#  TARDIR, TARFILE, TAR, DUMPDIR, TECHSUPPORT_TIME_INFO, NOOP
 # Arguments:
 #  None
 # Returns:
@@ -867,16 +946,20 @@ save_log_files() {
 ###############################################################################
 save_warmboot_files() {
     # Copy the warmboot files
-    mkdir -p $TARDIR
-    $CP $V -rf /host/warmboot $TARDIR
+    if $NOOP; then
+        echo "$CP $V -rf /host/warmboot $TARDIR"
+    else
+        mkdir -p $TARDIR
+        $CP $V -rf /host/warmboot $TARDIR
 
-    start_t=$(date +%s%3N)
-    ($TAR $V --warning=no-file-removed  -rhf $TARFILE -C $DUMPDIR --mode=+rw \
-        $BASE/warmboot \
-        || abort "${ERROR_TAR_FAILED}" "Tar append operation failed. Aborting for safety.") \
-        && $RM $V -rf $TARDIR
-    end_t=$(date +%s%3N)
-    echo "[ Warm-boot Files ] : $(($end_t-$start_t)) msec" >> $TECHSUPPORT_TIME_INFO
+        start_t=$(date +%s%3N)
+        ($TAR $V --warning=no-file-removed  -rhf $TARFILE -C $DUMPDIR --mode=+rw \
+            $BASE/warmboot \
+            || abort "${ERROR_TAR_FAILED}" "Tar append operation failed. Aborting for safety.") \
+            && $RM $V -rf $TARDIR
+        end_t=$(date +%s%3N)
+        echo "[ Warm-boot Files ] : $(($end_t-$start_t)) msec" >> $TECHSUPPORT_TIME_INFO
+    fi
 }
 
 ###############################################################################
@@ -1122,24 +1205,6 @@ main() {
     end_t=$(date +%s%3N)
     echo "[ TAR /etc Files ] : $(($end_t-$start_t)) msec" >> $TECHSUPPORT_TIME_INFO
 
-    if [ "$asic" = "broadcom" ]; then
-        if [[ ("$NUM_ASICS" > 1) ]]; then
-            for (( i=0; i<$NUM_ASICS; i++ ))
-            do
-                sudo docker exec -i syncd$i touch /var/log/diagrun.log
-                sudo docker exec -i syncd$i touch /var/log/bcm_diag_post
-
-                sudo docker cp syncd$i:/var/log/diagrun.log /var/log/diagrun.log.$i
-                sudo docker cp syncd$i:/var/log/bcm_diag_post /var/log/bcm_diag_post.$i
-            done
-        else
-           sudo docker exec -i syncd touch /var/log/diagrun.log
-           sudo docker exec -i syncd touch /var/log/bcm_diag_post
-
-           sudo docker cp syncd:/var/log/diagrun.log /var/log/diagrun.log
-           sudo docker cp syncd:/var/log/bcm_diag_post /var/log/bcm_diag_post
-        fi
-    fi
     save_log_files
     save_warmboot_files
     save_crash_files

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -570,8 +570,7 @@ save_proc() {
     for f in $procfiles
     do
         if $NOOP; then
-            if [ -e $f ]
-            then
+            if [ -e $f ]; then
                 echo "$CP $V -r $f $TARDIR/proc"
             fi
         else

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -910,13 +910,13 @@ save_log_files() {
 ###############################################################################
 save_warmboot_files() {
     # Copy the warmboot files
+    start_t=$(date +%s%3N)
     if $NOOP; then
         echo "$CP $V -rf /host/warmboot $TARDIR"
     else
         mkdir -p $TARDIR
         $CP $V -rf /host/warmboot $TARDIR
 
-        start_t=$(date +%s%3N)
         ($TAR $V --warning=no-file-removed  -rhf $TARFILE -C $DUMPDIR --mode=+rw \
             $BASE/warmboot \
             || abort "${ERROR_TAR_FAILED}" "Tar append operation failed. Aborting for safety.") \

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -156,8 +156,7 @@ save_cmd() {
     # This is required if $cmd has quoted strings that should be bunched
     # as one argument, e.g. vtysh -c "COMMAND HERE" needs to have
     # "COMMAND HERE" bunched together as 1 arg to vtysh -c
-    if $do_gzip
-    then
+    if $do_gzip; then
         tarpath="${tarpath}.gz"
         filepath="${filepath}.gz"
         local cmds="$cmd 2>&1 | gzip -c > '${filepath}'"
@@ -297,6 +296,7 @@ get_vtysh_namespace() {
     else
         ns=" -n  ${asic_id}"
     fi
+    echo "$ns"
 }
 
 ###############################################################################
@@ -620,41 +620,6 @@ save_saidump() {
 }
 
 ###############################################################################
-# Runs a 'show platform' command, append the output to 'filename' and add to the incrementally built tar.
-# Globals:
-#  LOGDIR
-#  BASE
-#  MKDIR
-#  TAR
-#  TARFILE
-#  DUMPDIR
-#  V
-#  RM
-# Arguments:
-#  type: the type of platform information
-#  filename: the filename to save the output as in $BASE/dump
-# Returns:
-#  None
-###############################################################################
-save_platform() {
-    local start_t=$(date +%s%3N)
-    local end_t=0
-    local type="$1"
-    local filename=$2
-    local filepath="${LOGDIR}/$filename"
-    local tarpath="${BASE}/dump/$filename"
-    [ ! -d $LOGDIR ] && $MKDIR $V -p $LOGDIR
-
-    eval "show platform $type" &>> "$filepath"
-    echo $'\r' >> "$filepath"
-
-    ($TAR $V -uhf $TARFILE -C $DUMPDIR "$tarpath" \
-        || abort "${ERROR_TAR_FAILED}" "tar append operation failed. Aborting to prevent data loss.")
-    end_t=$(date +%s%3N)
-    echo "[ save_platform:$type ] : $(($end_t-$start_t)) msec" >> $TECHSUPPORT_TIME_INFO
-}
-
-###############################################################################
 # Save platform related info
 # Globals:
 #  None
@@ -664,11 +629,11 @@ save_platform() {
 #  None
 ###############################################################################
 save_platform_info() {
-    save_platform "syseeprom" "platform"
-    save_platform "psustatus" "platform"
-    save_platform "ssdhealth" "platform"
-    save_platform "temperature" "platform"
-    save_platform "fan" "platform"
+    save_cmd "show platform syseeprom" "syseeprom"
+    save_cmd "show platform psustatus" "psustatus"
+    save_cmd "show platform ssdhealth" "ssdhealth"
+    save_cmd "show platform temperature" "temperature"
+    save_cmd "show platform fan" "fan"
 }
 
 ###############################################################################


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Add NOOP option for 'save_proc' and 'docker cp' commands. 
(this option can be used in pytest to check against all commands that will be executed for techsupport collection)

#### How I did it
Added "NOOP" option to print the command without executing it.

#### How to verify it
```
admin@str-s6000-acs-8:~$ generate_dump -n
mkdir -p /var/dump/sonic_dump_str-s6000-acs-8_20210218_230943
ln -s /usr/local/bin/generate_dump /var/dump/sonic_dump_str-s6000-acs-8_20210218_230943
tar -chf /var/dump/sonic_dump_str-s6000-acs-8_20210218_230943.tar -C /var/dump sonic_dump_str-s6000-acs-8_20210218_230943
rm -f /var/dump/sonic_dump_str-s6000-acs-8_20210218_230943/sonic_dump
mkdir -p /var/dump/sonic_dump_str-s6000-acs-8_20210218_230943/proc
echo cp  -r /proc/buddyinfo /var/dump/sonic_dump_str-s6000-acs-8_20210218_230943/proc
echo cp  -r /proc/cmdline /var/dump/sonic_dump_str-s6000-acs-8_20210218_230943/proc
echo cp  -r /proc/consoles /var/dump/sonic_dump_str-s6000-acs-8_20210218_230943/proc
echo cp  -r /proc/cpuinfo /var/dump/sonic_dump_str-s6000-acs-8_20210218_230943/proc
.
.
.

admin@str-s6000-acs-8:~$ generate_dump -n
mkdir -p /var/dump/sonic_dump_str-s6000-acs-8_20210218_231041
ln -s /usr/local/bin/generate_dump /var/dump/sonic_dump_str-s6000-acs-8_20210218_231041
tar -chf /var/dump/sonic_dump_str-s6000-acs-8_20210218_231041.tar -C /var/dump sonic_dump_str-s6000-acs-8_20210218_231041
rm -f /var/dump/sonic_dump_str-s6000-acs-8_20210218_231041/sonic_dump
timeout --foreground 5m sudo docker exec -i syncd touch /var/log/diagrun.log
timeout --foreground 5m sudo docker cp syncd:/var/log/diagrun.log /var/log/diagrun.log
timeout --foreground 5m sudo docker exec -i syncd touch /var/log/bcm_diag_post
timeout --foreground 5m sudo docker cp syncd:/var/log/bcm_diag_post /var/log/bcm_diag_post

```

Platform INFO:

```
admin@svcstr-nmasic-acs-1:/var/dump$ sudo generate_dump -n | grep timeout 
timeout --foreground 5m show platform syseeprom &> '/var/dump/sonic_dump_svcstr-nmasic-acs-1_20210219_194632/dump/syseeprom'
timeout --foreground 5m show platform psustatus &> '/var/dump/sonic_dump_svcstr-nmasic-acs-1_20210219_194632/dump/psustatus'
timeout --foreground 5m show platform ssdhealth &> '/var/dump/sonic_dump_svcstr-nmasic-acs-1_20210219_194632/dump/ssdhealth'
timeout --foreground 5m show platform temperature &> '/var/dump/sonic_dump_svcstr-nmasic-acs-1_20210219_194632/dump/temperature'
timeout --foreground 5m show platform fan &> '/var/dump/sonic_dump_svcstr-nmasic-acs-1_20210219_194632/dump/fan'


admin@svcstr-nmasic-acs-1:~$ sudo generate_dump 
tar: sonic_dump_svcstr-nmasic-acs-1_20210219_194041/generate_dump: File removed before we read it
Command: show platform syseeprom timedout after 5 minutes.
admin@svcstr-nmasic-acs-1:~$ cd /var/dump/
admin@svcstr-nmasic-acs-1:/var/dump$ sudo tar -xvf sonic_dump_svcstr-nmasic-acs-1_20210219_194041.tar 
sonic_dump_svcstr-nmasic-acs-1_20210219_194041/
sonic_dump_svcstr-nmasic-acs-1_20210219_194041/dump/syseeprom
sonic_dump_svcstr-nmasic-acs-1_20210219_194041/dump/psustatus
sonic_dump_svcstr-nmasic-acs-1_20210219_194041/dump/ssdhealth
sonic_dump_svcstr-nmasic-acs-1_20210219_194041/dump/temperature
sonic_dump_svcstr-nmasic-acs-1_20210219_194041/dump/fan

PSU    Status
-----  --------
PSU 1  OK
PSU 2  OK
Device Model : Micron_M600_MTFDDAT064MBF
Health       : N/A
Temperature  : N/A
Fan Not detected

admin@svcstr-masic-acs-1:/var/dump$ cat sonic_dump_svcstr-nmasic-acs-1_20210219_194041/dump/fan
Fan Not detected

admin@svcstr-masic-acs-1:/var/dump$ cat sonic_dump_svcstr-nmasic-acs-1_20210219_194041/dump/temperature
Thermal Not detected

admin@svcstr-masic-acs-1:/var/dump$ cat sonic_dump_svcstr-nmasic-acs-1_20210219_194041/dump/ssdhealth
Device Model : Micron_M600_MTFDDAT064MBF
Health       : N/A
Temperature  : N/A


```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

