### PR TITLE
[reboot] Add platform-specific reboot cause update hook

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -1,6 +1,7 @@
 #!/bin/bash
 DEVPATH="/usr/share/sonic/device"
 PLAT_REBOOT="platform_reboot"
+PLATFORM_UPDATE_REBOOT_CAUSE="platform_update_reboot_cause"
 REBOOT_CAUSE_FILE="/host/reboot-cause/reboot-cause.txt"
 REBOOT_TIME=$(date)
 
@@ -165,6 +166,11 @@ fi
 if [ -x ${DEVPATH}/${PLATFORM}/${SSD_FW_UPDATE} ]; then
     debug "updating ssd fw for${REBOOT_TYPE}"
     ${DEVPATH}/${PLATFORM}/${SSD_FW_UPDATE} ${REBOOT_TYPE}
+fi
+
+if [ -x ${DEVPATH}/${PLATFORM}/${PLATFORM_UPDATE_REBOOT_CAUSE} ]; then
+    debug "updating reboot cause for ${PLATFORM}"
+    ${DEVPATH}/${PLATFORM}/${PLATFORM_UPDATE_REBOOT_CAUSE}
 fi
 
 if [ -x ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT} ]; then


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
The S6000 devices, the cold reboot is abrupt and it is likely to cause issues which will cause the device to land into EFI shell. Hence the platform reboot will happen after graceful unmount of all the filesystems as in S6100.

#### How I did it
In reboot script, if platform-specific reboot cause update script exists, run it

#### How to verify it
Issue "reboot" command to verify if the reboot is happening gracefully.
[UT_logs.txt](https://github.com/Azure/sonic-utilities/files/6017269/UT_logs.txt)

These changes are associated with https://github.com/Azure/sonic-buildimage/pull/6835.
Please cherry pick the changes to 201811, 201911 branches
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

