### PR TITLE
[acl-loader] Add support for matching on ICMP and VLAN info

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -482,7 +482,7 @@ class AclLoader(object):
         type_key = "ICMPV6_TYPE" if is_table_v6 else "ICMP_TYPE"
         code_key = "ICMPV6_CODE" if is_table_v6 else "ICMP_CODE"
 
-        if rule.icmp.config.type:
+        if rule.icmp.config.type or rule.icmp.config.type == 0:
             try:
                 icmp_type = int(rule.icmp.config.type)
 
@@ -495,7 +495,7 @@ class AclLoader(object):
                     "Failed to convert %s; table %s, rule %s; exception=%s" %
                     (type_key, table_name, rule_idx, str(e)))
 
-        if rule.icmp.config.code:
+        if rule.icmp.config.code or rule.icmp.config.code == 0:
             try:
                 icmp_code = int(rule.icmp.config.code)
 

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -103,6 +103,7 @@ class AclLoader(object):
         "IP_RSVP": 46,
         "IP_GRE": 47,
         "IP_AUTH": 51,
+        "IP_ICMPV6": 58,
         "IP_L2TP": 115
     }
 
@@ -444,7 +445,12 @@ class AclLoader(object):
         # so there isn't currently a good way to check if the user defined proto=0 or not.
         if rule.ip.config.protocol:
             if rule.ip.config.protocol in self.ip_protocol_map:
-                rule_props["IP_PROTOCOL"] = self.ip_protocol_map[rule.ip.config.protocol]
+                # Special case: "1" is the wrong protocol number for ICMPV6, we need to use "58" instead if
+                # the target table is an IPV6 table.
+                if rule.ip.config.protocol == "IP_ICMP" and self.is_table_ipv6(table_name):
+                    rule_props["IP_PROTOCOL"] = self.ip_protocol_map["IP_ICMPV6"]
+                else:
+                    rule_props["IP_PROTOCOL"] = self.ip_protocol_map[rule.ip.config.protocol]
             else:
                 try:
                     int(rule.ip.config.protocol)

--- a/tests/acl_input/acl1.json
+++ b/tests/acl_input/acl1.json
@@ -218,6 +218,28 @@
 										"code": "0"
 									}
 								}
+							},
+							"2": {
+								"config": {
+									"sequence-id": 100
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "IP_ICMP",
+										"source-ip-address": "::1/128",
+										"destination-ip-address": "::1/128"
+									}
+								},
+								"icmp": {
+									"config": {
+										"type": "128"
+									}
+								}
 							}
 						}
 					}

--- a/tests/acl_input/acl1.json
+++ b/tests/acl_input/acl1.json
@@ -151,7 +151,58 @@
 								},
 								"actions": {
 									"config": {
-										"forwarding-action": "DROP"
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "IP_ICMP",
+										"source-ip-address": "20.0.0.2/32",
+										"destination-ip-address": "30.0.0.3/32"
+									}
+								},
+								"icmp": {
+									"config": {
+										"type": "3",
+										"code": "0"
+									}
+								}
+							},
+							"2": {
+								"config": {
+									"sequence-id": 2
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"l2": {
+									"config": {
+										"vlan-id": "369"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "IP_TCP",
+										"source-ip-address": "20.0.0.2/32",
+										"destination-ip-address": "30.0.0.3/32"
+									}
+								}
+							}
+						}
+					}
+				},
+				"DATAACLV6": {
+					"acl-entries": {
+						"acl-entry": {
+							"1": {
+								"config": {
+									"sequence-id": 1
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
 									}
 								},
 								"ip": {
@@ -163,30 +214,8 @@
 								},
 								"icmp": {
 									"config": {
-										"type": "4",
-										"code": "1"
-									}
-								}
-							},
-							"2": {
-								"config": {
-									"sequence-id": 2
-								},
-								"actions": {
-									"config": {
-										"forwarding-action": "DROP"
-									}
-								},
-								"l2": {
-									"config": {
-										"vlan-id": "369"
-									}
-								},
-								"ip": {
-									"config": {
-										"protocol": "IP_TCP",
-										"source-ip-address": "::1/128",
-										"destination-ip-address": "::1/128"
+										"type": "1",
+										"code": "0"
 									}
 								}
 							}

--- a/tests/acl_input/acl1.json
+++ b/tests/acl_input/acl1.json
@@ -141,6 +141,57 @@
 					"config": {
 						"name": "everflowV6"
 					}
+				},
+				"DATAACL": {
+					"acl-entries": {
+						"acl-entry": {
+							"1": {
+								"config": {
+									"sequence-id": 1
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "DROP"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "IP_ICMP",
+										"source-ip-address": "::1/128",
+										"destination-ip-address": "::1/128"
+									}
+								},
+								"icmp": {
+									"config": {
+										"type": "4",
+										"code": "1"
+									}
+								}
+							},
+							"2": {
+								"config": {
+									"sequence-id": 2
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "DROP"
+									}
+								},
+								"l2": {
+									"config": {
+										"vlan-id": "369"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "IP_TCP",
+										"source-ip-address": "::1/128",
+										"destination-ip-address": "::1/128"
+									}
+								}
+							}
+						}
+					}
 				}
 			}
 		}

