### PR TITLE
[decode-syseeprom] When reading from DB, display CRC-32 and all Vendor Extensions

### DIFF
--- a/scripts/decode-syseeprom
+++ b/scripts/decode-syseeprom
@@ -62,7 +62,7 @@ def print_eeprom_dict(tlv_dict):
     tlv_table_header = ['TLV Name', 'Code', 'Len', 'Value']
     tlv_table_body = []
     for tlv in tlv_dict['tlv_list']:
-        tlv_table_body.append([tlv['name'], tlv['code'].upper(), tlv['length'], tlv['value']])
+        tlv_table_body.append([tlv['name'], tlv['code'], tlv['length'], tlv['value']])
 
     print(tabulate(tlv_table_body, tlv_table_header, tablefmt='simple'))
 
@@ -91,16 +91,33 @@ def read_eeprom_from_db():
     tlv_dict['header']['length'] = tlv_header.get('Total Length', 'N/A')
 
     tlv_dict['tlv_list'] = []
-    for tlv_code in range(TlvInfoDecoder._TLV_CODE_PRODUCT_NAME, TlvInfoDecoder._TLV_CODE_SERVICE_TAG + 1):
-        tlv_code_string = '0x{:02x}'.format(tlv_code)
-        tlv_data = db.get_all(db.STATE_DB, '{}|{}'.format(EEPROM_INFO_TABLE, tlv_code_string))
+    concerned_tlvs = []
+    concerned_tlvs.extend(range(TlvInfoDecoder._TLV_CODE_PRODUCT_NAME, TlvInfoDecoder._TLV_CODE_SERVICE_TAG + 1))
+    concerned_tlvs.append(TlvInfoDecoder._TLV_CODE_VENDOR_EXT)
+    concerned_tlvs.append(TlvInfoDecoder._TLV_CODE_CRC_32)
+    for tlv_code in concerned_tlvs:
+        tlv_code_string = '0x{:02X}'.format(tlv_code)
 
-        tlv = {}
-        tlv['code'] = tlv_code_string
-        tlv['name'] = tlv_data.get('Name', 'N/A')
-        tlv['length'] = tlv_data.get('Len', 'N/A')
-        tlv['value'] = tlv_data.get('Value', 'N/A')
-        tlv_dict['tlv_list'].append(tlv)
+        tlv_data = db.get_all(db.STATE_DB, '{}|{}'.format(EEPROM_INFO_TABLE, tlv_code_string.lower()))
+        if not tlv_data:
+            continue
+
+        if tlv_code == TlvInfoDecoder._TLV_CODE_VENDOR_EXT:
+            num_vendor_ext = int(tlv_data.get('Num_vendor_ext', '0'))
+            for i in range(num_vendor_ext):
+                tlv = {}
+                tlv['code'] = tlv_code_string
+                tlv['name'] = tlv_data.get('Name_{}'.format(i), 'N/A')
+                tlv['length'] = tlv_data.get('Len_{}'.format(i), 'N/A')
+                tlv['value'] = tlv_data.get('Value_{}'.format(i), 'N/A')
+                tlv_dict['tlv_list'].append(tlv)
+        else:
+            tlv = {}
+            tlv['code'] = tlv_code_string
+            tlv['name'] = tlv_data.get('Name', 'N/A')
+            tlv['length'] = tlv_data.get('Len', 'N/A')
+            tlv['value'] = tlv_data.get('Value', 'N/A')
+            tlv_dict['tlv_list'].append(tlv)
 
     checksum_valid = db.get(db.STATE_DB, '{}|{}'.format(EEPROM_INFO_TABLE, 'Checksum'), 'Valid')
     tlv_dict['checksum_valid'] = (checksum_valid == '1')

--- a/tests/decode_syseeprom_test.py
+++ b/tests/decode_syseeprom_test.py
@@ -121,6 +121,18 @@ SAMPLE_TLV_DICT = {
             'name': 'Service Tag',
             'length': '7',
             'value': 'F3CD9Z2'
+        },
+        {
+            'code': '0xfd',
+            'name': 'Vendor Extension',
+            'length': '7',
+            'value': ''
+        },
+        {
+            'code': '0xfe',
+            'name': 'CRC-32',
+            'length': '4',
+            'value': '0xAC518FB3'
         }
     ],
     'checksum_valid': True
@@ -136,21 +148,23 @@ TlvInfo Header:
    Total Length: 170
 TLV Name             Code      Len  Value
 -------------------  ------  -----  --------------------------
