### PR TITLE
[pytest] Increase verbosity

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --cov-config=.coveragerc --cov --cov-report html --cov-report term --cov-report xml --junitxml=test-results.xml -v
+addopts = --cov-config=.coveragerc --cov --cov-report html --cov-report term --cov-report xml --junitxml=test-results.xml -vv


### PR DESCRIPTION
#### What I did

Increase verbosity of pytest to allow for full, non-truncated error messages to appear in CI unit test results in order to help facilitate troubleshooting of unit test failures.

#### How I did it

Replace `-v` with `-vv` in pytest options in pytest.ini

#### How to verify it

Ensure unit test failure messages are no longer truncated
