### PR TITLE
[ 201911 ] Fixed value error when check whether IP address relates to IPv4/IPv6

### DIFF
--- a/scripts/fast-reboot-dump.py
+++ b/scripts/fast-reboot-dump.py
@@ -274,7 +274,7 @@ def send_garp_nd(neighbor_entries, map_mac_ip_per_vlan):
     # send arp/ndp packets
     for vlan_name, dst_mac, dst_ip in neighbor_entries:
         src_if = map_mac_ip_per_vlan[vlan_name][dst_mac]
-        if ipaddress.ip_interface(dst_ip).ip.version == 4:
+        if ipaddress.ip_interface(unicode(dst_ip)).ip.version == 4:
             send_arp(sockets[src_if], src_mac_addrs[src_if], src_ip_addrs[vlan_name], dst_mac, dst_ip)
         else:
             send_ndp(sockets[src_if], src_mac_addrs[src_if], src_ip_addrs[vlan_name], dst_mac, dst_ip)


### PR DESCRIPTION
#### What I did
When run [fast_reboot](https://github.com/Azure/sonic-mgmt/blob/master/tests/platform_tests/test_advanced_reboot.py) TC it fails due to error:
`ERR fast-reboot-dump: Got an exception '192.168.1.133' does not appear to be an IPv4 or IPv6 interface: Traceback: Traceback (most recent call last):#012  File "/usr/bin/fast-reboot-dump.py", line 340, in <module>#012    res = main()#012  File "/usr/bin/fast-reboot-dump.py", line 333, in main#012    send_garp_nd(neighbor_entries, map_mac_ip_per_vlan)#012  File "/usr/bin/fast-reboot-dump.py", line 277, in send_garp_nd#012    if ipaddress.ip_interface(dst_ip).ip.version == 4:#012  File "/usr/local/lib/python2.7/dist-packages/ipaddress.py", line 239, in ip_interface#012    address)#012ValueError: '192.168.1.133' does not appear to be an IPv4 or IPv6 interface`

#### How I did it
Wrapped `(dst_ip) to unicode(dst_ip)`
#### How to verify it
Run fast-reboot case. TC passed

Platform info:
```
SONiC Software Version: SONiC.201911.267-dirty-20210424.082658
Distribution: Debian 9.13
Kernel: 4.9.0-14-2-amd64
Build commit: a754e4b1
Build date: Sat Apr 24 08:36:35 UTC 2021
Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
ASIC: barefoot
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
