### PR TITLE
Fix bug: show vlan config for vlan with no members

### DIFF
--- a/tests/vlan_test.py
+++ b/tests/vlan_test.py
@@ -85,6 +85,7 @@ Vlan1000   1000  Ethernet12  untagged
 Vlan1000   1000  Ethernet16  untagged
 Vlan2000   2000  Ethernet24  untagged
 Vlan2000   2000  Ethernet28  untagged
+Vlan3000   3000
 """
 
 show_vlan_config_in_alias_mode_output="""\
@@ -96,6 +97,7 @@ Vlan1000   1000  etp4      untagged
 Vlan1000   1000  etp5      untagged
 Vlan2000   2000  etp7      untagged
 Vlan2000   2000  etp8      untagged
+Vlan3000   3000
 """
 
 config_vlan_add_dhcp_relay_output="""\


### PR DESCRIPTION
Signed-off-by: allas <allas@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

It fixes the community bug: 
https://github.com/Azure/sonic-buildimage/issues/6606
#### What I did
The problem was that there is VLAN without members `show vlan config` wasn't presented VLAN.
```
Name    VID    Member    Mode
------  -----  --------  ------
```
I modified existed code to fix this problem.
#### How I did it
File show/vlan.py, function config(db) was modified to fill the table with VLAN even without members.
#### How to verify it
```
sudo config vlan add 10
sudo config vlan add 11
```
#### Previous command output (if the output of a command-line utility has changed)
```
Name    VID    Member    Mode
------  -----  --------  ------
```
#### New command output (if the output of a command-line utility has changed)
```
Name      VID  Member    Mode
------  -----  --------  ------
Vlan10     10
Vlan11     11
```
