### PR TITLE
[show][config] cli support for firmware upgrade on Y-Cable

### DIFF
--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -635,8 +635,6 @@ def setswitchmode(state, port):
 
 def get_per_npu_statedb(per_npu_statedb, port_table_keys):
 
-    y_cable_asic_table_keys = {}
-
     # Getting all front asic namespace and correspding config and state DB connector
 
     namespaces = multi_asic.get_front_end_namespaces()
@@ -689,18 +687,18 @@ def perform_download_firmware(physical_port, fwfile):
         return False
 
 
-def perform_activate_firmware(physical_port, fwfile):
+def perform_activate_firmware(physical_port):
     import sonic_y_cable.y_cable
     result = sonic_y_cable.y_cable.activate_firmware(physical_port)
     if result == sonic_y_cable.y_cable.FIRMWARE_ACTIVATE_SUCCESS:
-        click.echo("firmware ACTIVATE successful for {}".format(port))
+        click.echo("firmware activate successful for {}".format(port))
         return True
     else:
-        click.echo("firmware ACTIVATE failure for {}".format(port))
+        click.echo("firmware activate failure for {}".format(port))
         return False
 
 
-def perform_rollback_firmware(physical_port, fwfile):
+def perform_rollback_firmware(physical_port):
     import sonic_y_cable.y_cable
     result = sonic_y_cable.y_cable.rollback_firmware(physical_port)
     if result == sonic_y_cable.y_cable.FIRMWARE_ROLLBACK_SUCCESS:
@@ -718,19 +716,20 @@ def firmware():
 
 
 @firmware.command()
-@click.argument('fwfile', metavar='<operation_status>', required=True)
+@click.argument('fwfile', metavar='<firmware_file>', required=True)
 @click.argument('port', metavar='<port_name>', required=True, default=None)
 def download(fwfile, port):
     """Config muxcable firmware download"""
 
     per_npu_statedb = {}
-    physical_port_list = []
+    y_cable_asic_table_keys = {}
     port_table_keys = {}
 
     get_per_npu_statedb(per_npu_statedb, port_table_keys)
 
     if port is not None and port != "all":
 
+        physical_port_list = []
         get_physical_port_list(port, physical_port_list)
         physical_port = physical_port_list[0]
         if per_npu_statedb[asic_index] is not None:
@@ -775,21 +774,22 @@ def download(fwfile, port):
 def activate(port):
     """Config muxcable firmware activate"""
 
-    port_table_keys = {}
-    y_cable_asic_table_keys = {}
     per_npu_statedb = {}
+    y_cable_asic_table_keys = {}
+    port_table_keys = {}
 
     get_per_npu_statedb(per_npu_statedb, port_table_keys)
 
     if port is not None and port != "all":
 
+        physical_port_list = []
         get_physical_port_list(port, physical_port_list)
         physical_port = physical_port_list[0]
         if per_npu_statedb[asic_index] is not None:
             y_cable_asic_table_keys = port_table_keys[asic_index]
             logical_key = "MUX_CABLE_TABLE|{}".format(port)
             if logical_key in y_cable_asic_table_keys:
-                perform_activate_firmware(physical_port, fwfile)
+                perform_activate_firmware(physical_port)
 
             else:
                 click.echo("this is not a valid port present on mux_cable".format(port))
@@ -806,9 +806,11 @@ def activate(port):
             for key in port_table_keys[asic_id]:
                 port = key.split("|")[1]
 
+                physical_port_list = []
+
                 get_physical_port_list(port, physical_port_list)
                 physical_port = physical_port_list[0]
-                status = perform_activate_firmware(physical_port, fwfile)
+                status = perform_activate_firmware(physical_port)
 
                 if status is not True:
                     rc = False
@@ -832,13 +834,14 @@ def rollback(port):
 
     if port is not None and port != "all":
 
+        physical_port_list = []
         get_physical_port_list(port, physical_port_list)
         physical_port = physical_port_list[0]
         if per_npu_statedb[asic_index] is not None:
             y_cable_asic_table_keys = port_table_keys[asic_index]
             logical_key = "MUX_CABLE_TABLE|{}".format(port)
             if logical_key in y_cable_asic_table_keys:
-                perform_rollback_firmware(physical_port, fwfile)
+                perform_rollback_firmware(physical_port)
 
             else:
                 click.echo("this is not a valid port present on mux_cable".format(port))
@@ -855,9 +858,10 @@ def rollback(port):
             for key in port_table_keys[asic_id]:
                 port = key.split("|")[1]
 
+                physical_port_list = []
                 get_physical_port_list(port, physical_port_list)
                 physical_port = physical_port_list[0]
-                status = perform_rollback_firmware(physical_port, fwfile)
+                status = perform_rollback_firmware(physical_port)
 
                 if status is not True:
                     rc = False

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -650,7 +650,7 @@ def get_per_npu_statedb(per_npu_statedb, port_table_keys):
             per_npu_statedb[asic_id].STATE_DB, 'MUX_CABLE_TABLE|*')
 
 
-def get_physical_port_list(port, physical_port_list)
+def get_physical_port_list(port, physical_port_list):
 
     if platform_sfputil is not None:
         physical_port_list = platform_sfputil_helper.logical_port_name_to_physical_port_list(port)

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -706,7 +706,6 @@ def download(fwfile, port):
 
     elif port == "all" and port is not None:
 
-        port_status_dict = {}
         rc = True
         for namespace in namespaces:
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
@@ -807,7 +806,6 @@ def activate(port):
 
     elif port == "all" and port is not None:
 
