### PR TITLE
[config]: Create portchannel with LACP key

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1500,7 +1500,8 @@ def add_portchannel(ctx, portchannel_name, min_links, fallback):
         ctx.fail("{} already exists!".format(portchannel_name))
 
     fvs = {'admin_status': 'up',
-           'mtu': '9100'}
+           'mtu': '9100',
+           'lacp_key': 'auto'}
     if min_links != 0:
         fvs['min_links'] = str(min_links)
     if fallback != 'false':

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -44,7 +44,7 @@ class DBMigrator():
                      none-zero values.
               build: sequentially increase within a minor version domain.
         """
-        self.CURRENT_VERSION = 'version_2_0_0'
+        self.CURRENT_VERSION = 'version_2_0_2'
 
         self.TABLE_NAME      = 'VERSIONS'
         self.TABLE_KEY       = 'DATABASE'
@@ -525,9 +525,24 @@ class DBMigrator():
 
     def version_2_0_1(self):
         """
-        Current latest version. Nothing to do here.
+        Version 2_0_1.
         """
         log.log_info('Handling version_2_0_1')
+        warmreboot_state = self.stateDB.get(self.stateDB.STATE_DB, 'WARM_RESTART_ENABLE_TABLE|system', 'enable')
+
+        if warmreboot_state != 'true':
+            portchannel_table = self.configDB.get_table('PORTCHANNEL')
+            for name, data in portchannel_table.items():
+                data['lacp_key'] = 'auto'
+                self.configDB.set_entry('PORTCHANNEL', name, data)
+        self.set_version('version_2_0_2')
+        return 'version_2_0_2'
+
+    def version_2_0_2(self):
+        """
+        Current latest version. Nothing to do here.
+        """
+        log.log_info('Handling version_2_0_2')
         return None
 
     def get_version(self):

--- a/tests/db_migrator_input/config_db/portchannel-expected.json
+++ b/tests/db_migrator_input/config_db/portchannel-expected.json
@@ -1,0 +1,39 @@
+{
+    "PORTCHANNEL|PortChannel0": {
+        "admin_status": "up",
+        "members@": "Ethernet0,Ethernet4",
+        "min_links": "2",
+        "mtu": "9100",
+        "lacp_key": "auto"
+    },
+    "PORTCHANNEL|PortChannel1": {
+        "admin_status": "up",
+        "members@": "Ethernet8,Ethernet12",
+        "min_links": "2",
+        "mtu": "9100",
+        "lacp_key": "auto"
+    },
+    "PORTCHANNEL|PortChannel0123": {
+        "admin_status": "up",
+        "members@": "Ethernet16",
+        "min_links": "1",
+        "mtu": "9100",
+        "lacp_key": "auto"
+    },
+    "PORTCHANNEL|PortChannel0011": {
+        "admin_status": "up",
+        "members@": "Ethernet20,Ethernet24",
+        "min_links": "2",
+        "mtu": "9100",
+        "lacp_key": "auto"
+    },
+    "PORTCHANNEL|PortChannel9999": {
+        "admin_status": "up",
+        "mtu": "9100",
+        "lacp_key": "auto"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_2_0_2"
+    }
+} 
+

--- a/tests/db_migrator_input/config_db/portchannel-input.json
+++ b/tests/db_migrator_input/config_db/portchannel-input.json
@@ -1,0 +1,33 @@
+{
+    "PORTCHANNEL|PortChannel0": {
+        "admin_status": "up",
+        "members@": "Ethernet0,Ethernet4",
+        "min_links": "2",
+        "mtu": "9100"
+    },
+    "PORTCHANNEL|PortChannel1": {
+        "admin_status": "up",
+        "members@": "Ethernet8,Ethernet12",
+        "min_links": "2",
+        "mtu": "9100"
+    },
+    "PORTCHANNEL|PortChannel0123": {
+        "admin_status": "up",
+        "members@": "Ethernet16",
+        "min_links": "1",
+        "mtu": "9100"
+    },
+    "PORTCHANNEL|PortChannel0011": {
+        "admin_status": "up",
+        "members@": "Ethernet20,Ethernet24",
+        "min_links": "2",
+        "mtu": "9100"
+    },
+    "PORTCHANNEL|PortChannel9999": {
+        "admin_status": "up",
+        "mtu": "9100"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_2_0_1"
+    }
+} 

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -247,3 +247,26 @@ class TestInitConfigMigrator(object):
         assert not diff
 
         assert not expected_db.cfgdb.get_table('CONTAINER_FEATURE')
+
+
+class TestLacpKeyMigrator(object):
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "2"
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        dbconnector.dedicated_dbs['CONFIG_DB'] = None
+        
+    def test_lacp_key_migrator(self):
+        dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', 'portchannel-input')
+        import db_migrator
+        dbmgtr = db_migrator.DBMigrator(None)
+        dbmgtr.migrate()
+        dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', 'portchannel-expected')
+        expected_db = Db()
+        advance_version_for_expected_database(dbmgtr.configDB, expected_db.cfgdb, 'version_2_0_2')
+
+        assert dbmgtr.configDB.get_table('PORTCHANNEL') == expected_db.cfgdb.get_table('PORTCHANNEL')
+        assert dbmgtr.configDB.get_table('VERSIONS') == expected_db.cfgdb.get_table('VERSIONS')


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
This PR depends on:

- https://github.com/Azure/sonic-utilities/pull/1566
- https://github.com/Azure/sonic-swss/pull/1660

#### What I did
Fix issue - https://github.com/Azure/sonic-buildimage/issues/4009
Change the LACP key to be generated from the Port Channel name instead of always being 0.
When upgrading without warm-reboot update old port channels to use the new default.


#### How I did it
When adding a new port-channel add by default the key lacp_key with the value 'auto' to the port-channel table, this is done to change the port-channel LACP key to be generated from the Port Channel name instead of always being 0.

When upgrading without warm-reboot, also update old port channels to use the new default.
This is not done on warm-reboot to avoid the link from going down.

#### How to verify it
Create a new port-channel, add a port and run tcpdump on this port.
LACP Key should be the number in the end of the port channel name with leading 1.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012