### PR TITLE
Use 'importlib' module in lieu of deprecated 'imp' module

### DIFF
--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -2,31 +2,21 @@
 config_mgmt.py provides classes for configuration validation and for Dynamic
 Port Breakout.
 '''
-try:
-    import importlib.machinery
-    import importlib.util
-    import re
-    import syslog
+import re
+import syslog
+from json import load
+from sys import flags
+from time import sleep as tsleep
 
-    from json import load
-    from time import sleep as tsleep
-    from jsondiff import diff
-    from sys import flags
+import sonic_yang
+from jsondiff import diff
+from swsssdk import port_util
+from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
+from utilities_common.general import load_module_from_source
 
-    # SONiC specific imports
-    import sonic_yang
-    from swsssdk import port_util
-    from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
 
-    # Using load_source to 'import /usr/local/bin/sonic-cfggen as sonic_cfggen'
-    # since /usr/local/bin/sonic-cfggen does not have .py extension.
-    loader = importlib.machinery.SourceFileLoader('sonic_cfggen', '/usr/local/bin/sonic-cfggen')
-    spec = importlib.util.spec_from_loader(loader.name, loader)
-    sonic_cfggen = importlib.util.module_from_spec(spec)
-    loader.exec_module(sonic_cfggen)
-
-except ImportError as e:
-    raise ImportError("%s - required module not found" % str(e))
+# Load sonic-cfggen from source since /usr/local/bin/sonic-cfggen does not have .py extension.
+sonic_cfggen = load_module_from_source('sonic_cfggen', '/usr/local/bin/sonic-cfggen')
 
 # Globals
 YANG_DIR = "/usr/local/yang-models"

--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -3,7 +3,8 @@ config_mgmt.py provides classes for configuration validation and for Dynamic
 Port Breakout.
 '''
 try:
-    import importlib
+    import importlib.machinery
+    import importlib.util
     import re
     import syslog
 

--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -1,11 +1,9 @@
+import importlib
 import os
-import imp
 import sys
 
 import click
-
 import utilities_common.cli as clicommon
-
 from natsort import natsorted
 from sonic_py_common.multi_asic import get_external_ports
 from tabulate import tabulate
@@ -27,7 +25,7 @@ try:
         import mock_tables.dbconnector
     if os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] == "multi_asic":
         import mock_tables.mock_multi_asic
-        imp.reload(mock_tables.mock_multi_asic)
+        importlib.reload(mock_tables.mock_multi_asic)
         mock_tables.dbconnector.load_namespace_config()
 
 except KeyError:

--- a/tests/aclshow_test.py
+++ b/tests/aclshow_test.py
@@ -22,8 +22,8 @@ from .mock_tables import dbconnector
 
 
 # Expected output for aclshow
-default_output = ''+ \
-"""RULE NAME     TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
+default_output = """\
+RULE NAME     TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
 ------------  ------------  ------  ---------------  -------------
 RULE_1        DATAACL         9999              101            100
 RULE_2        DATAACL         9998              201            200
@@ -37,8 +37,8 @@ RULE_6        EVERFLOW        9994              601            600
 """
 
 # Expected output for aclshow -a
-all_output = '' + \
-"""RULE NAME     TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
+all_output = """\
+RULE NAME     TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
 ------------  ------------  ------  ---------------  -------------
 RULE_1        DATAACL         9999              101            100
 RULE_2        DATAACL         9998              201            200
@@ -54,35 +54,35 @@ RULE_08       EVERFLOW        9992                0              0
 """
 
 # Expected output for aclshow -r RULE_1 -t DATAACL
-rule1_dataacl_output = '' + \
-"""RULE NAME    TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
+rule1_dataacl_output = """\
+RULE NAME    TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
 -----------  ------------  ------  ---------------  -------------
 RULE_1       DATAACL         9999              101            100
 """
 
 # Expected output for aclshow -r RULE_1 -t DATAACL
-rule10_dataacl_output = '' + \
-"""RULE NAME    TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
+rule10_dataacl_output = """\
+RULE NAME    TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
 -----------  ------------  ------  ---------------  -------------
 RULE_10      DATAACL         9989             1001           1000
 """
 
 # Expected output for aclshow -a -r RULE_05
-rule05_all_output = ''+ \
-"""RULE NAME    TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
+rule05_all_output = """\
+RULE NAME    TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
 -----------  ------------  ------  ---------------  -------------
 RULE_05      DATAACL         9995                0              0
 """
 
 # Expected output for aclshow -r RULE_0
-rule0_output = '' + \
-"""RULE NAME    TABLE NAME    PRIO    PACKETS COUNT    BYTES COUNT
+rule0_output = """\
+RULE NAME    TABLE NAME    PRIO    PACKETS COUNT    BYTES COUNT
 -----------  ------------  ------  ---------------  -------------
 """
 
 # Expected output for aclshow -r RULE_4,RULE_6 -vv
-rule4_rule6_verbose_output = '' + \
-"""Reading ACL info...
+rule4_rule6_verbose_output = """\
+Reading ACL info...
 Total number of ACL Tables: 8
 Total number of ACL Rules: 11
 
