### PR TITLE
[fwutil]: Fix next image mount

### DIFF
--- a/fwutil/lib.py
+++ b/fwutil/lib.py
@@ -210,7 +210,7 @@ class SquashFs(object):
     OVERLAY_MOUNTPOINT_TEMPLATE = "/tmp/image-{}-overlay"
 
     def __init__(self):
-        image_stem = self.next_image.lstrip(self.OS_PREFIX)
+        image_stem = self.next_image.replace(self.OS_PREFIX, EMPTY, 1)
 
         self.fs_path = self.FS_PATH_TEMPLATE.format(image_stem)
         self.fs_rw = self.FS_RW_TEMPLATE.format(image_stem)

--- a/fwutil/lib.py
+++ b/fwutil/lib.py
@@ -210,7 +210,10 @@ class SquashFs(object):
     OVERLAY_MOUNTPOINT_TEMPLATE = "/tmp/image-{}-overlay"
 
     def __init__(self):
-        image_stem = self.next_image.replace(self.OS_PREFIX, EMPTY, 1)
+        image_stem = self.next_image
+
+        if image_stem.startswith(self.OS_PREFIX):
+            image_stem = image_stem[len(self.OS_PREFIX):]
 
         self.fs_path = self.FS_PATH_TEMPLATE.format(image_stem)
         self.fs_rw = self.FS_RW_TEMPLATE.format(image_stem)
@@ -244,6 +247,9 @@ class SquashFs(object):
             self.fs_mountpoint
         )
         subprocess.check_call(cmd, shell=True)
+
+        if not (os.path.exists(self.fs_rw) and os.path.exists(self.fs_work)):
+            return self.fs_mountpoint
 
         os.mkdir(self.overlay_mountpoint)
         cmd = "mount -n -r -t overlay -o lowerdir={},upperdir={},workdir={} overlay {}".format(


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
* Fixed next image mount

#### How I did it
* Removed `lstrip`

#### How to verify it
1. root@sonic:/home/admin# fwutil update chassis component <component_name> fw -i next

#### Which release branch to backport (provide reason below if selected)
<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [x] 202012

#### Previous command output (if the output of a command-line utility has changed)
```bash
root@sonic:/home/admin# fwutil update chassis component SSD fw -i next
mount: /tmp/image-IC.202012.53-aee4892c_Internal-fs: special device /host/image-IC.202012.53-aee4892c_Internal/fs.squashfs does not exist.
Error: Command 'mount -t squashfs /host/image-IC.202012.53-aee4892c_Internal/fs.squashfs /tmp/image-IC.202012.53-aee4892c_Internal-fs' returned non-zero exit status 32.. Aborting...
Aborted!

root@sonic:/home/admin# fwutil update chassis component SSD fw -i next
mount: /tmp/image-SONIC.202012.55-0269fc1_Internal-overlay: special device overlay does not exist.
Error: Command 'mount -n -r -t overlay -o lowerdir=/tmp/image-SONIC.202012.55-0269fc1_Internal-fs,upperdir=/host/image-SONIC.202012.55-0269fc1_Internal/rw,workdir=/host/image-SONIC.202012.55-0269fc1_Internal/work overlay /tmp/image-SONIC.202012.55-0269fc1_Internal-overlay' returned non-zero exit status 32.. Aborting...
Aborted!
```

#### New command output (if the output of a command-line utility has changed)
```bash
root@sonic:/home/admin# fwutil update chassis component SSD fw -i next
Info: Firmware update is not available.
```