### PR TITLE
[201811] Fast reboot: check if the files are present before accessing

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -281,18 +281,20 @@ function reboot_pre_check()
     fi
     
     # Make sure ASIC configuration has not changed between images
-    ASIC_CONFIG_CHECK_SCRIPT="/usr/bin/asic_config_check"
-    ASIC_CONFIG_CHECK_SUCCESS=0
-    if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; then
-        ASIC_CONFIG_CHECK_EXIT_CODE=0
-        ${ASIC_CONFIG_CHECK_SCRIPT} || ASIC_CONFIG_CHECK_EXIT_CODE=$?
+    if [[ -x /usr/bin/asic_config_check ]]; then
+        ASIC_CONFIG_CHECK_SCRIPT="/usr/bin/asic_config_check"
+        ASIC_CONFIG_CHECK_SUCCESS=0
+        if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; then
+            ASIC_CONFIG_CHECK_EXIT_CODE=0
+            ${ASIC_CONFIG_CHECK_SCRIPT} || ASIC_CONFIG_CHECK_EXIT_CODE=$?
 
-        if [[ "${ASIC_CONFIG_CHECK_EXIT_CODE}" != "${ASIC_CONFIG_CHECK_SUCCESS}" ]]; then
-            if [[ x"${FORCE}" == x"yes" ]]; then
-                debug "Ignoring ASIC config checksum failure..."
-            else
-                error "ASIC config may have changed: errno=${ASIC_CONFIG_CHECK_EXIT_CODE}"
-                exit "${EXIT_FAILURE}"
+            if [[ "${ASIC_CONFIG_CHECK_EXIT_CODE}" != "${ASIC_CONFIG_CHECK_SUCCESS}" ]]; then
+                if [[ x"${FORCE}" == x"yes" ]]; then
+                    debug "Ignoring ASIC config checksum failure..."
+                else
+                    error "ASIC config may have changed: errno=${ASIC_CONFIG_CHECK_EXIT_CODE}"
+                    exit "${EXIT_FAILURE}"
+                fi
             fi
         fi
     fi
@@ -393,14 +395,15 @@ if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
         unload_kernel
         exit "${EXIT_FAST_REBOOT_DUMP_FAILURE}"
     fi
-
-    FILTER_FDB_ENTRIES_RC=0
-    # Filter FDB entries using MAC addresses from ARP table
-    /usr/bin/filter_fdb_entries -f $DUMP_DIR/fdb.json -a $DUMP_DIR/arp.json -c $CONFIG_DB_FILE || FILTER_FDB_ENTRIES_RC=$?
-    if [[ FILTER_FDB_ENTRIES_RC -ne 0 ]]; then
-        error "Failed to filter FDb entries. Exit code: $FILTER_FDB_ENTRIES_RC"
-        unload_kernel
-        exit "${EXIT_FILTER_FDB_ENTRIES_FAILURE}"
+    if [[ -x /usr/bin/filter_fdb_entries ]]; then
+       FILTER_FDB_ENTRIES_RC=0
+       # Filter FDB entries using MAC addresses from ARP table
+       /usr/bin/filter_fdb_entries -f $DUMP_DIR/fdb.json -a $DUMP_DIR/arp.json -c $CONFIG_DB_FILE || FILTER_FDB_ENTRIES_RC=$?
+       if [[ FILTER_FDB_ENTRIES_RC -ne 0 ]]; then
+           error "Failed to filter FDb entries. Exit code: $FILTER_FDB_ENTRIES_RC"
+           unload_kernel
+           exit "${EXIT_FILTER_FDB_ENTRIES_FAILURE}"
+       fi
     fi
 fi
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Check if the below files exist and are executable, before executing them.
`/usr/bin/asic_config_check`
`/usr/bin/filter_fdb_entries`

#### How I did it

#### How to verify it
Tested on a physical DUT, where the files are present/absent.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