--- a/tests/acl_input/illegal_icmp_code_300.json
+++ b/tests/acl_input/illegal_icmp_code_300.json
@@ -1,0 +1,37 @@
+{
+	"acl": {
+		"acl-sets": {
+			"acl-set": {
+                "DATAACL": {
+					"acl-entries": {
+						"acl-entry": {
+							"1": {
+								"config": {
+									"sequence-id": 1
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "IP_ICMP",
+										"source-ip-address": "20.0.0.2/32",
+										"destination-ip-address": "30.0.0.3/32"
+									}
+								},
+								"icmp": {
+									"config": {
+										"type": "3",
+										"code": "300"
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/tests/acl_input/illegal_icmp_code_nan.json
+++ b/tests/acl_input/illegal_icmp_code_nan.json
@@ -1,0 +1,37 @@
+{
+	"acl": {
+		"acl-sets": {
+			"acl-set": {
+                "DATAACL": {
+					"acl-entries": {
+						"acl-entry": {
+							"1": {
+								"config": {
+									"sequence-id": 1
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "IP_ICMP",
+										"source-ip-address": "20.0.0.2/32",
+										"destination-ip-address": "30.0.0.3/32"
+									}
+								},
+								"icmp": {
+									"config": {
+										"type": "3",
+										"code": "foo"
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/tests/acl_input/illegal_icmp_code_neg_1.json
+++ b/tests/acl_input/illegal_icmp_code_neg_1.json
@@ -1,0 +1,37 @@
+{
+	"acl": {
+		"acl-sets": {
+			"acl-set": {
+                "DATAACL": {
+					"acl-entries": {
+						"acl-entry": {
+							"1": {
+								"config": {
+									"sequence-id": 1
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "IP_ICMP",
+										"source-ip-address": "20.0.0.2/32",
+										"destination-ip-address": "30.0.0.3/32"
+									}
+								},
+								"icmp": {
+									"config": {
+										"type": "3",
+										"code": "-1"
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/tests/acl_input/illegal_icmp_type_300.json
+++ b/tests/acl_input/illegal_icmp_type_300.json
@@ -1,0 +1,37 @@
+{
+	"acl": {
+		"acl-sets": {
+			"acl-set": {
+                "DATAACL": {
+					"acl-entries": {
+						"acl-entry": {
+							"1": {
+								"config": {
+									"sequence-id": 1
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "IP_ICMP",
+										"source-ip-address": "20.0.0.2/32",
+										"destination-ip-address": "30.0.0.3/32"
+									}
+								},
+								"icmp": {
+									"config": {
+										"type": "300",
+										"code": "0"
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/tests/acl_input/illegal_icmp_type_nan.json
+++ b/tests/acl_input/illegal_icmp_type_nan.json
@@ -1,0 +1,37 @@
+{
+	"acl": {
+		"acl-sets": {
+			"acl-set": {
+                "DATAACL": {
+					"acl-entries": {
+						"acl-entry": {
+							"1": {
+								"config": {
+									"sequence-id": 1
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "IP_ICMP",
+										"source-ip-address": "20.0.0.2/32",
+										"destination-ip-address": "30.0.0.3/32"
+									}
+								},
+								"icmp": {
+									"config": {
+										"type": "foo",
+										"code": "0"
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/tests/acl_input/illegal_icmp_type_neg_1.json
+++ b/tests/acl_input/illegal_icmp_type_neg_1.json
@@ -1,0 +1,37 @@
+{
+	"acl": {
+		"acl-sets": {
+			"acl-set": {
+                "DATAACL": {
+					"acl-entries": {
+						"acl-entry": {
+							"1": {
+								"config": {
+									"sequence-id": 1
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "IP_ICMP",
+										"source-ip-address": "20.0.0.2/32",
+										"destination-ip-address": "30.0.0.3/32"
+									}
+								},
+								"icmp": {
+									"config": {
+										"type": "-1",
+										"code": "0"
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/tests/acl_input/illegal_vlan_0.json
+++ b/tests/acl_input/illegal_vlan_0.json
@@ -1,0 +1,36 @@
+{
+	"acl": {
+		"acl-sets": {
+			"acl-set": {
+                "DATAACL": {
+					"acl-entries": {
+						"acl-entry": {
+							"1": {
+								"config": {
+									"sequence-id": 1
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"l2": {
+									"config": {
+										"vlan-id": "0"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "IP_TCP",
+										"source-ip-address": "20.0.0.2/32",
+										"destination-ip-address": "30.0.0.3/32"
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/tests/acl_input/illegal_vlan_9000.json
+++ b/tests/acl_input/illegal_vlan_9000.json
@@ -1,0 +1,36 @@
+{
+	"acl": {
+		"acl-sets": {
+			"acl-set": {
+                "DATAACL": {
+					"acl-entries": {
+						"acl-entry": {
+							"1": {
+								"config": {
+									"sequence-id": 1
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"l2": {
+									"config": {
+										"vlan-id": "9000"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "IP_TCP",
+										"source-ip-address": "20.0.0.2/32",
+										"destination-ip-address": "30.0.0.3/32"
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/tests/acl_input/illegal_vlan_nan.json
+++ b/tests/acl_input/illegal_vlan_nan.json
@@ -1,0 +1,36 @@
+{
+	"acl": {
+		"acl-sets": {
+			"acl-set": {
+                "DATAACL": {
+					"acl-entries": {
+						"acl-entry": {
+							"1": {
+								"config": {
+									"sequence-id": 1
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"l2": {
+									"config": {
+										"vlan-id": "nan"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "IP_TCP",
+										"source-ip-address": "20.0.0.2/32",
+										"destination-ip-address": "30.0.0.3/32"
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/tests/acl_loader_test.py
+++ b/tests/acl_loader_test.py
@@ -58,7 +58,14 @@ class TestAclLoader(object):
         acl_loader.rules_info = {}
         acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/acl1.json'))
         assert acl_loader.rules_info[("DATAACL", "RULE_2")]
-        assert acl_loader.rules_info[("DATAACL", "RULE_2")]["VLAN_ID"] == 369
+        assert acl_loader.rules_info[("DATAACL", "RULE_2")] == {
+            "VLAN_ID": 369,
+            "IP_PROTOCOL": 6,
+            "SRC_IP": "20.0.0.2/32",
+            "DST_IP": "30.0.0.3/32",
+            "PACKET_ACTION": "FORWARD",
+            "PRIORITY": "9998"
+        }
 
     def test_vlan_id_lower_bound(self, acl_loader):
         with pytest.raises(ValueError):
@@ -79,15 +86,37 @@ class TestAclLoader(object):
         acl_loader.rules_info = {}
         acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/acl1.json'))
         assert acl_loader.rules_info[("DATAACL", "RULE_1")]
-        assert acl_loader.rules_info[("DATAACL", "RULE_1")]["ICMP_TYPE"] == 3
-        assert acl_loader.rules_info[("DATAACL", "RULE_1")]["ICMP_CODE"] == 0
+        assert acl_loader.rules_info[("DATAACL", "RULE_1")] == {
+            "ICMP_TYPE": 3,
+            "ICMP_CODE": 0,
+            "IP_PROTOCOL": 1,
+            "SRC_IP": "20.0.0.2/32",
+            "DST_IP": "30.0.0.3/32",
+            "PACKET_ACTION": "FORWARD",
+            "PRIORITY": "9999"
+        }
 
     def test_icmpv6_translation(self, acl_loader):
         acl_loader.rules_info = {}
         acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/acl1.json'))
-        assert acl_loader.rules_info[("DATAACLV6", "RULE_1")]
-        assert acl_loader.rules_info[("DATAACLV6", "RULE_1")]["ICMPV6_TYPE"] == 1
-        assert acl_loader.rules_info[("DATAACLV6", "RULE_1")]["ICMPV6_CODE"] == 0
+        print(acl_loader.rules_info)
+        assert acl_loader.rules_info[("DATAACLV6", "RULE_1")] == {
+            "ICMPV6_TYPE": 1,
+            "ICMPV6_CODE": 0,
+            "IP_PROTOCOL": 1,
+            "SRC_IPV6": "::1/128",
+            "DST_IPV6": "::1/128",
+            "PACKET_ACTION": "FORWARD",
+            "PRIORITY": "9999"
+        }
+        assert acl_loader.rules_info[("DATAACLV6", "RULE_100")] == {
+            "ICMPV6_TYPE": 128,
+            "IP_PROTOCOL": 1,
+            "SRC_IPV6": "::1/128",
+            "DST_IPV6": "::1/128",
+            "PACKET_ACTION": "FORWARD",
+            "PRIORITY": "9900"
+        }
 
     def test_icmp_type_lower_bound(self, acl_loader):
         with pytest.raises(ValueError):

--- a/tests/acl_loader_test.py
+++ b/tests/acl_loader_test.py
@@ -103,7 +103,7 @@ class TestAclLoader(object):
         assert acl_loader.rules_info[("DATAACLV6", "RULE_1")] == {
             "ICMPV6_TYPE": 1,
             "ICMPV6_CODE": 0,
-            "IP_PROTOCOL": 1,
+            "IP_PROTOCOL": 58,
             "SRC_IPV6": "::1/128",
             "DST_IPV6": "::1/128",
             "PACKET_ACTION": "FORWARD",
@@ -111,7 +111,7 @@ class TestAclLoader(object):
         }
         assert acl_loader.rules_info[("DATAACLV6", "RULE_100")] == {
             "ICMPV6_TYPE": 128,
-            "IP_PROTOCOL": 1,
+            "IP_PROTOCOL": 58,
             "SRC_IPV6": "::1/128",
             "DST_IPV6": "::1/128",
             "PACKET_ACTION": "FORWARD",

--- a/tests/acl_loader_test.py
+++ b/tests/acl_loader_test.py
@@ -19,7 +19,7 @@ class TestAclLoader(object):
 
     def test_valid(self):
         yang_acl = AclLoader.parse_acl_json(os.path.join(test_path, 'acl_input/acl1.json'))
-        assert len(yang_acl.acl.acl_sets.acl_set) == 4
+        assert len(yang_acl.acl.acl_sets.acl_set) == 6
 
     def test_invalid(self):
         with pytest.raises(AclLoaderException):

--- a/tests/acl_loader_test.py
+++ b/tests/acl_loader_test.py
@@ -10,8 +10,9 @@ from acl_loader import *
 from acl_loader.main import *
 
 class TestAclLoader(object):
-    def setUp(self):
-        pass
+    @pytest.fixture(scope="class")
+    def acl_loader(self):
+        yield AclLoader()
 
     def test_acl_empty(self):
         yang_acl = AclLoader.parse_acl_json(os.path.join(test_path, 'acl_input/empty_acl.json'))
@@ -25,7 +26,7 @@ class TestAclLoader(object):
         with pytest.raises(AclLoaderException):
             yang_acl = AclLoader.parse_acl_json(os.path.join(test_path, 'acl_input/acl2.json'))
 
-    def test_validate_mirror_action(self):
+    def test_validate_mirror_action(self, acl_loader):
         ingress_mirror_rule_props = {
             "MIRROR_INGRESS_ACTION": "everflow0"
         }
@@ -34,7 +35,6 @@ class TestAclLoader(object):
             "mirror_egress_action": "everflow0"
         }
 
-        acl_loader = AclLoader()
         # switch capability taken from mock_tables/state_db.json SWITCH_CAPABILITY table
         assert acl_loader.validate_actions("EVERFLOW", ingress_mirror_rule_props)
         assert not acl_loader.validate_actions("EVERFLOW", egress_mirror_rule_props)
@@ -53,3 +53,68 @@ class TestAclLoader(object):
         # switch capability taken from mock_tables/state_db.json SWITCH_CAPABILITY table
         assert acl_loader.validate_actions("DATAACL", forward_packet_action)
         assert not acl_loader.validate_actions("DATAACL", drop_packet_action)
+
+    def test_vlan_id_translation(self, acl_loader):
+        acl_loader.rules_info = {}
+        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/acl1.json'))
+        assert acl_loader.rules_info[("DATAACL", "RULE_2")]
+        assert acl_loader.rules_info[("DATAACL", "RULE_2")]["VLAN_ID"] == 369
+
+    def test_vlan_id_lower_bound(self, acl_loader):
+        acl_loader.rules_info = {}
+        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_vlan_0.json'))
+        assert not acl_loader.rules_info.get(("DATAACL", "RULE_1"))
+
+    def test_vlan_id_upper_bound(self, acl_loader):
+        acl_loader.rules_info = {}
+        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_vlan_9000.json'))
+        assert not acl_loader.rules_info.get(("DATAACL", "RULE_1"))
+
+    def test_vlan_id_not_a_number(self, acl_loader):
+        acl_loader.rules_info = {}
+        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_vlan_nan.json'))
+        assert not acl_loader.rules_info.get(("DATAACL", "RULE_1"))
+
+    def test_icmp_translation(self, acl_loader):
+        acl_loader.rules_info = {}
+        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/acl1.json'))
+        assert acl_loader.rules_info[("DATAACL", "RULE_1")]
+        assert acl_loader.rules_info[("DATAACL", "RULE_1")]["ICMP_TYPE"] == 3
+        assert acl_loader.rules_info[("DATAACL", "RULE_1")]["ICMP_CODE"] == 0
+
+    def test_icmpv6_translation(self, acl_loader):
+        acl_loader.rules_info = {}
+        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/acl1.json'))
+        assert acl_loader.rules_info[("DATAACLV6", "RULE_1")]
+        assert acl_loader.rules_info[("DATAACLV6", "RULE_1")]["ICMPV6_TYPE"] == 1
+        assert acl_loader.rules_info[("DATAACLV6", "RULE_1")]["ICMPV6_CODE"] == 0
+
+    def test_icmp_type_lower_bound(self, acl_loader):
+        acl_loader.rules_info = {}
+        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_icmp_type_neg_1.json'))
+        assert not acl_loader.rules_info.get(("DATAACL", "RULE_1"))
+
+    def test_icmp_type_upper_bound(self, acl_loader):
+        acl_loader.rules_info = {}
+        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_icmp_type_300.json'))
+        assert not acl_loader.rules_info.get(("DATAACL", "RULE_1"))
+
+    def test_icmp_type_not_a_number(self, acl_loader):
+        acl_loader.rules_info = {}
+        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_icmp_type_nan.json'))
+        assert not acl_loader.rules_info.get(("DATAACL", "RULE_1"))
+
+    def test_icmp_code_lower_bound(self, acl_loader):
+        acl_loader.rules_info = {}
+        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_icmp_code_neg_1.json'))
+        assert not acl_loader.rules_info.get(("DATAACL", "RULE_1"))
+
+    def test_icmp_code_upper_bound(self, acl_loader):
+        acl_loader.rules_info = {}
+        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_icmp_code_300.json'))
+        assert not acl_loader.rules_info.get(("DATAACL", "RULE_1"))
+
+    def test_icmp_code_not_a_number(self, acl_loader):
+        acl_loader.rules_info = {}
+        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_icmp_code_nan.json'))
+        assert not acl_loader.rules_info.get(("DATAACL", "RULE_1"))

--- a/tests/acl_loader_test.py
+++ b/tests/acl_loader_test.py
@@ -61,19 +61,19 @@ class TestAclLoader(object):
         assert acl_loader.rules_info[("DATAACL", "RULE_2")]["VLAN_ID"] == 369
 
     def test_vlan_id_lower_bound(self, acl_loader):
-        acl_loader.rules_info = {}
-        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_vlan_0.json'))
-        assert not acl_loader.rules_info.get(("DATAACL", "RULE_1"))
+        with pytest.raises(ValueError):
+            acl_loader.rules_info = {}
+            acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_vlan_0.json'))
 
     def test_vlan_id_upper_bound(self, acl_loader):
-        acl_loader.rules_info = {}
-        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_vlan_9000.json'))
-        assert not acl_loader.rules_info.get(("DATAACL", "RULE_1"))
+        with pytest.raises(ValueError):
+            acl_loader.rules_info = {}
+            acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_vlan_9000.json'))
 
     def test_vlan_id_not_a_number(self, acl_loader):
-        acl_loader.rules_info = {}
-        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_vlan_nan.json'))
-        assert not acl_loader.rules_info.get(("DATAACL", "RULE_1"))
+        with pytest.raises(ValueError):
+            acl_loader.rules_info = {}
+            acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_vlan_nan.json'))
 
     def test_icmp_translation(self, acl_loader):
         acl_loader.rules_info = {}
@@ -90,31 +90,31 @@ class TestAclLoader(object):
         assert acl_loader.rules_info[("DATAACLV6", "RULE_1")]["ICMPV6_CODE"] == 0
 
     def test_icmp_type_lower_bound(self, acl_loader):
-        acl_loader.rules_info = {}
-        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_icmp_type_neg_1.json'))
-        assert not acl_loader.rules_info.get(("DATAACL", "RULE_1"))
+        with pytest.raises(ValueError):
+            acl_loader.rules_info = {}
+            acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_icmp_type_neg_1.json'))
 
     def test_icmp_type_upper_bound(self, acl_loader):
-        acl_loader.rules_info = {}
-        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_icmp_type_300.json'))
-        assert not acl_loader.rules_info.get(("DATAACL", "RULE_1"))
+        with pytest.raises(ValueError):
+            acl_loader.rules_info = {}
+            acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_icmp_type_300.json'))
 
     def test_icmp_type_not_a_number(self, acl_loader):
-        acl_loader.rules_info = {}
-        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_icmp_type_nan.json'))
-        assert not acl_loader.rules_info.get(("DATAACL", "RULE_1"))
+        with pytest.raises(ValueError):
+            acl_loader.rules_info = {}
+            acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_icmp_type_nan.json'))
 
     def test_icmp_code_lower_bound(self, acl_loader):
-        acl_loader.rules_info = {}
-        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_icmp_code_neg_1.json'))
-        assert not acl_loader.rules_info.get(("DATAACL", "RULE_1"))
+        with pytest.raises(ValueError):
+            acl_loader.rules_info = {}
+            acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_icmp_code_neg_1.json'))
 
     def test_icmp_code_upper_bound(self, acl_loader):
-        acl_loader.rules_info = {}
-        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_icmp_code_300.json'))
-        assert not acl_loader.rules_info.get(("DATAACL", "RULE_1"))
+        with pytest.raises(ValueError):
+            acl_loader.rules_info = {}
+            acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_icmp_code_300.json'))
 
     def test_icmp_code_not_a_number(self, acl_loader):
-        acl_loader.rules_info = {}
-        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_icmp_code_nan.json'))
-        assert not acl_loader.rules_info.get(("DATAACL", "RULE_1"))
+        with pytest.raises(ValueError):
+            acl_loader.rules_info = {}
+            acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_icmp_code_nan.json'))

--- a/tests/aclshow_test.py
+++ b/tests/aclshow_test.py
@@ -78,7 +78,7 @@ rule0_output = '' + \
 # Expected output for aclshow -r RULE_4,RULE_6 -vv
 rule4_rule6_verbose_output = '' + \
 """Reading ACL info...
-Total number of ACL Tables: 5
+Total number of ACL Tables: 6
 Total number of ACL Rules: 11
 
 RULE NAME    TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -400,6 +400,11 @@
         "ports@": "PortChannel0002,PortChannel0005,PortChannel0008,PortChannel0011,PortChannel0014,PortChannel0017,PortChannel0020,PortChannel0023,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124",
         "type": "L3"
     },
+    "ACL_TABLE|DATAACLV6": {
+        "policy_desc": "DATAACLV6",
+        "ports@": "PortChannel0002,PortChannel0005,PortChannel0008,PortChannel0011,PortChannel0014,PortChannel0017,PortChannel0020,PortChannel0023,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124",
+        "type": "L3V6"
+    },
     "ACL_TABLE|EVERFLOW": {
         "policy_desc": "EVERFLOW",
         "ports@": "PortChannel0002,PortChannel0005,PortChannel0008,PortChannel0011,PortChannel0014,PortChannel0017,PortChannel0020,PortChannel0023,Ethernet100,Ethernet104,Ethernet92,Ethernet96,Ethernet84,Ethernet88,Ethernet76,Ethernet80,Ethernet108,Ethernet112,Ethernet64,Ethernet120,Ethernet116,Ethernet124,Ethernet72,Ethernet68",


### PR DESCRIPTION
- Add ICMP and VLAN fields
- Add new unit test cases

Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
I added support for loading rules that match on VLAN ID and ICMP type/code in acl-loader.

#### How I did it
These fields were added to the model in https://github.com/Azure/sonic-buildimage/pull/6896. This PR extracts those fields so that users can use them in their rules.

#### How to verify it
Updated unit tests. Can also verify locally that existing acl.json files can still be loaded, and those using the new fields add the correct output to config DB.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

