### PR TITLE
[generate-dump] Remove Arista specific logic

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -855,21 +855,6 @@ collect_broadcom() {
 }
 
 ###############################################################################
-# Collect Arista specific information
-# Globals:
-#  None
-# Arguments:
-#  None
-# Returns:
-#  None
-###############################################################################
-collect_arista() {
-    save_cmd "cat /proc/scd" "scd"
-    save_cmd "arista syseeprom" "arista.syseeprom"
-    save_cmd "arista dump" "arista.dump"
-}
-
-###############################################################################
 # Save log file
 # Globals:
 #  TAR, TARFILE, DUMPDIR, BASE, TARDIR, TECHSUPPORT_TIME_INFO
@@ -1146,10 +1131,6 @@ main() {
 
     if [ "$asic" = "broadcom" ]; then
         collect_broadcom
-    fi
-
-    if $GREP -qi "aboot_platform=.*arista" /host/machine.conf; then
-        collect_arista
     fi
 
     # 2nd counter snapshot late. Need 2 snapshots to make sense of counters trend.


### PR DESCRIPTION
#### What I did

Cleanup review to remove Arista specific logic from `generate_dump`.
We now implement the vendor specific `hw-management-generate-dump.sh` hook which achieves the same purpose.

#### How I did it

Our platform drivers install the hook under `/usr/bin/hw-management-generate-dump.sh`

#### How to verify it

Run `generate_dump` and validate that the `hw-mgmt-dump` file in the dump gets populated and has content.


