### PR TITLE
Warmboot script improvements - timeout exec, disable swss autorestart, remove trap

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -155,7 +155,7 @@ function initialize_pre_shutdown()
 {
     debug "Initialize pre-shutdown ..."
     TABLE="WARM_RESTART_TABLE|warm-shutdown"
-    RESTORE_COUNT=`sonic-db-cli STATE_DB hget "${TABLE}" restore_count`
+    RESTORE_COUNT=$(/usr/bin/redis-cli -n 6 hget "${TABLE}" restore_count)
     if [[ -z "$RESTORE_COUNT" ]]; then
         sonic-db-cli STATE_DB hset "${TABLE}" "restore_count" "0" > /dev/null
     fi
@@ -168,7 +168,7 @@ function request_pre_shutdown()
     STATE=$(timeout 5s docker exec syncd /usr/bin/syncd_request_shutdown --pre &> /dev/null; if [[ $? == 124 ]]; then echo "timed out"; fi)
     if [[ x"${STATE}" == x"timed out" ]]; then
         error "Failed to request pre-shutdown"
-    }
+    fi
 }
 
 function recover_issu_bank_file_instruction()
@@ -221,7 +221,7 @@ function wait_for_pre_shutdown_complete_or_fail()
     while [[ ${elapsed_time} -lt 60 ]]; do
         # timeout doesn't work with -i option of "docker exec". Therefore we have
         # to invoke docker exec directly below.
-        STATE=$(timeout 5s docker exec database redis-cli -n 6 hget "${TABLE}" state; if [[ $? == 124 ]]; then echo "timed out"; fi)
+        STATE=$(timeout 5s sonic-db-cli STATE_DB hget "${TABLE}" state; if [[ $? == 124 ]]; then echo "timed out"; fi)
 
         if [[ x"${STATE}" == x"timed out" ]]; then
             retrycount+=1
@@ -268,7 +268,10 @@ function backup_database()
 
     # Dump redis content to a file 'dump.rdb' in warmboot directory
     docker cp database:/var/lib/$target_db_inst/$REDIS_FILE $WARM_DIR
-    docker exec -i database rm /var/lib/$target_db_inst/$REDIS_FILE
+    STATE=$(timeout 5s docker exec database rm /var/lib/$target_db_inst/$REDIS_FILE; if [[ $? == 124 ]]; then echo "timed out"; fi)
+    if [[ x"${STATE}" == x"timed out" ]]; then
+        error "Timed out during attempting to remove Redis dump file from database container"
+    fi
 }
 
 function setup_control_plane_assistant()
@@ -611,7 +614,7 @@ fi
 # Disabling swss auto restart and then kill stop swss service
 debug "Disabling swss auto restart ..."
 docker exec swss supervisorctl stop supervisor-proc-exit-listener &> /dev/null || /bin/true
-sed -i -e "s/\<RestartSec=30\>/RestartSec=300/" /etc/systemd/system/swss.service || /bin/true
+sed -i -e "s/\<RestartSec=30\>/RestartSec=300/" /etc/systemd/system/sonic.target.wants/swss.service || /bin/true
 systemctl daemon-reload || /bin/true
 
 debug "Stopping swss service ..."
@@ -737,6 +740,9 @@ if [ -x ${DEVPATH}/${PLATFORM}/${PLATFORM_PLUGIN} ]; then
     debug "Running ${PLATFORM} specific plugin..."
     ${DEVPATH}/${PLATFORM}/${PLATFORM_PLUGIN}
 fi
+
+# Reset swss restart time
+sed -i -e "s/\<RestartSec=300\>/RestartSec=30/" /etc/systemd/system/sonic.target.wants/swss.service || /bin/true
 
 # Reboot: explicitly call Linux native reboot under sbin
 debug "Rebooting with ${REBOOT_METHOD} to ${NEXT_SONIC_IMAGE} ..."

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -611,10 +611,6 @@ if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
     debug "Stopped teamd ..."
 fi
 
-# Disabling swss auto restart and then stop swss service
-debug "Disabling swss auto restart ..."
-config feature autorestart swss disabled
-
 debug "Stopping swss service ..."
 systemctl stop swss
 debug "Stopped swss service ..."