-        port_status_dict = {}
         rc = True
         for namespace in namespaces:
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
@@ -909,7 +907,6 @@ def rollback(port):
 
     elif port == "all" and port is not None:
 
-        port_status_dict = {}
         rc = True
         for namespace in namespaces:
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -637,9 +637,8 @@ def firmware():
     """Configure muxcable firmware command"""
     pass
 
-# 'muxcable' command ("config muxcable mode <port|all> active|auto")
 @firmware.command()
-@click.argument('fwfile', metavar='<operation_status>', required=True))
+@click.argument('fwfile', metavar='<operation_status>', required=True)
 @click.argument('port', metavar='<port_name>', required=True, default=None)
 def download(fwfile, port):
     """Config muxcable firmware download"""

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -732,9 +732,6 @@ def download(fwfile, port):
 
         physical_port_list = []
         physical_port_list, asic_index = get_physical_port_list(port)
-        f = open("demofile2.txt", "w")
-        f.write("yes ")
-        f.write("{} ".format(len(physical_port_list)))
         physical_port = physical_port_list[0]
         if per_npu_statedb[asic_index] is not None:
             y_cable_asic_table_keys = port_table_keys[asic_index]

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -673,7 +673,7 @@ def get_physical_port_list(port, physical_port_list):
     if len(physical_port_list) != 1:
         click.echo("ERR: Found multiple physical ports ({}) associated with {}".format(
             ", ".join(physical_port_list), port))
-            sys.exit(CONFIG_FAIL)
+        sys.exit(CONFIG_FAIL)
 
     return asic_index
 

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -631,3 +631,315 @@ def setswitchmode(state, port):
         if rc == False:
             click.echo("ERR: Unable to set switching mode one or more ports to {}".format(state))
             sys.exit(CONFIG_FAIL)
