### PR TITLE
cache the bvid to vlan translations

### DIFF
--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -118,11 +118,11 @@ class FdbShow(object):
                 else:
                     try:
                         vlan_id = port_util.get_vlan_id_from_bvid(self.db, bvid)
+                        bvid_tlb[bvid] = vlan_id
                         if vlan_id is None:
                             # the situation could be faced if the system has an FDB entries,
                             # which are linked to default Vlan(caused by untagged trafic)
                             continue
-                        bvid_tlb[bvid] = vlan_id
                     except Exception:
                         vlan_id = bvid
                         print("Failed to get Vlan id for bvid {}\n".format(bvid))

--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -87,6 +87,7 @@ class FdbShow(object):
         if not fdb_str:
             return
 
+        bvid_tlb = {}
         oid_pfx = len("oid:0x")
         for s in fdb_str:
             fdb_entry = s
@@ -111,15 +112,20 @@ class FdbShow(object):
                 if 'bvid' not in fdb:
                     # no possibility to find the Vlan id. skip the FDB entry
                     continue
-                try:
-                    vlan_id = port_util.get_vlan_id_from_bvid(self.db, fdb["bvid"])
-                    if vlan_id is None:
-                        # the situation could be faced if the system has an FDB entries,
-                        # which are linked to default Vlan(caused by untagged trafic)
-                        continue
-                except Exception:
-                    vlan_id = fdb["bvid"]
-                    print("Failed to get Vlan id for bvid {}\n".format(fdb["bvid"]))
+                bvid = fdb["bvid"]
+                if bvid in bvid_tlb:
+                    vlan_id = bvid_tlb[bvid]
+                else:
+                    try:
+                        vlan_id = port_util.get_vlan_id_from_bvid(self.db, bvid)
+                        if vlan_id is None:
+                            # the situation could be faced if the system has an FDB entries,
+                            # which are linked to default Vlan(caused by untagged trafic)
+                            continue
+                        bvid_tlb[bvid] = vlan_id
+                    except Exception:
+                        vlan_id = bvid
+                        print("Failed to get Vlan id for bvid {}\n".format(bvid))
             self.bridge_mac_list.append((int(vlan_id),) + (fdb["mac"],) + (if_name,) + (fdb_type,))
 
         self.bridge_mac_list.sort(key = lambda x: x[0])


### PR DESCRIPTION
Add lookup table for bvid to vlan translations.
bvid_tlb will store previous successful translations from slow  get_vlan_id_from_bvid()
This patch does not change the output from the command, only speeds up it for case of 10k+ MAC tables.
