### PR TITLE
[201811] Warmboot script improvements - timeout in exec and disable swss autorestart

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -37,7 +37,7 @@ function error()
 function debug()
 {
     if [[ x"${VERBOSE}" == x"yes" ]]; then
-        echo `date` $@
+        echo $(date) $@
     fi
     logger "$@"
 }
@@ -103,17 +103,13 @@ function clear_warm_boot()
 {
     clear_fast_boot
 
-    result=`timeout 10s config warm_restart disable; if [[ $? == 124 ]]; then echo timeout; else echo "code ($?)"; fi` || /bin/true
+    result=$(timeout 10s config warm_restart disable; res=$?; if [[ $res == 124 ]]; then echo timeout; else echo "code ($res)"; fi) || /bin/true
     debug "Cancel warm-reboot: ${result}"
 
-    TIMESTAMP=`date +%Y%m%d-%H%M%S`
+    TIMESTAMP=$(date +%Y%m%d-%H%M%S)
     if [[ -f ${WARM_DIR}/${REDIS_FILE} ]]; then
         mv -f ${WARM_DIR}/${REDIS_FILE} ${WARM_DIR}/${REDIS_FILE}.${TIMESTAMP} || /bin/true
     fi
-    # enabling swss auto restart
-    docker exec swss supervisorctl start supervisor-proc-exit-listener || /bin/true
-    sed -i -e "s/\<RestartSec=300\>/RestartSec=30/" /etc/systemd/system/swss.service || /bin/true
-    systemctl daemon-reload
 }
 
 function init_warm_reboot_states()