-Product Name         0X21        8  S6100-ON
-Part Number          0X22        6  0F6N2R
-Serial Number        0X23       20  TH0F6N2RCET0007600NG
-Base MAC Address     0X24        6  0C:29:EF:CF:AC:A0
-Manufacture Date     0X25       19  07/07/2020 15:05:34
-Device Version       0X26        1  1
-Label Revision       0X27        3  A08
-Platform Name        0X28       26  x86_64-dell_s6100_c2538-r0
-ONIE Version         0X29        8  3.15.1.0
-MAC Addresses        0X2A        2  384
-Manufacturer         0X2B        5  CET00
-Manufacture Country  0X2C        2  TH
-Vendor Name          0X2D        4  DELL
-Diag Version         0X2E        8  3.25.4.1
-Service Tag          0X2F        7  F3CD9Z2
+Product Name         0x21        8  S6100-ON
+Part Number          0x22        6  0F6N2R
+Serial Number        0x23       20  TH0F6N2RCET0007600NG
+Base MAC Address     0x24        6  0C:29:EF:CF:AC:A0
+Manufacture Date     0x25       19  07/07/2020 15:05:34
+Device Version       0x26        1  1
+Label Revision       0x27        3  A08
+Platform Name        0x28       26  x86_64-dell_s6100_c2538-r0
+ONIE Version         0x29        8  3.15.1.0
+MAC Addresses        0x2A        2  384
+Manufacturer         0x2B        5  CET00
+Manufacture Country  0x2C        2  TH
+Vendor Name          0x2D        4  DELL
+Diag Version         0x2E        8  3.25.4.1
+Service Tag          0x2F        7  F3CD9Z2
+Vendor Extension     0xFD        7
+CRC-32               0xFE        4  0xAC518FB3
 
 (checksum valid)
 '''

--- a/tests/decode_syseeprom_test.py
+++ b/tests/decode_syseeprom_test.py
@@ -87,49 +87,49 @@ SAMPLE_TLV_DICT = {
             'value': '3.15.1.0'
         },
         {
-            'code': '0x2a',
+            'code': '0x2A',
             'name': 'MAC Addresses',
             'length': '2',
             'value': '384'
         },
         {
-            'code': '0x2b',
+            'code': '0x2B',
             'name': 'Manufacturer',
             'length': '5',
             'value': 'CET00'
         },
         {
-            'code': '0x2c',
+            'code': '0x2C',
             'name': 'Manufacture Country',
             'length': '2',
             'value': 'TH'
         },
         {
-            'code': '0x2d',
+            'code': '0x2D',
             'name': 'Vendor Name',
             'length': '4',
             'value': 'DELL'
         },
         {
-            'code': '0x2e',
+            'code': '0x2E',
             'name': 'Diag Version',
             'length': '8',
             'value': '3.25.4.1'
         },
         {
-            'code': '0x2f',
+            'code': '0x2F',
             'name': 'Service Tag',
             'length': '7',
             'value': 'F3CD9Z2'
         },
         {
-            'code': '0xfd',
+            'code': '0xFD',
             'name': 'Vendor Extension',
             'length': '7',
             'value': ''
         },
         {
-            'code': '0xfe',
+            'code': '0xFE',
             'name': 'CRC-32',
             'length': '4',
             'value': '0xAC518FB3'


### PR DESCRIPTION
#### What I did

Changes when reading system EEPROM values from State DB (`decode-syseeprom -d`):
- Display CRC-32
- Display all present vendor extensions
- Display hex TLV code with lower-case `x` to match the output when reading directly from EEPROM
- If a TLV code is not available, omit it from the output rather than displaying 'N/A' for all fields

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)
```
admin@sonic:~$ sudo decode-syseeprom -d
TlvInfo Header:
   Id String:    TlvInfo
   Version:      1
   Total Length: 170
TLV Name             Code      Len  Value
-------------------  ------  -----  --------------------------
Product Name         0X21        8  S6100-ON
Part Number          0X22        6  0F6N2R
Serial Number        0X23       20  TH0F6N2RCET0007600NG
Base MAC Address     0X24        6  0C:29:EF:CF:AC:A0
Manufacture Date     0X25       19  07/07/2020 15:05:34
Device Version       0X26        1  1
Label Revision       0X27        3  A08
Platform Name        0X28       26  x86_64-dell_s6100_c2538-r0
ONIE Version         0X29        8  3.15.1.0
MAC Addresses        0X2A        2  384
Manufacturer         0X2B        5  CET00
Manufacture Country  0X2C        2  TH
Vendor Name          0X2D        4  DELL
Diag Version         0X2E        8  3.25.4.1
Service Tag          0X2F        7  F3CD9Z2
```
#### New command output (if the output of a command-line utility has changed)
```
admin@sonic:~$ sudo decode-syseeprom -d
TlvInfo Header:
   Id String:    TlvInfo
   Version:      1
   Total Length: 170
TLV Name             Code      Len  Value
-------------------  ------  -----  --------------------------
Product Name         0x21        8  S6100-ON
Part Number          0x22        6  0F6N2R
Serial Number        0x23       20  TH0F6N2RCET0007600NG
Base MAC Address     0x24        6  0C:29:EF:CF:AC:A0
Manufacture Date     0x25       19  07/07/2020 15:05:34
Device Version       0x26        1  1
Label Revision       0x27        3  A08
Platform Name        0x28       26  x86_64-dell_s6100_c2538-r0
ONIE Version         0x29        8  3.15.1.0
MAC Addresses        0x2A        2  384
Manufacturer         0x2B        5  CET00
Manufacture Country  0x2C        2  TH
Vendor Name          0x2D        4  DELL
Diag Version         0x2E        8  3.25.4.1
Service Tag          0x2F        7  F3CD9Z2
Vendor Extension     0xFD        7
CRC-32               0xFE        4  0xAC518FB3
```