### PR TITLE
[route_check] Filter out VNET routes

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -364,6 +364,36 @@ def filter_out_default_routes(lst):
     return upd
 
 
+def filter_out_vnet_routes(routes):
+    """
+    Helper to filter out VNET routes
+    :param routes: list of routes to filter
+    :return filtered list of routes.
+    """
+    db = swsscommon.DBConnector('APPL_DB', 0)
+
+    vnet_route_table = swsscommon.Table(db, 'VNET_ROUTE_TABLE')
+    vnet_route_tunnel_table = swsscommon.Table(db, 'VNET_ROUTE_TUNNEL_TABLE')
+
+    vnet_routes_db_keys = vnet_route_table.getKeys() + vnet_route_tunnel_table.getKeys()
+
+    vnet_routes = []
+
+    for vnet_route_db_key in vnet_routes_db_keys:
+        vnet_route_attrs = vnet_route_db_key.split(':')
+        vnet_name = vnet_route_attrs[0]
+        vnet_route = vnet_route_attrs[1]
+        vnet_routes.append(vnet_route)
+
+    updated_routes = []
+
+    for route in routes:
+        if not (route in vnet_routes):
+            updated_routes.append(route)
+
+    return updated_routes
+
+
 def check_routes():
     """
     The heart of this script which runs the checks.
@@ -399,6 +429,7 @@ def check_routes():
     # Check missed ASIC routes against APPL-DB INTF_TABLE
     _, rt_asic_miss = diff_sorted_lists(intf_appl, rt_asic_miss)
     rt_asic_miss = filter_out_default_routes(rt_asic_miss)
+    rt_asic_miss = filter_out_vnet_routes(rt_asic_miss)
 
     # Check APPL-DB INTF_TABLE with ASIC table route entries
     intf_appl_miss, _ = diff_sorted_lists(intf_appl, rt_asic)


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixed errors related to VNET routes printed by ```route_check``` script.

#### How I did it
Filtered out VNET routes for the list of routes that are taken into account by ```route_check``` script.

#### How to verify it
1. Configure VNET routes and run ```route_check``` script on the switch
2. Verify that no errors are onserved

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