@@ -134,7 +130,7 @@ function initialize_pre_shutdown()
 {
     debug "Initialize pre-shutdown ..."
     TABLE="WARM_RESTART_TABLE|warm-shutdown"
-    RESTORE_COUNT=`/usr/bin/redis-cli -n 6 hget "${TABLE}" restore_count`
+    RESTORE_COUNT=$(/usr/bin/redis-cli -n 6 hget "${TABLE}" restore_count)
     if [[ -z "$RESTORE_COUNT" ]]; then
         /usr/bin/redis-cli -n 6 hset "${TABLE}" "restore_count" "0" > /dev/null
     fi
@@ -144,7 +140,7 @@ function initialize_pre_shutdown()
 function request_pre_shutdown()
 {
     debug "Requesting pre-shutdown ..."
-    STATE=`timeout 5s docker exec syncd /usr/bin/syncd_request_shutdown --pre &> /dev/null; if [[ $? == 124 ]]; then echo "timed out"; fi`
+    STATE=$(timeout 5s docker exec syncd /usr/bin/syncd_request_shutdown --pre &> /dev/null; if [[ $? == 124 ]]; then echo "timed out"; fi)
     if [[ x"${STATE}" == x"timed out" ]]; then
         error "Failed to request pre-shutdown"
     fi
@@ -164,7 +160,7 @@ function wait_for_pre_shutdown_complete_or_fail()
     while [[ ${elapsed_time} -lt 60 ]]; do
         # timeout doesn't work with -i option of "docker exec". Therefore we have
         # to invoke docker exec directly below.
-        STATE=`timeout 5s docker exec database redis-cli -n 6 hget "${TABLE}" state; if [[ $? == 124 ]]; then echo "timed out"; fi`
+        STATE=$(timeout 5s docker exec database redis-cli -n 6 hget "${TABLE}" state; if [[ $? == 124 ]]; then echo "timed out"; fi)
 
         if [[ x"${STATE}" == x"timed out" ]]; then
             retrycount+=1
@@ -204,7 +200,7 @@ function backup_database()
     " 0 > /dev/null
     redis-cli save > /dev/null
     docker cp database:/var/lib/redis/$REDIS_FILE $WARM_DIR
-    STATE=`timeout 5s docker exec database rm /var/lib/redis/$REDIS_FILE; if [[ $? == 124 ]]; then echo "timed out"; fi`
+    STATE=$(timeout 5s docker exec database rm /var/lib/redis/$REDIS_FILE; if [[ $? == 124 ]]; then echo "timed out"; fi)
     if [[ x"${STATE}" == x"timed out" ]]; then
         error "Timedout during attempting to remove Redis dump file from database container"
     fi
@@ -248,10 +244,23 @@ function setup_reboot_variables()
     INITRD=$(echo $KERNEL_IMAGE | sed 's/vmlinuz/initrd.img/g')
 }
 
+function check_docker_exec()
+{
+    containers="radv bgp lldp swss database teamd syncd"
+    for container in $containers; do
+        STATE=$(timeout 1s docker exec $container echo "success"; if [[ $? == 124 ]]; then echo "timed out"; fi)
+        if [[ x"${STATE}" == x"timed out" ]]; then
+            error "Docker exec on $container timedout"
+            exit "${EXIT_FAILURE}"
+        fi
+    done
+}
+
 function reboot_pre_check()
 {
+    check_docker_exec
     # Make sure that the file system is normal: read-write able
-    filename="/host/test-`date +%Y%m%d-%H%M%S`"
+    filename="/host/test-$(date +%Y%m%d-%H%M%S)"
     if [[ ! -f ${filename} ]]; then
         touch ${filename}
     fi
@@ -296,17 +305,6 @@ function unload_kernel()
     fi
 }
 
-function check_docker_exec()
-{
-    containers="radv bgp lldp swss database teamd syncd"
-    for container in $containers; do
-        STATE=`timeout 1s docker exec $container echo "test"; if [[ $? == 124 ]]; then echo "timed out"; fi`
-        if [[ x"${STATE}" == x"timed out" ]]; then
-            error "Docker exec on $container timedout"
-            exit "${EXIT_FAILURE}"
-        fi
-    done
-}
 # main starts here
 parseOptions $@
 
@@ -344,8 +342,6 @@ case "$REBOOT_TYPE" in
         exit "${EXIT_NOT_SUPPORTED}"
         ;;
 esac
-
-check_docker_exec
 
 unload_kernel
 
@@ -412,11 +408,6 @@ init_warm_reboot_states
 setup_control_plane_assistant
 
 if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; then
-    debug "Disabling swss auto restart ..."
-    docker exec swss supervisorctl stop supervisor-proc-exit-listener &> /dev/null || /bin/true
-    sed -i -e "s/\<RestartSec=30\>/RestartSec=300/" /etc/systemd/system/swss.service || /bin/true
-    systemctl daemon-reload || /bin/true
-
     # Freeze orchagent for warm restart
     # Ask orchagent_restart_check to try freeze 5 times with interval of 2 seconds,
     # it is possible that the orchagent is in transient state and no opportunity to be freezed
@@ -475,10 +466,14 @@ if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
     debug "Stopped teamd ..."
 fi
 
-# Kill swss Docker container
+# Disabling swss auto restart and then kill swss Docker container
 # We call `docker kill swss` to ensure the container stops as quickly as possible,
 # then immediately call `systemctl stop swss` to prevent the service from
 # restarting the container automatically.
+debug "Disabling swss auto restart ..."
+docker exec swss supervisorctl stop supervisor-proc-exit-listener &> /dev/null || /bin/true
+sed -i -e "s/\<RestartSec=30\>/RestartSec=300/" /etc/systemd/system/swss.service || /bin/true
+systemctl daemon-reload || /bin/true
 docker kill swss &> /dev/null || debug "Docker swss is not running ($?) ..."
 systemctl stop swss
 
@@ -508,7 +503,7 @@ if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; t
     # Send USR1 signal to all teamd instances to stop them
     # It will prepare teamd for warm-reboot
     # Note: We must send USR1 signal before syncd, because it will send the last packet through CPU port
-    STATE=`timeout 5s docker exec teamd pkill -USR1 teamd; if [[ $? == 124 ]]; then echo "timed out"; fi`
+    STATE=$(timeout 5s docker exec teamd pkill -USR1 teamd; if [[ $? == 124 ]]; then echo "timed out"; fi)
     if [[ x"${STATE}" == x"timed out" ]]; then
         error "Timedout while attempting to stop teamd instances"
     else
@@ -541,7 +536,7 @@ systemctl stop docker.service || debug "Ignore stopping docker service error $?"
 # Stop kernel modules for Nephos platform
 if [[ "$sonic_asic_type" = 'nephos' ]];
 then
-  systemctl stop nps-modules-`uname -r`.service || debug "Ignore stopping nps service error $?"
+  systemctl stop nps-modules-$(uname -r).service || debug "Ignore stopping nps service error $?"
 fi
 
 # Update the reboot cause file to reflect that user issued this script

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -110,6 +110,10 @@ function clear_warm_boot()
     if [[ -f ${WARM_DIR}/${REDIS_FILE} ]]; then
         mv -f ${WARM_DIR}/${REDIS_FILE} ${WARM_DIR}/${REDIS_FILE}.${TIMESTAMP} || /bin/true
     fi
+    # enabling swss auto restart
+    docker exec swss supervisorctl start supervisor-proc-exit-listener || /bin/true
+    sed -i -e "s/\<RestartSec=300\>/RestartSec=30/" /etc/systemd/system/swss.service || /bin/true
+    systemctl daemon-reload
 }
 
 function init_warm_reboot_states()
