### PR TITLE
[acl_loader]: add iptype match to the rules for dataplane acl

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -299,6 +299,22 @@ class AclLoader(object):
         """
         return self.tables_db_info[tname]['type'].upper().startswith(self.ACL_TABLE_TYPE_MIRROR)
 
+    def is_table_l3v6(self, tname):
+        """
+        Check if ACL table type is L3V6
+        :param tname: ACL table name
+        :return: True if table type is L3V6 else False
+        """
+        return self.tables_db_info[tname]["type"].upper() == "L3V6"
+
+    def is_table_l3(self, tname):
+        """
+        Check if ACL table type is L3
+        :param tname: ACL table name
+        :return: True if table type is L3 else False
+        """
+        return self.tables_db_info[tname]["type"].upper() == "L3"
+
     def is_table_ipv6(self, tname):
         """
         Check if ACL table type is IPv6 (L3V6 or MIRRORV6)
@@ -592,6 +608,12 @@ class AclLoader(object):
         rule_data = {(table_name, "RULE_" + str(rule_idx)): rule_props}
 
         rule_props["PRIORITY"] = str(self.max_priority - rule_idx)
+
+        # setup default ip type match to dataplane acl (could be overriden by rule later)
+        if self.is_table_l3v6(table_name):
+            rule_props["IP_TYPE"] = "IPV6ANY"  # ETHERTYPE is not supported for DATAACLV6
+        elif self.is_table_l3(table_name):
+            rule_props["ETHER_TYPE"] = str(self.ethertype_map["ETHERTYPE_IPV4"])
 
         deep_update(rule_props, self.convert_action(table_name, rule_idx, rule))
         deep_update(rule_props, self.convert_l2(table_name, rule_idx, rule))

--- a/tests/acl_input/acl1.json
+++ b/tests/acl_input/acl1.json
@@ -189,6 +189,22 @@
 										"destination-ip-address": "30.0.0.3/32"
 									}
 								}
+							},
+							"3": {
+								"config": {
+									"sequence-id": 3
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"l2": {
+									"config": {
+										"vlan-id": "369",
+										"ethertype": "ETHERTYPE_LLDP"
+									}
+								}
 							}
 						}
 					}

--- a/tests/acl_loader_test.py
+++ b/tests/acl_loader_test.py
@@ -60,6 +60,7 @@ class TestAclLoader(object):
         assert acl_loader.rules_info[("DATAACL", "RULE_2")]
         assert acl_loader.rules_info[("DATAACL", "RULE_2")] == {
             "VLAN_ID": 369,
+            "ETHER_TYPE": "2048",
             "IP_PROTOCOL": 6,
             "SRC_IP": "20.0.0.2/32",
             "DST_IP": "30.0.0.3/32",
@@ -82,6 +83,17 @@ class TestAclLoader(object):
             acl_loader.rules_info = {}
             acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_vlan_nan.json'))
 
+    def test_ethertype_translation(self, acl_loader):
+        acl_loader.rules_info = {}
+        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/acl1.json'))
+        assert acl_loader.rules_info[("DATAACL", "RULE_3")]
+        assert acl_loader.rules_info[("DATAACL", "RULE_3")] == {
+            "VLAN_ID": 369,
+            "ETHER_TYPE": 35020,
+            "PACKET_ACTION": "FORWARD",
+            "PRIORITY": "9997"
+        }
+
     def test_icmp_translation(self, acl_loader):
         acl_loader.rules_info = {}
         acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/acl1.json'))
@@ -92,6 +104,7 @@ class TestAclLoader(object):
             "IP_PROTOCOL": 1,
             "SRC_IP": "20.0.0.2/32",
             "DST_IP": "30.0.0.3/32",
+            "ETHER_TYPE": "2048",
             "PACKET_ACTION": "FORWARD",
             "PRIORITY": "9999"
         }
@@ -106,6 +119,7 @@ class TestAclLoader(object):
             "IP_PROTOCOL": 58,
             "SRC_IPV6": "::1/128",
             "DST_IPV6": "::1/128",
+            "IP_TYPE": "IPV6ANY",
             "PACKET_ACTION": "FORWARD",
             "PRIORITY": "9999"
         }
@@ -114,6 +128,7 @@ class TestAclLoader(object):
             "IP_PROTOCOL": 58,
             "SRC_IPV6": "::1/128",
             "DST_IPV6": "::1/128",
+            "IP_TYPE": "IPV6ANY",
             "PACKET_ACTION": "FORWARD",
             "PRIORITY": "9900"
         }


### PR DESCRIPTION


<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
dataplane acl has v4 and v6 type. in case the rule does not
specify the iptype, the acl_loader will automatically add
the match for the iptype based on the table type.

for l3 table, it will add ethertype = 0x800
for l3v6 table, it will add iptype = ipv4any

Signed-off-by: Guohan Lu <lguohan@gmail.com>

#### How I did it

#### How to verify it
unit test

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

