### PR TITLE
[config][vxlan] fix 'vxlan evpn_nvo add' command error

### DIFF
--- a/config/vxlan.py
+++ b/config/vxlan.py
@@ -47,7 +47,7 @@ def del_vxlan(db, vxlan_name):
     if(vxlan_count > 0):
         ctx.fail("Please delete the EVPN NVO configuration.")  
 
-    vxlan_keys = db.cfgdb.get_keys('CONFIG_DB', "VXLAN_TUNNEL_MAP|*")
+    vxlan_keys = db.cfgdb.get_keys("VXLAN_TUNNEL_MAP|*")
     if not vxlan_keys:
       vxlan_count = 0
     else:
@@ -69,7 +69,7 @@ def vxlan_evpn_nvo():
 def add_vxlan_evpn_nvo(db, nvo_name, vxlan_name):
     """Add NVO"""
     ctx = click.get_current_context()
-    vxlan_keys = db.cfgdb.get_keys('CONFIG_DB', "VXLAN_EVPN_NVO|*")
+    vxlan_keys = db.cfgdb.get_keys("VXLAN_EVPN_NVO|*")
     if not vxlan_keys:
       vxlan_count = 0
     else:

--- a/tests/vxlan_test.py
+++ b/tests/vxlan_test.py
@@ -215,6 +215,11 @@ class TestVxlan(object):
         print(result.output)
         assert result.exit_code == 0
 
+        result = runner.invoke(config.config.commands["vxlan"].commands["evpn_nvo"].commands["add"], ["nvo1", "vtep1"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+
         result = runner.invoke(show.cli.commands["vxlan"].commands["interface"], [])
         print(result.exit_code)
         print(result.output)


### PR DESCRIPTION
Remove extra 'CONFIG_DB' argument from db.cfgdb.get_keys()

Signed-off-by: shikenghua <kh_shi@edge-core.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix `config vxlan evpn_nvo add` command error.

#### How I did it
Remove extra argument `'CONFIG_DB'` from `db.cfgdb.get_keys()`.

#### How to verify it
Run `config vxlan evpn_nvo add` command and verify the output.

#### Previous command output (if the output of a command-line utility has changed)
    admin@as7816-64x-3:~$ sudo config vxlan evpn_nvo add nvo1 vtep1
    Traceback (most recent call last):
      File "/usr/local/bin/config", line 8, in <module>
        sys.exit(config())
      File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 764, in __call__
        return self.main(*args, **kwargs)
      File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 717, in main
        rv = self.invoke(ctx)
      File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1137, in invoke
        return _process_result(sub_ctx.command.invoke(sub_ctx))
      File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1137, in invoke
        return _process_result(sub_ctx.command.invoke(sub_ctx))
      File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1137, in invoke
        return _process_result(sub_ctx.command.invoke(sub_ctx))
      File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 956, in invoke
        return ctx.invoke(self.callback, **ctx.params)
      File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 555, in invoke
        return callback(*args, **kwargs)
      File "/usr/local/lib/python3.7/dist-packages/click/decorators.py", line 64, in new_func
        return ctx.invoke(f, obj, *args, **kwargs)
      File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 555, in invoke
        return callback(*args, **kwargs)
      File "/usr/local/lib/python3.7/dist-packages/config/vxlan.py", line 72, in add_vxlan_evpn_nvo
        vxlan_keys = db.cfgdb.get_keys('CONFIG_DB', "VXLAN_EVPN_NVO|*")
      File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 2072, in get_keys
        keys = super(ConfigDBConnector, self).get_keys(table, split)
      File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 1914, in get_keys
        return _swsscommon.ConfigDBConnector_Native_get_keys(self, table, split)
    TypeError: in method 'ConfigDBConnector_Native_get_keys', argument 3 of type 'bool'

#### New command output (if the output of a command-line utility has changed)
    admin@as7816-64x-3:~$ sudo config vxlan evpn_nvo add nvo1 vtep1
    admin@as7816-64x-3:~$