@@ -93,15 +93,15 @@ RULE_6       EVERFLOW        9994              601            600
 """
 
 # Expected output for aclshow -t EVERFLOW
-everflow_output = '' + \
-"""RULE NAME    TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
+everflow_output = """\
+RULE NAME    TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
 -----------  ------------  ------  ---------------  -------------
 RULE_6       EVERFLOW        9994              601            600
 """
 
 # Expected output for aclshow -t DATAACL
-dataacl_output = '' + \
-"""RULE NAME     TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
+dataacl_output = """\
+RULE NAME     TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
 ------------  ------------  ------  ---------------  -------------
 RULE_1        DATAACL         9999              101            100
 RULE_2        DATAACL         9998              201            200
@@ -118,8 +118,8 @@ clear_output = ''
 
 # Expected output for
 # aclshow -a -c ; aclshow -a
-all_after_clear_output = '' + \
-"""RULE NAME     TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
+all_after_clear_output = """\
+RULE NAME     TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
 ------------  ------------  ------  ---------------  -------------
 RULE_1        DATAACL         9999                0              0
 RULE_2        DATAACL         9998                0              0
@@ -133,6 +133,7 @@ DEFAULT_RULE  DATAACL            1                0              0
 RULE_6        EVERFLOW        9994                0              0
 RULE_08       EVERFLOW        9992                0              0
 """
+
 
 class Aclshow():
     def __init__(self, *args, **kwargs):
@@ -160,10 +161,10 @@ class Aclshow():
         This method invokes main() from aclshow utility (parametrized by argparse)
         parametrized by mock argparse.
         """
-        @mock.patch('argparse.ArgumentParser.parse_args', return_value = argparse.Namespace(**self.kwargs))
-        def run(mock_args):
+        with mock.patch.object(aclshow.argparse.ArgumentParser,
+                               'parse_args',
+                               return_value=aclshow.argparse.Namespace(**self.kwargs)):
             aclshow.main()
-        run()
 
     def setUp(self):
         if self.nullify_on_start:
@@ -178,56 +179,78 @@ class Aclshow():
         sys.stdout = self.old_stdout
 
 # aclshow
+
+
 def test_default():
-    test = Aclshow(all = None, clear = None, rules = None, tables = None, verbose = None)
+    test = Aclshow(all=None, clear=None, rules=None, tables=None, verbose=None)
     assert test.result.getvalue() == default_output
 
 # aclshow -a
+
+
 def test_all():
-    test = Aclshow(all = True, clear = None, rules = None, tables = None, verbose = None)
+    test = Aclshow(all=True, clear=None, rules=None, tables=None, verbose=None)
     assert test.result.getvalue() == all_output
 
 # aclshow -r RULE_1 -t DATAACL
+
+
 def test_rule1_dataacl():
-    test = Aclshow(all = None, clear = None, rules = 'RULE_1', tables = 'DATAACL', verbose = None)
+    test = Aclshow(all=None, clear=None, rules='RULE_1', tables='DATAACL', verbose=None)
     assert test.result.getvalue() == rule1_dataacl_output
 
 # aclshow -a -r RULE_05
+
+
 def test_rule05_all():
-    test = Aclshow(all = True, clear = None, rules = 'RULE_05', tables = None, verbose = None)
+    test = Aclshow(all=True, clear=None, rules='RULE_05', tables=None, verbose=None)
     assert test.result.getvalue() == rule05_all_output
 
 # aclshow -r RULE_0
+
+
 def test_rule0():
-    test = Aclshow(all = None, clear = None, rules = 'RULE_0', tables = None, verbose = None)
+    test = Aclshow(all=None, clear=None, rules='RULE_0', tables=None, verbose=None)
     assert test.result.getvalue() == rule0_output
 
 # aclshow -r RULE_10 -t DATAACL
+
+
 def test_rule10_lowercase_priority():
-    test = Aclshow(all = None, clear = None, rules = 'RULE_10', tables = 'DATAACL', verbose = None)
+    test = Aclshow(all=None, clear=None, rules='RULE_10', tables='DATAACL', verbose=None)
     assert test.result.getvalue() == rule10_dataacl_output
 
 # aclshow -r RULE_4,RULE_6 -vv
+
+
 def test_rule4_rule6_verbose():
-    test = Aclshow(all = None, clear = None, rules = 'RULE_4,RULE_6', tables = None, verbose = True)
+    test = Aclshow(all=None, clear=None, rules='RULE_4,RULE_6', tables=None, verbose=True)
     assert test.result.getvalue() == rule4_rule6_verbose_output
 
 # aclshow -t EVERFLOW
+
+
 def test_everflow():
     test = Aclshow(all=None, clear=None, rules=None, tables='EVERFLOW', verbose=None)
     assert test.result.getvalue() == everflow_output
 
 # aclshow -t DATAACL
+
+
 def test_dataacl():
     test = Aclshow(all=None, clear=None, rules=None, tables='DATAACL', verbose=None)
     assert test.result.getvalue() == dataacl_output
 
 # aclshow -c
+
+
 def test_clear():
     test = Aclshow(all=None, clear=True, rules=None, tables=None, verbose=None)
     assert test.result.getvalue() == clear_output
 
 # aclshow -a -c ; aclshow -a
+
+
 def test_all_after_clear():
     nullify_on_start, nullify_on_exit = True, False
     test = Aclshow(nullify_on_start, nullify_on_exit, all=True, clear=True, rules=None, tables=None, verbose=None)