+
+@muxcable.group(cls=clicommon.AbbreviationGroup)
+def firmware():
+    """Configure muxcable firmware command"""
+    pass
+
+# 'muxcable' command ("config muxcable mode <port|all> active|auto")
+@firmware.command()
+@click.argument('fwfile', metavar='<operation_status>', required=True))
+@click.argument('port', metavar='<port_name>', required=True, default=None)
+def download(fwfile, port):
+    """Config muxcable firmware download"""
+
+    port_table_keys = {}
+    y_cable_asic_table_keys = {}
+    per_npu_statedb = {}
+
+    # Getting all front asic namespace and correspding config and state DB connector
+
+    namespaces = multi_asic.get_front_end_namespaces()
+    for namespace in namespaces:
+        asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+        # replace these with correct macros
+        per_npu_statedb[asic_id] = SonicV2Connector(use_unix_socket_path=True, namespace=namespace)
+        per_npu_statedb[asic_id].connect(per_npu_statedb[asic_id].STATE_DB)
+
+
+        port_table_keys[asic_id] = per_npu_statedb[asic_id].keys(
+            per_npu_statedb[asic_id].STATE_DB, 'MUX_CABLE_TABLE|*')
+
+    if port is not None and port != "all":
+
+        if platform_sfputil is not None:
+            physical_port_list = platform_sfputil_helper.logical_port_name_to_physical_port_list(port)
+
+        asic_index = None
+        if platform_sfputil is not None:
+            asic_index = platform_sfputil_helper.get_asic_id_for_logical_port(port)
+            if asic_index is None:
+                # TODO this import is only for unit test purposes, and should be removed once sonic_platform_base
+                # is fully mocked
+                import sonic_platform_base.sonic_sfp.sfputilhelper
+                asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
+                if asic_index is None:
+                    click.echo("Got invalid asic index for port {}, cant retreive mux status".format(port))
+
+        if not isinstance(physical_port_list, list):
+            click.echo(("ERR: Unable to locate physical port information for {}".format(port)))
+            sys.exit(CONFIG_FAIL)
+
+        if len(physical_port_list) != 1:
+            click.echo("ERR: Found multiple physical ports ({}) associated with {}".format(
+                ", ".join(physical_port_list), port))
+            sys.exit(CONFIG_FAIL)
+
+        physical_port = physical_port_list[0]
+        if per_npu_statedb[asic_index] is not None:
+            y_cable_asic_table_keys = port_table_keys[asic_index]
+            logical_key = "MUX_CABLE_TABLE|{}".format(port)
+            if logical_key in y_cable_asic_table_keys:
+                import sonic_y_cable.y_cable
+                result = sonic_y_cable.y_cable.download_firmware(physical_port, fwfile)
+                if result == sonic_y_cable.y_cable.FIRMWARE_DOWNLOAD_SUCCESS:
+                    click.echo("firmware download successful {}".format(port))
+                else:
+                    click.echo("firmware download failure {}".format(port))
+
+            else:
+                click.echo("this is not a valid port present on mux_cable".format(port))
+                sys.exit(CONFIG_FAIL)
+        else:
+            click.echo("there is not a valid asic table for this asic_index".format(asic_index))
+            sys.exit(CONFIG_FAIL)
+
+    elif port == "all" and port is not None:
+
+        port_status_dict = {}
+        rc = True
+        for namespace in namespaces:
+            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+            for key in port_table_keys[asic_id]:
+                port = key.split("|")[1]
+                if platform_sfputil is not None:
+                    physical_port_list = platform_sfputil_helper.logical_port_name_to_physical_port_list(port)
+
+                if not isinstance(physical_port_list, list):
+                    click.echo(("ERR: Unable to locate physical port information for {}".format(port)))
+                    rc = False
+                    continue
+
+                if len(physical_port_list) != 1:
+                    click.echo("ERR: Found multiple physical ports ({}) associated with {}".format(
+                        ", ".join(physical_port_list), port))
+                    rc = False
+                    continue
+                physical_port = physical_port_list[0]
+                import sonic_y_cable.y_cable
+                result = sonic_y_cable.y_cable.download_firmware(physical_port, fwfile)
+                if result == sonic_y_cable.y_cable.FIRMWARE_DOWNLOAD_SUCCESS:
+                    click.echo("firmware download successful for {}".format(port))
+                else:
+                    click.echo("firmware download failure for {}".format(port))
+                    rc = False
+
+        if rc:
+            sys.exit(CONFIG_SUCCESSFUL)
+        else:
+            sys.exit(CONFIG_FAIL)
+
+@firmware.command()
+@click.argument('port', metavar='<port_name>', required=True, default=None)
+def activate(port):
+    """Config muxcable firmware activate"""
+
+    port_table_keys = {}
+    y_cable_asic_table_keys = {}
+    per_npu_statedb = {}
+
+    # Getting all front asic namespace and correspding config and state DB connector
+
+    namespaces = multi_asic.get_front_end_namespaces()
+    for namespace in namespaces:
+        asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+        # replace these with correct macros
+        per_npu_statedb[asic_id] = SonicV2Connector(use_unix_socket_path=True, namespace=namespace)
+        per_npu_statedb[asic_id].connect(per_npu_statedb[asic_id].STATE_DB)
+
+
+        port_table_keys[asic_id] = per_npu_statedb[asic_id].keys(
+            per_npu_statedb[asic_id].STATE_DB, 'MUX_CABLE_TABLE|*')
+
+    if port is not None and port != "all":
+
+        if platform_sfputil is not None:
+            physical_port_list = platform_sfputil_helper.logical_port_name_to_physical_port_list(port)
+
+        asic_index = None
+        if platform_sfputil is not None:
+            asic_index = platform_sfputil_helper.get_asic_id_for_logical_port(port)
+            if asic_index is None:
+                # TODO this import is only for unit test purposes, and should be removed once sonic_platform_base
+                # is fully mocked
+                import sonic_platform_base.sonic_sfp.sfputilhelper
+                asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
+                if asic_index is None:
+                    click.echo("Got invalid asic index for port {}, cant retreive mux status".format(port))
+
+        if not isinstance(physical_port_list, list):
+            click.echo(("ERR: Unable to locate physical port information for {}".format(port)))
+            sys.exit(CONFIG_FAIL)
+
+        if len(physical_port_list) != 1:
+            click.echo("ERR: Found multiple physical ports ({}) associated with {}".format(
+                ", ".join(physical_port_list), port))
+            sys.exit(CONFIG_FAIL)
+
+        physical_port = physical_port_list[0]
+        if per_npu_statedb[asic_index] is not None:
+            y_cable_asic_table_keys = port_table_keys[asic_index]
+            logical_key = "MUX_CABLE_TABLE|{}".format(port)
+            if logical_key in y_cable_asic_table_keys:
+                import sonic_y_cable.y_cable
+                result = sonic_y_cable.y_cable.activate_firmware(physical_port)
+                if result == sonic_y_cable.y_cable.FIRMWARE_ACTIVATE_SUCCESS:
+                    click.echo("firmware activate successful {}".format(port))
+                else:
+                    click.echo("firmware activate failure {}".format(port))
+
+            else:
+                click.echo("this is not a valid port present on mux_cable".format(port))
+                sys.exit(CONFIG_FAIL)
+        else:
+            click.echo("there is not a valid asic table for this asic_index".format(asic_index))
+            sys.exit(CONFIG_FAIL)
+
+    elif port == "all" and port is not None:
+
+        port_status_dict = {}
+        rc = True
+        for namespace in namespaces:
+            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+            for key in port_table_keys[asic_id]:
+                port = key.split("|")[1]
+                if platform_sfputil is not None:
+                    physical_port_list = platform_sfputil_helper.logical_port_name_to_physical_port_list(port)
+
+                if not isinstance(physical_port_list, list):
+                    click.echo(("ERR: Unable to locate physical port information for {}".format(port)))
+                    rc = False
+                    continue
+
+                if len(physical_port_list) != 1:
+                    click.echo("ERR: Found multiple physical ports ({}) associated with {}".format(
+                        ", ".join(physical_port_list), port))
+                    rc = False
+                    continue
+
+                physical_port = physical_port_list[0]
+                import sonic_y_cable.y_cable
+                result = sonic_y_cable.y_cable.activate_firmware(physical_port)
+                if result == sonic_y_cable.y_cable.FIRMWARE_ACTIVATE_SUCCESS:
+                    click.echo("firmware ACTIVATE successful for {}".format(port))
+                else:
+                    click.echo("firmware ACTIVATE failure for {}".format(port))
+                    rc = False
+
+        if rc:
+            sys.exit(CONFIG_SUCCESSFUL)
+        else:
+            sys.exit(CONFIG_FAIL)
+            i
+@firmware.command()
+@click.argument('port', metavar='<port_name>', required=True, default=None)
+def rollback(port):
+    """Config muxcable firmware rollback"""
+
+    port_table_keys = {}
+    y_cable_asic_table_keys = {}
+    per_npu_statedb = {}
+
+    # Getting all front asic namespace and correspding config and state DB connector
+
+    namespaces = multi_asic.get_front_end_namespaces()
+    for namespace in namespaces:
+        asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+        # replace these with correct macros
+        per_npu_statedb[asic_id] = SonicV2Connector(use_unix_socket_path=True, namespace=namespace)
+        per_npu_statedb[asic_id].connect(per_npu_statedb[asic_id].STATE_DB)
+
+
+        port_table_keys[asic_id] = per_npu_statedb[asic_id].keys(
+            per_npu_statedb[asic_id].STATE_DB, 'MUX_CABLE_TABLE|*')
+
+    if port is not None and port != "all":
+
+        if platform_sfputil is not None:
+            physical_port_list = platform_sfputil_helper.logical_port_name_to_physical_port_list(port)
+
+        asic_index = None
+        if platform_sfputil is not None:
+            asic_index = platform_sfputil_helper.get_asic_id_for_logical_port(port)
+            if asic_index is None:
+                # TODO this import is only for unit test purposes, and should be removed once sonic_platform_base
+                # is fully mocked
+                import sonic_platform_base.sonic_sfp.sfputilhelper
+                asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
+                if asic_index is None:
+                    click.echo("Got invalid asic index for port {}, cant retreive mux status".format(port))
+
+        if not isinstance(physical_port_list, list):
+            click.echo(("ERR: Unable to locate physical port information for {}".format(port)))
+            sys.exit(CONFIG_FAIL)
+
+        if len(physical_port_list) != 1:
+            click.echo("ERR: Found multiple physical ports ({}) associated with {}".format(
+                ", ".join(physical_port_list), port))
+            sys.exit(CONFIG_FAIL)
+
+        physical_port = physical_port_list[0]
+        if per_npu_statedb[asic_index] is not None:
+            y_cable_asic_table_keys = port_table_keys[asic_index]
+            logical_key = "MUX_CABLE_TABLE|{}".format(port)
+            if logical_key in y_cable_asic_table_keys:
+                import sonic_y_cable.y_cable
+                result = sonic_y_cable.y_cable.rollback_firmware(physical_port)
+                if result == sonic_y_cable.y_cable.FIRMWARE_ROLLBACK_SUCCESS:
+                    click.echo("firmware rollback successful {}".format(port))
+                else:
+                    click.echo("firmware rollback failure {}".format(port))
+
+            else:
+                click.echo("this is not a valid port present on mux_cable".format(port))
+                sys.exit(CONFIG_FAIL)
+        else:
+            click.echo("there is not a valid asic table for this asic_index".format(asic_index))
+            sys.exit(CONFIG_FAIL)
+
+    elif port == "all" and port is not None:
+
+        port_status_dict = {}
+        rc = True
+        for namespace in namespaces:
+            asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+            for key in port_table_keys[asic_id]:
+                port = key.split("|")[1]
+                if platform_sfputil is not None:
+                    physical_port_list = platform_sfputil_helper.logical_port_name_to_physical_port_list(port)
+
+                if not isinstance(physical_port_list, list):
+                    click.echo(("ERR: Unable to locate physical port information for {}".format(port)))
+                    rc = False
+                    continue
+
+                if len(physical_port_list) != 1:
+                    click.echo("ERR: Found multiple physical ports ({}) associated with {}".format(
+                        ", ".join(physical_port_list), port))
+                    rc = False
+                    continue
+
+                physical_port = physical_port_list[0]
+                import sonic_y_cable.y_cable
+                result = sonic_y_cable.y_cable.rollback_firmware(physical_port)
+                if result == sonic_y_cable.y_cable.FIRMWARE_ROLLBACK_SUCCESS:
+                    click.echo("firmware ROLLBACK successful for {}".format(port))
+                else:
+                    click.echo("firmware ROLLBACK failure for {}".format(port))
+                    rc = False
+
+        if rc:
+            sys.exit(CONFIG_SUCCESSFUL)
+        else:
+            sys.exit(CONFIG_FAIL)

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -747,7 +747,7 @@ def download(fwfile, port):
 
     elif port == "all" and port is not None:
 
