### PR TITLE
[reboot] No need enable the Linux magic system request key

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -17,7 +17,6 @@ if [ -e $VMCORE_FILE -a -s $VMCORE_FILE ]; then
         fi
         # If no platform-specific reboot tool, just run /sbin/reboot
         /sbin/reboot
-        echo 1 > /proc/sys/kernel/sysrq
         echo b > /proc/sysrq-trigger
 fi
 


### PR DESCRIPTION
Signed-off-by: Yong Zhao <yozhao@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
As introduced by the [kernel doc](https://mjmwired.net/kernel/Documentation/sysrq.txt#37), we do not need the line 20 in reboot script since it only influenced the capability to reboot the Linux kernel by hitting the combo magic key of keyboard.

#### How I did it
I removed this command.

#### How to verify it
I can reboot the Linux kernel by running command `echo b > /proc/sysrq-trigger` with root privilege. As such, there is no need to keep the line 20 in reboot script.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