--- a/tests/aclshow_test.py
+++ b/tests/aclshow_test.py
@@ -1,6 +1,7 @@
-import sys
+import importlib
+import json
 import os
-from imp import load_source
+import sys
 from io import StringIO
 from unittest import mock
 
@@ -10,8 +11,12 @@ modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, "scripts")
 sys.path.insert(0, modules_path)
 
-load_source('aclshow', scripts_path+'/aclshow')
-from aclshow import *
+# Load the file under test
+aclshow_path = os.path.join(scripts_path, 'aclshow')
+loader = importlib.machinery.SourceFileLoader('aclshow', aclshow_path)
+spec = importlib.util.spec_from_loader(loader.name, loader)
+aclshow = importlib.util.module_from_spec(spec)
+loader.exec_module(aclshow)
 
 from .mock_tables import dbconnector
 
@@ -146,8 +151,8 @@ class Aclshow():
         This method is used to empty dumped counters
         if exist in /tmp/.counters_acl.p (by default).
         """
-        if os.path.isfile(COUNTER_POSITION):
-            with open(COUNTER_POSITION, 'w') as fp:
+        if os.path.isfile(aclshow.COUNTER_POSITION):
+            with open(aclshow.COUNTER_POSITION, 'w') as fp:
                 json.dump([], fp)
 
     def runTest(self):
@@ -157,7 +162,7 @@ class Aclshow():
         """
         @mock.patch('argparse.ArgumentParser.parse_args', return_value = argparse.Namespace(**self.kwargs))
         def run(mock_args):
-            main()
+            aclshow.main()
         run()
 
     def setUp(self):

--- a/tests/aclshow_test.py
+++ b/tests/aclshow_test.py
@@ -1,11 +1,10 @@
-import importlib.machinery
-import importlib.util
 import json
 import os
 import sys
 from io import StringIO
 from unittest import mock
 
+from utilities_common.general import load_module_from_source
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
@@ -14,10 +13,7 @@ sys.path.insert(0, modules_path)
 
 # Load the file under test
 aclshow_path = os.path.join(scripts_path, 'aclshow')
-loader = importlib.machinery.SourceFileLoader('aclshow', aclshow_path)
-spec = importlib.util.spec_from_loader(loader.name, loader)
-aclshow = importlib.util.module_from_spec(spec)
-loader.exec_module(aclshow)
+aclshow = load_module_from_source('aclshow', aclshow_path)
 
 from .mock_tables import dbconnector
 

--- a/tests/aclshow_test.py
+++ b/tests/aclshow_test.py
@@ -1,4 +1,5 @@
-import importlib
+import importlib.machinery
+import importlib.util
 import json
 import os
 import sys

--- a/tests/buffer_test.py
+++ b/tests/buffer_test.py
@@ -1,4 +1,3 @@
-import imp
 import os
 import sys
 from click.testing import CliRunner

--- a/tests/config_dpb_test.py
+++ b/tests/config_dpb_test.py
@@ -1,5 +1,3 @@
-import importlib.machinery
-import importlib.util
 import json
 import os
 import re
@@ -8,22 +6,16 @@ from unittest import mock
 import pytest
 from click.testing import CliRunner
 from utilities_common.db import Db
+from utilities_common.general import load_module_from_source
 
 import config.main as config
 
-# Using load_source to 'import /usr/local/bin/sonic-cfggen as sonic_cfggen'
-# since /usr/local/bin/sonic-cfggen does not have .py extension.
-loader = importlib.machinery.SourceFileLoader('sonic_cfggen', '/usr/local/bin/sonic-cfggen')
-spec = importlib.util.spec_from_loader(loader.name, loader)
-sonic_cfggen = importlib.util.module_from_spec(spec)
-loader.exec_module(sonic_cfggen)
+# Load sonic-cfggen from source since /usr/local/bin/sonic-cfggen does not have .py extension.
+sonic_cfggen = load_module_from_source('sonic_cfggen', '/usr/local/bin/sonic-cfggen')
 
 # Import config_mgmt.py
 config_mgmt_py_path = os.path.join(os.path.dirname(__file__), '..', 'config', 'config_mgmt.py')
-loader = importlib.machinery.SourceFileLoader('config_mgmt', config_mgmt_py_path)
-spec = importlib.util.spec_from_loader(loader.name, loader)
-config_mgmt = importlib.util.module_from_spec(spec)
-loader.exec_module(config_mgmt)
+config_mgmt = load_module_from_source('config_mgmt', config_mgmt_py_path)
 
 
 # Sample platform.json for Test

--- a/tests/config_dpb_test.py
+++ b/tests/config_dpb_test.py
@@ -1,4 +1,5 @@
-import importlib
+import importlib.machinery
+import importlib.util
 import json
 import os
 import re

--- a/tests/config_mgmt_test.py
+++ b/tests/config_mgmt_test.py
@@ -1,18 +1,14 @@
-import importlib.machinery
-import importlib.util
 import os
 import sys
-from unittest import mock, TestCase
-
 from json import dump
 from copy import deepcopy
+from unittest import mock, TestCase
+
+from utilities_common.general import load_module_from_source
 
 # Import file under test i.e., config_mgmt.py
 config_mgmt_py_path = os.path.join(os.path.dirname(__file__), '..', 'config', 'config_mgmt.py')
