### PR TITLE
[reboot]: Stop mux before reboot on dual ToR

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -24,6 +24,7 @@ fi
 REBOOT_USER=$(logname)
 PLATFORM=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
 ASIC_TYPE=$(sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)
+SUBTYPE=$(sonic-cfggen -d -v DEVICE_METADATA.localhost.subtype)
 VERBOSE=no
 EXIT_NEXT_IMAGE_NOT_EXISTS=4
 EXIT_SONIC_INSTALLER_VERIFY_REBOOT=21
@@ -52,6 +53,10 @@ function tag_images()
 
 function stop_sonic_services()
 {
+    if [[ x"$SUBTYPE" == x"DualToR" ]]; then
+        debug "DualToR detected, stopping mux container before reboot..."
+        systemctl stop mux
+    fi
     if [[ x"$ASIC_TYPE" != x"mellanox" ]]; then
         debug "Stopping syncd process..."
         docker exec -i syncd /usr/bin/syncd_request_shutdown --cold > /dev/null


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
If the script detects it is running on a dual ToR system, stop the mux container before shutting down syncd

This is necessary to prevent some links from flapping when the standby ToR is rebooted - when reboot stop syncd, the linkmgr will stop receiving heartbeats and will then tell the mux to switchover. However, since the device is rebooting, no heartbeats will be sent out. The peer ToR will see this absence of heartbeats and tell the mux to switch back to itself (the peer ToR), causing the flap.

By stopping the mux container before shutting down syncd, we prevent the rebooting ToR from switching the mux.

#### How I did it
Read the `subtype` field from config DB. Run `systemctl stop mux` if it is `DualToR`.

#### How to verify it
* Reboot on a dual ToR device. Confirm that no links flap, and reboot occurs successfully.
* Reboot on a single ToR device. Confirm that reboot occurs normally.

#### Previous command output (if the output of a command-line utility has changed)
```
admin@sonic:~$ sudo reboot -v
Sat 13 Mar 2021 01:09:47 AM UTC User requested rebooting device ...
Sat 13 Mar 2021 01:09:50 AM UTC Stopping syncd process...
requested COLD shutdown
/var/log: 265.9 MiB (278816768 bytes) trimmed on /dev/loop1
/host: 24.4 GiB (26194464768 bytes) trimmed on /dev/sda1
Sat 13 Mar 2021 01:09:58 AM UTC Rebooting with platform x86_64-arista_7050cx3_32s specific tool ...
Running powercycle script
INFO: Initiating powercycle through CPLD
INFO: Powercycle triggered from CPLD
```

#### New command output (if the output of a command-line utility has changed)
```
admin@sonic:~$ sudo reboot -v
Sat 13 Mar 2021 01:09:47 AM UTC User requested rebooting device ...
Sat 13 Mar 2021 01:09:48 AM UTC DualToR detected, stopping mux container before reboot...
Sat 13 Mar 2021 01:09:50 AM UTC Stopping syncd process...
requested COLD shutdown
/var/log: 265.9 MiB (278816768 bytes) trimmed on /dev/loop1
/host: 24.4 GiB (26194464768 bytes) trimmed on /dev/sda1
Sat 13 Mar 2021 01:09:58 AM UTC Rebooting with platform x86_64-arista_7050cx3_32s specific tool ...
Running powercycle script
INFO: Initiating powercycle through CPLD
INFO: Powercycle triggered from CPLD
```