-        rc = True
+        rc = CONFIG_SUCCESSFUL
         for namespace in namespaces:
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
             for key in port_table_keys[asic_id]:
@@ -761,12 +761,9 @@ def download(fwfile, port):
                 status = perform_download_firmware(physical_port, fwfile)
 
                 if status is not True:
-                    rc = False
+                    rc = CONFIG_FAIL
 
-        if rc:
-            sys.exit(CONFIG_SUCCESSFUL)
-        else:
-            sys.exit(CONFIG_FAIL)
+        sys.exit(rc)
 
 
 @firmware.command()
@@ -800,7 +797,7 @@ def activate(port):
 
     elif port == "all" and port is not None:
 
-        rc = True
+        rc = CONFIG_SUCCESSFUL
         for namespace in namespaces:
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
             for key in port_table_keys[asic_id]:
@@ -813,13 +810,9 @@ def activate(port):
                 status = perform_activate_firmware(physical_port)
 
                 if status is not True:
-                    rc = False
+                    rc = CONFIG_FAIL
 
-        if rc:
-            sys.exit(CONFIG_SUCCESSFUL)
-        else:
-            sys.exit(CONFIG_FAIL)
-
+        sys.exit(rc)
 
 @firmware.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
@@ -852,7 +845,7 @@ def rollback(port):
 
     elif port == "all" and port is not None:
 
