### PR TITLE
[ci]: use the same snapshot of pytests as the docker-sonic-vs image

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -30,14 +30,22 @@ jobs:
       runBranch: 'refs/heads/master'
     displayName: "Download sonic swss common deb packages"
 
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      source: specific
+      project: build
+      pipeline: 15
+      artifact: sonic-swss-pytests
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/master'
+    displayName: "Download sonic swss pytests"
+
   - checkout: self
-    displayName: "Checkout sonic-swss-common"
-  - checkout: sonic-swss
-    displayName: "Checkout sonic-swss"
+    displayName: "Checkout sonic-utilities"
 
   - script: |
       set -x
-      sudo sonic-utilities/.azure-pipelines/build_and_install_module.sh
+      sudo .azure-pipelines/build_and_install_module.sh
 
       sudo apt-get install -y libhiredis0.14
       sudo dpkg -i --force-confask,confnew ../libswsscommon_1.0.0_amd64.deb || apt-get install -f
@@ -54,7 +62,8 @@ jobs:
       sudo docker load -i ../docker-sonic-vs.gz
       docker ps
       ip netns list
-      pushd sonic-swss/tests
+      tar xf ../pytest.tgz
+      pushd tests
       sudo py.test -v --force-flaky --junitxml=tr.xml --imgname=docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber)
     displayName: "Run vs tests"
 
@@ -65,7 +74,7 @@ jobs:
     condition: always()
 
   - script: |
-      cp -r sonic-swss/tests/log $(Build.ArtifactStagingDirectory)/
+      cp -r tests/log $(Build.ArtifactStagingDirectory)/
     displayName: "Collect logs"
     condition: always()
 

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -62,6 +62,9 @@ jobs:
       sudo docker load -i ../docker-sonic-vs.gz
       docker ps
       ip netns list
+      cd ../
+      mkdir -p sonic-swss
+      pushd sonic-swss
       tar xf ../pytest.tgz
       pushd tests
       sudo py.test -v --force-flaky --junitxml=tr.xml --imgname=docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber)

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -77,7 +77,7 @@ jobs:
     condition: always()
 
   - script: |
-      cp -r tests/log $(Build.ArtifactStagingDirectory)/
+      cp -r ../sonic-swss/tests/log $(Build.ArtifactStagingDirectory)/
     displayName: "Collect logs"
     condition: always()
 


### PR DESCRIPTION


<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
use the same snapshot of pytests as the docker-sonic-vs image

#### Why I did it
in case sonic-swss build failure, the docker-sonic-vs may not
match exactly the same pytest checkout from master

Signed-off-by: Guohan Lu <lguohan@gmail.com>

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

