### PR TITLE
Add self timeout and crash if exceeded.

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -462,9 +462,9 @@ def main():
     while True:
         signal.alarm(TIMEOUT_SECONDS)
         ret, res= check_routes()
+        signal.alarm(0)
 
         if interval:
-            signal.alarm(0)
             time.sleep(interval)
             if UNIT_TESTING:
                 return ret, res

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -43,6 +43,8 @@ import re
 import sys
 import syslog
 import time
+import signal
+import traceback
 
 from swsscommon import swsscommon
 
@@ -52,6 +54,9 @@ ASIC_TABLE_NAME = 'ASIC_STATE'
 ASIC_KEY_PREFIX = 'SAI_OBJECT_TYPE_ROUTE_ENTRY:'
 
 SUBSCRIBE_WAIT_SECS = 1
+
+# Max of 2 minutes
+TIMEOUT_SECONDS = 120
 
 UNIT_TESTING = 0
 
@@ -74,6 +79,14 @@ class Level(Enum):
 
 report_level = syslog.LOG_ERR
 write_to_syslog = False
+
+def handler(signum, frame):
+    print_message(syslog.LOG_ERR,
+            "Aborting routeCheck.py upon timeout signal after {} seconds".
+            format(TIMEOUT_SECONDS))
+    print_message(syslog.LOG_ERR, str(traceback.extract_stack()))
+    raise Exception("timeout occurred")
+
 
 def set_level(lvl, log_to_syslog):
     """
@@ -429,7 +442,7 @@ def main():
     parser=argparse.ArgumentParser(description="Verify routes between APPL-DB & ASIC-DB are in sync")
     parser.add_argument('-m', "--mode", type=Level, choices=list(Level), default='ERR')
     parser.add_argument("-i", "--interval", type=int, default=0, help="Scan interval in seconds")
-    parser.add_argument("-s", "--log_to_syslog", action="store_true", default=False, help="Write message to syslog")
+    parser.add_argument("-s", "--log_to_syslog", action="store_true", default=True, help="Write message to syslog")
     args = parser.parse_args()
 
     set_level(args.mode, args.log_to_syslog)
@@ -444,10 +457,14 @@ def main():
         if UNIT_TESTING:
             interval = 1
 
+    signal.signal(signal.SIGALRM, handler)
+
     while True:
+        signal.alarm(TIMEOUT_SECONDS)
         ret, res= check_routes()
 
         if interval:
+            signal.alarm(0)
             time.sleep(interval)
             if UNIT_TESTING:
                 return ret, res

--- a/tests/route_check_test.py
+++ b/tests/route_check_test.py
@@ -276,6 +276,7 @@ def table_side_effect(db, tbl):
 
 class mock_selector:
     TIMEOUT = 1
+    EMULATE_HANG = False
 
     def __init__(self):
         self.select_state = 0
@@ -294,6 +295,9 @@ class mock_selector:
         #
         state = self.select_state
         self.subs.update()
+
+        if mock_selector.EMULATE_HANG:
+            time.sleep(60)
 
         if self.select_state == 0:
             self.select_state = self.TIMEOUT
@@ -421,6 +425,19 @@ class TestRouteCheck(object):
                     print("expect_res={}".format(json.dumps(expect_res, indent=4)))
                 assert ret == expect_ret
                 assert res == expect_res
+
+
+        # Test timeout
+        route_check.TIMEOUT_SECONDS = 5
+        mock_selector.EMULATE_HANG = True
+        ex_raised = False
+
+        try:
+            ret, res = route_check.main()
+        except Exception as err:
+            ex_raised = True
+            print("raised = {}".format(str(err)))
+        assert ex_raised, "Exception expected"
 
 
 

--- a/tests/route_check_test.py
+++ b/tests/route_check_test.py
@@ -2,6 +2,7 @@ import copy
 import json
 import os
 import sys
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -436,7 +437,9 @@ class TestRouteCheck(object):
             ret, res = route_check.main()
         except Exception as err:
             ex_raised = True
-            print("raised = {}".format(str(err)))
+            expect = "timeout occurred"
+            ex_str = str(err)
+            assert ex_str == expect, "{} != {}".format(ex_str, expect)
         assert ex_raised, "Exception expected"
 
 


### PR DESCRIPTION
Log callstack on timeout.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add self timeout and crash on timeout.
Before crash log the error and call stack.

#### How I did it
Add a signal based alarm and the handler to print error & call stack.

#### How to verify it
Artificially introduce a sleep (> TIMEOUT, which is 2mins) in the script in any function that is in the call path.
Invoke the script. Watch it crash and note the error & stack logged in syslog.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