-loader = importlib.machinery.SourceFileLoader('config_mgmt', config_mgmt_py_path)
-spec = importlib.util.spec_from_loader(loader.name, loader)
-config_mgmt = importlib.util.module_from_spec(spec)
-loader.exec_module(config_mgmt)
+config_mgmt = load_module_from_source('config_mgmt', config_mgmt_py_path)
 
 
 class TestConfigMgmt(TestCase):

--- a/tests/config_mgmt_test.py
+++ b/tests/config_mgmt_test.py
@@ -1,15 +1,18 @@
-import imp
+import importlib
 import os
 import sys
 from unittest import mock, TestCase
 
-# import file under test i.e. config_mgmt.py
-imp.load_source('config_mgmt', \
-    os.path.join(os.path.dirname(__file__), '..', 'config', 'config_mgmt.py'))
-import config_mgmt
-
 from json import dump
 from copy import deepcopy
+
+# Import file under test i.e., config_mgmt.py
+config_mgmt_py_path = os.path.join(os.path.dirname(__file__), '..', 'config', 'config_mgmt.py')
+loader = importlib.machinery.SourceFileLoader('config_mgmt', config_mgmt_py_path)
+spec = importlib.util.spec_from_loader(loader.name, loader)
+config_mgmt = importlib.util.module_from_spec(spec)
+loader.exec_module(config_mgmt)
+
 
 class TestConfigMgmt(TestCase):
     '''
@@ -41,15 +44,15 @@ class TestConfigMgmt(TestCase):
         curConfig = deepcopy(configDbJson)
         self.writeJson(curConfig, config_mgmt.CONFIG_DB_JSON_FILE)
         cmdpb = config_mgmt.ConfigMgmtDPB(source=config_mgmt.CONFIG_DB_JSON_FILE)
-        out = cmdpb.configWithKeys(portBreakOutConfigDbJson, \
-            ["Ethernet8","Ethernet9"])
+        out = cmdpb.configWithKeys(portBreakOutConfigDbJson,
+                                   ["Ethernet8", "Ethernet9"])
         assert "VLAN" not in out
         assert "INTERFACE" not in out
         for k in out['ACL_TABLE']:
             # only ports must be chosen
             len(out['ACL_TABLE'][k]) == 1
-        out = cmdpb.configWithKeys(portBreakOutConfigDbJson, \
-            ["Ethernet10","Ethernet11"])
+        out = cmdpb.configWithKeys(portBreakOutConfigDbJson,
+                                   ["Ethernet10", "Ethernet11"])
         assert "INTERFACE" in out
         for k in out['ACL_TABLE']:
             # only ports must be chosen
@@ -58,13 +61,13 @@ class TestConfigMgmt(TestCase):
 
     def test_break_out(self):
         # prepare default config
-        self.writeJson(portBreakOutConfigDbJson, \
-            config_mgmt.DEFAULT_CONFIG_DB_JSON_FILE)
+        self.writeJson(portBreakOutConfigDbJson,
+                       config_mgmt.DEFAULT_CONFIG_DB_JSON_FILE)
         # prepare config dj json to start with
         curConfig = deepcopy(configDbJson)
-        #Ethernet8: start from 4x25G-->2x50G with -f -l
+        # Ethernet8: start from 4x25G-->2x50G with -f -l
         self.dpb_port8_4x25G_2x50G_f_l(curConfig)
-        #Ethernet8: move from 2x50G-->1x100G without force, list deps
+        # Ethernet8: move from 2x50G-->1x100G without force, list deps
         self.dpb_port8_2x50G_1x100G(curConfig)
         # Ethernet8: move from 2x50G-->1x100G with force, where deps exists
         self.dpb_port8_2x50G_1x100G_f(curConfig)
@@ -136,28 +139,39 @@ class TestConfigMgmt(TestCase):
         '''
         # default params
         pre = "Ethernet"
-        laneMap = {"4x25G": [1,1,1,1], "2x50G": [2,2], "1x100G":[4], \
-            "1x50G(2)+2x25G(2)":[2,1,1], "2x25G(2)+1x50G(2)":[1,1,2]}
+        laneMap = {"4x25G": [1, 1, 1, 1], "2x50G": [2, 2], "1x100G": [4],
+                   "1x50G(2)+2x25G(2)": [2, 1, 1], "2x25G(2)+1x50G(2)": [1, 1, 2]}
         laneSpeed = 25000
         # generate dPorts
-        l = list(laneMap[curMode]); l.insert(0, 0); id = portIdx; dPorts = list()
+        l = list(laneMap[curMode])
+        l.insert(0, 0)
+        id = portIdx
+        dPorts = list()
         for i in l[:-1]:
             id = id + i
             portName = portName = "{}{}".format(pre, id)
             dPorts.append(portName)
         # generate aPorts
-        l = list(laneMap[newMode]); l.insert(0, 0); id = portIdx; aPorts = list()
+        l = list(laneMap[newMode])
+        l.insert(0, 0)
+        id = portIdx
+        aPorts = list()
         for i in l[:-1]:
             id = id + i
             portName = portName = "{}{}".format(pre, id)
             aPorts.append(portName)
         # generate pJson
