### PR TITLE
[201911] Fix show interface status command when interface is provided

### DIFF
--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -388,6 +388,8 @@ class IntfStatus(object):
                                 appl_db_port_status_get(self.db, key, PORT_ADMIN_STATUS),
                                 state_db_port_optics_get(self.db, key, PORT_OPTICS_TYPE),
                                 appl_db_port_status_get(self.db, key, PORT_PFC_ASYM_STATUS)))
+            if self.intf_name:
+                return table
 
             for po, value in self.portchannel_speed_dict.iteritems():
                 if self.multi_asic.skip_display(constants.PORT_CHANNEL_OBJ, po):
@@ -420,7 +422,7 @@ class IntfStatus(object):
     @multi_asic_util.run_on_multi_asic
     def get_intf_status(self):
         self.front_panel_ports_list = get_frontpanel_port_list(self.config_db)
-        self.appl_db_keys = appl_db_keys_get(self.db, self.front_panel_ports_list, None)
+        self.appl_db_keys = appl_db_keys_get(self.db, self.front_panel_ports_list, self.intf_name)
         self.int_to_vlan_dict = get_interface_vlan_dict(self.config_db)
         self.get_raw_po_int_configdb_info = get_raw_portchannel_info(self.config_db)
         self.portchannel_list = get_portchannel_list(self.get_raw_po_int_configdb_info)

--- a/sonic-utilities-tests/intfutil_test.py
+++ b/sonic-utilities-tests/intfutil_test.py
@@ -27,16 +27,37 @@ class TestIntfutil(TestCase):
         result = self.runner.invoke(show.cli.commands["interfaces"].commands["status"], [])
         print >> sys.stderr, result.output
         expected_output = (
-              "Interface    Lanes    Speed    MTU    FEC      Alias    Vlan    Oper    Admin             Type    Asym PFC\n"
-            "-----------  -------  -------  -----  -----  ---------  ------  ------  -------  ---------------  ----------\n"
-            "  Ethernet0        0      25G   9100     rs  Ethernet0  routed    down       up  QSFP28 or later         off"
+           "      Interface    Lanes    Speed    MTU    FEC       Alias             Vlan    Oper    Admin             Type    Asym PFC\n"
+           "---------------  -------  -------  -----  -----  ----------  ---------------  ------  -------  ---------------  ----------\n"
+           "      Ethernet0        0      25G   9100     rs   Ethernet0           routed    down       up  QSFP28 or later         off\n"
+           "    Ethernet104        0      25G   9100     rs  Ethernet20  PortChannel1001    down       up              N/A         off\n"
+           "PortChannel1001      N/A      25G   9100    N/A         N/A           routed      up       up              N/A         N/A\n"
         )
-        self.assertEqual(result.output.strip(), expected_output)
+        self.assertEqual(result.output, expected_output)
 
         # Test 'intfutil status'
         output = subprocess.check_output('intfutil -c status', stderr=subprocess.STDOUT, shell=True)
         print >> sys.stderr, output
-        self.assertEqual(output.strip(), expected_output)
+        self.assertEqual(output, expected_output)
+
+    # Test 'show interfaces status Ethernet104' / 'intfutil status -i Ethernet104'
+    def test_intf_status_Ethernet104(self):
+        # Test 'show interfaces status'
+        result = self.runner.invoke(show.cli.commands["interfaces"].commands["status"], ["Ethernet104"])
+        print >> sys.stderr, result.output
+        expected_output = (
+           "  Interface    Lanes    Speed    MTU    FEC       Alias             Vlan    Oper    Admin    Type    Asym PFC\n"
+           "-----------  -------  -------  -----  -----  ----------  ---------------  ------  -------  ------  ----------\n"
+           "Ethernet104        0      25G   9100     rs  Ethernet20  PortChannel1001    down       up     N/A         off\n"
+
+        )
+        self.assertEqual(result.output, expected_output)
+
+        # Test 'intfutil status'
+        output = subprocess.check_output('intfutil -c status -i Ethernet104', stderr=subprocess.STDOUT, shell=True)
+        print >> sys.stderr, output
+        self.assertEqual(output, expected_output)
+
 
     # Test 'show interfaces status --verbose'
     def test_intf_status_verbose(self):

--- a/sonic-utilities-tests/mock_tables/appl_db.json
+++ b/sonic-utilities-tests/mock_tables/appl_db.json
@@ -10,6 +10,17 @@
         "fec": "rs",
         "admin_status": "up"
     },
+    "PORT_TABLE:Ethernet104": {
+        "lanes": "0",
+        "alias": "Ethernet20",
+        "description": "ARISTA02T2:Ethernet1",
+        "speed": "25000",
+        "oper_status": "down",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "fec": "rs",
+        "admin_status": "up"
+    },
     "PORT_TABLE:Ethernet200": {
         "lanes": "200,201,202,203",
         "alias": "Ethernet200",
@@ -19,6 +30,11 @@
         "fec": "rs",
         "mtu": "9100",
         "pfc_asym": "off"
+    },
+    "LAG_TABLE:PortChannel1001": {
+        "admin_status": "up",
+        "oper_status": "up",
+        "mtu": "9100"
     },
     "INTF_TABLE:Ethernet0.10": {
         "admin_status": "up"

--- a/sonic-utilities-tests/mock_tables/config_db.json
+++ b/sonic-utilities-tests/mock_tables/config_db.json
@@ -42,6 +42,17 @@
         "mtu": "9100",
         "speed": "40000"
     },
+    "PORTCHANNEL|PortChannel1001": {
+        "admin_status": "up",
+        "members": [
+            "Ethernet104"
+        ],
+        "min_links": "1",
+        "mtu": "9100"
+    },
+    "PORTCHANNEL_MEMBER|PortChannel1001|Ethernet104": {
+        "NULL": "NULL"
+    },
     "VLAN_SUB_INTERFACE|Ethernet0.10": {
         "admin_status": "up"
     },

--- a/sonic-utilities-tests/multi_asic_intfutil_test.py
+++ b/sonic-utilities-tests/multi_asic_intfutil_test.py
@@ -110,6 +110,13 @@ class TestInterfacesMultiAsic(object):
         assert return_code == 0
         assert result == intf_status
 
+    def test_multi_asic_interface_status_Ethernet0(self):
+        return_code, result = get_result_and_return_code( 'intfutil -c status -i Ethernet0')
+        print("return_code: {}".format(return_code))
+        print("result = {}".format(result))
+        assert return_code == 0
+        assert result == intf_status_Ethernet0
+
     def test_multi_asic_interface_status_asic0_all(self):
         return_code, result = get_result_and_return_code('intfutil -c status -n asic0 -d all')
         print("return_code: {}".format(return_code))


### PR DESCRIPTION
What/Why I did:

Fix in 201911 branch:
```
- show interface status Ethernet* 
- intfutil -c status -i <interface>
```

How I did:

- Pass the interface name 
- Skip Port channel Output when interface name is provided

How I verfied:
Added unit test case. Some of this test case are missing for master also and will be added as separate PR.

