### PR TITLE
No more IP validation as it is more likely a URL

### DIFF
--- a/config/kube.py
+++ b/config/kube.py
@@ -21,22 +21,6 @@ KUBE_STATE_SERVER_TS = "last_update_ts"
 KUBE_LABEL_TABLE = "KUBE_LABELS"
 KUBE_LABEL_SET_KEY = "SET"
 
-def is_valid_ip4_addr(address):
-    try:
-        socket.inet_pton(socket.AF_INET, address)
-    except socket.error:  # not a valid address
-        return False
-    return True
-
-
-def is_valid_ip6_addr(address):
-    try:
-        socket.inet_pton(socket.AF_INET6, address)
-    except socket.error:  # not a valid address
-        return False
-    return True
-
-
 def _update_kube_server(db, field, val):
     db_data = db.cfgdb.get_entry(KUBE_SERVER_TABLE_NAME, KUBE_SERVER_TABLE_KEY)
     def_data = {
@@ -82,9 +66,7 @@ def server():
 @pass_db
 def ip(db, vip):
     """Specify a kubernetes cluster VIP"""
-    if vip and not is_valid_ip4_addr(vip) and not is_valid_ip6_addr(vip):
-        click.echo('Invalid IP address %s' % vip)
-        sys.exit(1)
+
     _update_kube_server(db, KUBE_SERVER_IP, vip)
 
 

--- a/config/kube.py
+++ b/config/kube.py
@@ -1,5 +1,4 @@
 import click
-import socket
 
 from utilities_common.cli import AbbreviationGroup, pass_db
 

--- a/tests/kube_test.py
+++ b/tests/kube_test.py
@@ -125,14 +125,10 @@ class TestKube(object):
         self.__check_res(result, "check server IP", show_server_output_1)
 
 
-    def test_set_server_invalid_ip_port(self, get_cmd_module):
+    def test_set_server_invalid_port(self, get_cmd_module):
         (config, show) = get_cmd_module
         db = Db()
         runner = CliRunner()
-
-        # test invalid IP
-        result = runner.invoke(config.config.commands["kubernetes"].commands["server"], ["ip", "10101011"], obj=db)
-        assert result.exit_code == 1
 
         # test invalid port
         result = runner.invoke(config.config.commands["kubernetes"].commands["server"], ["port", "10101011"], obj=db)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Dropped IP validation as server takes URL.

#### How I did it

#### How to verify it
Provide a URL for IP in kube server config command.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