-        l = laneMap[newMode]; pJson = {"PORT": {}}; li = laneIdx; pi = 0
+        l = laneMap[newMode]
+        pJson = {"PORT": {}}
+        li = laneIdx
+        pi = 0
         for i in l:
             speed = laneSpeed*i
-            lanes = [str(li+j) for j in range(i)]; lanes = ','.join(lanes)
+            lanes = [str(li+j) for j in range(i)]
+            lanes = ','.join(lanes)
             pJson['PORT'][aPorts[pi]] = {"speed": str(speed), "lanes": str(lanes)}
-            li = li+i; pi = pi + 1
+            li = li+i
+            pi = pi + 1
         return dPorts, pJson
 
     def updateConfig(self, conf, uconf):
@@ -256,10 +270,10 @@ class TestConfigMgmt(TestCase):
         '''
         cmdpb = self.config_mgmt_dpb(curConfig)
         # create ARGS
-        dPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
-            curMode='1x100G', newMode='1x50G(2)+2x25G(2)')
+        dPorts, pJson = self.generate_args(portIdx=8, laneIdx=73,
+                                           curMode='1x100G', newMode='1x50G(2)+2x25G(2)')
         deps, ret = cmdpb.breakOutPort(delPorts=dPorts, portJson=pJson,
-            force=True, loadDefConfig=True)
+                                       force=True, loadDefConfig=True)
         # Expected Result delConfig and addConfig is pushed in order
         delConfig = {
             'PORT': {
@@ -322,10 +336,10 @@ class TestConfigMgmt(TestCase):
         '''
         cmdpb = self.config_mgmt_dpb(curConfig)
         # create ARGS
