### PR TITLE
[show] cli support for show muxcable cableinfo

### DIFF
--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -382,6 +382,7 @@ def eyeinfo(port, target):
     click.echo(tabulate(lane_data, headers=headers))
     sys.exit(EXIT_SUCCESS)
 
+
 @muxcable.command()
 @click.argument('port', required=True, default=None)
 def cableinfo(port):

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -381,3 +381,36 @@ def eyeinfo(port, target):
     lane_data.append(res)
     click.echo(tabulate(lane_data, headers=headers))
     sys.exit(EXIT_SUCCESS)
+
+@muxcable.command()
+@click.argument('port', required=True, default=None)
+def cableinfo(port):
+    """Show muxcable cable information"""
+
+    if platform_sfputil is not None:
+        physical_port_list = platform_sfputil_helper.logical_port_name_to_physical_port_list(port)
+
+    if not isinstance(physical_port_list, list):
+        click.echo("ERR: Unable to get a port on muxcable port")
+        sys.exit(EXIT_FAIL)
+        if len(physical_port_list) != 1:
+            click.echo("ERR: Unable to get a single port on muxcable")
+            sys.exit(EXIT_FAIL)
+
+    physical_port = physical_port_list[0]
+    import sonic_y_cable.y_cable
+    res = sonic_y_cable.y_cable.get_pn_number_and_vendor_name(physical_port)
+    if res == False or res == -1:
+        click.echo("ERR: Unable to get cable info")
+        sys.exit(EXIT_FAIL)
+    headers = ['pin_number', 'vendor_name']
+    lane_data = []
+    pin = str(res[0].decode())
+    vendor = str(res[1].decode())
+    temp_list = []
+
+    temp_list.append(pin)
+    temp_list.append(vendor)
+    lane_data.append(temp_list)
+    click.echo(tabulate(lane_data, headers=headers))
+    sys.exit(EXIT_SUCCESS)

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -399,18 +399,20 @@ def cableinfo(port):
 
     physical_port = physical_port_list[0]
     import sonic_y_cable.y_cable
-    res = sonic_y_cable.y_cable.get_pn_number_and_vendor_name(physical_port)
-    if res == False or res == -1:
-        click.echo("ERR: Unable to get cable info")
+    part = sonic_y_cable.y_cable.get_part_number(physical_port)
+    if part == False or part == -1:
+        click.echo("ERR: Unable to get cable info part number")
         sys.exit(EXIT_FAIL)
-    headers = ['pin_number', 'vendor_name']
+    vendor = sonic_y_cable.y_cable.get_vendor(physical_port)
+    if vendor == False or vendor == -1:
+        click.echo("ERR: Unable to get cable info vendor name")
+        sys.exit(EXIT_FAIL)
+    headers = ['Vendor', 'Model']
     lane_data = []
-    pin = str(res[0].decode())
-    vendor = str(res[1].decode())
     temp_list = []
 
-    temp_list.append(pin)
     temp_list.append(vendor)
+    temp_list.append(part)
     lane_data.append(temp_list)
     click.echo(tabulate(lane_data, headers=headers))
     sys.exit(EXIT_SUCCESS)

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -399,8 +399,8 @@ def cableinfo(port):
 
     physical_port = physical_port_list[0]
     import sonic_y_cable.y_cable
-    part = sonic_y_cable.y_cable.get_part_number(physical_port)
-    if part == False or part == -1:
+    part_num = sonic_y_cable.y_cable.get_part_number(physical_port)
+    if part_num == False or part_num == -1:
         click.echo("ERR: Unable to get cable info part number")
         sys.exit(EXIT_FAIL)
     vendor = sonic_y_cable.y_cable.get_vendor(physical_port)
@@ -408,11 +408,6 @@ def cableinfo(port):
         click.echo("ERR: Unable to get cable info vendor name")
         sys.exit(EXIT_FAIL)
     headers = ['Vendor', 'Model']
-    lane_data = []
-    temp_list = []
 