@@ -140,9 +144,10 @@ function initialize_pre_shutdown()
 function request_pre_shutdown()
 {
     debug "Requesting pre-shutdown ..."
-    /usr/bin/docker exec -i syncd /usr/bin/syncd_request_shutdown --pre &> /dev/null || {
+    STATE=`timeout 5s docker exec syncd /usr/bin/syncd_request_shutdown --pre &> /dev/null; if [[ $? == 124 ]]; then echo "timed out"; fi`
+    if [[ x"${STATE}" == x"timed out" ]]; then
         error "Failed to request pre-shutdown"
-    }
+    fi
 }
 
 function wait_for_pre_shutdown_complete_or_fail()
@@ -152,18 +157,18 @@ function wait_for_pre_shutdown_complete_or_fail()
     STATE="requesting"
     declare -i waitcount
     declare -i retrycount
-    waitcount=0
     retrycount=0
+    start_time=$SECONDS
+    elapsed_time=$(($SECONDS - $start_time))
     # Wait up to 60 seconds for pre-shutdown to complete
-    while [[ ${waitcount} -lt 600 ]]; do
+    while [[ ${elapsed_time} -lt 60 ]]; do
         # timeout doesn't work with -i option of "docker exec". Therefore we have
         # to invoke docker exec directly below.
         STATE=`timeout 5s docker exec database redis-cli -n 6 hget "${TABLE}" state; if [[ $? == 124 ]]; then echo "timed out"; fi`
 
         if [[ x"${STATE}" == x"timed out" ]]; then
-            waitcount+=50
             retrycount+=1
-            debug "Timed out getting pre-shutdown state (${waitcount}) retry count ${retrycount} ..."
+            debug "Timed out getting pre-shutdown state, retry count ${retrycount} ..."
             if [[ retrycount -gt 2 ]]; then
                 break
             fi
@@ -171,8 +176,8 @@ function wait_for_pre_shutdown_complete_or_fail()
             break
         else
             sleep 0.1
-            waitcount+=1
         fi
+        elapsed_time=$(($SECONDS - $start_time))
     done
 
     if [[ x"${STATE}" != x"pre-shutdown-succeeded" ]]; then
@@ -199,7 +204,10 @@ function backup_database()
     " 0 > /dev/null
     redis-cli save > /dev/null
     docker cp database:/var/lib/redis/$REDIS_FILE $WARM_DIR
-    docker exec -i database rm /var/lib/redis/$REDIS_FILE
+    STATE=`timeout 5s docker exec database rm /var/lib/redis/$REDIS_FILE; if [[ $? == 124 ]]; then echo "timed out"; fi`
+    if [[ x"${STATE}" == x"timed out" ]]; then
+        error "Timedout during attempting to remove Redis dump file from database container"
+    fi
 }
 
 function setup_control_plane_assistant()
@@ -288,6 +296,17 @@ function unload_kernel()
     fi
 }
 
+function check_docker_exec()
+{
+    containers="radv bgp lldp swss teamd syncd"
+    for container in $containers; do
+        STATE=`timeout 1s docker exec $container echo "test"; if [[ $? == 124 ]]; then echo "timed out"; fi`
+        if [[ x"${STATE}" == x"timed out" ]]; then
+            error "Docker exec on $container timedout"
+            exit "${EXIT_FAILURE}"
+        fi
+    done
+}
 # main starts here
 parseOptions $@
 
@@ -325,6 +344,8 @@ case "$REBOOT_TYPE" in
         exit "${EXIT_NOT_SUPPORTED}"
         ;;
 esac
+
+check_docker_exec
 
 unload_kernel
 
@@ -391,6 +412,11 @@ init_warm_reboot_states
 setup_control_plane_assistant
 
 if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; then
