### PR TITLE
[201811] Add missing variable DEVPATH to fast-reboot script

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -13,6 +13,7 @@ STRICT=no
 REBOOT_METHOD="/sbin/kexec -e"
 ASSISTANT_IP_LIST=""
 ASSISTANT_SCRIPT="/usr/bin/neighbor_advertiser"
+DEVPATH="/usr/share/sonic/device"
 SSD_FW_UPDATE="ssd-fw-upgrade"
 
 # Require 100M available on the hard drive for warm reboot temp files,

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -14,6 +14,7 @@ REBOOT_METHOD="/sbin/kexec -e"
 ASSISTANT_IP_LIST=""
 ASSISTANT_SCRIPT="/usr/bin/neighbor_advertiser"
 DEVPATH="/usr/share/sonic/device"
+PLATFORM=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
 SSD_FW_UPDATE="ssd-fw-upgrade"
 
 # Require 100M available on the hard drive for warm reboot temp files,


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Path to `ssd-fw-upgrade` is not correct. Adding a path variable, that was missed in the PR https://github.com/Azure/sonic-utilities/pull/1487

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