-    temp_list.append(vendor)
-    temp_list.append(part)
-    lane_data.append(temp_list)
-    click.echo(tabulate(lane_data, headers=headers))
-    sys.exit(EXIT_SUCCESS)
+    body = [[vendor, part_num]]
+    click.echo(tabulate(body, headers=headers))

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -156,6 +156,13 @@ json_data_config_output_active_expected = """\
 }
 """
 
+expected_muxcable_cableinfo_output = """\
+pin_number       vendor_name
+---------------  -------------
+CACL1X321P2PA1M  Credo
+"""
+
+
 
 class TestMuxcable(object):
     @classmethod
@@ -501,6 +508,7 @@ class TestMuxcable(object):
                                ["Ethernet0"], obj=db)
 
         assert result.exit_code == 0
+        assert result.output == expected_muxcable_cableinfo_output
 
     @mock.patch('sonic_y_cable.y_cable.get_pn_number_and_vendor_name', mock.MagicMock(return_value=(False)))
     @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value=1))

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -157,9 +157,9 @@ json_data_config_output_active_expected = """\
 """
 
 expected_muxcable_cableinfo_output = """\
-pin_number       vendor_name
----------------  -------------
-CACL1X321P2PA1M  Credo
+Vendor    Model
+--------  ---------------
+Credo     CACL1X321P2PA1M
 """
 
 
@@ -496,7 +496,8 @@ class TestMuxcable(object):
 
         assert result.exit_code == 100
 
-    @mock.patch('sonic_y_cable.y_cable.get_pn_number_and_vendor_name', mock.MagicMock(return_value=(bytearray(b'CACL1X321P2PA1M'), bytearray(b'Credo          '))))
+    @mock.patch('sonic_y_cable.y_cable.get_part_number', mock.MagicMock(return_value=("CACL1X321P2PA1M")))
+    @mock.patch('sonic_y_cable.y_cable.get_vendor', mock.MagicMock(return_value=("Credo          ")))
     @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value=1))
     @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
     def test_show_muxcable_cableinfo(self):
@@ -509,7 +510,8 @@ class TestMuxcable(object):
         assert result.exit_code == 0
         assert result.output == expected_muxcable_cableinfo_output
 
-    @mock.patch('sonic_y_cable.y_cable.get_pn_number_and_vendor_name', mock.MagicMock(return_value=(False)))
+    @mock.patch('sonic_y_cable.y_cable.get_part_number', mock.MagicMock(return_value=(False)))
+    @mock.patch('sonic_y_cable.y_cable.get_vendor', mock.MagicMock(return_value=(False)))
     @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value=1))
     @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
     def test_show_muxcable_cableinfo_incorrect_port(self):
@@ -520,7 +522,8 @@ class TestMuxcable(object):
                                ["Ethernet0"], obj=db)
         assert result.exit_code == 1
 
-    @mock.patch('sonic_y_cable.y_cable.get_pn_number_and_vendor_name', mock.MagicMock(return_value=(False)))
+    @mock.patch('sonic_y_cable.y_cable.get_part_number', mock.MagicMock(return_value=(False)))
+    @mock.patch('sonic_y_cable.y_cable.get_vendor', mock.MagicMock(return_value=(False)))
     @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value=1))
     @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=0))
     def test_show_muxcable_cableinfo_incorrect_port_return_value(self):
@@ -531,7 +534,8 @@ class TestMuxcable(object):
                                ["Ethernet0"], obj=db)
         assert result.exit_code == 1
 
-    @mock.patch('sonic_y_cable.y_cable.get_pn_number_and_vendor_name', mock.MagicMock(return_value=(False)))
+    @mock.patch('sonic_y_cable.y_cable.get_part_number', mock.MagicMock(return_value=(False)))
+    @mock.patch('sonic_y_cable.y_cable.get_vendor', mock.MagicMock(return_value=(False)))
     @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value=1))
     @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0, 1]))
     def test_show_muxcable_cableinfo_incorrect_logical_port_return_value(self):

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -13,6 +13,9 @@ sys.modules['sonic_platform_base.sonic_sfp.sfputilhelper'] = mock.Mock()
 sys.modules['sonic_y_cable'] = mock.Mock()
 sys.modules['y_cable'] = mock.Mock()
 sys.modules['sonic_y_cable.y_cable'] = mock.Mock()
