### PR TITLE
[acl-loader] Improve input validation for acl_loader

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -559,6 +559,19 @@ class AclLoader(object):
 
         return rule_props
 
+    def validate_rule_fields(self, rule_props):
+        protocol = rule_props.get("IP_PROTOCOL", 6)
+        if "TCP_FLAGS" in rule_props and protocol != 6:
+            raise AclLoaderException("IP_PROTOCOL={} is not TCP, but TCP flags were provided".format(protocol))
+
+        protocol = rule_props.get("IP_PROTOCOL", 1)
+        if ("ICMP_TYPE" in rule_props or "ICMP_CODE" in rule_props) and protocol != 1:
+            raise AclLoaderException("IP_PROTOCOL={} is not ICMP, but ICMP fields were provided".format(protocol))
+
+        protocol = rule_props.get("IP_PROTOCOL", 58)
+        if ("ICMPV6_TYPE" in rule_props or "ICMPV6_CODE" in rule_props) and protocol != 58:
+            raise AclLoaderException("IP_PROTOCOL={} is not ICMPV6, but ICMPV6 fields were provided".format(protocol))
+
     def convert_rule_to_db_schema(self, table_name, rule):
         """
         Convert rules format from openconfig ACL to Config DB schema
@@ -579,6 +592,8 @@ class AclLoader(object):
         deep_update(rule_props, self.convert_transport(table_name, rule_idx, rule))
         deep_update(rule_props, self.convert_input_interface(table_name, rule_idx, rule))
 
+        self.validate_rule_fields(rule_props)
+
         return rule_data
 
     def deny_rule(self, table_name):
@@ -591,7 +606,7 @@ class AclLoader(object):
         rule_data = {(table_name, "DEFAULT_RULE"): rule_props}
         rule_props["PRIORITY"] = str(self.min_priority)
         rule_props["PACKET_ACTION"] = "DROP"
-        if 'v6' in table_name.lower():
+        if self.is_table_ipv6(table_name):
             rule_props["IP_TYPE"] = "IPV6ANY"  # ETHERTYPE is not supported for DATAACLV6
         else:
             rule_props["ETHER_TYPE"] = str(self.ethertype_map["ETHERTYPE_IPV4"])

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -560,17 +560,17 @@ class AclLoader(object):
         return rule_props
 
     def validate_rule_fields(self, rule_props):
-        protocol = rule_props.get("IP_PROTOCOL", 6)
-        if "TCP_FLAGS" in rule_props and protocol != 6:
-            raise AclLoaderException("IP_PROTOCOL={} is not TCP, but TCP flags were provided".format(protocol))
+        protocol = rule_props.get("IP_PROTOCOL")
 
-        protocol = rule_props.get("IP_PROTOCOL", 1)
-        if ("ICMP_TYPE" in rule_props or "ICMP_CODE" in rule_props) and protocol != 1:
-            raise AclLoaderException("IP_PROTOCOL={} is not ICMP, but ICMP fields were provided".format(protocol))
+        if protocol:
+            if "TCP_FLAGS" in rule_props and protocol != 6:
+                raise AclLoaderException("IP_PROTOCOL={} is not TCP, but TCP flags were provided".format(protocol))
 
-        protocol = rule_props.get("IP_PROTOCOL", 58)
-        if ("ICMPV6_TYPE" in rule_props or "ICMPV6_CODE" in rule_props) and protocol != 58:
-            raise AclLoaderException("IP_PROTOCOL={} is not ICMPV6, but ICMPV6 fields were provided".format(protocol))
+            if ("ICMP_TYPE" in rule_props or "ICMP_CODE" in rule_props) and protocol != 1:
+                raise AclLoaderException("IP_PROTOCOL={} is not ICMP, but ICMP fields were provided".format(protocol))
+
+            if ("ICMPV6_TYPE" in rule_props or "ICMPV6_CODE" in rule_props) and protocol != 58:
+                raise AclLoaderException("IP_PROTOCOL={} is not ICMPV6, but ICMPV6 fields were provided".format(protocol))
 
     def convert_rule_to_db_schema(self, table_name, rule):
         """

--- a/tests/acl_input/acl1.json
+++ b/tests/acl_input/acl1.json
@@ -193,7 +193,7 @@
 						}
 					}
 				},
