### PR TITLE
[ci] No longer pass '--privileged' option to slave container

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,6 @@ pool:
 
 container:
   image: sonicdev-microsoft.azurecr.io:443/sonic-slave-buster:latest
-  options: --privileged
 
 steps:
 - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
#### What I did

Now that https://github.com/Azure/sonic-utilities/pull/1427 has merged, we should be able to successfully run all unit tests in a non-privileged slave container.

#### How I did it

Remove `--privileged` option from sonic-slave-buster container

#### How to verify it

Ensure PR unit tests pass

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

