### PR TITLE
Platform specific version invoked by generic show.version

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -977,6 +977,12 @@ def version(verbose):
     click.echo("ASIC: {}".format(asic_type))
     click.echo("ASIC Count: {}".format(asic_count))
     click.echo("Serial Number: {}".format(serial_number.stdout.read().strip()))
+    try:
+        sonic_platform.cli.show.version(verbose)
+    except (AttributeError, NameError):
+        pass
+    except Exception as e:
+        click.echo(e)
     click.echo("Uptime: {}".format(sys_uptime.stdout.read().strip()))
     click.echo("\nDocker images:")
     cmd = 'sudo docker images --format "table {{.Repository}}\\t{{.Tag}}\\t{{.ID}}\\t{{.Size}}"'


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This generic enhancement can invoke a platform specific show version method "if available" else skip. The routine is helpful to provide details of Vendor Specific SDK info or SKU etc. 

#### How I did it

Simply Invoke a  python platform routine for capturing any platform specific variables if exists. 

#### How to verify it

cisco@sonic:~$ show version

<...snip...>

Cisco Silicon One SDK: 1.33.1-SDK-1.5.2-17
Cisco BSP: 0.1.11-32-g19b3d77
Cisco FPD: 0.1-22-gfbde9e1

<...snip...>



#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

