### PR TITLE
Dropped redundant code.

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -327,9 +327,6 @@ def filter_out_local_interfaces(keys):
 
     for k in keys:
         e = dict(tbl.get(k)[1])
-        if not e:
-            # Prefix might have been added. So try w/o it.
-            e = dict(tbl.get(k.split("/"))[1])
         if not e or all([not re.match(x, e['ifname']) for x in local_if_re]):
             rt.append(k)
 


### PR DESCRIPTION

#### What I did
Removed code that had bug, because it is redundant

#### How I did it
The key used is as read from APPL-DB, hence use it as such to get the value,
to help get the interface name, so it can be used for filtering out.

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

