### PR TITLE
Fixed the possibility of using uninitialized variable in route_check.py

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -390,6 +390,8 @@ def check_routes():
     rt_asic_miss = []
 
     results = {}
+    adds = []
+    deletes = []
 
     selector, subs, rt_asic = get_route_entries()
 
@@ -431,8 +433,8 @@ def check_routes():
     if results:
         print_message(syslog.LOG_WARNING, "Failure results: {",  json.dumps(results, indent=4), "}")
         print_message(syslog.LOG_WARNING, "Failed. Look at reported mismatches above")
-        print_message(syslog.LOG_WARNING, "add: {", json.dumps(adds, indent=4), "}")
-        print_message(syslog.LOG_WARNING, "del: {", json.dumps(deletes, indent=4), "}")
+        print_message(syslog.LOG_WARNING, "add: ", json.dumps(adds, indent=4))
+        print_message(syslog.LOG_WARNING, "del: ", json.dumps(deletes, indent=4))
         return -1, results
     else:
         print_message(syslog.LOG_INFO, "All good!")


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Declared uninitialized variable, before its use.
No logical code change, other than avoiding crash in a print statement.

#### How I did it

#### How to verify it
Little tough. We need a APP & ASIC DBs in sync state and run route_check.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

