### PR TITLE
[techsupport] Update show ip interface command

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -242,17 +242,20 @@ copy_from_docker() {
     local dstpath=$3
     local timeout_cmd="timeout --foreground ${TIMEOUT_MIN}m"
 
+    local touch_cmd="sudo docker exec -i ${docker} touch ${filename}"
+    local cp_cmd="sudo docker cp ${docker}:${filename} ${dstpath}"
+
     if $NOOP; then
-        echo "${timeout_cmd} sudo docker exec -i ${docker} touch ${filename}"
-        echo "${timeout_cmd} sudo docker cp ${docker}:${filename} ${dstpath}"
+        echo "${timeout_cmd} ${touch_cmd}"
+        echo "${timeout_cmd} ${cp_cmd}"
     else
-        eval "${timeout_cmd} sudo docker exec -i ${docker} touch ${filename}"
+        eval "${timeout_cmd} ${touch_cmd}"
         if [ $? -ne 0 ]; then
-            echo "Command: $cmd timedout after ${TIMEOUT_MIN} minutes."
+            echo "Command: $touch_cmd timedout after ${TIMEOUT_MIN} minutes."
         fi
-        eval "${timeout_cmd} sudo docker cp ${docker}:${filename} ${dstpath}"
+        eval "${timeout_cmd} ${cp_cmd}"
         if [ $? -ne 0 ]; then
-            echo "Command: $cmd timedout after ${TIMEOUT_MIN} minutes."
+            echo "Command: $cp_cmd timedout after ${TIMEOUT_MIN} minutes."
         fi
     fi
     end_t=$(date +%s%3N)

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1084,7 +1084,7 @@ main() {
     save_cmd "show interface status -d all" "interface.status"
     save_cmd "show interface transceiver presence" "interface.xcvrs.presence"
     save_cmd "show interface transceiver eeprom --dom" "interface.xcvrs.eeprom"
-    save_cmd_all_ns "show ip interface" "ip.interface"
+    save_cmd "show ip interface -d all" "ip.interface"
 
     save_cmd "lldpctl" "lldpctl"
     if [[ ( "$NUM_ASICS" > 1 ) ]]; then


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Update "show ip interface" command

After adding multi ASIC support to "show ip interface" CLI command, the existing command in tech support collection script will not work.

#### How I did it
Updated the command

#### How to verify it
```
admin@svcstr-nmasic-acs-1:~$ show ip interface -d all
Interface        Master    IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
---------------  --------  -------------------  ------------  --------------  -------------
Loopback0                  10.1.0.32/32         up/up         N/A             N/A
Loopback4096               8.0.0.0/32           up/up         N/A             N/A
                           8.0.0.1/32                         N/A             N/A
                           8.0.0.2/32                         N/A             N/A
                           8.0.0.3/32                         N/A             N/A
                           8.0.0.4/32                         N/A             N/A
                           8.0.0.5/32                         N/A             N/A
PortChannel0001            10.0.0.32/31         up/up         ARISTA01T0      10.0.0.33
PortChannel0002            10.0.0.0/31          up/up         ARISTA01T2      10.0.0.1
PortChannel0003            10.0.0.34/31         up/up         ARISTA02T0      10.0.0.35
PortChannel0004            10.0.0.36/31         up/up         ARISTA03T0      10.0.0.37
PortChannel0005            10.0.0.4/31          up/up         ARISTA03T2      10.0.0.5
.
.
.
eth0                       240.127.1.7/24       up/up         N/A             N/A
                           240.127.1.3/24                     N/A             N/A
                           240.127.1.2/24                     N/A             N/A
                           240.127.1.5/24                     N/A             N/A
                           240.127.1.4/24                     N/A             N/A
                           240.127.1.6/24                     N/A             N/A
                           10.206.144.15/24                   N/A             N/A
lo                         127.0.0.1/8          up/up         N/A             N/A
```

Unbound variable:

before:

```
Error response from daemon: Container 5765564f41bee75f4349e5ddc2e7a20bc85a3fa852dd1986540cba7375660701 is not running
/usr/bin/generate_dump: line 251: cmd: unbound variable
```

after:
```
admin@str-s6000-acs-8:~$ sudo generate_dump -s "-1 hours"
Error response from daemon: Container 5765564f41bee75f4349e5ddc2e7a20bc85a3fa852dd1986540cba7375660701 is not running
Command: sudo docker exec -i syncd touch /var/log/diagrun.log timedout after 5 minutes.
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