-        rc = True
+        rc = CONFIG_SUCCESSFUL
         for namespace in namespaces:
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
             for key in port_table_keys[asic_id]:
@@ -864,9 +857,6 @@ def rollback(port):
                 status = perform_rollback_firmware(physical_port)
 
                 if status is not True:
-                    rc = False
+                    rc = CONFIG_FAIL
 
-        if rc:
-            sys.exit(CONFIG_SUCCESSFUL)
-        else:
-            sys.exit(CONFIG_FAIL)
+        sys.exit(rc)

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -632,20 +632,10 @@ def setswitchmode(state, port):
             click.echo("ERR: Unable to set switching mode one or more ports to {}".format(state))
             sys.exit(CONFIG_FAIL)
 
-@muxcable.group(cls=clicommon.AbbreviationGroup)
-def firmware():
-    """Configure muxcable firmware command"""
-    pass
 
-@firmware.command()
-@click.argument('fwfile', metavar='<operation_status>', required=True)
-@click.argument('port', metavar='<port_name>', required=True, default=None)
-def download(fwfile, port):
-    """Config muxcable firmware download"""
+def get_per_npu_statedb(per_npu_statedb, port_table_keys):
 
-    port_table_keys = {}
     y_cable_asic_table_keys = {}
-    per_npu_statedb = {}
 
     # Getting all front asic namespace and correspding config and state DB connector
 
@@ -656,46 +646,98 @@ def download(fwfile, port):
         per_npu_statedb[asic_id] = SonicV2Connector(use_unix_socket_path=True, namespace=namespace)
         per_npu_statedb[asic_id].connect(per_npu_statedb[asic_id].STATE_DB)
 
-
         port_table_keys[asic_id] = per_npu_statedb[asic_id].keys(
             per_npu_statedb[asic_id].STATE_DB, 'MUX_CABLE_TABLE|*')
 
+
+def get_physical_port_list(port, physical_port_list)
+
+    if platform_sfputil is not None:
+        physical_port_list = platform_sfputil_helper.logical_port_name_to_physical_port_list(port)
+
+    asic_index = None
+    if platform_sfputil is not None:
+        asic_index = platform_sfputil_helper.get_asic_id_for_logical_port(port)
+        if asic_index is None:
+            # TODO this import is only for unit test purposes, and should be removed once sonic_platform_base
+            # is fully mocked
+            import sonic_platform_base.sonic_sfp.sfputilhelper
+            asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
+            if asic_index is None:
+                click.echo("Got invalid asic index for port {}, cant retreive mux status".format(port))
+
+    if not isinstance(physical_port_list, list):
+        click.echo(("ERR: Unable to locate physical port information for {}".format(port)))
+        sys.exit(CONFIG_FAIL)
+
+    if len(physical_port_list) != 1:
+        click.echo("ERR: Found multiple physical ports ({}) associated with {}".format(
+            ", ".join(physical_port_list), port))
+            sys.exit(CONFIG_FAIL)
+
+    return asic_index
+
+
+def perform_download_firmware(physical_port, fwfile):
+    import sonic_y_cable.y_cable
+    result = sonic_y_cable.y_cable.download_firmware(physical_port, fwfile)
+    if result == sonic_y_cable.y_cable.FIRMWARE_DOWNLOAD_SUCCESS:
+        click.echo("firmware download successful {}".format(port))
+        return True
+    else:
+        click.echo("firmware download failure {}".format(port))
+        return False
+
+
+def perform_activate_firmware(physical_port, fwfile):
+    import sonic_y_cable.y_cable
+    result = sonic_y_cable.y_cable.activate_firmware(physical_port)
+    if result == sonic_y_cable.y_cable.FIRMWARE_ACTIVATE_SUCCESS:
+        click.echo("firmware ACTIVATE successful for {}".format(port))
+        return True
+    else:
+        click.echo("firmware ACTIVATE failure for {}".format(port))
+        return False
+
+
+def perform_rollback_firmware(physical_port, fwfile):
+    import sonic_y_cable.y_cable
+    result = sonic_y_cable.y_cable.rollback_firmware(physical_port)
+    if result == sonic_y_cable.y_cable.FIRMWARE_ROLLBACK_SUCCESS:
+        click.echo("firmware rollback successful {}".format(port))
+        return True
+    else:
+        click.echo("firmware rollback failure {}".format(port))
+        return False
+
+
+@muxcable.group(cls=clicommon.AbbreviationGroup)
+def firmware():
+    """Configure muxcable firmware command"""
+    pass
+
+
+@firmware.command()
+@click.argument('fwfile', metavar='<operation_status>', required=True)
+@click.argument('port', metavar='<port_name>', required=True, default=None)
+def download(fwfile, port):
+    """Config muxcable firmware download"""
+
+    per_npu_statedb = {}
+    physical_port_list = []
+    port_table_keys = {}
+
+    get_per_npu_statedb(per_npu_statedb, port_table_keys)
+
     if port is not None and port != "all":
 