@@ -738,9 +734,6 @@ if [ -x ${DEVPATH}/${PLATFORM}/${PLATFORM_PLUGIN} ]; then
     debug "Running ${PLATFORM} specific plugin..."
     ${DEVPATH}/${PLATFORM}/${PLATFORM_PLUGIN}
 fi
-
-# Re-enable swss autorestart for the next boot
-config feature autorestart swss enabled
 
 # Reboot: explicitly call Linux native reboot under sbin
 debug "Rebooting with ${REBOOT_METHOD} to ${NEXT_SONIC_IMAGE} ..."

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -155,7 +155,7 @@ function initialize_pre_shutdown()
 {
     debug "Initialize pre-shutdown ..."
     TABLE="WARM_RESTART_TABLE|warm-shutdown"
-    RESTORE_COUNT=$(/usr/bin/redis-cli -n 6 hget "${TABLE}" restore_count)
+    RESTORE_COUNT=$(sonic-db-cli STATE_DB hget "${TABLE}" restore_count)
     if [[ -z "$RESTORE_COUNT" ]]; then
         sonic-db-cli STATE_DB hset "${TABLE}" "restore_count" "0" > /dev/null
     fi
@@ -611,11 +611,9 @@ if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
     debug "Stopped teamd ..."
 fi
 
-# Disabling swss auto restart and then kill stop swss service
+# Disabling swss auto restart and then stop swss service
 debug "Disabling swss auto restart ..."
-docker exec swss supervisorctl stop supervisor-proc-exit-listener &> /dev/null || /bin/true
-sed -i -e "s/\<RestartSec=30\>/RestartSec=300/" /etc/systemd/system/sonic.target.wants/swss.service || /bin/true
-systemctl daemon-reload || /bin/true
+config feature autorestart swss disabled
 
 debug "Stopping swss service ..."
 systemctl stop swss
@@ -741,8 +739,8 @@ if [ -x ${DEVPATH}/${PLATFORM}/${PLATFORM_PLUGIN} ]; then
     ${DEVPATH}/${PLATFORM}/${PLATFORM_PLUGIN}
 fi
 
-# Reset swss restart time
-sed -i -e "s/\<RestartSec=300\>/RestartSec=30/" /etc/systemd/system/sonic.target.wants/swss.service || /bin/true
+# Re-enable swss autorestart for the next boot
+config feature autorestart swss enabled
 
 # Reboot: explicitly call Linux native reboot under sbin
 debug "Rebooting with ${REBOOT_METHOD} to ${NEXT_SONIC_IMAGE} ..."

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -47,7 +47,7 @@ function error()
 function debug()
 {
     if [[ x"${VERBOSE}" == x"yes" ]]; then
-        echo `date` $@
+        echo $(date) $@
     fi
     logger "$@"
 }
@@ -128,10 +128,10 @@ function clear_warm_boot()
 {
     common_clear
 
-    result=`timeout 10s config warm_restart disable; if [[ $? == 124 ]]; then echo timeout; else echo "code ($?)"; fi` || /bin/true
+    result=$(timeout 10s config warm_restart disable; res=$?; if [[ $res == 124 ]]; then echo timeout; else echo "code ($res)"; fi) || /bin/true
     debug "Cancel warm-reboot: ${result}"
 
-    TIMESTAMP=`date +%Y%m%d-%H%M%S`
+    TIMESTAMP=$(date +%Y%m%d-%H%M%S)
     if [[ -f ${WARM_DIR}/${REDIS_FILE} ]]; then
         mv -f ${WARM_DIR}/${REDIS_FILE} ${WARM_DIR}/${REDIS_FILE}.${TIMESTAMP} || /bin/true
     fi
@@ -165,7 +165,8 @@ function initialize_pre_shutdown()
 function request_pre_shutdown()
 {
     debug "Requesting pre-shutdown ..."
-    /usr/bin/docker exec -i syncd /usr/bin/syncd_request_shutdown --pre &> /dev/null || {
+    STATE=$(timeout 5s docker exec syncd /usr/bin/syncd_request_shutdown --pre &> /dev/null; if [[ $? == 124 ]]; then echo "timed out"; fi)
+    if [[ x"${STATE}" == x"timed out" ]]; then
         error "Failed to request pre-shutdown"
     }
 }
@@ -213,18 +214,18 @@ function wait_for_pre_shutdown_complete_or_fail()
     STATE="requesting"
     declare -i waitcount
     declare -i retrycount
-    waitcount=0
     retrycount=0
+    start_time=$SECONDS
+    elapsed_time=$(($SECONDS - $start_time))
     # Wait up to 60 seconds for pre-shutdown to complete
-    while [[ ${waitcount} -lt 600 ]]; do
+    while [[ ${elapsed_time} -lt 60 ]]; do
         # timeout doesn't work with -i option of "docker exec". Therefore we have
         # to invoke docker exec directly below.
-        STATE=`timeout 5s sonic-db-cli STATE_DB hget "${TABLE}" state; if [[ $? == 124 ]]; then echo "timed out"; fi`
+        STATE=$(timeout 5s docker exec database redis-cli -n 6 hget "${TABLE}" state; if [[ $? == 124 ]]; then echo "timed out"; fi)
 
         if [[ x"${STATE}" == x"timed out" ]]; then
-            waitcount+=50
             retrycount+=1
-            debug "Timed out getting pre-shutdown state (${waitcount}) retry count ${retrycount} ..."
+            debug "Timed out getting pre-shutdown state, retry count ${retrycount} ..."
             if [[ retrycount -gt 2 ]]; then
                 break
             fi
@@ -232,14 +233,14 @@ function wait_for_pre_shutdown_complete_or_fail()
             break
         else
             sleep 0.1
-            waitcount+=1
         fi
+        elapsed_time=$(($SECONDS - $start_time))
     done
 
     if [[ x"${STATE}" != x"pre-shutdown-succeeded" ]]; then
-        debug "Syncd pre-shutdown failed: ${STATE} ..."
+        debug "Syncd pre-shutdown failed, state: ${STATE} ..."
     else
-        debug "Pre-shutdown succeeded ..."
+        debug "Pre-shutdown succeeded, state: ${STATE} ..."
     fi
 }
 
@@ -317,10 +318,23 @@ function setup_reboot_variables()
     INITRD=$(echo $KERNEL_IMAGE | sed 's/vmlinuz/initrd.img/g')
 }
 
