### PR TITLE
[warm-reboot] Check if warm restart flag is set when issuing a warm-reboot

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -400,8 +400,8 @@ function save_counters_folder() {
 
 function check_warm_restart_in_progress() {
     sonic-db-cli STATE_DB keys "WARM_RESTART_ENABLE_TABLE|*" | while read key ; do
-        if [[ "$(sonic-db-cli STATE_DB hget $key enable)" = "true" ]]; then
-            if [[ "${FORCE}" = "yes" ]]; then
+        if [[ x"$(sonic-db-cli STATE_DB hget $key enable)" == x"true" ]]; then
+            if [[ x"${FORCE}" == x"yes" ]]; then
                 debug "Ignoring warm restart flag for ${key#*|}"
             else
                 echo "Warm restart flag for ${key#*|} is set. Please check if a warm restart for ${key#*|} is in progress."

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -401,8 +401,12 @@ function save_counters_folder() {
 function check_warm_restart_in_progress() {
     sonic-db-cli STATE_DB keys "WARM_RESTART_ENABLE_TABLE|*" | while read key ; do
         if [[ "$(sonic-db-cli STATE_DB hget $key enable)" = "true" ]]; then
-            echo "Warm restart flag for ${key#*|} is set. Please check if a warm restart for ${key#*|} is in progress."
-            exit "${EXIT_FAILURE}"
+            if [[ "${FORCE}" = "yes" ]]; then
+                debug "Ignoring warm restart flag for ${key#*|}"
+            else
+                echo "Warm restart flag for ${key#*|} is set. Please check if a warm restart for ${key#*|} is in progress."
+                exit "${EXIT_FAILURE}"
+            fi
         fi
     done
 }

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -398,6 +398,15 @@ function save_counters_folder() {
     fi
 }
 
+function check_warm_restart_in_progress() {
+    sonic-db-cli STATE_DB keys "WARM_RESTART_ENABLE_TABLE|*" | while read key ; do
+        if [[ "$(sonic-db-cli STATE_DB hget $key enable)" = "true" ]]; then
+            echo "Warm restart flag for ${key#*|} is set. Please check if a warm restart for ${key#*|} is in progress."
+            exit "${EXIT_FAILURE}"
+        fi
+    done
+}
+
 # main starts here
 parseOptions $@
 
@@ -419,6 +428,7 @@ case "$REBOOT_TYPE" in
         sonic-db-cli STATE_DB SET "FAST_REBOOT|system" "1" "EX" "180" &>/dev/null
         ;;
     "warm-reboot")
+        check_warm_restart_in_progress
         if [[ "$sonic_asic_type" == "mellanox" ]]; then
             REBOOT_TYPE="fastfast-reboot"
             BOOT_TYPE_ARG="fastfast"


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Check if any warm restart flag is set when issuing a warm-reboot. This check avoids starting a warm reboot while another warm restart is in progress. In the scenario where a warm reboot is issued with another warm restart in progress, the warm restart flag may be reset and part of the components have a risk of doing cold reboot. 
Fix: https://github.com/Azure/sonic-buildimage/issues/6509

#### How I did it
Check if any warm restart flag is set when issuing a warm-reboot.

#### How to verify it
Verified that warm-reboot exits when any warm restart flag is set true.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