-        if platform_sfputil is not None:
-            physical_port_list = platform_sfputil_helper.logical_port_name_to_physical_port_list(port)
-
-        asic_index = None
-        if platform_sfputil is not None:
-            asic_index = platform_sfputil_helper.get_asic_id_for_logical_port(port)
-            if asic_index is None:
-                # TODO this import is only for unit test purposes, and should be removed once sonic_platform_base
-                # is fully mocked
-                import sonic_platform_base.sonic_sfp.sfputilhelper
-                asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
-                if asic_index is None:
-                    click.echo("Got invalid asic index for port {}, cant retreive mux status".format(port))
-
-        if not isinstance(physical_port_list, list):
-            click.echo(("ERR: Unable to locate physical port information for {}".format(port)))
-            sys.exit(CONFIG_FAIL)
-
-        if len(physical_port_list) != 1:
-            click.echo("ERR: Found multiple physical ports ({}) associated with {}".format(
-                ", ".join(physical_port_list), port))
-            sys.exit(CONFIG_FAIL)
-
+        get_physical_port_list(port, physical_port_list)
         physical_port = physical_port_list[0]
         if per_npu_statedb[asic_index] is not None:
             y_cable_asic_table_keys = port_table_keys[asic_index]
             logical_key = "MUX_CABLE_TABLE|{}".format(port)
             if logical_key in y_cable_asic_table_keys:
-                import sonic_y_cable.y_cable
-                result = sonic_y_cable.y_cable.download_firmware(physical_port, fwfile)
-                if result == sonic_y_cable.y_cable.FIRMWARE_DOWNLOAD_SUCCESS:
-                    click.echo("firmware download successful {}".format(port))
-                else:
-                    click.echo("firmware download failure {}".format(port))
+                perform_download_firmware(physical_port, fwfile)
 
             else:
                 click.echo("this is not a valid port present on mux_cable".format(port))
@@ -711,32 +753,22 @@ def download(fwfile, port):
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
             for key in port_table_keys[asic_id]:
                 port = key.split("|")[1]
-                if platform_sfputil is not None:
-                    physical_port_list = platform_sfputil_helper.logical_port_name_to_physical_port_list(port)
 
-                if not isinstance(physical_port_list, list):
-                    click.echo(("ERR: Unable to locate physical port information for {}".format(port)))
-                    rc = False
-                    continue
+                physical_port_list = []
+                get_physical_port_list(port, physical_port_list)
 
-                if len(physical_port_list) != 1:
-                    click.echo("ERR: Found multiple physical ports ({}) associated with {}".format(
-                        ", ".join(physical_port_list), port))
-                    rc = False
-                    continue
                 physical_port = physical_port_list[0]
-                import sonic_y_cable.y_cable
-                result = sonic_y_cable.y_cable.download_firmware(physical_port, fwfile)
-                if result == sonic_y_cable.y_cable.FIRMWARE_DOWNLOAD_SUCCESS:
-                    click.echo("firmware download successful for {}".format(port))
-                else:
-                    click.echo("firmware download failure for {}".format(port))
+
+                status = perform_download_firmware(physical_port, fwfile)
+
+                if !status:
                     rc = False
 
         if rc:
             sys.exit(CONFIG_SUCCESSFUL)
         else:
             sys.exit(CONFIG_FAIL)
+
 
 @firmware.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
@@ -747,55 +779,17 @@ def activate(port):
     y_cable_asic_table_keys = {}
     per_npu_statedb = {}
 
-    # Getting all front asic namespace and correspding config and state DB connector
-
-    namespaces = multi_asic.get_front_end_namespaces()
-    for namespace in namespaces:
-        asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-        # replace these with correct macros
-        per_npu_statedb[asic_id] = SonicV2Connector(use_unix_socket_path=True, namespace=namespace)
-        per_npu_statedb[asic_id].connect(per_npu_statedb[asic_id].STATE_DB)
-
-
-        port_table_keys[asic_id] = per_npu_statedb[asic_id].keys(
-            per_npu_statedb[asic_id].STATE_DB, 'MUX_CABLE_TABLE|*')
+    get_per_npu_statedb(per_npu_statedb, port_table_keys)
 
     if port is not None and port != "all":
 
-        if platform_sfputil is not None:
-            physical_port_list = platform_sfputil_helper.logical_port_name_to_physical_port_list(port)
-
-        asic_index = None
-        if platform_sfputil is not None:
-            asic_index = platform_sfputil_helper.get_asic_id_for_logical_port(port)
-            if asic_index is None:
-                # TODO this import is only for unit test purposes, and should be removed once sonic_platform_base
-                # is fully mocked
-                import sonic_platform_base.sonic_sfp.sfputilhelper
-                asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
-                if asic_index is None:
-                    click.echo("Got invalid asic index for port {}, cant retreive mux status".format(port))
-
-        if not isinstance(physical_port_list, list):
-            click.echo(("ERR: Unable to locate physical port information for {}".format(port)))
-            sys.exit(CONFIG_FAIL)
-
-        if len(physical_port_list) != 1:
-            click.echo("ERR: Found multiple physical ports ({}) associated with {}".format(
-                ", ".join(physical_port_list), port))
-            sys.exit(CONFIG_FAIL)
-
+        get_physical_port_list(port, physical_port_list)
         physical_port = physical_port_list[0]
         if per_npu_statedb[asic_index] is not None:
             y_cable_asic_table_keys = port_table_keys[asic_index]
             logical_key = "MUX_CABLE_TABLE|{}".format(port)
             if logical_key in y_cable_asic_table_keys:
-                import sonic_y_cable.y_cable
-                result = sonic_y_cable.y_cable.activate_firmware(physical_port)
-                if result == sonic_y_cable.y_cable.FIRMWARE_ACTIVATE_SUCCESS:
-                    click.echo("firmware activate successful {}".format(port))
-                else:
-                    click.echo("firmware activate failure {}".format(port))
+                perform_activate_firmware(physical_port, fwfile)
 
             else:
                 click.echo("this is not a valid port present on mux_cable".format(port))