+function check_docker_exec()
+{
+    containers="radv bgp lldp swss database teamd syncd"
+    for container in $containers; do
+        STATE=$(timeout 1s docker exec $container echo "success"; if [[ $? == 124 ]]; then echo "timed out"; fi)
+        if [[ x"${STATE}" == x"timed out" ]]; then
+            error "Docker exec on $container timedout"
+            exit "${EXIT_FAILURE}"
+        fi
+    done
+}
+
 function reboot_pre_check()
 {
+    check_docker_exec
     # Make sure that the file system is normal: read-write able
-    filename="/host/test-`date +%Y%m%d-%H%M%S`"
+    filename="/host/test-$(date +%Y%m%d-%H%M%S)"
     if [[ ! -f ${filename} ]]; then
         touch ${filename}
     fi
@@ -549,6 +563,9 @@ fi
 # service will go down and we cannot recover from it.
 set +e
 
+# disable trap-handlers which were set before
+trap '' EXIT HUP INT QUIT TERM KILL ABRT ALRM
+
 if [ -x ${LOG_SSD_HEALTH} ]; then
     debug "Collecting logs to check ssd health before ${REBOOT_TYPE}..."
     ${LOG_SSD_HEALTH}
@@ -590,6 +607,12 @@ if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
     systemctl stop teamd
     debug "Stopped teamd ..."
 fi
+
+# Disabling swss auto restart and then kill stop swss service
+debug "Disabling swss auto restart ..."
+docker exec swss supervisorctl stop supervisor-proc-exit-listener &> /dev/null || /bin/true
+sed -i -e "s/\<RestartSec=30\>/RestartSec=300/" /etc/systemd/system/swss.service || /bin/true
+systemctl daemon-reload || /bin/true
 
 debug "Stopping swss service ..."
 systemctl stop swss


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Related PR for 201811 branch - https://github.com/Azure/sonic-utilities/pull/1474

Below changes are made to warmboot/fastboot script:

1. Disable swss auto-restart during warm reboot.
2. Add timeout to make sure syncd shutdown request will return in time. 5s
3. Disable trap handler after +e.
4. Make sure that syncd pre-shutdown wait won't take more than 60 seconds.
5. Make sure subsequent docker exec won't stuck for long time
6. Before shutdown, check docker exec on the relevant docker containers still works.

#### How I did it

#### How to verify it
Tested warmreboot on a physical testbed.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

