### PR TITLE
[config reload]: On dual ToR systems, cache ARP and FDB tables

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -911,6 +911,38 @@ def update_sonic_environment():
             display_cmd=True
         )
 
+def cache_arp_entries():
+    success = True
+    cache_dir = '/host/config-reload'
+    click.echo('Caching ARP table to {}'.format(cache_dir))
+
+    if not os.path.exists(cache_dir):
+        os.mkdir(cache_dir)
+
+    arp_cache_cmd = '/usr/local/bin/fast-reboot-dump.py -t {}'.format(cache_dir)
+    cache_proc = subprocess.Popen(arp_cache_cmd, shell=True, text=True, stdout=subprocess.PIPE)
+    _, cache_err = cache_proc.communicate()
+    if cache_err:
+        click.echo("Could not cache ARP and FDB info prior to reloading")
+        success = False
+
+    if not cache_err:
+        fdb_cache_file = os.path.join(cache_dir, 'fdb.json')
+        arp_cache_file = os.path.join(cache_dir, 'arp.json')
+        fdb_filter_cmd = '/usr/local/bin/filter_fdb_entries -f {} -a {} -c /etc/sonic/configdb.json'.format(fdb_cache_file, arp_cache_file)
+        filter_proc = subprocess.Popen(fdb_filter_cmd, shell=True, text=True, stdout=subprocess.PIPE)
+        _, filter_err = filter_proc.communicate()
+        if filter_err:
+            click.echo("Could not filter FDB entries prior to reloading")
+            success = False
+    
+    # If we are able to successfully cache ARP table info, signal SWSS to restore from our cache
+    # by creating /host/config-reload/needs-restore
+    if success:
+        restore_flag_file = os.path.join(cache_dir, 'needs-restore')
+        open(restore_flag_file, 'w').close()
+    return success
+
 # This is our main entrypoint - the main 'config' command
 @click.group(cls=clicommon.AbbreviationGroup, context_settings=CONTEXT_SETTINGS)
 @click.pass_context
@@ -1071,9 +1103,10 @@ def load(filename, yes):
 @click.option('-y', '--yes', is_flag=True)
 @click.option('-l', '--load-sysinfo', is_flag=True, help='load system default information (mac, portmap etc) first.')
 @click.option('-n', '--no_service_restart', default=False, is_flag=True, help='Do not restart docker services')
+@click.option('-d', '--disable_arp_cache', default=False, is_flag=True, help='Do not cache ARP table before reloading (applies to dual ToR systems only)')
 @click.argument('filename', required=False)
 @clicommon.pass_db
-def reload(db, filename, yes, load_sysinfo, no_service_restart):
+def reload(db, filename, yes, load_sysinfo, no_service_restart, disable_arp_cache):
     """Clear current configuration and import a previous saved config DB dump file.
        <filename> : Names of configuration file(s) to load, separated by comma with no spaces in between
     """
@@ -1111,6 +1144,13 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart):
             sys.exit(1)
         else:
             cfg_hwsku = cfg_hwsku.strip()
+
+    # For dual ToR devices, cache ARP and FDB info
+    localhost_metadata = db.cfgdb.get_table('DEVICE_METADATA')['localhost']
+    cache_arp_table = not disable_arp_cache and 'subtype' in localhost_metadata and localhost_metadata['subtype'].lower() == 'dualtor'
+
+    if cache_arp_table:
+        cache_arp_entries()
 
     #Stop services before config push
     if not no_service_restart:


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
On dual ToR systems, before performing `config reload` cache the ARP and FDB tables (similar to fast reboot) so that the standby ToR is able to resume normal operation afterwards.

Note: will require a separate change in sonic-buildimage for the `docker_image_ctl.j2` file for the SWSS container

#### How I did it
Add an optional flag to disable caching behavior (enabled by default for dual ToR systems, disabled for all others).

Use the `fast-reboot-dump` and `filter_fdb_entries` scripts to cache the current ARP and FDB tables in `/host/config-reload`. Also create a file in the same directory to indicate to SWSS that it should restore from the cache.

#### How to verify it
* Run `config reload -d` on a dual ToR system. Confirm that no cache is created in `/host/config-reload`. 
* Run `config reload` on a dual ToR system. Confirm a cache IS created in `/host/config-reload`. There should be an `arp.json`, `fdb.json`, and `default_routes.json` (this one will be unused)
* Run `config reload` and `config reload -d` on a dual ToR system. Confirm that no cache is created in `/host/config-reload`.

#### Previous command output (if the output of a command-line utility has changed)

```
admin@sonic:~$ sudo config reload -y
Executing stop of service telemetry...
Warning: Stopping telemetry.service, but it can still be activated by:
  telemetry.timer
Executing stop of service swss...
Executing stop of service lldp...
Executing stop of service pmon...
Executing stop of service bgp...
Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/init_cfg.json -j /etc/sonic/config_db.json --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate
Executing reset-failed of service bgp...
Executing reset-failed of service dhcp_relay...
Executing reset-failed of service hostname-config...
Executing reset-failed of service interfaces-config...
Executing reset-failed of service lldp...
Executing reset-failed of service ntp-config...
Executing reset-failed of service pmon...
Executing reset-failed of service radv...
Executing reset-failed of service rsyslog-config...
Executing reset-failed of service snmp...
Executing reset-failed of service swss...
Executing reset-failed of service syncd...
Executing reset-failed of service teamd...
Executing reset-failed of service telemetry...
Executing restart of service hostname-config...
Executing restart of service interfaces-config...
Executing restart of service ntp-config...
Executing restart of service rsyslog-config...
Executing restart of service swss...
Executing restart of service bgp...
Executing restart of service pmon...
Executing restart of service lldp...
Executing restart of service telemetry...
Reloading Monit configuration ...
Reinitializing monit daemon
```

#### New command output (if the output of a command-line utility has changed)

```
admin@sonic:~$ sudo config reload -y
Caching ARP table to /host/config-reload                  <-------- New message, only on dual ToR systems
Executing stop of service telemetry...
Warning: Stopping telemetry.service, but it can still be activated by:
  telemetry.timer
Executing stop of service swss...
Executing stop of service lldp...
Executing stop of service pmon...
Executing stop of service bgp...
Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/init_cfg.json -j /etc/sonic/config_db.json --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate
Executing reset-failed of service bgp...
Executing reset-failed of service dhcp_relay...
Executing reset-failed of service hostname-config...
Executing reset-failed of service interfaces-config...
Executing reset-failed of service lldp...
Executing reset-failed of service ntp-config...
Executing reset-failed of service pmon...
Executing reset-failed of service radv...
Executing reset-failed of service rsyslog-config...
Executing reset-failed of service snmp...
Executing reset-failed of service swss...
Executing reset-failed of service syncd...
Executing reset-failed of service teamd...
Executing reset-failed of service telemetry...
Executing restart of service hostname-config...
Executing restart of service interfaces-config...
Executing restart of service ntp-config...
Executing restart of service rsyslog-config...
Executing restart of service swss...
Executing restart of service bgp...
Executing restart of service pmon...
Executing restart of service lldp...
Executing restart of service telemetry...
Reloading Monit configuration ...
Reinitializing monit daemon
