### PR TITLE
[console] Include Flow Control status in show line result

### DIFF
--- a/consutil/main.py
+++ b/consutil/main.py
@@ -41,7 +41,7 @@ def show(db, brief):
     ports.sort(key=lambda p: int(p.line_num))
 
     # set table header style
-    header = ["Line", "Baud", "PID", "Start Time", "Device"]
+    header = ["Line", "Baud", "Flow Control", "PID", "Start Time", "Device"]
     body = []
     for port in ports:
         # runtime information
@@ -49,7 +49,8 @@ def show(db, brief):
         pid = port.session_pid if port.session_pid else "-"
         date = port.session_start_date if port.session_start_date else "-"
         baud = port.baud
-        body.append([busy+port.line_num, baud if baud else "-", pid if pid else "-", date if date else "-", port.remote_device])
+        flow_control = "Enabled" if port.flow_control else "Disabled"
+        body.append([busy+port.line_num, baud if baud else "-", flow_control, pid if pid else "-", date if date else "-", port.remote_device])
     click.echo(tabulate(body, header, stralign='right'))
 
 # 'clear' subcommand

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -1993,13 +1993,13 @@ This command displays serial port or a virtual network connection status.
 - Example:
   ```
   admin@sonic:~$ show line
-  Line    Baud    PID    Start Time    Device
-  ------  ------  -----  ------------  --------
-      0       -      -             -
-      1    9600      -             -   switch1
-      2       -      -             -
-      3       -      -             -
-      4       -      -             -
+    Line    Baud    Flow Control    PID    Start Time    Device
+  ------  ------  --------------  -----  ------------  --------
+       1    9600         Enabled      -             -   switch1
+       2       -        Disabled      -             -
+       3       -        Disabled      -             -
+       4       -        Disabled      -             -
+       5       -        Disabled      -             -
   ```
 
 Optionally, you can display configured console ports only by specifying the `-b` or `--breif` flag.
@@ -2007,9 +2007,9 @@ Optionally, you can display configured console ports only by specifying the `-b`
 - Example:
   ```
   admin@sonic:~$ show line -b
-    Line    Baud    PID    Start Time    Device
-  ------  ------  -----  ------------  --------
-       1    9600      -             -   switch1
+    Line    Baud    Flow Control    PID    Start Time    Device
+  ------  ------  --------------  -----  ------------  --------
+       1    9600         Enabled      -             -   switch1
   ```
 
 ## Console config commands

--- a/tests/console_test.py
+++ b/tests/console_test.py
@@ -531,11 +531,11 @@ class TestConsutilShow(object):
         print("SETUP")
 
     expect_show_output = ''+ \
-        """  Line    Baud    PID                Start Time    Device
-------  ------  -----  ------------------------  --------
-     1    9600      -                         -   switch1
-    *2    9600    223  Wed Mar  6 08:31:35 2019   switch2
-     3    9600      -                         -
+        """  Line    Baud    Flow Control    PID                Start Time    Device
+------  ------  --------------  -----  ------------------------  --------
+     1    9600        Disabled      -                         -   switch1
+    *2    9600        Disabled    223  Wed Mar  6 08:31:35 2019   switch2
+     3    9600         Enabled      -                         -
 """
     @mock.patch('consutil.lib.SysInfoProvider.init_device_prefix', mock.MagicMock(return_value=None))
     def test_show(self):
@@ -543,7 +543,7 @@ class TestConsutilShow(object):
         db = Db()
         db.cfgdb.set_entry("CONSOLE_PORT", 1, { "remote_device" : "switch1", "baud_rate" : "9600" })
         db.cfgdb.set_entry("CONSOLE_PORT", 2, { "remote_device" : "switch2", "baud_rate" : "9600" })
-        db.cfgdb.set_entry("CONSOLE_PORT", 3, { "baud_rate" : "9600" })
+        db.cfgdb.set_entry("CONSOLE_PORT", 3, { "baud_rate" : "9600", "flow_control" : "1" })
 
         db.db.set(db.db.STATE_DB, "CONSOLE_PORT|2", "state", "busy")
         db.db.set(db.db.STATE_DB, "CONSOLE_PORT|2", "pid", "223")


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Include flow control status in `show line` result.

#### How I did it

1. Render the flow control option in `show line` table
2. Update unit test case
3. Update document

#### How to verify it

1. UT pass
2. Install and test the new package in a physical SONiC box

#### Previous command output (if the output of a command-line utility has changed)

```
admin@sonic:~$ show line
  Line    Baud    PID    Start Time    Device
------  ------  -----  ------------  --------
     1    9600      -             -
     2       -      -             -
     3       -      -             -
     4       -      -             -
     5       -      -             -
```

#### New command output (if the output of a command-line utility has changed)

```
admin@sonic:~$ show line
  Line    Baud    Flow Control    PID    Start Time    Device
------  ------  --------------  -----  ------------  --------
     1    9600         Enabled      -             -
     2       -        Disabled      -             -
     3       -        Disabled      -             -
     4       -        Disabled      -             -
     5       -        Disabled      -             -
```
