### PR TITLE
[201911][acl] Expand VLAN into VLAN members when creating an ACL table

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2552,6 +2552,62 @@ def get_acl_bound_ports():
 
     return list(ports)
 
+
+def expand_vlan_ports(port_name):
+    """
+    Expands a given VLAN interface into its member ports.
+
+    If the provided interface is a VLAN, then this method will return its member ports.
+
+    If the provided interface is not a VLAN, then this method will return a list with only
+    the provided interface in it.
+    """
+    config_db = ConfigDBConnector()
+    config_db.connect()
+
+    if port_name not in config_db.get_keys("VLAN"):
+        return [port_name]
+
+    vlan_members = config_db.get_keys("VLAN_MEMBER")
+
+    members = [member for vlan, member in vlan_members if port_name == vlan]
+
+    if not members:
+        raise ValueError("Cannot bind empty VLAN {}".format(port_name))
+
+    return members
+
+
+def parse_acl_table_info(table_name, table_type, description, ports, stage):
+    table_info = {"type": table_type}
+
+    if description:
+        table_info["policy_desc"] = description
+    else:
+        table_info["policy_desc"] = table_name
+
+    if not ports and ports != None:
+        raise ValueError("Cannot bind empty list of ports")
+
+    port_list = []
+    valid_acl_ports = get_acl_bound_ports()
+    if ports:
+        for port in ports.split(","):
+            port_list += expand_vlan_ports(port)
+        port_list = set(port_list)
+    else:
+        port_list = valid_acl_ports
+
+    for port in port_list:
+        if port not in valid_acl_ports:
+            raise ValueError("Cannot bind ACL to specified port {}".format(port))
+
+    table_info["ports@"] = ",".join(port_list)
+
+    table_info["stage"] = stage
+
+    return table_info
+
 #
 # 'table' subcommand ('config acl add table ...')
 #
@@ -2562,26 +2618,18 @@ def get_acl_bound_ports():
 @click.option("-d", "--description")
 @click.option("-p", "--ports")
 @click.option("-s", "--stage", type=click.Choice(["ingress", "egress"]), default="ingress")
-def table(table_name, table_type, description, ports, stage):
+@click.pass_context
+def table(ctx, table_name, table_type, description, ports, stage):
     """
     Add ACL table
     """
     config_db = ConfigDBConnector()
     config_db.connect()
 
-    table_info = {"type": table_type}
-
-    if description:
-        table_info["policy_desc"] = description
-    else:
-        table_info["policy_desc"] = table_name
-
-    if ports:
-        table_info["ports@"] = ports
-    else:
-        table_info["ports@"] = ",".join(get_acl_bound_ports())
-
-    table_info["stage"] = stage
+    try:
+        table_info = parse_acl_table_info(table_name, table_type, description, ports, stage)
+    except ValueError as e:
+        ctx.fail("Failed to parse ACL table config: exception={}".format(e))
 
     config_db.set_entry("ACL_TABLE", table_name, table_info)
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -1317,6 +1317,35 @@ When the optional argument "max_priority"  is specified, each rule’s priority 
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#acl)
 
