### PR TITLE
[warm-reboot] Fix key error - check empty key before issuing redis hget

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -392,7 +392,7 @@ function save_counters_folder() {
 
 function check_warm_restart_in_progress() {
     sonic-db-cli STATE_DB keys "WARM_RESTART_ENABLE_TABLE|*" | while read key ; do
-        if [[ x"$(sonic-db-cli STATE_DB hget $key enable)" == x"true" ]]; then
+        if [ -n "$key" ] && [[ x"$(sonic-db-cli STATE_DB hget $key enable)" == x"true" ]]; then
             if [[ x"${FORCE}" == x"yes" ]]; then
                 debug "Ignoring warm restart flag for ${key#*|}"
             else


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix for: https://github.com/Azure/sonic-buildimage/issues/7015

#### How I did it
Added a check for empty key before checking `WARM_RESTART_ENABLE_TABLE `

#### How to verify it
Without fix: 
```
admin@str-s6100-acs-2:~$ sudo warm-reboot -vvv
Traceback (most recent call last):
  File "/usr/local/bin/sonic-db-cli", line 131, in <module>
    main()
  File "/usr/local/bin/sonic-db-cli", line 114, in main
    execute_cmd(args.db_or_op, args.cmd, args.namespace, args.unixsocket)
  File "/usr/local/bin/sonic-db-cli", line 73, in execute_cmd
    resp = client.execute_command(*cmd)
  File "/usr/local/lib/python2.7/dist-packages/redis/client.py", line 901, in execute_command
    return self.parse_response(conn, command_name, **options)
  File "/usr/local/lib/python2.7/dist-packages/redis/client.py", line 915, in parse_response
    response = connection.read_response()
  File "/usr/local/lib/python2.7/dist-packages/redis/connection.py", line 756, in read_response
    raise response
redis.exceptions.ResponseError: wrong number of arguments for 'hget' command
```

With fix (after cold reboot, issue a `warm-reboot`):
```
admin@str-s6100-acs-2:~$ sonic-db-cli STATE_DB hget "WARM_RESTART_ENABLE_TABLE|system" enable

admin@str-s6100-acs-2:~$ sonic-db-cli STATE_DB keys "WARM_RESTART_ENABLE_TABLE|*"            

admin@str-s6100-acs-2:~$ sudo warm-reboot -vvv
Thu 11 Mar 2021 08:41:48 PM UTC Saving counters folder before warmboot...
Thu 11 Mar 2021 08:41:51 PM UTC Pausing orchagent ...
Thu 11 Mar 2021 08:41:51 PM UTC Collecting logs to check ssd health before warm-reboot...
Thu 11 Mar 2021 08:41:51 PM UTC Stopping nat ...
Dumping conntrack entries failed
Error response from daemon: Cannot kill container: nat: No such container: nat
Thu 11 Mar 2021 08:41:51 PM UTC Stopped nat ...
Thu 11 Mar 2021 08:41:51 PM UTC Stopping radv service...
Thu 11 Mar 2021 08:41:52 PM UTC Stopped radv service...
Thu 11 Mar 2021 08:41:52 PM UTC Stopping bgp ...
Thu 11 Mar 2021 08:41:57 PM UTC Stopped bgp ...
Thu 11 Mar 2021 08:41:57 PM UTC Stopping sflow ...
Thu 11 Mar 2021 08:41:58 PM UTC Stopped sflow ...
Thu 11 Mar 2021 08:42:00 PM UTC Stopping swss service ...
Thu 11 Mar 2021 08:42:01 PM UTC Stopped swss service ...
Thu 11 Mar 2021 08:42:01 PM UTC Initialize pre-shutdown ...
Thu 11 Mar 2021 08:42:02 PM UTC Requesting pre-shutdown ...
Thu 11 Mar 2021 08:42:02 PM UTC Waiting for pre-shutdown ...
Thu 11 Mar 2021 08:42:03 PM UTC Pre-shutdown succeeded ...
Thu 11 Mar 2021 08:42:03 PM UTC Backing up database ...
Thu 11 Mar 2021 08:42:04 PM UTC Stopping teamd ...
Thu 11 Mar 2021 08:42:10 PM UTC Stopped teamd ...
Thu 11 Mar 2021 08:42:10 PM UTC Stopping syncd ...
Thu 11 Mar 2021 08:42:26 PM UTC Stopped syncd ...
Thu 11 Mar 2021 08:42:27 PM UTC Stopping all remaining containers ...
Thu 11 Mar 2021 08:42:35 PM UTC Stopped all remaining containers ...
Thu 11 Mar 2021 08:42:37 PM UTC updating ssd fw forwarm-reboot
Thu 11 Mar 2021 08:42:37 PM UTC Enabling Watchdog before warm-reboot
Watchdog armed for 180 seconds
Thu 11 Mar 2021 08:42:38 PM UTC Running x86_64-dell_s6100_c2538-r0 specific plugin...
Thu 11 Mar 2021 08:42:38 PM UTC Rebooting with /sbin/kexec -e to SONiC-OS-HEAD.487-377ea1a2 ...
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

