### PR TITLE
[show] revert back to swsssdk from swsscommon for ConfigDBConnector() for muxcable

### DIFF
--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -8,7 +8,7 @@ import utilities_common.cli as clicommon
 from natsort import natsorted
 from sonic_py_common import multi_asic
 from swsscommon import swsscommon
-from swsscommon.swsscommon import ConfigDBConnector
+from swsssdk import ConfigDBConnector
 from tabulate import tabulate
 from utilities_common import platform_sfputil_helper
 


### PR DESCRIPTION
 
For 202012 branch ConfigDBConnector() is imported from swsssdk. 
So to use  ConfigDBConnector() we still have to import from swsssdk instead of swsscommon.
The [https://github.com/Azure/sonic-utilities/pull/1558](url) changed ConfigDBConnector() to be imported from swsscommon in show/muxcable.py
which causes unit test failure in sonic-utilities. 
This PR fixes that. 
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
changed the import

#### How I did it

#### How to verify it
ran a local build to pass unit tests

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

