### PR TITLE
[show] Can't show runningconfiguration syslog for IPv6 address

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1142,11 +1142,13 @@ def syslog(verbose):
     syslog_dict = {}
     with open("/etc/rsyslog.conf") as syslog_file:
         data = syslog_file.readlines()
+
     for line in data:
-        if line.startswith("*.* @"):
-            line = line.split(":")
-            server = line[0][5:]
+        match = re.search('target="([\w:.]*)"|@\[([\w:.]*)\]:', line)
+        if match:
+            server = match.group(1) if match.group(1) else match.group(2)
             syslog_servers.append(server)
+
     syslog_dict['Syslog Servers'] = syslog_servers
     print(tabulate(syslog_dict, headers=list(syslog_dict.keys()), tablefmt="simple", stralign='left', missingval=""))
 


### PR DESCRIPTION
What I did:
  Support to show IPv6 address in "show runningconfiguration syslog"

Why I did it:
  Current implementation is only support to show IPv4 address

How I verified it:
```
  $ sudo config syslog add 2001:db8:2de::e13
  $ sudo config syslog add ::100
  $ sudo config syslog add 192.168.1.33
  $ sudo config syslog add 192.168.50.33
  $ show runningconfiguration syslog
  Syslog Servers
  ----------------
  192.168.1.33
  192.168.50.33
  2001:db8:2de::e13
  ::100
```