@@ -811,34 +805,20 @@ def activate(port):
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
             for key in port_table_keys[asic_id]:
                 port = key.split("|")[1]
-                if platform_sfputil is not None:
-                    physical_port_list = platform_sfputil_helper.logical_port_name_to_physical_port_list(port)
 
-                if not isinstance(physical_port_list, list):
-                    click.echo(("ERR: Unable to locate physical port information for {}".format(port)))
-                    rc = False
-                    continue
-
-                if len(physical_port_list) != 1:
-                    click.echo("ERR: Found multiple physical ports ({}) associated with {}".format(
-                        ", ".join(physical_port_list), port))
-                    rc = False
-                    continue
-
+                get_physical_port_list(port, physical_port_list)
                 physical_port = physical_port_list[0]
-                import sonic_y_cable.y_cable
-                result = sonic_y_cable.y_cable.activate_firmware(physical_port)
-                if result == sonic_y_cable.y_cable.FIRMWARE_ACTIVATE_SUCCESS:
-                    click.echo("firmware ACTIVATE successful for {}".format(port))
-                else:
-                    click.echo("firmware ACTIVATE failure for {}".format(port))
+                status = perform_activate_firmware(physical_port, fwfile)
+
+                if !status:
                     rc = False
 
         if rc:
             sys.exit(CONFIG_SUCCESSFUL)
         else:
             sys.exit(CONFIG_FAIL)
-            i
+
+
 @firmware.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
 def rollback(port):
@@ -848,55 +828,17 @@ def rollback(port):
     y_cable_asic_table_keys = {}
     per_npu_statedb = {}
 
-    # Getting all front asic namespace and correspding config and state DB connector
-
-    namespaces = multi_asic.get_front_end_namespaces()
-    for namespace in namespaces:
-        asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-        # replace these with correct macros
-        per_npu_statedb[asic_id] = SonicV2Connector(use_unix_socket_path=True, namespace=namespace)
-        per_npu_statedb[asic_id].connect(per_npu_statedb[asic_id].STATE_DB)
-
-
-        port_table_keys[asic_id] = per_npu_statedb[asic_id].keys(
-            per_npu_statedb[asic_id].STATE_DB, 'MUX_CABLE_TABLE|*')
+    get_per_npu_statedb(per_npu_statedb, port_table_keys)
 
     if port is not None and port != "all":
 
-        if platform_sfputil is not None:
-            physical_port_list = platform_sfputil_helper.logical_port_name_to_physical_port_list(port)
-
-        asic_index = None
-        if platform_sfputil is not None:
-            asic_index = platform_sfputil_helper.get_asic_id_for_logical_port(port)
-            if asic_index is None:
-                # TODO this import is only for unit test purposes, and should be removed once sonic_platform_base
-                # is fully mocked
-                import sonic_platform_base.sonic_sfp.sfputilhelper
-                asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
-                if asic_index is None:
-                    click.echo("Got invalid asic index for port {}, cant retreive mux status".format(port))
-
-        if not isinstance(physical_port_list, list):
-            click.echo(("ERR: Unable to locate physical port information for {}".format(port)))
-            sys.exit(CONFIG_FAIL)
-
-        if len(physical_port_list) != 1:
-            click.echo("ERR: Found multiple physical ports ({}) associated with {}".format(
-                ", ".join(physical_port_list), port))
-            sys.exit(CONFIG_FAIL)
-
+        get_physical_port_list(port, physical_port_list)
         physical_port = physical_port_list[0]
         if per_npu_statedb[asic_index] is not None:
             y_cable_asic_table_keys = port_table_keys[asic_index]
             logical_key = "MUX_CABLE_TABLE|{}".format(port)
             if logical_key in y_cable_asic_table_keys:
-                import sonic_y_cable.y_cable
-                result = sonic_y_cable.y_cable.rollback_firmware(physical_port)
-                if result == sonic_y_cable.y_cable.FIRMWARE_ROLLBACK_SUCCESS:
-                    click.echo("firmware rollback successful {}".format(port))
-                else:
-                    click.echo("firmware rollback failure {}".format(port))
+                perform_rollback_firmware(physical_port, fwfile)
 
             else:
                 click.echo("this is not a valid port present on mux_cable".format(port))
@@ -912,27 +854,12 @@ def rollback(port):
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
             for key in port_table_keys[asic_id]:
                 port = key.split("|")[1]
-                if platform_sfputil is not None:
-                    physical_port_list = platform_sfputil_helper.logical_port_name_to_physical_port_list(port)
 
-                if not isinstance(physical_port_list, list):
-                    click.echo(("ERR: Unable to locate physical port information for {}".format(port)))
-                    rc = False
-                    continue
-
-                if len(physical_port_list) != 1:
-                    click.echo("ERR: Found multiple physical ports ({}) associated with {}".format(
-                        ", ".join(physical_port_list), port))
-                    rc = False
-                    continue
-
+                get_physical_port_list(port, physical_port_list)
                 physical_port = physical_port_list[0]
-                import sonic_y_cable.y_cable
-                result = sonic_y_cable.y_cable.rollback_firmware(physical_port)
-                if result == sonic_y_cable.y_cable.FIRMWARE_ROLLBACK_SUCCESS:
-                    click.echo("firmware ROLLBACK successful for {}".format(port))
-                else:
-                    click.echo("firmware ROLLBACK failure for {}".format(port))
+                status = perform_rollback_firmware(physical_port, fwfile)
+
+                if !status:
                     rc = False
 
         if rc:

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -761,7 +761,7 @@ def download(fwfile, port):
 
                 status = perform_download_firmware(physical_port, fwfile)
 
