### PR TITLE
[fast-reboot] Fix fast-reboot-dump.py SonicV2Connector after late merge

### DIFF
--- a/scripts/fast-reboot-dump.py
+++ b/scripts/fast-reboot-dump.py
@@ -190,8 +190,8 @@ def get_fdb(db, vlan_name, vlan_id, bridge_id_2_iface):
     return fdb_entries, available_macs, map_mac_ip
 
 def generate_fdb_entries(filename):
-    asic_db = swsssdk.SonicV2Connector(host='127.0.0.1')
-    app_db = swsssdk.SonicV2Connector(host='127.0.0.1')
+    asic_db = SonicV2Connector(use_unix_socket_path=False)
+    app_db = SonicV2Connector(use_unix_socket_path=False)
     asic_db.connect(asic_db.ASIC_DB, False)   # Make one attempt only
     app_db.connect(app_db.APPL_DB, False)   # Make one attempt only
 


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This PR https://github.com/Azure/sonic-utilities/pull/1393 merged after PR: https://github.com/Azure/sonic-utilities/pull/1392
This caused the first PR to be not aligned with SonicV2Connector change.
This PR motivation is to fix it.

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