+    debug "Disabling swss auto restart ..."
+    docker exec swss supervisorctl stop supervisor-proc-exit-listener &> /dev/null || /bin/true
+    sed -i -e "s/\<RestartSec=30\>/RestartSec=300/" /etc/systemd/system/swss.service || /bin/true
+    systemctl daemon-reload || /bin/true
+
     # Freeze orchagent for warm restart
     # Ask orchagent_restart_check to try freeze 5 times with interval of 2 seconds,
     # it is possible that the orchagent is in transient state and no opportunity to be freezed
@@ -407,9 +433,12 @@ if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; t
     fi
 fi
 
-# We are fully committed to reboot from this point on becasue critical
+# We are fully committed to reboot from this point on because critical
 # service will go down and we cannot recover from it.
 set +e
+
+# disable trap handlers which were set before
+trap - EXIT HUP INT QUIT TERM KILL ABRT ALRM
 
 # Kill radv before stopping BGP service to prevent annoucing our departure.
 debug "Stopping radv ..."
@@ -479,8 +508,12 @@ if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; t
     # Send USR1 signal to all teamd instances to stop them
     # It will prepare teamd for warm-reboot
     # Note: We must send USR1 signal before syncd, because it will send the last packet through CPU port
-    docker exec -i teamd pkill -USR1 teamd > /dev/null || [ $? == 1 ]
-    debug "Stopped  teamd ..."
+    STATE=`timeout 5s docker exec teamd pkill -USR1 teamd; if [[ $? == 124 ]]; then echo "timed out"; fi`
+    if [[ x"${STATE}" == x"timed out" ]]; then
+        error "Timedout while attempting to stop teamd instances"
+    else
+        debug "Stopped  teamd ..."
+    fi
 fi
 
 debug "Stopping syncd ..."
@@ -531,6 +564,9 @@ if [[ -x /usr/bin/watchdog ]]; then
     debug "Enabling Watchdog before ${REBOOT_TYPE}"
     /usr/bin/watchdog -e
 fi
+
+# Reset swss restart time
+sed -i -e "s/\<RestartSec=300\>/RestartSec=30/" /etc/systemd/system/swss.service || /bin/true
 
 # Reboot: explicity call Linux native reboot under sbin
 debug "Rebooting with ${REBOOT_METHOD} to ${NEXT_SONIC_IMAGE} ..."

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -181,9 +181,9 @@ function wait_for_pre_shutdown_complete_or_fail()
     done
 
     if [[ x"${STATE}" != x"pre-shutdown-succeeded" ]]; then
-        debug "Syncd pre-shutdown failed: ${STATE} ..."
+        debug "Syncd pre-shutdown failed, state: ${STATE} ..."
     else
-        debug "Pre-shutdown succeeded ..."
+        debug "Pre-shutdown succeeded, state: ${STATE} ..."
     fi
 }
 
