### PR TITLE
Copy missing values from INIT_CFG to config_db during db_migration

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -838,7 +838,7 @@ def reload(filename, yes, load_sysinfo, no_service_restart):
         log.log_info("'reload' stopping services...")
         _stop_services()
 
-    # In Single AISC platforms we have single DB service. In multi-ASIC platforms we have a global DB
+    # In Single ASIC platforms we have single DB service. In multi-ASIC platforms we have a global DB
     # service running in the host + DB services running in each ASIC namespace created per ASIC.
     # In the below logic, we get all namespaces in this platform and add an empty namespace ''
     # denoting the current namespace which we are in ( the linux host )

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -2,6 +2,7 @@
 
 import os
 import argparse
+import json
 import sys
 import traceback
 
@@ -19,7 +20,7 @@ try:
 except KeyError:
     pass
 
-
+INIT_CFG_FILE = '/etc/sonic/init_cfg.json'
 SYSLOG_IDENTIFIER = 'db_migrator'
 
 # Global logger instance
@@ -254,6 +255,24 @@ class DBMigrator():
         self.configDB.set_entry(self.TABLE_NAME, self.TABLE_KEY, entry)
 
 
+    def common_migration_ops(self):
+        try:
+            with open(INIT_CFG_FILE) as f:
+                init_db = json.load(f)
+        except Exception as e:
+            raise Exception(str(e))
+
+        for init_cfg_table, table_val in init_db.items():
+            data = self.configDB.get_table(init_cfg_table)
+            if data:
+                # Ignore overriding the values that pre-exist in configDB
+                continue
+            log.log_info("Migrating table {} from INIT_CFG to config_db".format(init_cfg_table))
+            # Update all tables that do not exist in configDB but are present in INIT_CFG
+            for init_table_key, init_table_val in table_val.items():
+                self.configDB.set_entry(init_cfg_table, init_table_key, init_table_val)
+
+
     def migrate(self):
         version = self.get_version()
         log.log_info('Upgrading from version ' + version)
@@ -262,6 +281,8 @@ class DBMigrator():
             if next_version == version:
                 raise Exception('Version migrate from %s stuck in same version' % version)
             version = next_version
+        # Perform common migration ops
+        self.common_migration_ops()
 
 
 def main():


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixes: https://github.com/Azure/sonic-buildimage/issues/6659

This PR is to port a fix into 201911 branch that is already available in master branch. Original fix for master branch is here - https://github.com/Azure/sonic-utilities/pull/1209

FEATURE table is a part of 201911 image database, but absent in 201811 images. The warm upgrade from 201811 image to 201911 image fails as the feature table is missing in the DB and multiple errors are seen in syslog.

This PR fixes DB_MIGRATOR code to update missing init_cfg tables into config_db.

- How I did it
Iterate through the tables in /etc/sonic/init_cfg.json, if a table is found missing in configDB, update the configDB with the missing table. Otherwise, ignore it, so to avoid overriding configDB tables with init_cfg.

- How to verify it
Verified upgrade with the fix in 201911 image, and the error is not seen.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