-                if !status:
+                if status is not True:
                     rc = False
 
         if rc:
@@ -810,7 +810,7 @@ def activate(port):
                 physical_port = physical_port_list[0]
                 status = perform_activate_firmware(physical_port, fwfile)
 
-                if !status:
+                if status is not True:
                     rc = False
 
         if rc:
@@ -859,7 +859,7 @@ def rollback(port):
                 physical_port = physical_port_list[0]
                 status = perform_rollback_firmware(physical_port, fwfile)
 
-                if !status:
+                if status is not True:
                     rc = False
 
         if rc:

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -1005,7 +1005,7 @@ def version(port):
                 get_firmware_dict(physical_port, 0, "nic", mux_info_dict)
                 get_firmware_dict(physical_port, 1, "tor1", mux_info_dict)
                 get_firmware_dict(physical_port, 2, "tor2", mux_info_dict)
-                create_result_dict(physical_port, mux_info_dict, result_dict):
+                create_result_dict(physical_port, mux_info_dict, result_dict)
                 click.echo("{}".format(json.dumps(mux_info_dict, indent=4)))
 
             else:

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -899,7 +899,6 @@ def version(port):
             sys.exit(CONFIG_FAIL)
 
         mux_info_dict = {}
-        result_dict = {}
         physical_port = physical_port_list[0]
         if per_npu_statedb[asic_index] is not None:
             y_cable_asic_table_keys = port_table_keys[asic_index]

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -175,6 +175,20 @@ Port        Direction
 Ethernet12  standby
 """
 
+show_muxcable_firmware_version_expected_output = """\
+{
+    "version_self_active": "0.6MS",
+    "version_self_inactive": "0.6MS",
+    "version_self_next": "0.6MS",
+    "version_peer_active": "0.6MS",
+    "version_peer_inactive": "0.6MS",
+    "version_peer_next": "0.6MS",
+    "version_nic_active": "0.6MS",
+    "version_nic_inactive": "0.6MS",
+    "version_nic_next": "0.6MS"
+}
+"""
+
 
 class TestMuxcable(object):
     @classmethod
@@ -694,6 +708,76 @@ class TestMuxcable(object):
 
         result = runner.invoke(config.config.commands["muxcable"].commands["hwmode"].commands["state"],
                                ["standby", "all"], obj=db)
+        assert result.exit_code == 0
+
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    @mock.patch('sonic_y_cable.y_cable.get_firmware_version', mock.MagicMock(return_value={"version_active": "0.6MS",
+                                                                                           "version_inactive": "0.6MS",
+                                                                                           "version_next": "0.6MS"}))
+    def test_show_muxcable_firmware_version(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["firmware"].commands["version"], [
+                               "Ethernet0"], obj=db)
+        assert result.exit_code == 0
+        assert result.output == show_muxcable_firmware_version_expected_output
+
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    @mock.patch('sonic_y_cable.y_cable.download_fimware', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.FIRMWARE_DOWNLOAD_SUCCESS', mock.MagicMock(return_value=(1)))
+    def test_config_muxcable_download_firmware(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["muxcable"].commands["firmware"].commands["download"], [
+                               "fwfile", "Ethernet0"], obj=db)
+        assert result.exit_code == 0
+
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    @mock.patch('sonic_y_cable.y_cable.activate_firmware', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.FIRMWARE_ACTIVATE_SUCCESS', mock.MagicMock(return_value=(1)))
+    def test_config_muxcable_activate_firmware(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["muxcable"].commands["firmware"].commands["activate"], [
+                               "Ethernet0"], obj=db)
+        assert result.exit_code == 0
+
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    @mock.patch('sonic_y_cable.y_cable.rollback_firmware', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.FIRMWARE_ROLLBACK_SUCCESS', mock.MagicMock(return_value=(1)))
+    def test_config_muxcable_rollback_firmware(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["muxcable"].commands["firmware"].commands["rollback"], [
+                               "Ethernet0"], obj=db)
         assert result.exit_code == 0
 
     @classmethod


### PR DESCRIPTION
Summary:
This PR provides the support for adding CLI commands for activatie, download, upgrade firmware on the Y-cable
In particular these Cli commands are supported:
sudo config muxcable firmware download Ethernet0
sudo config muxcable firmware rollback Ethernet0
sudo config muxcable firmware download ~/AEC_WYOMING_B52Yb0_MS_0.6_20201218.bin Ethernet0

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added the support for firmware upgrade CLI on Y cable

#### How I did it
added the changes in sonic-utilities/show and sonic-utilities/config by changing the muxcable.py

```
admin@STR43-0101-0101-01LT0:/usr$ sudo config muxcable firmware download ~/AEC_WYOMING_B52Yb0_MS_0.6_20201218.bin Ethernet0
firmware download successful Ethernet0

admin@STR43-0101-0101-01LT0:~/credo_script_01_21$ sudo config muxcable firmware activate Ethernet0
firmware activate successful Ethernet0

admin@STR43-0101-0101-01LT0:~/credo_script_01_21$ sudo config muxcable firmware rollback Ethernet0
firmware rollback successful Ethernet0
```

#### How to verify it
Ran the command on a 7050cx3 arista switch

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

