### PR TITLE
route_check: Fix hanging & logging level

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -115,14 +115,13 @@ def print_message(lvl, *args):
     :param args: message as list of strings or convertible to string
     :return None
     """
-    rem_len = PRINT_MSG_LEN_MAX
     msg = ""
     if (lvl <= report_level):
         for arg in args:
-            msg += str(arg)[0:rem_len]
-            rem_len -= len(msg)
+            rem_len = PRINT_MSG_LEN_MAX - len(msg)
             if rem_len <= 0:
                 break
+            msg += str(arg)[0:rem_len]
 
         print(msg)
         if write_to_syslog:

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -68,6 +68,8 @@ IPV6_SEPARATOR = ':'
 MIN_SCAN_INTERVAL = 10      # Every 10 seconds
 MAX_SCAN_INTERVAL = 3600    # An hour
 
+PRINT_MSG_LEN_MAX = 1000
+
 class Level(Enum):
     ERR = 'ERR'
     INFO = 'INFO'
@@ -77,7 +79,7 @@ class Level(Enum):
         return self.value
 
 
-report_level = syslog.LOG_ERR
+report_level = syslog.LOG_WARNING
 write_to_syslog = False
 
 def handler(signum, frame):
@@ -113,13 +115,20 @@ def print_message(lvl, *args):
     :param args: message as list of strings or convertible to string
     :return None
     """
+    rem_len = PRINT_MSG_LEN_MAX
+    msg = ""
     if (lvl <= report_level):
-        msg = ""
         for arg in args:
-            msg += " " + str(arg)
+            msg += str(arg)[0:rem_len]
+            rem_len -= len(msg)
+            if rem_len <= 0:
+                break
+
         print(msg)
         if write_to_syslog:
             syslog.syslog(lvl, msg)
+
+    return msg
 
 
 def add_prefix(ip):
@@ -421,10 +430,10 @@ def check_routes():
         results["Unaccounted_ROUTE_ENTRY_TABLE_entries"] = rt_asic_miss
 
     if results:
-        print_message(syslog.LOG_ERR, "Failure results: {",  json.dumps(results, indent=4), "}")
-        print_message(syslog.LOG_ERR, "Failed. Look at reported mismatches above")
-        print_message(syslog.LOG_ERR, "add: {", json.dumps(adds, indent=4), "}")
-        print_message(syslog.LOG_ERR, "del: {", json.dumps(deletes, indent=4), "}")
+        print_message(syslog.LOG_WARNING, "Failure results: {",  json.dumps(results, indent=4), "}")
+        print_message(syslog.LOG_WARNING, "Failed. Look at reported mismatches above")
+        print_message(syslog.LOG_WARNING, "add: {", json.dumps(adds, indent=4), "}")
+        print_message(syslog.LOG_WARNING, "del: {", json.dumps(deletes, indent=4), "}")
         return -1, results
     else:
         print_message(syslog.LOG_INFO, "All good!")

--- a/tests/route_check_test.py
+++ b/tests/route_check_test.py
@@ -2,6 +2,7 @@ import copy
 import json
 import os
 import sys
+import syslog
 import time
 from unittest.mock import MagicMock, patch
 
@@ -442,8 +443,18 @@ class TestRouteCheck(object):
             assert ex_str == expect, "{} != {}".format(ex_str, expect)
         assert ex_raised, "Exception expected"
 
-
-
+        # Test print_msg
+        route_check.PRINT_MSG_LEN_MAX = 5
+        msg = route_check.print_message(syslog.LOG_ERR, "abcdefghi")
+        assert len(msg) == 5
+        msg = route_check.print_message(syslog.LOG_ERR, "ab")
+        assert len(msg) == 2
+        msg = route_check.print_message(syslog.LOG_ERR, "abcde")
+        assert len(msg) == 5
+        msg = route_check.print_message(syslog.LOG_ERR, "ab", "cde")
+        assert len(msg) == 5
+               
+        
 
 
 

--- a/tests/route_check_test.py
+++ b/tests/route_check_test.py
@@ -451,7 +451,7 @@ class TestRouteCheck(object):
         assert len(msg) == 2
         msg = route_check.print_message(syslog.LOG_ERR, "abcde")
         assert len(msg) == 5
-        msg = route_check.print_message(syslog.LOG_ERR, "ab", "cde")
+        msg = route_check.print_message(syslog.LOG_ERR, "a", "b", "c", "d", "e", "f")
         assert len(msg) == 5
                
         


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
**Fix for hanging:**
Enforce max len on string to be printed to stdout.
With huge mismatch, the message to print can be too long to hang python print statement.

**Lower logging level:**
The log for "_details of route mismatch_" is lowered to WARNING. The caller of the route_check may log error, as it sees it fit. The failure of route_check is indicated to caller via exit code.

#### How to verify it
Simulate error (_route-mismatch_), and verify
a) message len does not exceed set MAX
b) log level is WARNING

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

