### PR TITLE
[show] Fix show arp in case with FDB entries, linked to default VLAN

### DIFF
--- a/scripts/nbrshow
+++ b/scripts/nbrshow
@@ -93,6 +93,10 @@ class NbrBase(object):
             elif 'bvid' in fdb:
                 try:
                     vlan_id = port_util.get_vlan_id_from_bvid(self.db, fdb["bvid"])
+                    if vlan_id is None:
+                        # the case could be happened if the FDB entry has created with linking to
+                        # default VLAN 1, which is not present in the system
+                        continue
                 except:
                     vlan_id = fdb["bvid"]
                     print "Failed to get Vlan id for bvid {}\n".format(fdb["bvid"])


### PR DESCRIPTION
Same as https://github.com/Azure/sonic-utilities/pull/1357
But target for 201911 branch