+**config acl add table**
+
+This command is used to create new ACL tables.
+
+- Usage:
+  ```
+  config acl add table [OPTIONS] <table_name> <table_type> [-d <description>] [-p <ports>] [-s (ingress | egress)]
+  ```
+
+- Parameters:
+  - table_name: The name of the ACL table to create.
+  - table_type: The type of ACL table to create (e.g. "L3", "L3V6", "MIRROR")
+  - description: A description of the table for the user. (default is the table_name)
+  - ports: A comma-separated list of ports/interfaces to add to the table. The behavior is as follows:
+    - Physical ports will be bound as physical ports
+    - Portchannels will be bound as portchannels - passing a portchannel member is invalid
+    - VLANs will be expanded into their members (e.g. "Vlan1000" will become "Ethernet0,Ethernet2,Ethernet4...")
+  - stage: The stage this ACL table will be applied to, either ingress or egress. (default is ingress)
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config acl add table EXAMPLE L3 -p Ethernet0,Ethernet4 -s ingress
+  ```
+  ```
+  admin@sonic:~$ sudo config acl add table EXAMPLE_2 L3V6 -p Vlan1000,PortChannel0001,Ethernet128 -s egress
+  ```
+
+Go Back To [Beginning of the document](#) or [Beginning of this section](#acl)
+
 
 ## ARP & NDP
 

--- a/sonic-utilities-tests/acl_config_test.py
+++ b/sonic-utilities-tests/acl_config_test.py
@@ -1,0 +1,83 @@
+import pytest
+
+import config.main as config
+
+from click.testing import CliRunner
+from config.main import expand_vlan_ports, parse_acl_table_info
+
+
+class TestConfigAcl(object):
+    def test_expand_vlan(self):
+        assert set(expand_vlan_ports("Vlan1000")) == {"Ethernet4", "Ethernet8", "Ethernet12", "Ethernet16"}
+
+    def test_expand_lag(self):
+        assert set(expand_vlan_ports("PortChannel1001")) == {"PortChannel1001"}
+
+    def test_expand_physical_interface(self):
+        assert set(expand_vlan_ports("Ethernet4")) == {"Ethernet4"}
+
+    def test_expand_empty_vlan(self):
+        with pytest.raises(ValueError):
+            expand_vlan_ports("Vlan3000")
+
+    def test_parse_table_with_vlan_expansion(self):
+        table_info = parse_acl_table_info("TEST", "L3", None, "Vlan1000", "egress")
+        assert table_info["type"] == "L3"
+        assert table_info["policy_desc"] == "TEST"
+        assert table_info["stage"] == "egress"
+
+        port_list = table_info["ports@"].split(",")
+        assert set(port_list) == {"Ethernet4", "Ethernet8", "Ethernet12", "Ethernet16"}
+
+    def test_parse_table_with_vlan_and_duplicates(self):
+        table_info = parse_acl_table_info("TEST", "L3", None, "Ethernet4,Vlan1000", "egress")
+        assert table_info["type"] == "L3"
+        assert table_info["policy_desc"] == "TEST"
+        assert table_info["stage"] == "egress"
+
+        # Since Ethernet4 is a member of Vlan1000 we should not include it twice in the output
+        port_list = table_info["ports@"].split(",")
+        assert len(port_list) == 4
+        assert set(port_list) == {"Ethernet4", "Ethernet8", "Ethernet12", "Ethernet16"}
+
+    def test_parse_table_with_empty_vlan(self):
+        with pytest.raises(ValueError):
+            parse_acl_table_info("TEST", "L3", None, "Ethernet4,Vlan3000", "egress")
+
+    def test_parse_table_with_invalid_ports(self):
+        with pytest.raises(ValueError):
+            parse_acl_table_info("TEST", "L3", None, "Ethernet200", "egress")
+
+    def test_parse_table_with_empty_ports(self):
+        with pytest.raises(ValueError):
+            parse_acl_table_info("TEST", "L3", None, "", "egress")
+
+    def test_acl_add_table_nonexistent_port(self):
+        runner = CliRunner()
+
+        result = runner.invoke(
+            config.config.commands["acl"].commands["add"].commands["table"],
+            ["TEST", "L3", "-p", "Ethernet200"])
+
+        assert result.exit_code != 0
+        assert "Cannot bind ACL to specified port Ethernet200" in result.output
+
+    def test_acl_add_table_empty_string_port_list(self):
+        runner = CliRunner()
+
+        result = runner.invoke(
+            config.config.commands["acl"].commands["add"].commands["table"],
+            ["TEST", "L3", "-p", ""])
+
+        assert result.exit_code != 0
+        assert "Cannot bind empty list of ports" in result.output
+
+    def test_acl_add_table_empty_vlan(self):
+        runner = CliRunner()
+
+        result = runner.invoke(
+            config.config.commands["acl"].commands["add"].commands["table"],
+            ["TEST", "L3", "-p", "Vlan3000"])
+
+        assert result.exit_code != 0
+        assert "Cannot bind empty VLAN Vlan3000" in result.output

--- a/sonic-utilities-tests/acl_config_test.py
+++ b/sonic-utilities-tests/acl_config_test.py
@@ -27,7 +27,7 @@ class TestConfigAcl(object):
         assert table_info["stage"] == "egress"
 
         port_list = table_info["ports@"].split(",")
-        assert set(port_list) == {"Ethernet0", "Ethernet20"}
+        assert set(port_list) == {"Ethernet20", "Ethernet100"}
 
     def test_parse_table_with_vlan_and_duplicates(self):
         table_info = parse_acl_table_info("TEST", "L3", None, "Ethernet20,Vlan1000", "egress")

--- a/sonic-utilities-tests/acl_config_test.py
+++ b/sonic-utilities-tests/acl_config_test.py
@@ -8,13 +8,13 @@ from config.main import expand_vlan_ports, parse_acl_table_info
 
 class TestConfigAcl(object):
     def test_expand_vlan(self):
-        assert set(expand_vlan_ports("Vlan1000")) == {"Ethernet4", "Ethernet8", "Ethernet12", "Ethernet16"}
+        assert set(expand_vlan_ports("Vlan1000")) == {"Ethernet0", "Ethernet20"}
 
     def test_expand_lag(self):
         assert set(expand_vlan_ports("PortChannel1001")) == {"PortChannel1001"}
 
     def test_expand_physical_interface(self):
-        assert set(expand_vlan_ports("Ethernet4")) == {"Ethernet4"}
+        assert set(expand_vlan_ports("Ethernet0")) == {"Ethernet0"}
 
     def test_expand_empty_vlan(self):
         with pytest.raises(ValueError):
@@ -27,22 +27,22 @@ class TestConfigAcl(object):
         assert table_info["stage"] == "egress"
 
         port_list = table_info["ports@"].split(",")
-        assert set(port_list) == {"Ethernet4", "Ethernet8", "Ethernet12", "Ethernet16"}
+        assert set(port_list) == {"Ethernet0", "Ethernet20"}
 
     def test_parse_table_with_vlan_and_duplicates(self):
-        table_info = parse_acl_table_info("TEST", "L3", None, "Ethernet4,Vlan1000", "egress")
+        table_info = parse_acl_table_info("TEST", "L3", None, "Ethernet0,Vlan1000", "egress")
         assert table_info["type"] == "L3"
         assert table_info["policy_desc"] == "TEST"
         assert table_info["stage"] == "egress"
 
         # Since Ethernet4 is a member of Vlan1000 we should not include it twice in the output
         port_list = table_info["ports@"].split(",")
-        assert len(port_list) == 4
-        assert set(port_list) == {"Ethernet4", "Ethernet8", "Ethernet12", "Ethernet16"}
+        assert len(port_list) == 2
+        assert set(port_list) == {"Ethernet0", "Ethernet20"}
 
     def test_parse_table_with_empty_vlan(self):
         with pytest.raises(ValueError):
-            parse_acl_table_info("TEST", "L3", None, "Ethernet4,Vlan3000", "egress")
+            parse_acl_table_info("TEST", "L3", None, "Ethernet0,Vlan3000", "egress")
 
     def test_parse_table_with_invalid_ports(self):
         with pytest.raises(ValueError):

--- a/sonic-utilities-tests/acl_config_test.py
+++ b/sonic-utilities-tests/acl_config_test.py
@@ -3,7 +3,7 @@ import pytest
 import config.main as config
 
 from click.testing import CliRunner
-from config.main import expand_vlan_ports, parse_acl_table_info
+from config import expand_vlan_ports, parse_acl_table_info
 
 
 class TestConfigAcl(object):

--- a/sonic-utilities-tests/acl_config_test.py
+++ b/sonic-utilities-tests/acl_config_test.py
@@ -3,25 +3,24 @@ import pytest
 import config.main as config
 
 from click.testing import CliRunner
-from config.main import expand_vlan_ports, parse_acl_table_info
 
 
 class TestConfigAcl(object):
     def test_expand_vlan(self):
-        assert set(expand_vlan_ports("Vlan1000")) == {"Ethernet20", "Ethernet100"}
+        assert set(config.expand_vlan_ports("Vlan1000")) == {"Ethernet20", "Ethernet100"}
 
     def test_expand_lag(self):
-        assert set(expand_vlan_ports("PortChannel1001")) == {"PortChannel1001"}
+        assert set(config.expand_vlan_ports("PortChannel1001")) == {"PortChannel1001"}
 
     def test_expand_physical_interface(self):
-        assert set(expand_vlan_ports("Ethernet20")) == {"Ethernet20"}
+        assert set(config.expand_vlan_ports("Ethernet20")) == {"Ethernet20"}
 
     def test_expand_empty_vlan(self):
         with pytest.raises(ValueError):
-            expand_vlan_ports("Vlan3000")
+            config.expand_vlan_ports("Vlan3000")
 
     def test_parse_table_with_vlan_expansion(self):
-        table_info = parse_acl_table_info("TEST", "L3", None, "Vlan1000", "egress")
+        table_info = config.parse_acl_table_info("TEST", "L3", None, "Vlan1000", "egress")
         assert table_info["type"] == "L3"
         assert table_info["policy_desc"] == "TEST"
         assert table_info["stage"] == "egress"
@@ -30,7 +29,7 @@ class TestConfigAcl(object):
         assert set(port_list) == {"Ethernet20", "Ethernet100"}
 
     def test_parse_table_with_vlan_and_duplicates(self):
-        table_info = parse_acl_table_info("TEST", "L3", None, "Ethernet20,Vlan1000", "egress")
+        table_info = config.parse_acl_table_info("TEST", "L3", None, "Ethernet20,Vlan1000", "egress")
         assert table_info["type"] == "L3"
         assert table_info["policy_desc"] == "TEST"
         assert table_info["stage"] == "egress"
@@ -42,15 +41,15 @@ class TestConfigAcl(object):
 
     def test_parse_table_with_empty_vlan(self):
         with pytest.raises(ValueError):
-            parse_acl_table_info("TEST", "L3", None, "Ethernet20,Vlan3000", "egress")
+            config.parse_acl_table_info("TEST", "L3", None, "Ethernet20,Vlan3000", "egress")
 
     def test_parse_table_with_invalid_ports(self):
         with pytest.raises(ValueError):
-            parse_acl_table_info("TEST", "L3", None, "Ethernet200", "egress")
+            config.parse_acl_table_info("TEST", "L3", None, "Ethernet200", "egress")
 
     def test_parse_table_with_empty_ports(self):
         with pytest.raises(ValueError):
-            parse_acl_table_info("TEST", "L3", None, "", "egress")
+            config.parse_acl_table_info("TEST", "L3", None, "", "egress")
 
     def test_acl_add_table_nonexistent_port(self):
         runner = CliRunner()

--- a/sonic-utilities-tests/acl_config_test.py
+++ b/sonic-utilities-tests/acl_config_test.py
@@ -8,13 +8,13 @@ from config.main import expand_vlan_ports, parse_acl_table_info
 
 class TestConfigAcl(object):
     def test_expand_vlan(self):
-        assert set(expand_vlan_ports("Vlan1000")) == {"Ethernet0", "Ethernet20"}
+        assert set(expand_vlan_ports("Vlan1000")) == {"Ethernet20", "Ethernet100"}
 
     def test_expand_lag(self):
         assert set(expand_vlan_ports("PortChannel1001")) == {"PortChannel1001"}
 
     def test_expand_physical_interface(self):
-        assert set(expand_vlan_ports("Ethernet0")) == {"Ethernet0"}
+        assert set(expand_vlan_ports("Ethernet20")) == {"Ethernet20"}
 
     def test_expand_empty_vlan(self):
         with pytest.raises(ValueError):
@@ -30,7 +30,7 @@ class TestConfigAcl(object):
         assert set(port_list) == {"Ethernet0", "Ethernet20"}
 
     def test_parse_table_with_vlan_and_duplicates(self):
-        table_info = parse_acl_table_info("TEST", "L3", None, "Ethernet0,Vlan1000", "egress")
+        table_info = parse_acl_table_info("TEST", "L3", None, "Ethernet20,Vlan1000", "egress")
         assert table_info["type"] == "L3"
         assert table_info["policy_desc"] == "TEST"
         assert table_info["stage"] == "egress"
@@ -38,11 +38,11 @@ class TestConfigAcl(object):
         # Since Ethernet4 is a member of Vlan1000 we should not include it twice in the output
         port_list = table_info["ports@"].split(",")
         assert len(port_list) == 2
-        assert set(port_list) == {"Ethernet0", "Ethernet20"}
+        assert set(port_list) == {"Ethernet20", "Ethernet100"}
 
     def test_parse_table_with_empty_vlan(self):
         with pytest.raises(ValueError):
-            parse_acl_table_info("TEST", "L3", None, "Ethernet0,Vlan3000", "egress")
+            parse_acl_table_info("TEST", "L3", None, "Ethernet20,Vlan3000", "egress")
 
     def test_parse_table_with_invalid_ports(self):
         with pytest.raises(ValueError):

--- a/sonic-utilities-tests/acl_config_test.py
+++ b/sonic-utilities-tests/acl_config_test.py
@@ -3,7 +3,7 @@ import pytest
 import config.main as config
 
 from click.testing import CliRunner
-from config import expand_vlan_ports, parse_acl_table_info
+from config.main import expand_vlan_ports, parse_acl_table_info
 
 
 class TestConfigAcl(object):

--- a/sonic-utilities-tests/mock_tables/config_db.json
+++ b/sonic-utilities-tests/mock_tables/config_db.json
@@ -120,6 +120,25 @@
             "services@": "SSH",
             "type": "CTRLPLANE"
     },
+    "VLAN|Vlan1000": {
+        "dhcp_servers@": "192.0.0.1,192.0.0.2,192.0.0.3,192.0.0.4",
+        "vlanid": "1000"
+    },
+    "VLAN|Vlan3000": {
+        "vlanid": "3000"
+    },
+    "VLAN_MEMBER|Vlan1000|Ethernet4": {
+        "tagging_mode": "untagged"
+    },
+    "VLAN_MEMBER|Vlan1000|Ethernet8": {
+        "tagging_mode": "untagged"
+    },
+    "VLAN_MEMBER|Vlan1000|Ethernet12": {
+        "tagging_mode": "untagged"
+    },
+    "VLAN_MEMBER|Vlan1000|Ethernet16": {
+        "tagging_mode": "untagged"
+    },
     "DEBUG_COUNTER|DEBUG_0": {
         "type": "PORT_INGRESS_DROPS"
     },

--- a/sonic-utilities-tests/mock_tables/config_db.json
+++ b/sonic-utilities-tests/mock_tables/config_db.json
@@ -127,16 +127,10 @@
     "VLAN|Vlan3000": {
         "vlanid": "3000"
     },
-    "VLAN_MEMBER|Vlan1000|Ethernet4": {
+    "VLAN_MEMBER|Vlan1000|Ethernet0": {
         "tagging_mode": "untagged"
     },
-    "VLAN_MEMBER|Vlan1000|Ethernet8": {
-        "tagging_mode": "untagged"
-    },
-    "VLAN_MEMBER|Vlan1000|Ethernet12": {
-        "tagging_mode": "untagged"
-    },
-    "VLAN_MEMBER|Vlan1000|Ethernet16": {
+    "VLAN_MEMBER|Vlan1000|Ethernet20": {
         "tagging_mode": "untagged"
     },
     "DEBUG_COUNTER|DEBUG_0": {

--- a/sonic-utilities-tests/mock_tables/config_db.json
+++ b/sonic-utilities-tests/mock_tables/config_db.json
@@ -127,10 +127,10 @@
     "VLAN|Vlan3000": {
         "vlanid": "3000"
     },
-    "VLAN_MEMBER|Vlan1000|Ethernet0": {
+    "VLAN_MEMBER|Vlan1000|Ethernet20": {
         "tagging_mode": "untagged"
     },
-    "VLAN_MEMBER|Vlan1000|Ethernet20": {
+    "VLAN_MEMBER|Vlan1000|Ethernet100": {
         "tagging_mode": "untagged"
     },
     "DEBUG_COUNTER|DEBUG_0": {


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Ported #1475 to 201911.

#### How I did it
Moved files from tests to sonic-utilities-tests.

#### How to verify it
Run unit tests + run ACL tests against 201911 image with this change and verify there is no regression.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