-        dPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
-            curMode='4x25G', newMode='1x100G')
+        dPorts, pJson = self.generate_args(portIdx=8, laneIdx=73,
+                                           curMode='4x25G', newMode='1x100G')
         deps, ret = cmdpb.breakOutPort(delPorts=dPorts, portJson=pJson,
-            force=False, loadDefConfig=False)
+                                       force=False, loadDefConfig=False)
         # Expected Result delConfig and addConfig is pushed in order
         delConfig = {
             'PORT': {
@@ -352,10 +366,10 @@ class TestConfigMgmt(TestCase):
             assert for success and failure.
         '''
         cmdpb = self.config_mgmt_dpb(curConfig)
-        dPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
-            curMode='1x100G', newMode='4x25G')
+        dPorts, pJson = self.generate_args(portIdx=8, laneIdx=73,
+                                           curMode='1x100G', newMode='4x25G')
         deps, ret = cmdpb.breakOutPort(delPorts=dPorts, portJson=pJson,
-            force=False, loadDefConfig=False)
+                                       force=False, loadDefConfig=False)
         # Expected Result delConfig and addConfig is pushed in order
         delConfig = {
             'PORT': {
@@ -380,10 +394,10 @@ class TestConfigMgmt(TestCase):
         '''
         cmdpb = self.config_mgmt_dpb(curConfig)
         # create ARGS
-        dPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
-            curMode='2x50G', newMode='1x100G')
+        dPorts, pJson = self.generate_args(portIdx=8, laneIdx=73,
+                                           curMode='2x50G', newMode='1x100G')
         deps, ret = cmdpb.breakOutPort(delPorts=dPorts, portJson=pJson,
-            force=True, loadDefConfig=False)
+                                       force=True, loadDefConfig=False)
         # Expected Result delConfig and addConfig is pushed in order
         delConfig = {
             'ACL_TABLE': {
@@ -416,10 +430,10 @@ class TestConfigMgmt(TestCase):
         '''
         cmdpb = self.config_mgmt_dpb(curConfig)
         # create ARGS
-        dPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
-            curMode='2x50G', newMode='1x100G')
+        dPorts, pJson = self.generate_args(portIdx=8, laneIdx=73,
+                                           curMode='2x50G', newMode='1x100G')
         deps, ret = cmdpb.breakOutPort(delPorts=dPorts, portJson=pJson,
-            force=False, loadDefConfig=False)
+                                       force=False, loadDefConfig=False)
         # Expected Result
         assert ret == False and len(deps) == 3
         assert cmdpb.writeConfigDB.call_count == 0
@@ -438,10 +452,10 @@ class TestConfigMgmt(TestCase):
         '''
         cmdpb = self.config_mgmt_dpb(curConfig)
         # create ARGS
-        dPorts, pJson = self.generate_args(portIdx=8, laneIdx=73, \
-            curMode='4x25G', newMode='2x50G')
-        cmdpb.breakOutPort(delPorts=dPorts, portJson=pJson, force=True, \
-            loadDefConfig=True)
+        dPorts, pJson = self.generate_args(portIdx=8, laneIdx=73,
+                                           curMode='4x25G', newMode='2x50G')
+        cmdpb.breakOutPort(delPorts=dPorts, portJson=pJson, force=True,
+                           loadDefConfig=True)
         # Expected Result delConfig and addConfig is pushed in order
         delConfig = {
             'ACL_TABLE': {
@@ -504,10 +518,10 @@ class TestConfigMgmt(TestCase):
         '''
         cmdpb = self.config_mgmt_dpb(curConfig)
         # create ARGS
-        dPorts, pJson = self.generate_args(portIdx=4, laneIdx=69, \
-            curMode='4x25G', newMode='2x50G')
-        cmdpb.breakOutPort(delPorts=dPorts, portJson=pJson, force=True, \
-            loadDefConfig=True)
+        dPorts, pJson = self.generate_args(portIdx=4, laneIdx=69,
+                                           curMode='4x25G', newMode='2x50G')
+        cmdpb.breakOutPort(delPorts=dPorts, portJson=pJson, force=True,
+                           loadDefConfig=True)
         # Expected Result delConfig and addConfig is pushed in order
         delConfig = {
             'ACL_TABLE': {
@@ -543,8 +557,9 @@ class TestConfigMgmt(TestCase):
         self.postUpdateConfig(curConfig, delConfig, addConfig)
         return
 
+
 ###########GLOBAL Configs#####################################
-configDbJson =  {
+configDbJson = {
     "ACL_TABLE": {
         "NO-NSW-PACL-TEST": {
             "policy_desc": "NO-NSW-PACL-TEST",
@@ -553,7 +568,7 @@ configDbJson =  {
             "ports": [
                 "Ethernet9",
                 "Ethernet11",
-                ]
+            ]
         },
         "NO-NSW-PACL-V4": {
             "policy_desc": "NO-NSW-PACL-V4",
@@ -564,7 +579,7 @@ configDbJson =  {
                 "Ethernet4",
                 "Ethernet8",
                 "Ethernet10"
-                ]
+            ]
         }
     },
     "VLAN": {
@@ -691,7 +706,7 @@ portBreakOutConfigDbJson = {
             "ports": [
                 "Ethernet9",
                 "Ethernet11",
-                ]
+            ]
         },
         "NO-NSW-PACL-V4": {
             "policy_desc": "NO-NSW-PACL-V4",
@@ -700,7 +715,7 @@ portBreakOutConfigDbJson = {
                 "Ethernet4",
                 "Ethernet8",
                 "Ethernet10"
-                ]
+            ]
         }
     },
     "VLAN": {
@@ -718,7 +733,7 @@ portBreakOutConfigDbJson = {
         },
         "Vlan100|Ethernet11": {
             "tagging_mode": "untagged"
-       }
+        }
     },
     "INTERFACE": {
         "Ethernet11": {},

--- a/tests/config_mgmt_test.py
+++ b/tests/config_mgmt_test.py
@@ -1,4 +1,5 @@
-import importlib
+import importlib.machinery
+import importlib.util
 import os
 import sys
 from unittest import mock, TestCase

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,5 +1,5 @@
 import filecmp
-import imp
+import importlib
 import os
 import traceback
 import json
@@ -37,7 +37,7 @@ class TestLoadMinigraph(object):
         os.environ['UTILITIES_UNIT_TESTING'] = "1"
         print("SETUP")
         import config.main
-        imp.reload(config.main)
+        importlib.reload(config.main)
 
     def test_load_minigraph(self, get_cmd_module, setup_single_broadcom_asic):
         with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command:
@@ -63,7 +63,7 @@ class TestConfigQos(object):
         print("SETUP")
         os.environ['UTILITIES_UNIT_TESTING'] = "2"
         import config.main
-        imp.reload(config.main)
+        importlib.reload(config.main)
 
     def test_qos_reload_single(
             self, get_cmd_module, setup_qos_mock_apis,
@@ -105,7 +105,7 @@ class TestConfigQosMasic(object):
         os.environ['UTILITIES_UNIT_TESTING'] = "2"
         os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = "multi_asic"
         import config.main
-        imp.reload(config.main)
+        importlib.reload(config.main)
 
     def test_qos_reload_masic(
             self, get_cmd_module, setup_qos_mock_apis,
@@ -148,5 +148,5 @@ class TestConfigQosMasic(object):
         # change back to single asic config
         from .mock_tables import dbconnector
         from .mock_tables import mock_single_asic
-        imp.reload(mock_single_asic)
+        importlib.reload(mock_single_asic)
         dbconnector.load_namespace_config()

--- a/tests/crm_test.py
+++ b/tests/crm_test.py
@@ -1,4 +1,4 @@
-import imp
+import importlib
 import os
 import sys
 from importlib import reload
@@ -1577,5 +1577,5 @@ class TestCrmMultiAsic(object):
         os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = ""
         from .mock_tables import dbconnector
         from .mock_tables import mock_single_asic
-        imp.reload(mock_single_asic)
+        importlib.reload(mock_single_asic)
         dbconnector.load_namespace_config()

--- a/tests/decode_syseeprom_test.py
+++ b/tests/decode_syseeprom_test.py
@@ -1,10 +1,10 @@
-import importlib
 import os
 import sys
 from unittest import mock
 
 import pytest
 from click.testing import CliRunner
+from utilities_common.general import load_module_from_source
 
 from .mock_tables import dbconnector
 
@@ -17,10 +17,7 @@ sys.modules['sonic_platform'] = mock.MagicMock()
 
 
 decode_syseeprom_path = os.path.join(scripts_path, 'decode-syseeprom')
-loader = importlib.machinery.SourceFileLoader('decode-syseeprom', decode_syseeprom_path)
-spec = importlib.util.spec_from_loader(loader.name, loader)
-decode_syseeprom = importlib.util.module_from_spec(spec)
-loader.exec_module(decode_syseeprom)
+decode_syseeprom = load_module_from_source('decode-syseeprom', decode_syseeprom_path)
 
 # Replace swsscommon objects with mocked objects
 decode_syseeprom.SonicV2Connector = dbconnector.SonicV2Connector

--- a/tests/feature_test.py
+++ b/tests/feature_test.py
@@ -1,4 +1,4 @@
-from importlib import reload
+import importlib
 
 from click.testing import CliRunner
 
@@ -395,7 +395,7 @@ class TestFeatureMultiAsic(object):
     def test_config_bgp_feature_inconsistent_state(self, get_cmd_module):
         from .mock_tables import dbconnector
         from .mock_tables import mock_multi_asic_3_asics
-        reload(mock_multi_asic_3_asics)
+        importlib.reload(mock_multi_asic_3_asics)
         dbconnector.load_namespace_config()
         (config, show) = get_cmd_module
         db = Db()
@@ -414,7 +414,7 @@ class TestFeatureMultiAsic(object):
     def test_config_bgp_feature_inconsistent_autorestart(self, get_cmd_module):
         from .mock_tables import dbconnector
         from .mock_tables import mock_multi_asic_3_asics
-        reload(mock_multi_asic_3_asics)
+        importlib.reload(mock_multi_asic_3_asics)
         dbconnector.load_namespace_config()
         (config, show) = get_cmd_module
         db = Db()
@@ -433,7 +433,7 @@ class TestFeatureMultiAsic(object):
     def test_config_bgp_feature_consistent_state(self, get_cmd_module):
         from .mock_tables import dbconnector
         from .mock_tables import mock_multi_asic
-        reload(mock_multi_asic)
+        importlib.reload(mock_multi_asic)
         dbconnector.load_namespace_config()
         (config, show) = get_cmd_module
         db = Db()
@@ -457,7 +457,7 @@ class TestFeatureMultiAsic(object):
     def test_config_bgp_feature_consistent_autorestart(self, get_cmd_module):
         from .mock_tables import dbconnector
         from .mock_tables import mock_multi_asic
-        reload(mock_multi_asic)
+        importlib.reload(mock_multi_asic)
         dbconnector.load_namespace_config()
         (config, show) = get_cmd_module
         db = Db()
@@ -484,4 +484,4 @@ class TestFeatureMultiAsic(object):
     def teardown_class(cls):
         print("TEARDOWN")
         from .mock_tables import mock_single_asic
-        reload(mock_single_asic)
+        importlib.reload(mock_single_asic)

--- a/tests/neighbor_advertiser_test.py
+++ b/tests/neighbor_advertiser_test.py
@@ -1,8 +1,10 @@
-import sys
+import importlib
 import os
-import pytest
-from unittest import mock
 import subprocess
+import sys
+from unittest import mock
+
+import pytest
 from swsscommon.swsscommon import ConfigDBConnector
 
 test_path = os.path.dirname(os.path.abspath(__file__))
@@ -10,9 +12,13 @@ modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, "scripts")
 sys.path.insert(0, modules_path)
 
-from imp import load_source
-load_source('neighbor_advertiser', scripts_path+'/neighbor_advertiser')
-import neighbor_advertiser
+# Load the file under test
+neighbor_advertiser_path = os.path.join(scripts_path, 'neighbor_advertiser')
+loader = importlib.machinery.SourceFileLoader('neighbor_advertiser', neighbor_advertiser_path)
+spec = importlib.util.spec_from_loader(loader.name, loader)
+neighbor_advertiser = importlib.util.module_from_spec(spec)
+loader.exec_module(neighbor_advertiser)
+
 
 class TestNeighborAdvertiser(object):
     @pytest.fixture

--- a/tests/neighbor_advertiser_test.py
+++ b/tests/neighbor_advertiser_test.py
@@ -1,4 +1,5 @@
-import importlib
+import importlib.machinery
+import importlib.util
 import os
 import subprocess
 import sys

--- a/tests/neighbor_advertiser_test.py
+++ b/tests/neighbor_advertiser_test.py
@@ -1,5 +1,3 @@
-import importlib.machinery
-import importlib.util
 import os
 import subprocess
 import sys
@@ -7,6 +5,7 @@ from unittest import mock
 
 import pytest
 from swsscommon.swsscommon import ConfigDBConnector
+from utilities_common.general import load_module_from_source
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
@@ -15,10 +14,7 @@ sys.path.insert(0, modules_path)
 
 # Load the file under test
 neighbor_advertiser_path = os.path.join(scripts_path, 'neighbor_advertiser')
-loader = importlib.machinery.SourceFileLoader('neighbor_advertiser', neighbor_advertiser_path)
-spec = importlib.util.spec_from_loader(loader.name, loader)
-neighbor_advertiser = importlib.util.module_from_spec(spec)
-loader.exec_module(neighbor_advertiser)
+neighbor_advertiser = load_module_from_source('neighbor_advertiser', neighbor_advertiser_path)
 
 
 class TestNeighborAdvertiser(object):

--- a/tests/pfcstat_test.py
+++ b/tests/pfcstat_test.py
@@ -1,4 +1,3 @@
-import imp
 import os
 import shutil
 import sys

--- a/tests/pfcwd_test.py
+++ b/tests/pfcwd_test.py
@@ -1,4 +1,4 @@
-import imp
+import importlib
 import os
 import sys
 from unittest.mock import patch
@@ -273,7 +273,7 @@ class TestMultiAsicPfcwdShow(object):
         os.environ["UTILITIES_UNIT_TESTING"] = "2"
         os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = "multi_asic"
         import pfcwd.main
-        imp.reload(pfcwd.main)
+        importlib.reload(pfcwd.main)
 
     def test_pfcwd_stats_all(self):
         import pfcwd.main as pfcwd

--- a/tests/port2alias_test.py
+++ b/tests/port2alias_test.py
@@ -1,15 +1,12 @@
-import importlib.machinery
-import importlib.util
 import os
 import sys
 from unittest import TestCase
 
+from utilities_common.general import load_module_from_source
+
 # Load the file under test
 port2alias_path = os.path.join(os.path.dirname(__file__), '..', 'scripts', 'port2alias')
-loader = importlib.machinery.SourceFileLoader('port2alias', port2alias_path)
-spec = importlib.util.spec_from_loader(loader.name, loader)
-port2alias = importlib.util.module_from_spec(spec)
-loader.exec_module(port2alias)
+port2alias = load_module_from_source('port2alias', port2alias_path)
 
 
 class TestPort2Alias(TestCase):

--- a/tests/port2alias_test.py
+++ b/tests/port2alias_test.py
@@ -1,10 +1,15 @@
-import sys
+import importlib
 import os
+import sys
 from unittest import TestCase
 
-import imp
+# Load the file under test
+port2alias_path = os.path.join(os.path.dirname(__file__), '..', 'scripts', 'port2alias')
+loader = importlib.machinery.SourceFileLoader('port2alias', port2alias_path)
+spec = importlib.util.spec_from_loader(loader.name, loader)
+port2alias = importlib.util.module_from_spec(spec)
+loader.exec_module(port2alias)
 
-port2alias = imp.load_source('port2alias', os.path.join(os.path.dirname(__file__), '..', 'scripts', 'port2alias'))
 
 class TestPort2Alias(TestCase):
     def setUp(self):

--- a/tests/port2alias_test.py
+++ b/tests/port2alias_test.py
@@ -1,4 +1,5 @@
-import importlib
+import importlib.machinery
+import importlib.util
 import os
 import sys
 from unittest import TestCase

--- a/tests/psushow_test.py
+++ b/tests/psushow_test.py
@@ -1,10 +1,10 @@
-import importlib
 import os
 import sys
 from unittest import mock
 
 import pytest
 from click.testing import CliRunner
+from utilities_common.general import load_module_from_source
 
 from .mock_tables import dbconnector
 
@@ -17,10 +17,7 @@ sys.modules['sonic_platform'] = mock.MagicMock()
 
 # Load the file under test
 psushow_path = os.path.join(scripts_path, 'psushow')
-loader = importlib.machinery.SourceFileLoader('psushow', psushow_path)
-spec = importlib.util.spec_from_loader(loader.name, loader)
-psushow = importlib.util.module_from_spec(spec)
-loader.exec_module(psushow)
+psushow = load_module_from_source('psushow', psushow_path)
 
 # Replace swsscommon objects with mocked objects
 psushow.SonicV2Connector = dbconnector.SonicV2Connector

--- a/tests/watermarkstat_test.py
+++ b/tests/watermarkstat_test.py
@@ -1,4 +1,3 @@
-import imp
 import os
 import sys
 

--- a/utilities_common/general.py
+++ b/utilities_common/general.py
@@ -1,0 +1,17 @@
+import importlib.machinery
+import importlib.util
+import sys
+
+def load_module_from_source(module_name, file_path):
+    """
+    This function will load the Python source file specified by <file_path>
+    as a module named <module_name> and return an instance of the module
+    """
+    loader = importlib.machinery.SourceFileLoader(module_name, file_path)
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+
+    sys.modules[module_name] = module
+
+    return module

--- a/utilities_common/util_base.py
+++ b/utilities_common/util_base.py
@@ -49,7 +49,7 @@ class UtilHelper(object):
     # try get information from platform API and return a default value if caught NotImplementedError
     def try_get(self, callback, default=None):
         """
-        Handy function to invoke the callback and catch NotImplementedError
+        Handy function to invoke the callback, catch NotImplementedError and return a default value
         :param callback: Callback to be invoked
         :param default: Default return value if exception occur
         :return: Default return value if exception occur else return value of the callback

--- a/utilities_common/util_base.py
+++ b/utilities_common/util_base.py
@@ -82,4 +82,3 @@ class UtilHelper(object):
             return True
         else:
             return False
-


### PR DESCRIPTION
#### What I did

Migrate from using the `imp` module to using the `importlib` module. As of Python 3, the `imp` module has been deprecated in favor of the `importlib` module.

Place logic in a new function, `load_module_from_source()` in a new file, `utilities_common/general.py`

Also fix some formatting

#### How I did it

Eliminate all importing of the `imp` module, and replace all which were actually used with imports of the `importlib` module, and modify all affected code appropriately.

#### How to verify it

Test all affected utilities and unit tests.
