### PR TITLE
[show][config] fix show mux status health field; add support for hwmode functionality to toggle mux, check mux direction for Y cable (#1467)

### DIFF
--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -288,7 +288,7 @@ def state(state, port):
     namespaces = multi_asic.get_front_end_namespaces()
     for namespace in namespaces:
         asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-        per_npu_statedb[asic_id] = SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
+        per_npu_statedb[asic_id] = swsscommon.SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
         per_npu_statedb[asic_id].connect(per_npu_statedb[asic_id].STATE_DB)
 
         transceiver_table_keys[asic_id] = per_npu_statedb[asic_id].keys(

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -17,6 +17,8 @@ REDIS_TIMEOUT_MSECS = 0
 CONFIG_SUCCESSFUL = 100
 CONFIG_FAIL = 1
 
+VENDOR_NAME = "Credo"
+VENDOR_MODEL = "CAC125321P2PA0MS"
 
 # Helper functions
 
@@ -147,7 +149,7 @@ def mode(state, port, json_output):
 
         if per_npu_statedb[asic_index] is not None:
             y_cable_asic_table_keys = port_table_keys[asic_index]
-            logical_key = "MUX_CABLE_TABLE"+"|"+port
+            logical_key = "MUX_CABLE_TABLE|{}".format(port)
             if logical_key in y_cable_asic_table_keys:
                 port_status_dict = {}
                 lookup_statedb_and_update_configdb(
@@ -189,10 +191,12 @@ def mode(state, port, json_output):
 
         sys.exit(CONFIG_SUCCESSFUL)
 
+
 @muxcable.group(cls=clicommon.AbbreviationGroup)
 def prbs():
     """Enable/disable PRBS mode on a port"""
     pass
+
 
 @prbs.command()
 @click.argument('port', required=True, default=None, type=click.INT)
@@ -210,6 +214,7 @@ def enable(port, target, mode_value, lane_map):
     click.echo("PRBS config sucessful")
     sys.exit(CONFIG_SUCCESSFUL)
 
+
 @prbs.command()
 @click.argument('port', required=True, default=None, type=click.INT)
 @click.argument('target', required=True, default=None, type=click.INT)
@@ -223,6 +228,7 @@ def disable(port, target):
         sys.exit(CONFIG_FAIL)
     click.echo("PRBS disable sucessful")
     sys.exit(CONFIG_SUCCESSFUL)
+
 
 @muxcable.group(cls=clicommon.AbbreviationGroup)
 def loopback():
@@ -245,6 +251,7 @@ def enable(port, target, lane_map):
     click.echo("loopback config sucessful")
     sys.exit(CONFIG_SUCCESSFUL)
 
+
 @loopback.command()
 @click.argument('port', required=True, default=None, type=click.INT)
 @click.argument('target', required=True, default=None, type=click.INT)
@@ -258,3 +265,208 @@ def disable(port, target):
         sys.exit(CONFIG_FAIL)
     click.echo("loopback disable sucessful")
     sys.exit(CONFIG_SUCCESSFUL)
+
+
+@muxcable.group(cls=clicommon.AbbreviationGroup)
+def hwmode():
+    """Configure muxcable hardware directly"""
+    pass
+
+
+@hwmode.command()
+@click.argument('state', metavar='<operation_status>', required=True, type=click.Choice(["active", "standby"]))
+@click.argument('port', metavar='<port_name>', required=True, default=None)
+def state(state, port):
+    """Configure the muxcable mux state {active/standby}"""
+
+    per_npu_statedb = {}
+    transceiver_table_keys = {}
+    transceiver_dict = {}
+
+    # Getting all front asic namespace and correspding config and state DB connector
+
+    namespaces = multi_asic.get_front_end_namespaces()
+    for namespace in namespaces:
+        asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+        per_npu_statedb[asic_id] = SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
+        per_npu_statedb[asic_id].connect(per_npu_statedb[asic_id].STATE_DB)
+
+        transceiver_table_keys[asic_id] = per_npu_statedb[asic_id].keys(
+            per_npu_statedb[asic_id].STATE_DB, 'TRANSCEIVER_INFO|*')
+
+    if port is not None and port != "all":
+        click.confirm(('Muxcable at port {} will be changed to {} state. Continue?'.format(port, state)), abort=True)
+        logical_port_list = platform_sfputil_helper.get_logical_list()
+        if port not in logical_port_list:
+            click.echo("ERR: This is not a valid port, valid ports ({})".format(", ".join(logical_port_list)))
+            sys.exit(CONFIG_FAIL)
+
+        asic_index = None
+        if platform_sfputil is not None:
+            asic_index = platform_sfputil_helper.get_asic_id_for_logical_port(port)
+            if asic_index is None:
+                # TODO this import is only for unit test purposes, and should be removed once sonic_platform_base
+                # is fully mocked
+                import sonic_platform_base.sonic_sfp.sfputilhelper
+                asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
+                if asic_index is None:
+                    click.echo("Got invalid asic index for port {}, cant retreive mux status".format(port))
+                    sys.exit(CONFIG_FAIL)
+
+        if platform_sfputil is not None:
+            physical_port_list = platform_sfputil_helper.logical_port_name_to_physical_port_list(port)
+
+        if not isinstance(physical_port_list, list):
+            click.echo(("ERR: Unable to locate physical port information for {}".format(port)))
+            sys.exit(CONFIG_FAIL)
+        if len(physical_port_list) != 1:
+            click.echo("ERR: Found multiple physical ports ({}) associated with {}".format(
+                ", ".join(physical_port_list), port))
+            sys.exit(CONFIG_FAIL)
+
+        transceiver_dict[asic_index] = per_npu_statedb[asic_index].get_all(
+            per_npu_statedb[asic_index].STATE_DB, 'TRANSCEIVER_INFO|{}'.format(port))
+
+        vendor_value = get_value_for_key_in_dict(transceiver_dict[asic_index], port, "manufacturer", "TRANSCEIVER_INFO")
+        model_value = get_value_for_key_in_dict(transceiver_dict[asic_index], port, "model", "TRANSCEIVER_INFO")
+
+        """ This check is required for checking whether or not this port is connected to a Y cable
+        or not. The check gives a way to differentiate between non Y cable ports and Y cable ports.
+        TODO: this should be removed once their is support for multiple vendors on Y cable"""
+
+        if vendor_value != VENDOR_NAME or model_value != VENDOR_MODEL:
+            click.echo("ERR: Got invalid vendor value and model for port {}".format(port))
+            sys.exit(CONFIG_FAIL)
+
+        physical_port = physical_port_list[0]
+
+        logical_port_list_for_physical_port = platform_sfputil_helper.get_physical_to_logical()
+
+        logical_port_list_per_port = logical_port_list_for_physical_port.get(physical_port, None)
+
+        """ This check is required for checking whether or not this logical port is the one which is 
+        actually mapped to physical port and by convention it is always the first port.
+        TODO: this should be removed with more logic to check which logical port maps to actual physical port
+        being used"""
+
+        if port != logical_port_list_per_port[0]:
+            click.echo("ERR: This logical Port {} is not on a muxcable".format(port))
+            sys.exit(CONFIG_FAIL)
+
+        import sonic_y_cable.y_cable
+        read_side = sonic_y_cable.y_cable.check_read_side(physical_port)
+        if read_side == False or read_side == -1:
+            click.echo(("ERR: Unable to get read_side for the cable port {}".format(port)))
+            sys.exit(CONFIG_FAIL)
+
+        mux_direction = sonic_y_cable.y_cable.check_mux_direction(physical_port)
+        if mux_direction == False or mux_direction == -1:
+            click.echo(("ERR: Unable to get mux direction for the cable port {}".format(port)))
+            sys.exit(CONFIG_FAIL)
+
+        if int(read_side) == 1:
+            if state == "active":
+                res = sonic_y_cable.y_cable.toggle_mux_to_torA(physical_port)
+            elif state == "standby":
+                res = sonic_y_cable.y_cable.toggle_mux_to_torB(physical_port)
+            click.echo("Success in toggling port {} to {}".format(port, state))
+        elif int(read_side) == 2:
+            if state == "active":
+                res = sonic_y_cable.y_cable.toggle_mux_to_torB(physical_port)
+            elif state == "standby":
+                res = sonic_y_cable.y_cable.toggle_mux_to_torA(physical_port)
+            click.echo("Success in toggling port {} to {}".format(port, state))
+
+        if res == False:
+            click.echo("ERR: Unable to toggle port {} to {}".format(port, state))
+            sys.exit(CONFIG_FAIL)
+
+    elif port == "all" and port is not None:
+
+        click.confirm(('Muxcables at all ports will be changed to {} state. Continue?'.format(state)), abort=True)
+        logical_port_list = platform_sfputil_helper.get_logical_list()
+
+        rc = True
+        for port in logical_port_list:
+            if platform_sfputil is not None:
+                physical_port_list = platform_sfputil_helper.logical_port_name_to_physical_port_list(port)
+
+            asic_index = None
+            if platform_sfputil is not None:
+                asic_index = platform_sfputil_helper.get_asic_id_for_logical_port(port)
+                if asic_index is None:
+                    # TODO this import is only for unit test purposes, and should be removed once sonic_platform_base
+                    # is fully mocked
+                    import sonic_platform_base.sonic_sfp.sfputilhelper
+                    asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
+                    if asic_index is None:
+                        click.echo("Got invalid asic index for port {}, cant retreive mux status".format(port))
+
+            if not isinstance(physical_port_list, list):
+                click.echo(("ERR: Unable to locate physical port information for {}".format(port)))
+                continue
+
+            if len(physical_port_list) != 1:
+                click.echo("ERR: Found multiple physical ports ({}) associated with {}".format(
+                    ", ".join(physical_port_list), port))
+                continue
+
+            transceiver_dict[asic_index] = per_npu_statedb[asic_index].get_all(
+                per_npu_statedb[asic_index].STATE_DB, 'TRANSCEIVER_INFO|{}'.format(port))
+            vendor_value = transceiver_dict[asic_index].get("manufacturer", None)
+            model_value = transceiver_dict[asic_index].get("model", None)
+
+            """ This check is required for checking whether or not this port is connected to a Y cable
+            or not. The check gives a way to differentiate between non Y cable ports and Y cable ports.
+            TODO: this should be removed once their is support for multiple vendors on Y cable"""
+
+            if vendor_value != VENDOR_NAME or model_value != VENDOR_MODEL:
+                continue
+
+            physical_port = physical_port_list[0]
+
+            logical_port_list_for_physical_port = platform_sfputil_helper.get_physical_to_logical()
+
+            logical_port_list_per_port = logical_port_list_for_physical_port.get(physical_port, None)
+
+            """ This check is required for checking whether or not this logical port is the one which is 
+            actually mapped to physical port and by convention it is always the first port.
+            TODO: this should be removed with more logic to check which logical port maps to actual physical port
+            being used"""
+
+            if port != logical_port_list_per_port[0]:
+                continue
+
+            import sonic_y_cable.y_cable
+            read_side = sonic_y_cable.y_cable.check_read_side(physical_port)
+            if read_side == False or read_side == -1:
+                click.echo(("ERR: Unable to get read side for the cable port {}".format(port)))
+                rc = False
+                continue
+
+            mux_direction = sonic_y_cable.y_cable.check_mux_direction(physical_port)
+            if mux_direction == False or mux_direction == -1:
+                click.echo(("ERR: Unable to get mux direction for the cable port {}".format(port)))
+                rc = False
+                continue
+
+            if int(read_side) == 1:
+                if state == "active":
+                    res = sonic_y_cable.y_cable.toggle_mux_to_torA(physical_port)
+                elif state == "standby":
+                    res = sonic_y_cable.y_cable.toggle_mux_to_torB(physical_port)
+                click.echo("Success in toggling port {} to {}".format(port, state))
+            elif int(read_side) == 2:
+                if state == "active":
+                    res = sonic_y_cable.y_cable.toggle_mux_to_torB(physical_port)
+                elif state == "standby":
+                    res = sonic_y_cable.y_cable.toggle_mux_to_torA(physical_port)
+                click.echo("Success in toggling port {} to {}".format(port, state))
+
+            if res == False:
+                rc = False
+                click.echo("ERR: Unable to toggle port {} to {}".format(port, state))
+
+        if rc == False:
+            click.echo("ERR: Unable to toggle one or more ports to {}".format(state))
+            sys.exit(CONFIG_FAIL)

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -455,7 +455,7 @@ def muxdirection(port):
     namespaces = multi_asic.get_front_end_namespaces()
     for namespace in namespaces:
         asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-        per_npu_statedb[asic_id] = SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
+        per_npu_statedb[asic_id] = swsscommon.SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
         per_npu_statedb[asic_id].connect(per_npu_statedb[asic_id].STATE_DB)
 
         transceiver_table_keys[asic_id] = per_npu_statedb[asic_id].keys(

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -22,6 +22,10 @@ EXIT_SUCCESS = 0
 STATUS_FAIL = 1
 STATUS_SUCCESSFUL = 102
 
+VENDOR_NAME = "Credo"
+VENDOR_MODEL = "CAC125321P2PA0MS"
+
+
 #
 # 'muxcable' command ("show muxcable")
 #
@@ -75,24 +79,25 @@ def get_switch_name(config_db):
         sys.exit(STATUS_FAIL)
 
 
-def create_json_dump_per_port_status(port_status_dict, muxcable_info_dict, asic_index, port):
+def create_json_dump_per_port_status(port_status_dict, muxcable_info_dict, muxcable_health_dict, asic_index, port):
 
     status_value = get_value_for_key_in_dict(muxcable_info_dict[asic_index], port, "state", "MUX_CABLE_TABLE")
     port_status_dict["MUX_CABLE"][port] = {}
     port_status_dict["MUX_CABLE"][port]["STATUS"] = status_value
-    # TODO : Fix the health status of the port
-    port_status_dict["MUX_CABLE"][port]["HEALTH"] = "HEALTHY"
+    health_value = get_value_for_key_in_dict(muxcable_health_dict[asic_index], port, "state", "MUX_LINKMGR_TABLE")
+    port_status_dict["MUX_CABLE"][port]["HEALTH"] = health_value
 
 
-def create_table_dump_per_port_status(print_data, muxcable_info_dict, asic_index, port):
+def create_table_dump_per_port_status(print_data, muxcable_info_dict, muxcable_health_dict, asic_index, port):
 
     print_port_data = []
 
     status_value = get_value_for_key_in_dict(muxcable_info_dict[asic_index], port, "state", "MUX_CABLE_TABLE")
     #status_value = get_value_for_key_in_tbl(y_cable_asic_table, port, "status")
+    health_value = get_value_for_key_in_dict(muxcable_health_dict[asic_index], port, "state", "MUX_LINKMGR_TABLE")
     print_port_data.append(port)
     print_port_data.append(status_value)
-    print_port_data.append("HEALTHY")
+    print_port_data.append(health_value)
     print_data.append(print_port_data)
 
 
@@ -127,8 +132,10 @@ def status(port, json_output):
     """Show muxcable status information"""
 
     port_table_keys = {}
+    port_health_table_keys = {}
     per_npu_statedb = {}
     muxcable_info_dict = {}
+    muxcable_health_dict = {}
 
     # Getting all front asic namespace and correspding config and state DB connector
 
@@ -140,6 +147,8 @@ def status(port, json_output):
 
         port_table_keys[asic_id] = per_npu_statedb[asic_id].keys(
             per_npu_statedb[asic_id].STATE_DB, 'MUX_CABLE_TABLE|*')
+        port_health_table_keys[asic_id] = per_npu_statedb[asic_id].keys(
+            per_npu_statedb[asic_id].STATE_DB, 'MUX_LINKMGR_TABLE|*')
 
     if port is not None:
         asic_index = None
@@ -156,22 +165,27 @@ def status(port, json_output):
 
         muxcable_info_dict[asic_index] = per_npu_statedb[asic_index].get_all(
             per_npu_statedb[asic_index].STATE_DB, 'MUX_CABLE_TABLE|{}'.format(port))
+        muxcable_health_dict[asic_index] = per_npu_statedb[asic_index].get_all(
+            per_npu_statedb[asic_index].STATE_DB, 'MUX_LINKMGR_TABLE|{}'.format(port))
         if muxcable_info_dict[asic_index] is not None:
-            logical_key = "MUX_CABLE_TABLE"+"|"+port
-            if logical_key in port_table_keys[asic_index]:
+            logical_key = "MUX_CABLE_TABLE|{}".format(port)
+            logical_health_key = "MUX_LINKMGR_TABLE|{}".format(port)
+            if logical_key in port_table_keys[asic_index] and logical_health_key in port_health_table_keys[asic_index]:
 
                 if json_output:
                     port_status_dict = {}
                     port_status_dict["MUX_CABLE"] = {}
 
-                    create_json_dump_per_port_status(port_status_dict, muxcable_info_dict, asic_index, port)
+                    create_json_dump_per_port_status(port_status_dict, muxcable_info_dict,
+                                                     muxcable_health_dict, asic_index, port)
 
                     click.echo("{}".format(json.dumps(port_status_dict, indent=4)))
                     sys.exit(STATUS_SUCCESSFUL)
                 else:
                     print_data = []
 
-                    create_table_dump_per_port_status(print_data, muxcable_info_dict, asic_index, port)
+                    create_table_dump_per_port_status(print_data, muxcable_info_dict,
+                                                      muxcable_health_dict, asic_index, port)
 
                     headers = ['PORT', 'STATUS', 'HEALTH']
 
@@ -195,7 +209,10 @@ def status(port, json_output):
                     port = key.split("|")[1]
                     muxcable_info_dict[asic_id] = per_npu_statedb[asic_id].get_all(
                         per_npu_statedb[asic_id].STATE_DB, 'MUX_CABLE_TABLE|{}'.format(port))
-                    create_json_dump_per_port_status(port_status_dict, muxcable_info_dict, asic_id, port)
+                    muxcable_health_dict[asic_id] = per_npu_statedb[asic_id].get_all(
+                        per_npu_statedb[asic_id].STATE_DB, 'MUX_LINKMGR_TABLE|{}'.format(port))
+                    create_json_dump_per_port_status(port_status_dict, muxcable_info_dict,
+                                                     muxcable_health_dict, asic_id, port)
 
             click.echo("{}".format(json.dumps(port_status_dict, indent=4)))
         else:
@@ -204,10 +221,13 @@ def status(port, json_output):
                 asic_id = multi_asic.get_asic_index_from_namespace(namespace)
                 for key in natsorted(port_table_keys[asic_id]):
                     port = key.split("|")[1]
+                    muxcable_health_dict[asic_id] = per_npu_statedb[asic_id].get_all(
+                        per_npu_statedb[asic_id].STATE_DB, 'MUX_LINKMGR_TABLE|{}'.format(port))
                     muxcable_info_dict[asic_id] = per_npu_statedb[asic_id].get_all(
                         per_npu_statedb[asic_id].STATE_DB, 'MUX_CABLE_TABLE|{}'.format(port))
 
-                    create_table_dump_per_port_status(print_data, muxcable_info_dict, asic_id, port)
+                    create_table_dump_per_port_status(print_data, muxcable_info_dict,
+                                                      muxcable_health_dict, asic_id, port)
 
             headers = ['PORT', 'STATUS', 'HEALTH']
             click.echo(tabulate(print_data, headers=headers))
@@ -413,3 +433,214 @@ def cableinfo(port):
 
     body = [[vendor, part_num]]
     click.echo(tabulate(body, headers=headers))
+
+
+@muxcable.group(cls=clicommon.AbbreviationGroup)
+def hwmode():
+    """Shows the muxcable hardware information directly"""
+    pass
+
+
+@hwmode.command()
+@click.argument('port', metavar='<port_name>', required=False, default=None)
+def muxdirection(port):
+    """Shows the current direction of the muxcable {active/standy}"""
+
+    per_npu_statedb = {}
+    transceiver_table_keys = {}
+    transceiver_dict = {}
+
+    # Getting all front asic namespace and correspding config and state DB connector
+
+    namespaces = multi_asic.get_front_end_namespaces()
+    for namespace in namespaces:
+        asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+        per_npu_statedb[asic_id] = SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
+        per_npu_statedb[asic_id].connect(per_npu_statedb[asic_id].STATE_DB)
+
+        transceiver_table_keys[asic_id] = per_npu_statedb[asic_id].keys(
+            per_npu_statedb[asic_id].STATE_DB, 'TRANSCEIVER_INFO|*')
+
+    if port is not None:
+
+        logical_port_list = platform_sfputil_helper.get_logical_list()
+        if port not in logical_port_list:
+            click.echo("ERR: This is not a valid port, valid ports ({})".format(", ".join(logical_port_list)))
+            sys.exit(EXIT_FAIL)
+
+        asic_index = None
+        if platform_sfputil is not None:
+            asic_index = platform_sfputil_helper.get_asic_id_for_logical_port(port)
+        if asic_index is None:
+            # TODO this import is only for unit test purposes, and should be removed once sonic_platform_base
+            # is fully mocked
+            import sonic_platform_base.sonic_sfp.sfputilhelper
+            asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
+            if asic_index is None:
+                click.echo("Got invalid asic index for port {}, cant retreive mux status".format(port))
+                sys.exit(CONFIG_FAIL)
+
+        transceiver_dict[asic_index] = per_npu_statedb[asic_index].get_all(
+            per_npu_statedb[asic_index].STATE_DB, 'TRANSCEIVER_INFO|{}'.format(port))
+
+        vendor_value = get_value_for_key_in_dict(transceiver_dict[asic_index], port, "manufacturer", "TRANSCEIVER_INFO")
+        model_value = get_value_for_key_in_dict(transceiver_dict[asic_index], port, "model", "TRANSCEIVER_INFO")
+
+        """ This check is required for checking whether or not this port is connected to a Y cable
+        or not. The check gives a way to differentiate between non Y cable ports and Y cable ports.
+        TODO: this should be removed once their is support for multiple vendors on Y cable"""
+
+        if vendor_value != VENDOR_NAME or model_value != VENDOR_MODEL:
+            click.echo("ERR: Got invalid vendor value and model for port {}".format(port))
+            sys.exit(EXIT_FAIL)
+
+        if platform_sfputil is not None:
+            physical_port_list = platform_sfputil_helper.logical_port_name_to_physical_port_list(port)
+
+        if not isinstance(physical_port_list, list):
+            click.echo(("ERR: Unable to locate physical port information for {}".format(port)))
+            sys.exit(EXIT_FAIL)
+        if len(physical_port_list) != 1:
+            click.echo("ERR: Found multiple physical ports ({}) associated with {}".format(
+                ", ".join(physical_port_list), port))
+            sys.exit(EXIT_FAIL)
+
+        physical_port = physical_port_list[0]
+
+        logical_port_list_for_physical_port = platform_sfputil_helper.get_physical_to_logical()
+
+        logical_port_list_per_port = logical_port_list_for_physical_port.get(physical_port, None)
+
+        """ This check is required for checking whether or not this logical port is the one which is 
+        actually mapped to physical port and by convention it is always the first port.
+        TODO: this should be removed with more logic to check which logical port maps to actual physical port
+        being used"""
+
+        if port != logical_port_list_per_port[0]:
+            click.echo("ERR: This logical Port {} is not on a muxcable".format(port))
+            sys.exit(EXIT_FAIL)
+
+        import sonic_y_cable.y_cable
+        read_side = sonic_y_cable.y_cable.check_read_side(physical_port)
+        if read_side == False or read_side == -1:
+            click.echo(("ERR: Unable to get read_side for the cable port {}".format(port)))
+            sys.exit(EXIT_FAIL)
+
+        mux_direction = sonic_y_cable.y_cable.check_mux_direction(physical_port)
+        if mux_direction == False or mux_direction == -1:
+            click.echo(("ERR: Unable to get mux direction for the cable port {}".format(port)))
+            sys.exit(EXIT_FAIL)
+
+        if int(read_side) == 1:
+            if mux_direction == 1:
+                state = "active"
+            elif mux_direction == 2:
+                state = "standby"
+        elif int(read_side) == 2:
+            if mux_direction == 1:
+                state = "standby"
+            elif mux_direction == 2:
+                state = "active"
+        else:
+            click.echo(("ERR: Unable to get mux direction, port {}".format(port)))
+            state = "unknown"
+        headers = ['Port', 'Direction']
+
+        body = [[port, state]]
+        click.echo(tabulate(body, headers=headers))
+
+    else:
+
+        logical_port_list = platform_sfputil_helper.get_logical_list()
+
+        rc = True
+        body = []
+        for port in logical_port_list:
+
+            temp_list = []
+            if platform_sfputil is not None:
+                physical_port_list = platform_sfputil_helper.logical_port_name_to_physical_port_list(port)
+
+            if not isinstance(physical_port_list, list):
+                continue
+            if len(physical_port_list) != 1:
+                continue
+
+            asic_index = None
+            if platform_sfputil is not None:
+                asic_index = platform_sfputil_helper.get_asic_id_for_logical_port(port)
+            if asic_index is None:
+                # TODO this import is only for unit test purposes, and should be removed once sonic_platform_base
+                # is fully mocked
+                import sonic_platform_base.sonic_sfp.sfputilhelper
+                asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
+                if asic_index is None:
+                    continue
+
+            transceiver_dict[asic_index] = per_npu_statedb[asic_index].get_all(
+                per_npu_statedb[asic_index].STATE_DB, 'TRANSCEIVER_INFO|{}'.format(port))
+            vendor_value = transceiver_dict[asic_index].get("manufacturer", None)
+            model_value = transceiver_dict[asic_index].get("model", None)
+
+            """ This check is required for checking whether or not this port is connected to a Y cable
+            or not. The check gives a way to differentiate between non Y cable ports and Y cable ports.
+            TODO: this should be removed once their is support for multiple vendors on Y cable"""
+
+            if vendor_value != VENDOR_NAME or model_value != VENDOR_MODEL:
+                continue
+
+            physical_port = physical_port_list[0]
+            logical_port_list_for_physical_port = platform_sfputil_helper.get_physical_to_logical()
+
+            logical_port_list_per_port = logical_port_list_for_physical_port.get(physical_port, None)
+
+            """ This check is required for checking whether or not this logical port is the one which is 
+            actually mapped to physical port and by convention it is always the first port.
+            TODO: this should be removed with more logic to check which logical port maps to actual physical port
+            being used"""
+
+            if port != logical_port_list_per_port[0]:
+                continue
+
+            import sonic_y_cable.y_cable
+            read_side = sonic_y_cable.y_cable.check_read_side(physical_port)
+            if read_side == False or read_side == -1:
+                rc = False
+                temp_list.append(port)
+                temp_list.append("unknown")
+                body.append(temp_list)
+                continue
+
+            mux_direction = sonic_y_cable.y_cable.check_mux_direction(physical_port)
+            if mux_direction == False or mux_direction == -1:
+                rc = False
+                temp_list.append(port)
+                temp_list.append("unknown")
+                body.append(temp_list)
+                continue
+
+            if int(read_side) == 1:
+                if mux_direction == 1:
+                    state = "active"
+                elif mux_direction == 2:
+                    state = "standby"
+            elif int(read_side) == 2:
+                if mux_direction == 1:
+                    state = "standby"
+                elif mux_direction == 2:
+                    state = "active"
+            else:
+                rc = False
+                temp_list.append(port)
+                temp_list.append("unknown")
+                body.append(temp_list)
+                continue
+            temp_list.append(port)
+            temp_list.append(state)
+            body.append(temp_list)
+
+        headers = ['Port', 'Direction']
+
+        click.echo(tabulate(body, headers=headers))
+        if rc == False:
+            sys.exit(EXIT_FAIL)

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -414,6 +414,21 @@
     "MUX_CABLE_TABLE|Ethernet12": {
         "state": "unknown"
     },
+    "MUX_LINKMGR_TABLE|Ethernet32": {
+        "state": "healthy"
+    },
+    "MUX_LINKMGR_TABLE|Ethernet0": {
+        "state": "healthy"
+    },
+    "MUX_LINKMGR_TABLE|Ethernet4": {
+        "state": "healthy"
+    },
+    "MUX_LINKMGR_TABLE|Ethernet8": {
+        "state": "unhealthy"
+    },
+    "MUX_LINKMGR_TABLE|Ethernet12": {
+        "state": "unhealthy"
+    },
     "VXLAN_TUNNEL_TABLE|EVPN_25.25.25.25": {
         "src_ip": "1.1.1.1",
         "dst_ip": "25.25.25.25",

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -17,6 +17,24 @@
         "nominal_bit_rate": "255",
         "application_advertisement": "N/A"
     },
+    "TRANSCEIVER_INFO|Ethernet12": {
+        "type": "QSFP28 or later",
+        "hardware_rev": "AC",
+        "serial": "MT1706FT02064",
+        "manufacturer": "Credo",
+        "model": "CAC125321P2PA0MS",
+        "vendor_oui": "00-02-c9",
+        "vendor_date": "2017-01-13 ",
+        "connector": "No separable connector",
+        "encoding": "64B66B",
+        "ext_identifier": "Power Class 3(2.5W max), CDR present in Rx Tx",
+        "ext_rateselect_compliance": "QSFP+ Rate Select Version 1",
+        "cable_type": "Length Cable Assembly(m)",
+        "cable_length": "3",
+        "specification_compliance": "{'10/40G Ethernet Compliance Code': '40G Active Cable (XLPPI)'}",
+        "nominal_bit_rate": "255",
+        "application_advertisement": "N/A"
+    },
     "TRANSCEIVER_DOM_SENSOR|Ethernet0": {
         "temperature": "30.9258",
         "voltage": "3.2824",

--- a/utilities_common/platform_sfputil_helper.py
+++ b/utilities_common/platform_sfputil_helper.py
@@ -5,6 +5,7 @@ from sonic_py_common import multi_asic, device_info
 
 platform_sfputil = None
 
+
 def load_platform_sfputil():
 
     global platform_sfputil
@@ -38,6 +39,7 @@ def platform_sfputil_read_porttab_mappings():
 
     return 0
 
+
 def logical_port_name_to_physical_port_list(port_name):
     if port_name.startswith("Ethernet"):
         if platform_sfputil.is_logical_port(port_name):
@@ -47,3 +49,18 @@ def logical_port_name_to_physical_port_list(port_name):
             return None
     else:
         return [int(port_name)]
+
+
+def get_logical_list():
+
+    return platform_sfputil.logical
+
+
+def get_asic_id_for_logical_port(port):
+
+    return platform_sfputil.get_asic_id_for_logical_port(port)
+
+
+def get_physical_to_logical():
+
+    return platform_sfputil.physical_to_logical


### PR DESCRIPTION
#### Summary

This PR fixes the show mux status  "health" field. 

There is also support for new commands for muxcable
show muxcable hwmode muxdirection 
sudo config muxcable hwmode state active all
which can check the muxdirection and toggle the mux direction directly through eeprom

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixed the show mux status health field
Also added these new commands

```
vdahiya@BN9-0101-0301-01UT0:~$ show muxcable hwmode muxdirection 
Port         Direction
-----------  -----------
Ethernet0    active
Ethernet4    active
Ethernet8    active
Ethernet12   active
Ethernet16   active
```

```
vdahiya@BN9-0101-0301-01UT0:~$ sudo config muxcable hwmode state active all
Muxcables at all ports will be changed to active state. Continue? [y/N]: y
Success in toggling port Ethernet0 to active
Success in toggling port Ethernet4 to active
Success in toggling port Ethernet8 to active
Success in toggling port Ethernet12 to active
Success in toggling port Ethernet16 to active
```

#### How I did it
Added the changes to show/muxcable.py to correctly retrieve health "state"  field from the "MUX_LINKMGR_TABLE"  state DB table.
For new cli commands added the support in show/muxcable.py and config/muxcable.py

#### How to verify it
Ran the command on the 7050 testbed

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>