@@ -298,7 +298,7 @@ function unload_kernel()
 
 function check_docker_exec()
 {
-    containers="radv bgp lldp swss teamd syncd"
+    containers="radv bgp lldp swss database teamd syncd"
     for container in $containers; do
         STATE=`timeout 1s docker exec $container echo "test"; if [[ $? == 124 ]]; then echo "timed out"; fi`
         if [[ x"${STATE}" == x"timed out" ]]; then
@@ -437,8 +437,8 @@ fi
 # service will go down and we cannot recover from it.
 set +e
 
-# disable trap handlers which were set before
-trap - EXIT HUP INT QUIT TERM KILL ABRT ALRM
+# disable trap-handlers which were set before
+trap ' ' EXIT HUP INT QUIT TERM KILL ABRT ALRM
 
 # Kill radv before stopping BGP service to prevent annoucing our departure.
 debug "Stopping radv ..."

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -429,7 +429,7 @@ fi
 set +e
 
 # disable trap-handlers which were set before
-trap ' ' EXIT HUP INT QUIT TERM KILL ABRT ALRM
+trap '' EXIT HUP INT QUIT TERM KILL ABRT ALRM
 
 # Kill radv before stopping BGP service to prevent annoucing our departure.
 debug "Stopping radv ..."


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Below changes are made to warmboot/fastboot script:

1. Disable swss auto-restart during warm reboot.
2. Add timeout to make sure syncd shutdown request will return in time. 5s
3. Disable trap handler after +e.
4. Make sure that syncd pre-shutdown wait won't take more than 60 seconds.
5. Make sure subsequent docker exec won't stuck for long time
6. Before shutdown, check docker exec on the relevant docker containers still works.

#### How I did it

#### How to verify it
Testing on a physical tested - 6100 T0:

Ideal warmboot
```
$ sudo warm-reboot -vvv
Wed Mar 3 21:08:15 UTC 2021 Disabling swss auto restart ...
Wed Mar 3 21:08:16 UTC 2021 Pausing orchagent ...
Wed Mar 3 21:08:16 UTC 2021 Stopping radv ...
Wed Mar 3 21:08:17 UTC 2021 Stopping bgp ...
Wed Mar 3 21:08:17 UTC 2021 Stopped bgp ...
Wed Mar 3 21:08:20 UTC 2021 Initialize pre-shutdown ...
Wed Mar 3 21:08:21 UTC 2021 Requesting pre-shutdown ...
Wed Mar 3 21:08:22 UTC 2021 Waiting for pre-shutdown ...
Wed Mar 3 21:08:24 UTC 2021 Pre-shutdown succeeded, state: pre-shutdown-succeeded ...
Wed Mar 3 21:08:24 UTC 2021 Backing up database ...
Wed Mar 3 21:08:25 UTC 2021 Stopping teamd ...
Wed Mar 3 21:08:25 UTC 2021 Stopped teamd ...
Wed Mar 3 21:08:25 UTC 2021 Stopping syncd ...
Wed Mar 3 21:08:36 UTC 2021 Stopped syncd ...
Wed Mar 3 21:08:36 UTC 2021 Stopping all remaining containers ...
Wed Mar 3 21:08:39 UTC 2021 Stopped all remaining containers ...
Wed Mar 3 21:08:41 UTC 2021 Enabling Watchdog before warm-reboot
Wed Mar 3 21:08:41 UTC 2021 Rebooting with /sbin/kexec -e to SONiC-OS-20181130.70 ...
```

Two attempts captured below
`Initialize pre-shutdown` took ~0.5s/~0.5s
`Requesting pre-shutdown` took ~0.2s/~0.2s (max allowed 1s)
`Waiting for pre-shutdown` took ~2.2s/~2s (max allowed 60s)

```
Mar  3 19:17:30.321555 str-s6100-acs-2 NOTICE admin: Initialize pre-shutdown ...

Mar  3 19:17:30.851934 str-s6100-acs-2 NOTICE admin: Requesting pre-shutdown ...
Mar  3 19:17:31.048557 str-s6100-acs-2 NOTICE syncd#syncd_request_shutdown: :- main: requested PRE-SHUTDOWN shutdown
Mar  3 19:17:31.049167 str-s6100-acs-2 NOTICE syncd#syncd: :- syncd_main: is asic queue empty: 1
Mar  3 19:17:31.049167 str-s6100-acs-2 NOTICE syncd#syncd: :- syncd_main: drained queue
Mar  3 19:17:31.049167 str-s6100-acs-2 NOTICE syncd#syncd: :- handleRestartQuery: received PRE_SHUTDOWN switch event

Mar  3 19:17:31.124613 str-s6100-acs-2 NOTICE admin: Waiting for pre-shutdown ...
Mar  3 19:17:31.155430 str-s6100-acs-2 NOTICE syncd#syncd: :- threadFunction:  span < 0 = -4926893 at 1614799051147423
Mar  3 19:17:31.155430 str-s6100-acs-2 NOTICE syncd#syncd: :- threadFunction:  new span  = 98742
Mar  3 19:17:32.151674 str-s6100-acs-2 NOTICE syncd#syncd: :- threadFunction:  span < 0 = -4926893 at 1614799052151410
Mar  3 19:17:32.151674 str-s6100-acs-2 NOTICE syncd#syncd: :- threadFunction:  new span  = 1102729
Mar  3 19:17:32.815999 str-s6100-acs-2 INFO syncd#supervisord: syncd tar: Removing leading `/' from member names#015
Mar  3 19:17:33.063404 str-s6100-acs-2 NOTICE syncd#syncd: :- syncd_main: switched to PRE_SHUTDOWN, from now on accepting only shurdown requests
Mar  3 19:17:33.063404 str-s6100-acs-2 NOTICE syncd#syncd: :- syncd_main: warm pre-shutdown took 2.014352 sec
Mar  3 19:17:33.383040 str-s6100-acs-2 NOTICE admin: Pre-shutdown succeeded ...
```


#### Negative cases tested:
**Added a wait during sync preshutdown request to see if SWSS restart happens, and it did not happen within this time duration:**
```
Mar  3 20:24:08.100815 str-s6100-acs-2 NOTICE admin: Initialize pre-shutdown ...
Mar  3 20:24:17.500676 str-s6100-acs-2 INFO systemd[1]: Stopped SNMP container.
Mar  3 20:25:08.642516 str-s6100-acs-2 NOTICE admin: Requesting pre-shutdown ...
```

**If syncd preshutdown request fails, the warmboot still proceeds. Also, pre-shutdown-wait timesout in 60s as expected by this change:**
```
# warm-reboot -vvv
Wed Mar 3 20:42:34 UTC 2021 Disabling swss auto restart ...
Wed Mar 3 20:42:35 UTC 2021 Pausing orchagent ...
Wed Mar 3 20:42:35 UTC 2021 Stopping radv ...
Wed Mar 3 20:42:36 UTC 2021 Stopping bgp ...
Wed Mar 3 20:42:37 UTC 2021 Stopped bgp ...
Wed Mar 3 20:42:40 UTC 2021 Initialize pre-shutdown ...
Wed Mar 3 20:42:40 UTC 2021 Requesting pre-shutdown ...
Failed to request pre-shutdown
Wed Mar 3 20:42:45 UTC 2021 Waiting for pre-shutdown ...
Wed Mar 3 20:43:45 UTC 2021 Syncd pre-shutdown failed, state: requesting ...
Wed Mar 3 20:43:45 UTC 2021 Backing up database ...
Wed Mar 3 20:43:46 UTC 2021 Stopping teamd ...
Wed Mar 3 20:43:46 UTC 2021 Stopped teamd ...
Wed Mar 3 20:43:46 UTC 2021 Stopping syncd ...
Wed Mar 3 20:43:59 UTC 2021 Stopped syncd ...
Wed Mar 3 20:43:59 UTC 2021 Stopping all remaining containers ...
Wed Mar 3 20:44:02 UTC 2021 Stopped all remaining containers ...
Wed Mar 3 20:44:04 UTC 2021 Enabling Watchdog before warm-reboot
Wed Mar 3 20:44:04 UTC 2021 Rebooting with /sbin/kexec -e to SONiC-OS-20181130.70 ...
```

**Issued KILL signal (CTRL C) after script sets (set +e), and ensured that the trap-handler functions are not called, and the warmboot still proceeds:**

```
# warm-reboot -vvv
Wed Mar 3 21:13:03 UTC 2021 Disabling swss auto restart ...
Wed Mar 3 21:13:04 UTC 2021 Pausing orchagent ...
Wed Mar 3 21:13:04 UTC 2021 Stopping radv ...
Wed Mar 3 21:13:05 UTC 2021 Stopping bgp ...
Wed Mar 3 21:13:06 UTC 2021 Stopped bgp ...
Wed Mar 3 21:13:09 UTC 2021 Initialize pre-shutdown ...
Wed Mar 3 21:13:09 UTC 2021 Requesting pre-shutdown ...
Wed Mar 3 21:13:09 UTC 2021 Waiting for pre-shutdown ...
^C^C^C^C^C^CWed Mar 3 21:13:22 UTC 2021 Pre-shutdown succeeded, state: pre-shutdown-succeeded ...
Wed Mar 3 21:13:22 UTC 2021 Backing up database ...
Wed Mar 3 21:13:23 UTC 2021 Stopping teamd ...
Wed Mar 3 21:13:23 UTC 2021 Stopped teamd ...
Wed Mar 3 21:13:23 UTC 2021 Stopping syncd ...
Wed Mar 3 21:13:34 UTC 2021 Stopped syncd ...
Wed Mar 3 21:13:34 UTC 2021 Stopping all remaining containers ...
Wed Mar 3 21:13:37 UTC 2021 Stopped all remaining containers ...
Wed Mar 3 21:13:39 UTC 2021 Enabling Watchdog before warm-reboot
Wed Mar 3 21:13:39 UTC 2021 Rebooting with /sbin/kexec -e to SONiC-OS-20181130.70 ...
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