+sys.modules['platform_sfputil'] = mock.Mock()
+sys.modules['platform_sfputil_helper'] = mock.Mock()
+sys.modules['utilities_common.platform_sfputil_helper'] = mock.Mock()
 #sys.modules['os'] = mock.Mock()
 #sys.modules['os.geteuid'] = mock.Mock()
 #sys.modules['platform_sfputil'] = mock.Mock()
@@ -486,6 +489,51 @@ class TestMuxcable(object):
                                ["0", "0"], obj=db)
 
         assert result.exit_code == 100
+
+    @mock.patch('sonic_y_cable.y_cable.get_pn_number_and_vendor_name', mock.MagicMock(return_value=(bytearray(b'CACL1X321P2PA1M'), bytearray(b'Credo          '))))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value=1))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    def test_show_muxcable_cableinfo(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["cableinfo"],
+                               ["Ethernet0"], obj=db)
+
+        assert result.exit_code == 0
+
+    @mock.patch('sonic_y_cable.y_cable.get_pn_number_and_vendor_name', mock.MagicMock(return_value=(False)))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value=1))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    def test_show_muxcable_cableinfo_incorrect_port(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["cableinfo"],
+                               ["Ethernet0"], obj=db)
+        assert result.exit_code == 1
+
+    @mock.patch('sonic_y_cable.y_cable.get_pn_number_and_vendor_name', mock.MagicMock(return_value=(False)))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value=1))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=0))
+    def test_show_muxcable_cableinfo_incorrect_port_return_value(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["cableinfo"],
+                               ["Ethernet0"], obj=db)
+        assert result.exit_code == 1
+
+    @mock.patch('sonic_y_cable.y_cable.get_pn_number_and_vendor_name', mock.MagicMock(return_value=(False)))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value=1))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0,1]))
+    def test_show_muxcable_cableinfo_incorrect_logical_port_return_value(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["cableinfo"],
+                               ["Ethernet0"], obj=db)
+        assert result.exit_code == 1
 
     @classmethod
     def teardown_class(cls):

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -163,7 +163,6 @@ CACL1X321P2PA1M  Credo
 """
 
 
-
 class TestMuxcable(object):
     @classmethod
     def setup_class(cls):
@@ -534,7 +533,7 @@ class TestMuxcable(object):
 
     @mock.patch('sonic_y_cable.y_cable.get_pn_number_and_vendor_name', mock.MagicMock(return_value=(False)))
     @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value=1))
-    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0,1]))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0, 1]))
     def test_show_muxcable_cableinfo_incorrect_logical_port_return_value(self):
         runner = CliRunner()
         db = Db()

--- a/utilities_common/platform_sfputil_helper.py
+++ b/utilities_common/platform_sfputil_helper.py
@@ -37,3 +37,13 @@ def platform_sfputil_read_porttab_mappings():
         sys.exit(1)
 
     return 0
+
+def logical_port_name_to_physical_port_list(port_name):
+    if port_name.startswith("Ethernet"):
+        if platform_sfputil.is_logical_port(port_name):
+            return platform_sfputil.get_logical_to_physical(port_name)
+        else:
+            click.echo("Invalid port '{}'".format(port_name))
+            return None
+    else:
+        return [int(port_name)]


### PR DESCRIPTION
Summary:
This PR provides the support for adding CLI commands for retrieving cable vendor name and part number information of the muxcable.
In particular these Cli commands are supported:
` show muxcable cableinfo <port>`


### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
added the changes in sonic-utilities/show and sonic-utilities/config by changing the muxcable.py 

#### What is the motivation for this PR?

To add the support for Cli for muxcable to be utilized for retrieving cable vendor name and part number information of the muxcable.

#### How did you do it?
Added the changes inside sonic-utilities and tested it on the testbed

#### How did you verify/test it?
Ran the cli commands on an Arista7050cx3 testbed with Gemini cable

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>
