### PR TITLE
[201911][acl] Use a list instead of a comma-separated string for ACL port list

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2594,7 +2594,7 @@ def parse_acl_table_info(table_name, table_type, description, ports, stage):
     if ports:
         for port in ports.split(","):
             port_list += expand_vlan_ports(port)
-        port_list = set(port_list)
+        port_list = list(set(port_list))  # convert to set first to remove duplicate ifaces
     else:
         port_list = valid_acl_ports
 
@@ -2602,7 +2602,7 @@ def parse_acl_table_info(table_name, table_type, description, ports, stage):
         if port not in valid_acl_ports:
             raise ValueError("Cannot bind ACL to specified port {}".format(port))
 
-    table_info["ports@"] = ",".join(port_list)
+    table_info["ports"] = port_list
 
     table_info["stage"] = stage
 

--- a/sonic-utilities-tests/acl_config_test.py
+++ b/sonic-utilities-tests/acl_config_test.py
@@ -24,9 +24,7 @@ class TestConfigAcl(object):
         assert table_info["type"] == "L3"
         assert table_info["policy_desc"] == "TEST"
         assert table_info["stage"] == "egress"
-
-        port_list = table_info["ports@"].split(",")
-        assert set(port_list) == {"Ethernet20", "Ethernet100"}
+        assert set(table_info["ports"]) == {"Ethernet20", "Ethernet100"}
 
     def test_parse_table_with_vlan_and_duplicates(self):
         table_info = config.parse_acl_table_info("TEST", "L3", None, "Ethernet20,Vlan1000", "egress")
@@ -34,10 +32,10 @@ class TestConfigAcl(object):
         assert table_info["policy_desc"] == "TEST"
         assert table_info["stage"] == "egress"
 
-        # Since Ethernet4 is a member of Vlan1000 we should not include it twice in the output
-        port_list = table_info["ports@"].split(",")
-        assert len(port_list) == 2
-        assert set(port_list) == {"Ethernet20", "Ethernet100"}
+        # Since Ethernet20 is a member of Vlan1000 we should not include it twice in the output
+        port_set = set(table_info["ports"])
+        assert len(port_set) == 2
+        assert set(port_set) == {"Ethernet20", "Ethernet100"}
 
     def test_parse_table_with_empty_vlan(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

How I did it
I discovered that using the @ syntax to insert the port list as a comma-separated list/array actually causes the port list to be deleted when the same table is config add-ed multiple times. Using a list works. (We still need to determine the root cause for why the @ syntax fails).

How to verify it
Updated the tests and ran the command locally to verify the fix. Still working on adding a new regression test case for this.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