-				"DATAACLV6": {
+				"DATAACL_2": {
 					"acl-entries": {
 						"acl-entry": {
 							"1": {

--- a/tests/acl_input/icmp_bad_protocol_number.json
+++ b/tests/acl_input/icmp_bad_protocol_number.json
@@ -1,0 +1,37 @@
+{
+	"acl": {
+		"acl-sets": {
+			"acl-set": {
+				"DATAACL": {
+					"acl-entries": {
+						"acl-entry": {
+							"1": {
+								"config": {
+									"sequence-id": 1
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "IP_UDP",
+										"source-ip-address": "20.0.0.2/32",
+										"destination-ip-address": "30.0.0.3/32"
+									}
+								},
+								"icmp": {
+									"config": {
+										"type": "3",
+										"code": "0"
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/tests/acl_input/icmpv6_bad_protocol_number.json
+++ b/tests/acl_input/icmpv6_bad_protocol_number.json
@@ -1,0 +1,37 @@
+{
+	"acl": {
+		"acl-sets": {
+			"acl-set": {
+				"DATAACL_2": {
+					"acl-entries": {
+						"acl-entry": {
+							"1": {
+								"config": {
+									"sequence-id": 1
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "IP_UDP",
+										"source-ip-address": "20.0.0.2/32",
+										"destination-ip-address": "30.0.0.3/32"
+									}
+								},
+								"icmp": {
+									"config": {
+										"type": "3",
+										"code": "0"
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/tests/acl_input/tcp_bad_protocol_number.json
+++ b/tests/acl_input/tcp_bad_protocol_number.json
@@ -1,0 +1,36 @@
+{
+	"acl": {
+		"acl-sets": {
+			"acl-set": {
+				"DATAACL": {
+					"acl-entries": {
+						"acl-entry": {
+							"1": {
+								"config": {
+									"sequence-id": 1
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "IP_UDP",
+										"source-ip-address": "20.0.0.2/32",
+										"destination-ip-address": "30.0.0.3/32"
+									}
+								},
+								"transport": {
+									"config": {
+										"tcp-flags": ["TCP_ACK"]
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/tests/acl_loader_test.py
+++ b/tests/acl_loader_test.py
@@ -100,7 +100,7 @@ class TestAclLoader(object):
         acl_loader.rules_info = {}
         acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/acl1.json'))
         print(acl_loader.rules_info)
-        assert acl_loader.rules_info[("DATAACLV6", "RULE_1")] == {
+        assert acl_loader.rules_info[("DATAACL_2", "RULE_1")] == {
             "ICMPV6_TYPE": 1,
             "ICMPV6_CODE": 0,
             "IP_PROTOCOL": 58,
@@ -109,7 +109,7 @@ class TestAclLoader(object):
             "PACKET_ACTION": "FORWARD",
             "PRIORITY": "9999"
         }
-        assert acl_loader.rules_info[("DATAACLV6", "RULE_100")] == {
+        assert acl_loader.rules_info[("DATAACL_2", "RULE_100")] == {
             "ICMPV6_TYPE": 128,
             "IP_PROTOCOL": 58,
             "SRC_IPV6": "::1/128",
@@ -147,3 +147,19 @@ class TestAclLoader(object):
         with pytest.raises(ValueError):
             acl_loader.rules_info = {}
             acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_icmp_code_nan.json'))
+
+    def test_icmp_fields_with_non_icmp_protocol(self, acl_loader):
+        acl_loader.rules_info = {}
+        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/icmp_bad_protocol_number.json'))
+        assert not acl_loader.rules_info.get("RULE_1")
+
+    def ttest_icmp_fields_with_non_icmpv6_protocol(self, acl_loader):
+        acl_loader.rules_info = {}
+        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/icmpv6_bad_protocol_number.json'))
+        assert not acl_loader.rules_info.get("RULE_1")
+
+
+    def test_icmp_fields_with_non_tcp_protocol(self, acl_loader):
+        acl_loader.rules_info = {}
+        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/tcp_bad_protocol_number.json'))
+        assert not acl_loader.rules_info.get("RULE_1")

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -400,8 +400,8 @@
         "ports@": "PortChannel0002,PortChannel0005,PortChannel0008,PortChannel0011,PortChannel0014,PortChannel0017,PortChannel0020,PortChannel0023,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124",
         "type": "L3"
     },
-    "ACL_TABLE|DATAACLV6": {
-        "policy_desc": "DATAACLV6",
+    "ACL_TABLE|DATAACL_2": {
+        "policy_desc": "DATAACL_2",
         "ports@": "PortChannel0002,PortChannel0005,PortChannel0008,PortChannel0011,PortChannel0014,PortChannel0017,PortChannel0020,PortChannel0023,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124",
         "type": "L3V6"
     },


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
I fixed two issues:
1) The IPv6 block rule was only looking at the table name, not the table type, when determining what type of default deny rule to add. This isn't very robust.

2) Individual fields are validated, but there are some invalid combinations like mixing certain protocol numbers like TCP (6) with fields that don't make sense for TCP (like ICMP type/code fields).

#### How I did it
1) Used the new `is_table_ipv6` method to verify that the table is a V6 dataacl table.
2) Added a post-check once all qualifiers are validated to ensure that they make sense when put together.

#### How to verify it
Added new test cases, verified that the existing ACL and CACL tests have no regression.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

