### PR TITLE
Handling error scenario of adding port to Vlan which is part of LAG

### DIFF
--- a/config/vlan.py
+++ b/config/vlan.py
@@ -145,6 +145,11 @@ def add_vlan_member(db, vid, port, untagged):
        (not is_port and clicommon.is_pc_router_interface(db.cfgdb, port)):
         ctx.fail("{} is a router interface!".format(port))
         
+    portchannel_member_table = db.cfgdb.get_table('PORTCHANNEL_MEMBER')
+
+    if (is_port and clicommon.interface_is_in_portchannel(portchannel_member_table, port)):
+        ctx.fail("{} is part of portchannel!".format(port))
+
     if (clicommon.interface_is_untagged_member(db.cfgdb, port) and untagged):
         ctx.fail("{} is already untagged member!".format(port))
 

--- a/tests/vlan_test.py
+++ b/tests/vlan_test.py
@@ -672,6 +672,16 @@ class TestVlan(object):
         assert result.exit_code == 0
         assert 'Interface Ethernet4 is a member of vlan' in result.output
         
+    def test_config_vlan_add_member_of_portchannel(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["vlan"].commands["member"].commands["add"], \
+				["1000", "Ethernet32", "--untagged"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Error: Ethernet32 is part of portchannel!" in result.output
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Handled error scenario when adding a port to Vlan which is already part of a LAG. Added unit test to cover the scenario. This is fix for the bug https://github.com/Azure/sonic-buildimage/issues/4456

#### How I did it
Fixed the config vlan script to check if port is a port channel member before setting config_db

#### How to verify it
config vlan add 10
config portchannel add PortChannel0
config portchannel member add PortChannel0 Ethernet0
config vlan member add 10 Ethernet0

Usage: config vlan member add [OPTIONS] port
Try "config vlan member add -h" for help.

Error: Ethernet0 is part of portchannel!



#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

