### PR TITLE
[201911]: add show bgp neigh/network support for multi asic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
                                   'mock_tables/asic0/*',
                                   'mock_tables/asic1/*',
                                   'mock_tables/asic2/*',
+                                  'bgp_commands_input/*',
                                   'filter_fdb_input/*',
                                   'pfcwd_input/*',
                                   'sku_create_input/*',

--- a/show/bgp_frr_v4.py
+++ b/show/bgp_frr_v4.py
@@ -47,7 +47,7 @@ def summary(namespace, display):
 def neighbors(ipaddress, info_type, namespace):
     """Show IP (IPv4) BGP neighbors"""
 
-    command = 'show ip bgp neighbor''
+    command = 'show ip bgp neighbor'
     if ipaddress is not None:
         if not bgp_util.is_ipv4_address(ipaddress):
             ctx = click.get_current_context()

--- a/show/bgp_frr_v4.py
+++ b/show/bgp_frr_v4.py
@@ -1,9 +1,11 @@
 import click
 
+from sonic_py_common import multi_asic
+from show.main import AliasedGroup, ip
 import utilities_common.bgp_util as bgp_util
 import utilities_common.constants as constants
 import utilities_common.multi_asic as multi_asic_util
-from show.main import AliasedGroup, ip, run_command
+
 
 
 ###############################################################################
@@ -30,36 +32,82 @@ def summary(namespace, display):
 # 'neighbors' subcommand ("show ip bgp neighbors")
 @bgp.command()
 @click.argument('ipaddress', required=False)
-@click.argument('info_type', type=click.Choice(['routes', 'advertised-routes', 'received-routes']), required=False)
-def neighbors(ipaddress, info_type):
+@click.argument('info_type',
+                type=click.Choice(
+                    ['routes', 'advertised-routes', 'received-routes']),
+                required=False)
+@click.option('--namespace',
+                '-n',
+                'namespace',
+                default=None,
+                type=str,
+                show_default=True,
+                help='Namespace name or all',
+                callback=multi_asic_util.multi_asic_namespace_validation_callback)
+def neighbors(ipaddress, info_type, namespace):
     """Show IP (IPv4) BGP neighbors"""
 
-    command = 'sudo vtysh -c "show ip bgp neighbor'
-
+    command = 'show ip bgp neighbor''
     if ipaddress is not None:
-        command += ' {}'.format(ipaddress)
+        if not bgp_util.is_ipv4_address(ipaddress):
+            ctx = click.get_current_context()
+            ctx.fail("{} is not valid ipv4 address\n".format(ipaddress))
+        try:
+            actual_namespace = bgp_util.get_namespace_for_bgp_neighbor(
+                ipaddress)
+            if namespace is not None and namespace != actual_namespace:
+                click.echo(
+                    "[WARNING]: bgp neighbor {} is present in namespace {} not in {}"
+                    .format(ipaddress, actual_namespace, namespace))
 
-        # info_type is only valid if ipaddress is specified
-        if info_type is not None:
-            command += ' {}'.format(info_type)
+            # save the namespace in which the bgp neighbor is configured
+            namespace = actual_namespace
 
-    command += '"'
+            command += ' {}'.format(ipaddress)
 
-    run_command(command)
+            # info_type is only valid if ipaddress is specified
+            if info_type is not None:
+                command += ' {}'.format(info_type)
+        except ValueError as err:
+            ctx = click.get_current_context()
+            ctx.fail("{}\n".format(err))
+
+    ns_list = multi_asic.get_namespace_list(namespace)
+    output = ""
+    for ns in ns_list:
+        output += bgp_util.run_bgp_command(command, ns)
+
+    click.echo(output.rstrip('\n'))
 
 # 'network' subcommand ("show ip bgp network")
 @bgp.command()
 @click.argument('ipaddress', metavar='[<ipv4-address>|<ipv4-prefix>]', required=False)
-@click.argument('info_type', metavar='[bestpath|json|longer-prefixes|multipath]',
-                type=click.Choice(['bestpath', 'json', 'longer-prefixes', 'multipath']), required=False)
-def network(ipaddress, info_type):
+@click.argument('info_type',
+                metavar='[bestpath|json|longer-prefixes|multipath]',
+                type=click.Choice(
+                    ['bestpath', 'json', 'longer-prefixes', 'multipath']),
+                required=False)
+@click.option('--namespace',
+                '-n',
+                'namespace',
+                type=str,
+                show_default=True,
+                required=True if multi_asic.is_multi_asic is True else False,
+                help='Namespace name or all',
+                default=None,
+                callback=multi_asic_util.multi_asic_namespace_validation_callback)
+def network(ipaddress, info_type, namespace):
     """Show IP (IPv4) BGP network"""
 
-    command = 'sudo vtysh -c "show ip bgp'
+    if multi_asic.is_multi_asic() and namespace not in multi_asic.get_namespace_list():
+        ctx = click.get_current_context()
+        ctx.fail('-n/--namespace option required. provide namespace from list {}'\
+            .format(multi_asic.get_namespace_list()))
 
+    command = 'show ip bgp'
     if ipaddress is not None:
         if '/' in ipaddress:
-        # For network prefixes then this all info_type(s) are available
+            # For network prefixes then this all info_type(s) are available
             pass
         else:
             # For an ipaddress then check info_type, exit if specified option doesn't work.
@@ -74,6 +122,5 @@ def network(ipaddress, info_type):
         if info_type is not None:
             command += ' {}'.format(info_type)
 
-    command += '"'
-
-    run_command(command)
+    output  =  bgp_util.run_bgp_command(command, namespace)
+    click.echo(output.rstrip('\n'))

--- a/show/bgp_frr_v6.py
+++ b/show/bgp_frr_v6.py
@@ -3,7 +3,7 @@ import click
 import utilities_common.bgp_util as bgp_util
 import utilities_common.constants as constants
 import utilities_common.multi_asic as multi_asic_util
-from show.main import AliasedGroup, ipv6, run_command
+from show.main import AliasedGroup, ipv6
 ###############################################################################
 #
 # 'show ipv6 bgp' cli stanza
@@ -28,27 +28,83 @@ def summary(namespace, display):
 # 'neighbors' subcommand ("show ipv6 bgp neighbors")
 @bgp.command()
 @click.argument('ipaddress', required=False)
-@click.argument('info_type', type=click.Choice(['routes', 'advertised-routes', 'received-routes']), required=False)
-def neighbors(ipaddress, info_type):
+@click.argument('info_type',
+                type=click.Choice(
+                    ['routes', 'advertised-routes', 'received-routes']),
+                required=False)
+@click.option('--namespace',
+                '-n',
+                'namespace',
+                default=None,
+                type=str,
+                show_default=True,
+                help='Namespace name or all',
+             callback=multi_asic_util.multi_asic_namespace_validation_callback)
+def neighbors(ipaddress, info_type, namespace):
     """Show IPv6 BGP neighbors"""
-    ipaddress = "" if ipaddress is None else ipaddress
+
+    if ipaddress is not None:
+        if not bgp_util.is_ipv6_address(ipaddress):
+            ctx = click.get_current_context()
+            ctx.fail("{} is not valid ipv6 address\n".format(ipaddress))
+        try:
+            actual_namespace = bgp_util.get_namespace_for_bgp_neighbor(
+                ipaddress)
+            if namespace is not None and namespace != actual_namespace:
+                click.echo(
+                    "bgp neighbor {} is present in namespace {} not in {}"
+                    .format(ipaddress, actual_namespace, namespace))
+
+            # save the namespace in which the bgp neighbor is configured
+            namespace = actual_namespace
+        except ValueError as err:
+            ctx = click.get_current_context()
+            ctx.fail("{}\n".format(err))
+    else:
+        ipaddress = ""
+
     info_type = "" if info_type is None else info_type
-    command = 'sudo vtysh -c "show bgp ipv6 neighbor {} {}"'.format(ipaddress, info_type)
-    run_command(command)
+    command = 'show bgp ipv6 neighbor {} {}'.format(
+        ipaddress, info_type)
+
+    ns_list = multi_asic.get_namespace_list(namespace)
+    output = ""
+    for ns in ns_list:
+        output += bgp_util.run_bgp_command(command, ns)
+    
+    click.echo(output.rstrip('\n'))
+
 
 # 'network' subcommand ("show ipv6 bgp network")
 @bgp.command()
 @click.argument('ipaddress', metavar='[<ipv6-address>|<ipv6-prefix>]', required=False)
-@click.argument('info_type', metavar='[bestpath|json|longer-prefixes|multipath]',
-                type=click.Choice(['bestpath', 'json', 'longer-prefixes', 'multipath']), required=False)
-def network(ipaddress, info_type):
+@click.argument('info_type',
+                metavar='[bestpath|json|longer-prefixes|multipath]',
+                type=click.Choice(
+                    ['bestpath', 'json', 'longer-prefixes', 'multipath']),
+                required=False)
+@click.option('--namespace',
+                '-n',
+                'namespace',
+                type=str,
+                show_default=True,
+                required=True if multi_asic.is_multi_asic is True else False,
+                help='Namespace name or all',
+                default=None,
+                callback=multi_asic_util.multi_asic_namespace_validation_callback)
+def network(ipaddress, info_type, namespace):
     """Show BGP ipv6 network"""
 
-    command = 'sudo vtysh -c "show bgp ipv6'
+    command = 'show bgp ipv6'
+
+    if multi_asic.is_multi_asic() and namespace not in multi_asic.get_namespace_list():
+        ctx = click.get_current_context()
+        ctx.fail('-n/--namespace option required. provide namespace from list {}'\
+            .format(multi_asic.get_namespace_list()))
 
     if ipaddress is not None:
         if '/' in ipaddress:
-        # For network prefixes then this all info_type(s) are available
+            # For network prefixes then this all info_type(s) are available
             pass
         else:
             # For an ipaddress then check info_type, exit if specified option doesn't work.
@@ -63,6 +119,5 @@ def network(ipaddress, info_type):
         if info_type is not None:
             command += ' {}'.format(info_type)
 
-    command += '"'
-
-    run_command(command)
+    output  =  bgp_util.run_bgp_command(command, namespace)
+    click.echo(output.rstrip('\n'))

--- a/show/bgp_frr_v6.py
+++ b/show/bgp_frr_v6.py
@@ -1,5 +1,6 @@
 import click
 
+from sonic_py_common import multi_asic
 import utilities_common.bgp_util as bgp_util
 import utilities_common.constants as constants
 import utilities_common.multi_asic as multi_asic_util

--- a/sonic-utilities-tests/bgp_command_input/bgp_neighbor_test_vector.py
+++ b/sonic-utilities-tests/bgp_command_input/bgp_neighbor_test_vector.py
@@ -1,0 +1,756 @@
+bgp_v4_neighbors_output = \
+"""
+BGP neighbor is 10.0.0.57, remote AS 64600, local AS 65100, external link
+ Description: ARISTA01T1
+ Member of peer-group PEER_V4 for session parameters
+  BGP version 4, remote router ID 100.1.0.29, local router ID 10.1.0.32
+  BGP state = Established, up for 00:00:39
+  Last read 00:00:00, Last write 00:00:00
+  Hold time is 10, keepalive interval is 3 seconds
+  Configured hold time is 10, keepalive interval is 3 seconds
+  Neighbor capabilities:
+    4 Byte AS: advertised and received
+    AddPath:
+      IPv4 Unicast: RX advertised IPv4 Unicast and received
+    Route refresh: advertised and received(new)
+    Address Family IPv4 Unicast: advertised and received
+    Hostname Capability: advertised (name: vlab-01,domain name: n/a) not received
+    Graceful Restart Capability: advertised and received
+      Remote Restart timer is 300 seconds
+      Address families by peer:
+        none
+  Graceful restart information:
+    End-of-RIB send: IPv4 Unicast
+    End-of-RIB received: IPv4 Unicast
+    Local GR Mode: Restart*
+    Remote GR Mode: Helper
+    R bit: False
+    Timers:
+      Configured Restart Time(sec): 240
+      Received Restart Time(sec): 300
+    IPv4 Unicast:
+      F bit: False
+      End-of-RIB sent: Yes
+      End-of-RIB sent after update: No
+      End-of-RIB received: Yes
+      Timers:
+        Configured Stale Path Time(sec): 360
+        Configured Selection Deferral Time(sec): 360
+  Message statistics:
+    Inq depth is 0
+    Outq depth is 0
+                         Sent       Rcvd
+    Opens:                  2          1
+    Notifications:          2          2
+    Updates:             3203       3202
+    Keepalives:            14         15
+    Route Refresh:          0          0
+    Capability:             0          0
+    Total:               3221       3220
+  Minimum time between advertisement runs is 0 seconds
+
+ For address family: IPv4 Unicast
+  PEER_V4 peer-group member
+  Update group 1, subgroup 1
+  Packet Queue length 0
+  Inbound soft reconfiguration allowed
+  Community attribute sent to this neighbor(all)
+  Inbound path policy configured
+  Outbound path policy configured
+  Route map for incoming advertisements is *FROM_BGP_PEER_V4
+  Route map for outgoing advertisements is *TO_BGP_PEER_V4
+  6400 accepted prefixes
+
+  Connections established 1; dropped 0
+  Last reset 00:01:01,  No AFI/SAFI activated for peer
+Local host: 10.0.0.56, Local port: 179
+Foreign host: 10.0.0.57, Foreign port: 44731
+Nexthop: 10.0.0.56
+Nexthop global: fc00::71
+Nexthop local: fe80::5054:ff:fea9:41c2
+BGP connection: shared network
+BGP Connect Retry Timer in Seconds: 10
+Estimated round trip time: 20 ms
+Read thread: on  Write thread: on  FD used: 28
+"""
+
+bgp_v4_neighbor_invalid = \
+"""Usage: neighbors [OPTIONS] [IPADDRESS] [[routes|advertised-routes|received-
+                 routes]]
+Try 'neighbors --help' for help.
+
+Error:  Bgp neighbor 20.1.1.1 not configured
+
+"""
+
+bgp_v4_neighbor_invalid_address = \
+"""Error: invalid_address is not valid ipv4 address"""
+
+bgp_v4_neighbor_output_adv_routes = \
+"""
+BGP table version is 6405, local router ID is 10.1.0.32, vrf id 0
+Default local pref 100, local AS 65100
+Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
+               i internal, r RIB-failure, S Stale, R Removed
+Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
+Origin codes:  i - IGP, e - EGP, ? - incomplete
+
+   Network          Next Hop            Metric LocPrf Weight Path
+*> 0.0.0.0/0        0.0.0.0                                0 64600 65534 6666 6667 i
+*> 10.1.0.32/32     0.0.0.0                  0         32768 i
+*> 100.1.0.29/32    0.0.0.0                                0 64600 i
+*> 100.1.0.30/32    0.0.0.0                                0 64600 i
+*> 100.1.0.31/32    0.0.0.0                                0 64600 i
+*> 100.1.0.32/32    0.0.0.0                                0 64600 i
+*> 192.168.0.0/21   0.0.0.0                  0         32768 i
+*> 192.168.8.0/25   0.0.0.0                                0 64600 65501 i
+*> 192.168.8.128/25 0.0.0.0                                0 64600 65501 i
+*> 192.168.16.0/25  0.0.0.0                                0 64600 65502 i
+*> 192.168.16.128/25
+                    0.0.0.0                                0 64600 65502 i
+*> 192.168.24.0/25  0.0.0.0                                0 64600 65503 i
+*> 192.168.24.128/25
+                    0.0.0.0                                0 64600 65503 i
+*> 192.168.32.0/25  0.0.0.0                                0 64600 65504 i
+*> 192.168.32.128/25
+                    0.0.0.0                                0 64600 65504 i
+*> 192.168.40.0/25  0.0.0.0                                0 64600 65505 i
+*> 192.168.40.128/25
+                    0.0.0.0                                0 64600 65505 i
+*> 192.168.48.0/25  0.0.0.0                                0 64600 65506 i
+*> 192.168.48.128/25
+                    0.0.0.0                                0 64600 65506 i
+*> 192.168.56.0/25  0.0.0.0                                0 64600 65507 i
+*> 192.168.56.128/25
+                    0.0.0.0                                0 64600 65507 i
+"""
+
+bgp_v4_neighbor_output_recv_routes = \
+"""
+BGP table version is 6405, local router ID is 10.1.0.32, vrf id 0
+Default local pref 100, local AS 65100
+Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
+               i internal, r RIB-failure, S Stale, R Removed
+Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
+Origin codes:  i - IGP, e - EGP, ? - incomplete
+
+   Network          Next Hop            Metric LocPrf Weight Path
+*> 0.0.0.0/0        10.0.0.57                              0 64600 65534 6666 6667 i
+*> 100.1.0.29/32    10.0.0.57                              0 64600 i
+*> 192.168.8.0/25   10.0.0.57                              0 64600 65501 i
+*> 192.168.8.128/25 10.0.0.57                              0 64600 65501 i
+*> 192.168.16.0/25  10.0.0.57                              0 64600 65502 i
+*> 192.168.16.128/25
+                    10.0.0.57                              0 64600 65502 i
+*> 192.168.24.0/25  10.0.0.57                              0 64600 65503 i
+*> 192.168.24.128/25
+                    10.0.0.57                              0 64600 65503 i
+*> 192.168.32.0/25  10.0.0.57                              0 64600 65504 i
+*> 192.168.32.128/25
+                    10.0.0.57                              0 64600 65504 i
+*> 192.168.40.0/25  10.0.0.57                              0 64600 65505 i
+*> 192.168.40.128/25
+                    10.0.0.57                              0 64600 65505 i
+*> 192.168.48.0/25  10.0.0.57                              0 64600 65506 i
+*> 192.168.48.128/25
+                    10.0.0.57                              0 64600 65506 i
+*> 192.168.56.0/25  10.0.0.57                              0 64600 65507 i
+*> 192.168.56.128/25
+                    10.0.0.57                              0 64600 65507 i 
+"""
+
+bgp_v6_neighbors_output = \
+"""
+BGP neighbor is fc00::72, remote AS 64600, local AS 65100, external link
+ Description: ARISTA01T1
+ Member of peer-group PEER_V6 for session parameters
+  BGP version 4, remote router ID 100.1.0.29, local router ID 10.1.0.32
+  BGP state = Established, up for 01:06:23
+  Last read 00:00:02, Last write 00:00:00
+  Hold time is 10, keepalive interval is 3 seconds
+  Configured hold time is 10, keepalive interval is 3 seconds
+  Neighbor capabilities:
+    4 Byte AS: advertised and received
+    AddPath:
+      IPv6 Unicast: RX advertised IPv6 Unicast and received
+    Route refresh: advertised and received(new)
+    Address Family IPv6 Unicast: advertised and received
+    Hostname Capability: advertised (name: vlab-01,domain name: n/a) not received
+    Graceful Restart Capability: advertised and received
+      Remote Restart timer is 300 seconds
+      Address families by peer:
+        none
+  Graceful restart information:
+    End-of-RIB send: IPv6 Unicast
+    End-of-RIB received: IPv6 Unicast
+    Local GR Mode: Restart*
+    Remote GR Mode: Helper
+    R bit: False
+    Timers:
+      Configured Restart Time(sec): 240
+      Received Restart Time(sec): 300
+    IPv6 Unicast:
+      F bit: False
+      End-of-RIB sent: Yes
+      End-of-RIB sent after update: No
+      End-of-RIB received: Yes
+      Timers:
+        Configured Stale Path Time(sec): 360
+        Configured Selection Deferral Time(sec): 360
+  Message statistics:
+    Inq depth is 0
+    Outq depth is 0
+                         Sent       Rcvd
+    Opens:                  1          1
+    Notifications:          0          0
+    Updates:             3206       3202
+    Keepalives:          1328       1329
+    Route Refresh:          0          0
+    Capability:             0          0
+    Total:               4535       4532
+  Minimum time between advertisement runs is 0 seconds
+
+ For address family: IPv6 Unicast
+  PEER_V6 peer-group member
+  Update group 2, subgroup 2
+  Packet Queue length 0
+  Inbound soft reconfiguration allowed
+  Community attribute sent to this neighbor(all)
+  Inbound path policy configured
+  Outbound path policy configured
+  Route map for incoming advertisements is *FROM_BGP_PEER_V6
+  Route map for outgoing advertisements is *TO_BGP_PEER_V6
+  6400 accepted prefixes
+
+  Connections established 1; dropped 0
+  Last reset 01:06:46,  Waiting for peer OPEN
+Local host: fc00::71, Local port: 59726
+Foreign host: fc00::72, Foreign port: 179
+Nexthop: 10.0.0.56
+Nexthop global: fc00::71
+Nexthop local: fe80::5054:ff:fea9:41c2
+BGP connection: shared network
+BGP Connect Retry Timer in Seconds: 10
+Estimated round trip time: 4 ms
+Read thread: on  Write thread: on  FD used: 30
+"""
+
+bgp_v6_neighbor_output_adv_routes = \
+"""
+BGP table version is 6407, local router ID is 10.1.0.32, vrf id 0
+Default local pref 100, local AS 65100
+Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
+               i internal, r RIB-failure, S Stale, R Removed
+Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
+Origin codes:  i - IGP, e - EGP, ? - incomplete
+
+   Network          Next Hop            Metric LocPrf Weight Path
+*> ::/0             ::                                     0 64600 65534 6666 6667 i
+*> 2064:100::1d/128 ::                                     0 64600 i
+*> 2064:100::1e/128 ::                                     0 64600 i
+*> 2064:100::1f/128 ::                                     0 64600 i
+*> 2064:100::20/128 ::                                     0 64600 i
+*> 20c0:a808::/64   ::                                     0 64600 65501 i
+*> 20c0:a808:0:80::/64
+                    ::                                     0 64600 65501 i
+*> 20c0:a810::/64   ::                                     0 64600 65502 i
+*> 20c0:a810:0:80::/64
+                    ::                                     0 64600 65502 i
+*> 20c0:a818::/64   ::                                     0 64600 65503 i
+*> 20c0:a818:0:80::/64
+                    ::                                     0 64600 65503 i
+*> 20c0:a820::/64   ::                                     0 64600 65504 i
+*> 20c0:a820:0:80::/64
+                    ::                                     0 64600 65504 i
+*> 20c0:a828::/64   ::                                     0 64600 65505 i
+*> 20c0:a828:0:80::/64
+                    ::                                     0 64600 65505 i
+*> 20c0:a830::/64   ::                                     0 64600 65506 i
+*> 20c0:a830:0:80::/64
+                    ::                                     0 64600 65506 i
+*> 20c0:a838::/64   ::                                     0 64600 65507 i
+*> 20c0:a838:0:80::/64
+                    ::                                     0 64600 65507 i
+*> 20c0:a840::/64   ::                                     0 64600 65508 i
+*> 20c0:a840:0:80::/64
+                    ::                                     0 64600 65508 i
+*> 20c0:a848::/64   ::                                     0 64600 65509 i
+*> 20c0:a848:0:80::/64
+                    ::                                     0 64600 65509 i
+*> 20c0:a850::/64   ::                                     0 64600 65510 i
+*> 20c0:a850:0:80::/64
+                    ::                                     0 64600 65510 i
+*> 20c0:a858::/64   ::                                     0 64600 65511 i
+*> 20c0:a858:0:80::/64
+                    ::                                     0 64600 65511 i
+*> 20c0:a860::/64   ::                                     0 64600 65512 i
+*> 20c0:a860:0:80::/64
+                    ::                                     0 64600 65512 i
+*> 20c0:a868::/64   ::                                     0 64600 65513 i
+*> 20c0:a868:0:80::/64
+                    ::                                     0 64600 65513 i
+"""
+
+bgp_v6_neighbor_output_recv_routes = \
+"""
+BGP table version is 6407, local router ID is 10.1.0.32, vrf id 0
+Default local pref 100, local AS 65100
+Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
+               i internal, r RIB-failure, S Stale, R Removed
+Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
+Origin codes:  i - IGP, e - EGP, ? - incomplete
+
+   Network          Next Hop            Metric LocPrf Weight Path
+*> ::/0             fc00::72                               0 64600 65534 6666 6667 i
+*> 2064:100::1d/128 fc00::72                               0 64600 i
+*> 20c0:a808::/64   fc00::72                               0 64600 65501 i
+*> 20c0:a808:0:80::/64
+                    fc00::72                               0 64600 65501 i
+*> 20c0:a810::/64   fc00::72                               0 64600 65502 i
+*> 20c0:a810:0:80::/64
+                    fc00::72                               0 64600 65502 i
+*> 20c0:a818::/64   fc00::72                               0 64600 65503 i
+*> 20c0:a818:0:80::/64
+                    fc00::72                               0 64600 65503 i
+*> 20c0:a820::/64   fc00::72                               0 64600 65504 i
+*> 20c0:a820:0:80::/64
+                    fc00::72                               0 64600 65504 i
+*> 20c0:a828::/64   fc00::72                               0 64600 65505 i
+*> 20c0:a828:0:80::/64
+                    fc00::72                               0 64600 65505 i
+*> 20c0:a830::/64   fc00::72                               0 64600 65506 i
+*> 20c0:a830:0:80::/64
+                    fc00::72                               0 64600 65506 i
+*> 20c0:a838::/64   fc00::72                               0 64600 65507 i
+*> 20c0:a838:0:80::/64
+                    fc00::72                               0 64600 65507 i
+*> 20c0:a840::/64   fc00::72                               0 64600 65508 i
+*> 20c0:a840:0:80::/64
+                    fc00::72                               0 64600 65508 i
+*> 20c0:a848::/64   fc00::72                               0 64600 65509 i
+*> 20c0:a848:0:80::/64
+                    fc00::72                               0 64600 65509 i
+*> 20c0:a850::/64   fc00::72                               0 64600 65510 i
+*> 20c0:a850:0:80::/64
+                    fc00::72                               0 64600 65510 i
+*> 20c0:a858::/64   fc00::72                               0 64600 65511 i
+*> 20c0:a858:0:80::/64
+                    fc00::72                               0 64600 65511 i
+*> 20c0:a860::/64   fc00::72                               0 64600 65512 i
+*> 20c0:a860:0:80::/64
+                    fc00::72                               0 64600 65512 i
+*> 20c0:a868::/64   fc00::72                               0 64600 65513 i
+*> 20c0:a868:0:80::/64
+                    fc00::72                               0 64600 65513 i
+"""
+
+bgp_v6_neighbor_invalid  = \
+"""Error:  Bgp neighbor aa00::72 not configured"""
+
+bgp_v6_neighbor_invalid_address = \
+"""Error: 20.1.1.1 is not valid ipv6 address"""
+
+bgp_v4_neighbors_output_asic0 = \
+"""
+BGP neighbor is 10.0.0.1, remote AS 65200, local AS 65100, external link
+ Description: ARISTA01T2
+ Member of peer-group TIER2_V4 for session parameters
+  BGP version 4, remote router ID 100.1.0.1, local router ID 10.1.0.32
+  BGP state = Established, up for 04:41:19
+  Last read 00:00:19, Last write 00:00:19
+  Hold time is 180, keepalive interval is 60 seconds
+  Neighbor capabilities:
+    4 Byte AS: advertised and received
+    AddPath:
+      IPv4 Unicast: RX advertised IPv4 Unicast and received
+    Route refresh: advertised and received(new)
+    Address Family IPv4 Unicast: advertised and received
+    Hostname Capability: advertised (name: str-nsonic-acs-2,domain name: n/a) not received
+    Graceful Restart Capabilty: advertised and received
+      Remote Restart timer is 300 seconds
+      Address families by peer:
+        IPv4 Unicast(not preserved)
+  Graceful restart information:
+    End-of-RIB send: IPv4 Unicast
+    End-of-RIB received: IPv4 Unicast
+  Message statistics:
+    Inq depth is 0
+    Outq depth is 0
+                         Sent       Rcvd
+    Opens:                  2          1
+    Notifications:          2          0
+    Updates:               43       3187
+    Keepalives:           282        283
+    Route Refresh:          0          0
+    Capability:             0          0
+    Total:                329       3471
+  Minimum time between advertisement runs is 0 seconds
+
+ For address family: IPv4 Unicast
+  TIER2_V4 peer-group member
+  Update group 3, subgroup 3
+  Packet Queue length 0
+  Inbound soft reconfiguration allowed
+  Community attribute sent to this neighbor(all)
+  Inbound path policy configured
+  Outbound path policy configured
+  Route map for incoming advertisements is *FROM_TIER2_V4
+  Route map for outgoing advertisements is *TO_TIER2_V4
+  6370 accepted prefixes
+  Maximum prefixes allowed 12000 (warning-only)
+  Threshold for warning message 90%
+
+  Connections established 1; dropped 0
+  Last reset 04:41:43,   No AFI/SAFI activated for peer
+Local host: 10.0.0.0, Local port: 179
+Foreign host: 10.0.0.1, Foreign port: 56376
+Nexthop: 10.0.0.0
+Nexthop global: fc00::1
+Nexthop local: fe80::2be:75ff:fe3a:ef50
+BGP connection: shared network
+BGP Connect Retry Timer in Seconds: 120
+Read thread: on  Write thread: on  FD used: 25
+"""
+bgp_v4_neighbors_output_asic1 = \
+"""
+BGP neighbor is 10.1.0.1, remote AS 65100, local AS 65100, internal link
+ Description: ASIC0
+Hostname: sonic
+ Member of peer-group INTERNAL_PEER_V4 for session parameters
+  BGP version 4, remote router ID 10.1.0.32, local router ID 8.0.0.4
+  BGP state = Established, up for 04:50:18
+  Last read 00:00:03, Last write 00:00:03
+  Hold time is 10, keepalive interval is 3 seconds
+  Configured hold time is 10, keepalive interval is 3 seconds
+  Neighbor capabilities:
+    4 Byte AS: advertised and received
+    AddPath:
+      IPv4 Unicast: RX advertised IPv4 Unicast and received
+    Route refresh: advertised and received(old & new)
+    Address Family IPv4 Unicast: advertised and received
+    Hostname Capability: advertised (name: str-nsonic-acs-2,domain name: n/a) received (name: str-nsonic-acs-2,domain name: n/a)
+    Graceful Restart Capabilty: advertised and received
+      Remote Restart timer is 240 seconds
+      Address families by peer:
+        IPv4 Unicast(preserved)
+  Graceful restart information:
+    End-of-RIB send: IPv4 Unicast
+    End-of-RIB received: IPv4 Unicast
+  Message statistics:
+    Inq depth is 0
+    Outq depth is 0
+                         Sent       Rcvd
+    Opens:                  1          1
+    Notifications:          0          0
+    Updates:             6390       3194
+    Keepalives:          5806       5806
+    Route Refresh:          0          0
+    Capability:             0          0
+    Total:              12197       9001
+  Minimum time between advertisement runs is 0 seconds
+
+ For address family: IPv4 Unicast
+  INTERNAL_PEER_V4 peer-group member
+  Update group 2, subgroup 2
+  Packet Queue length 0
+  Route-Reflector Client
+  Inbound soft reconfiguration allowed
+  NEXT_HOP is always this router
+  Community attribute sent to this neighbor(all)
+  Inbound path policy configured
+  Outbound path policy configured
+  Route map for incoming advertisements is *FROM_BGP_INTERNAL_PEER_V4
+  Route map for outgoing advertisements is *TO_BGP_INTERNAL_PEER_V4
+  6377 accepted prefixes
+
+  Connections established 1; dropped 0
+  Last reset 04:50:40,   Waiting for NHT
+Local host: 10.1.0.0, Local port: 52802
+Foreign host: 10.1.0.1, Foreign port: 179
+Nexthop: 10.1.0.0
+Nexthop global: 2603:10e2:400:1::1
+Nexthop local: fe80::42:f0ff:fe7f:104
+BGP connection: shared network
+BGP Connect Retry Timer in Seconds: 10
+Read thread: on  Write thread: on  FD used: 17
+"""
+bgp_v4_neighbors_output_all_asics = bgp_v4_neighbors_output_asic0 + bgp_v4_neighbors_output_asic1
+
+bgp_v6_neighbor_output_warning =\
+"""bgp neighbor 2603:10e2:400:1::2 is present in namespace asic2 not in asic0"""
+
+bgp_v6_neighbors_output_asic0  = \
+"""
+ BGP neighbor is fc00::2, remote AS 65200, local AS 65100, external link
+ Description: ARISTA01T2
+ Member of peer-group TIER2_V6 for session parameters
+  BGP version 4, remote router ID 100.1.0.1, local router ID 10.1.0.32
+  BGP state = Established, up for 13:26:44
+  Last read 00:00:45, Last write 00:00:44
+  Hold time is 180, keepalive interval is 60 seconds
+  Neighbor capabilities:
+    4 Byte AS: advertised and received
+    AddPath:
+      IPv6 Unicast: RX advertised IPv6 Unicast and received
+    Route refresh: advertised and received(new)
+    Address Family IPv6 Unicast: advertised and received
+    Hostname Capability: advertised (name: str-nsonic-acs-2,domain name: n/a) not received
+    Graceful Restart Capabilty: advertised and received
+      Remote Restart timer is 300 seconds
+      Address families by peer:
+        IPv6 Unicast(not preserved)
+  Graceful restart information:
+    End-of-RIB send: IPv6 Unicast
+    End-of-RIB received: IPv6 Unicast
+  Message statistics:
+    Inq depth is 0
+    Outq depth is 0
+                         Sent       Rcvd
+    Opens:                  2          1
+    Notifications:          2          0
+    Updates:                5       3187
+    Keepalives:           807        808
+    Route Refresh:          0          0
+    Capability:             0          0
+    Total:                816       3996
+  Minimum time between advertisement runs is 0 seconds
+
+ For address family: IPv6 Unicast
+  TIER2_V6 peer-group member
+  Update group 2, subgroup 2
+  Packet Queue length 0
+  Inbound soft reconfiguration allowed
+  Community attribute sent to this neighbor(all)
+  Inbound path policy configured
+  Outbound path policy configured
+  Route map for incoming advertisements is *FROM_TIER2_V6
+  Route map for outgoing advertisements is *TO_TIER2_V6
+  6370 accepted prefixes
+  Maximum prefixes allowed 8000 (warning-only)
+  Threshold for warning message 90%
+
+  Connections established 1; dropped 0
+  Last reset 13:27:08,   No AFI/SAFI activated for peer
+Local host: fc00::1, Local port: 179
+Foreign host: fc00::2, Foreign port: 57838
+Nexthop: 10.0.0.0
+Nexthop global: fc00::1
+Nexthop local: fe80::2be:75ff:fe3a:ef50
+BGP connection: shared network
+BGP Connect Retry Timer in Seconds: 120
+Read thread: on  Write thread: on  FD used: 26
+"""
+
+bgp_v6_neighbors_output_asic1 = \
+"""
+ BGP neighbor is 2603:10e2:400:1::2, remote AS 65100, local AS 65100, internal link
+ Description: ASIC0
+Hostname: str-nsonic-acs-2
+ Member of peer-group INTERNAL_PEER_V6 for session parameters
+  BGP version 4, remote router ID 10.1.0.32, local router ID 8.0.0.4
+  BGP state = Established, up for 13:28:48
+  Last read 00:00:02, Last write 00:00:02
+  Hold time is 10, keepalive interval is 3 seconds
+  Configured hold time is 10, keepalive interval is 3 seconds
+  Neighbor capabilities:
+    4 Byte AS: advertised and received
+    AddPath:
+      IPv6 Unicast: RX advertised IPv6 Unicast and received
+    Route refresh: advertised and received(old & new)
+    Address Family IPv6 Unicast: advertised and received
+    Hostname Capability: advertised (name: str-nsonic-acs-2,domain name: n/a) received (name: str-nsonic-acs-2,domain name: n/a)
+    Graceful Restart Capabilty: advertised and received
+      Remote Restart timer is 240 seconds
+      Address families by peer:
+        IPv6 Unicast(preserved)
+  Graceful restart information:
+    End-of-RIB send: IPv6 Unicast
+    End-of-RIB received: IPv6 Unicast
+  Message statistics:
+    Inq depth is 0
+    Outq depth is 0
+                         Sent       Rcvd
+    Opens:                  1          1
+    Notifications:          0          0
+    Updates:             6380       4746
+    Keepalives:         16176      16176
+    Route Refresh:          0          0
+    Capability:             0          0
+    Total:              22557      20923
+  Minimum time between advertisement runs is 0 seconds
+
+ For address family: IPv6 Unicast
+  INTERNAL_PEER_V6 peer-group member
+  Update group 1, subgroup 1
+  Packet Queue length 0
+  Route-Reflector Client
+  Inbound soft reconfiguration allowed
+  NEXT_HOP is always this router
+  Community attribute sent to this neighbor(all)
+  Inbound path policy configured
+  Outbound path policy configured
+  Route map for incoming advertisements is *FROM_BGP_INTERNAL_PEER_V6
+  Route map for outgoing advertisements is *TO_BGP_INTERNAL_PEER_V6
+  6380 accepted prefixes
+
+  Connections established 1; dropped 0
+  Last reset 13:29:08,   No AFI/SAFI activated for peer
+Local host: 2603:10e2:400:1::1, Local port: 179
+Foreign host: 2603:10e2:400:1::2, Foreign port: 58984
+Nexthop: 10.1.0.0
+Nexthop global: 2603:10e2:400:1::1
+Nexthop local: fe80::42:f0ff:fe7f:104
+BGP connection: shared network
+BGP Connect Retry Timer in Seconds: 10
+Read thread: on  Write thread: on  FD used: 22
+"""
+
+bgp_v6_neighbors_output_all_asics = bgp_v4_neighbors_output_asic0 +\
+     bgp_v4_neighbors_output_asic1
+
+
+def mock_show_bgp_neighbor_multi_asic(request):
+    if request.param == 'bgp_v4_neighbors_output_all_asics':
+        return bgp_v4_neighbors_output_all_asics
+    if request.param == 'bgp_v4_neighbors_output_asic0':
+        return bgp_v4_neighbors_output_asic0
+    if request.param == 'bgp_v4_neighbors_output_asic1':
+        return bgp_v4_neighbors_output_asic1
+    elif request.param == 'bgp_v6_neighbors_output_all_asics':
+        return bgp_v6_neighbors_output_all_asics
+    if request.param == 'bgp_v6_neighbors_output_asic0':
+        return bgp_v6_neighbors_output_asic0
+    if request.param == 'bgp_v6_neighbors_output_asic1':
+        return bgp_v6_neighbors_output_asic1
+    else:
+        return ""
+
+
+def mock_show_bgp_neighbor_single_asic(request):
+    if request.param == 'bgp_v4_neighbors_output':
+        return bgp_v4_neighbors_output
+    elif request.param == 'bgp_v6_neighbors_output':
+        return bgp_v6_neighbors_output
+    elif request.param == 'bgp_v4_neighbor_output_adv_routes':
+        return bgp_v4_neighbor_output_adv_routes
+    elif request.param == 'bgp_v4_neighbor_output_recv_routes':
+        return bgp_v4_neighbor_output_recv_routes
+    elif request.param == 'bgp_v6_neighbor_output_adv_routes':
+        return bgp_v6_neighbor_output_adv_routes
+    elif request.param == 'bgp_v6_neighbor_output_recv_routes':
+        return bgp_v6_neighbor_output_recv_routes
+    else:
+        return ""
+
+
+testData = {
+    'bgp_v4_neighbors': {
+        'args': [],
+        'rc': 0,
+        'rc_output': bgp_v4_neighbors_output
+    },
+    'bgp_v4_neighbor': {
+        'args': ['10.0.0.57'],
+        'rc': 0,
+        'rc_output': bgp_v4_neighbors_output
+    },
+    'bgp_v4_neighbor_invalid': {
+        'args': ['20.1.1.1'],
+        'rc': 2,
+        'rc_err_msg': bgp_v4_neighbor_invalid
+    },
+    'bgp_v4_neighbor_invalid_address': {
+        'args': ['invalid_address'],
+        'rc': 2,
+        'rc_err_msg': bgp_v4_neighbor_invalid_address
+    },
+    'bgp_v4_neighbor_adv_routes': {
+        'args': ["10.0.0.57", "advertised-routes"],
+        'rc': 0,
+        'rc_output': bgp_v4_neighbor_output_adv_routes
+    },
+    'bgp_v4_neighbor_recv_routes': {
+        'args': ["10.0.0.57", "received-routes"],
+        'rc': 0,
+        'rc_output': bgp_v4_neighbor_output_recv_routes
+    },
+    'bgp_v6_neighbors': {
+        'args': [],
+        'rc': 0,
+        'rc_output': bgp_v6_neighbors_output
+    },
+    'bgp_v6_neighbor': {
+        'args': ['fc00::72'],
+        'rc': 0,
+        'rc_output': bgp_v6_neighbors_output
+    },
+    'bgp_v6_neighbor_invalid': {
+        'args': ['aa00::72'],
+        'rc': 2,
+        'rc_err_msg': bgp_v6_neighbor_invalid
+    },
+    'bgp_v6_neighbor_invalid_address': {
+        'args': ['20.1.1.1'],
+        'rc': 2,
+        'rc_err_msg': bgp_v6_neighbor_invalid_address
+    },
+    'bgp_v6_neighbor_adv_routes': {
+        'args': ["fc00::72", "advertised-routes"],
+        'rc': 0,
+        'rc_output': bgp_v6_neighbor_output_adv_routes
+    },
+    'bgp_v4_neighbor_recv_routes': {
+        'args': ["fc00::72", "received-routes"],
+        'rc': 0,
+        'rc_output': bgp_v4_neighbor_output_recv_routes
+    }
+}
+
+testDataMultiAsic = {
+    'bgp_v4_neighbors' : {
+        'args': [],
+        'rc': 0,
+        'rc_output': bgp_v4_neighbors_output_all_asics
+    },
+    'bgp_v4_neighbors_asic' : {
+        'args': ['-nasic0'],
+        'rc': 0,
+        'rc_output': bgp_v4_neighbors_output_asic0
+    },
+    'bgp_v4_neighbors_external' : {
+        'args': ['10.0.0.1'],
+        'rc': 0,
+        'rc_output': bgp_v4_neighbors_output_asic0
+    },
+    'bgp_v4_neighbors_internal' : {
+        'args': ['10.1.0.1'],
+        'rc': 0,
+        'rc_output': bgp_v4_neighbors_output_asic1
+    },
+    ' bgp_v6_neighbors' : {
+        'args': [],
+        'rc': 0,
+        'rc_output': bgp_v6_neighbors_output_all_asics
+    },
+    'bgp_v6_neighbors_asic' : {
+        'args': ['-nasic0'],
+        'rc': 0,
+        'rc_output': bgp_v6_neighbors_output_asic0
+    },
+    'bgp_v6_neighbors_external' : {
+        'args': ['fc00::2'],
+        'rc': 0,
+        'rc_output': bgp_v6_neighbors_output_asic0
+    },
+    'bgp_v6_neighbors_internal' : {
+        'args': ['2603:10e2:400:1::2'],
+        'rc': 0,
+        'rc_output': bgp_v6_neighbors_output_asic1
+    },
+    'bgp_v6_neighbor_warning' : {
+        'args': ['10.1.0.1', '-nasic1'],
+        'rc': 2,
+        'rc_warning_msg': bgp_v6_neighbor_output_warning
+    },
+
+}

--- a/sonic-utilities-tests/bgp_command_input/bgp_network_test_vector.py
+++ b/sonic-utilities-tests/bgp_command_input/bgp_network_test_vector.py
@@ -1,0 +1,527 @@
+bgp_v4_network = \
+"""
+BGP table version is 6405, local router ID is 10.1.0.32, vrf id 0
+Default local pref 100, local AS 65100
+Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
+               i internal, r RIB-failure, S Stale, R Removed
+Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
+Origin codes:  i - IGP, e - EGP, ? - incomplete
+
+   Network          Next Hop            Metric LocPrf Weight Path
+*= 0.0.0.0/0        10.0.0.63                              0 64600 65534 6666 6667 i
+*=                  10.0.0.61                              0 64600 65534 6666 6667 i
+*=                  10.0.0.59                              0 64600 65534 6666 6667 i
+*>                  10.0.0.57                              0 64600 65534 6666 6667 i
+*> 10.1.0.32/32     0.0.0.0                  0         32768 i
+*> 100.1.0.29/32    10.0.0.57                              0 64600 i
+*> 100.1.0.30/32    10.0.0.59                              0 64600 i
+*> 100.1.0.31/32    10.0.0.61                              0 64600 i
+*> 100.1.0.32/32    10.0.0.63                              0 64600 i
+*> 192.168.0.0/21   0.0.0.0                  0         32768 i
+*= 192.168.8.0/25   10.0.0.63                              0 64600 65501 i
+*=                  10.0.0.61                              0 64600 65501 i
+*=                  10.0.0.59                              0 64600 65501 i
+*>                  10.0.0.57                              0 64600 65501 i
+*= 192.168.8.128/25 10.0.0.63                              0 64600 65501 i
+*=                  10.0.0.61                              0 64600 65501 i
+*=                  10.0.0.59                              0 64600 65501 i
+*>                  10.0.0.57                              0 64600 65501 i
+*= 192.168.16.0/25  10.0.0.63                              0 64600 65502 i
+*=                  10.0.0.61                              0 64600 65502 i
+*=                  10.0.0.59                              0 64600 65502 i
+*>                  10.0.0.57                              0 64600 65502 i
+*= 192.168.16.128/25
+                    10.0.0.63                              0 64600 65502 i
+*=                  10.0.0.61                              0 64600 65502 i
+*=                  10.0.0.59                              0 64600 65502 i
+*>                  10.0.0.57                              0 64600 65502 i
+*= 192.168.24.0/25  10.0.0.63                              0 64600 65503 i
+*=                  10.0.0.61                              0 64600 65503 i
+*=                  10.0.0.59                              0 64600 65503 i
+*>                  10.0.0.57                              0 64600 65503 i
+*= 192.168.24.128/25
+                    10.0.0.63                              0 64600 65503 i
+*=                  10.0.0.61                              0 64600 65503 i
+*=                  10.0.0.59                              0 64600 65503 i
+*>                  10.0.0.57                              0 64600 65503 i
+*= 192.168.32.0/25  10.0.0.63                              0 64600 65504 i
+*=                  10.0.0.61                              0 64600 65504 i
+*=                  10.0.0.59                              0 64600 65504 i
+*>                  10.0.0.57                              0 64600 65504 i
+"""
+
+bgp_v4_network_ip_address = \
+"""
+BGP routing table entry for 193.11.248.128/25
+Paths: (4 available, best #4, table default)
+  Advertised to non peer-group peers:
+  10.0.0.57 10.0.0.59 10.0.0.61 10.0.0.63
+  64600 65534 64799 65515
+    10.0.0.61 from 10.0.0.61 (100.1.0.31)
+      Origin IGP, valid, external, multipath
+      Community: 5060:12345
+      Last update: Tue Apr 20 05:54:41 2021
+  64600 65534 64799 65515
+    10.0.0.59 from 10.0.0.59 (100.1.0.30)
+      Origin IGP, valid, external, multipath
+      Community: 5060:12345
+      Last update: Tue Apr 20 05:54:19 2021
+  64600 65534 64799 65515
+    10.0.0.63 from 10.0.0.63 (100.1.0.32)
+      Origin IGP, valid, external, multipath
+      Community: 5060:12345
+      Last update: Tue Apr 20 05:54:16 2021
+  64600 65534 64799 65515
+    10.0.0.57 from 10.0.0.57 (100.1.0.29)
+      Origin IGP, valid, external, multipath, best (Router ID)
+    Community: 5060:12345
+      Last update: Tue Apr 20 05:54:16 2021 
+"""
+
+bgp_v4_network_longer_prefixes_error = \
+"""
+The parameter option: "longer-prefixes" only available if passing a network prefix
+EX: 'show ip bgp network 10.0.0.0/24 longer-prefixes'
+Aborted!
+"""
+
+bgp_v4_network_bestpath = \
+"""
+BGP routing table entry for 193.11.248.128/25
+Paths: (4 available, best #4, table default)
+  Advertised to non peer-group peers:
+  10.0.0.57 10.0.0.59 10.0.0.61 10.0.0.63
+  64600 65534 64799 65515
+    10.0.0.57 from 10.0.0.57 (100.1.0.29)
+      Origin IGP, valid, external, multipath, best (Router ID)
+      Community: 5060:12345
+      Last update: Tue Apr 20 05:54:15 2021
+"""
+
+bgp_v6_network = \
+"""
+BGP table version is 6407, local router ID is 10.1.0.32, vrf id 0
+Default local pref 100, local AS 65100
+Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
+               i internal, r RIB-failure, S Stale, R Removed
+Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
+Origin codes:  i - IGP, e - EGP, ? - incomplete
+
+   Network          Next Hop            Metric LocPrf Weight Path
+*= ::/0             fc00::7e                               0 64600 65534 6666 6667 i
+*=                  fc00::7a                               0 64600 65534 6666 6667 i
+*=                  fc00::76                               0 64600 65534 6666 6667 i
+*>                  fc00::72                               0 64600 65534 6666 6667 i
+*> 2064:100::1d/128 fc00::72                               0 64600 i
+*> 2064:100::1e/128 fc00::76                               0 64600 i
+*> 2064:100::1f/128 fc00::7a                               0 64600 i
+*> 2064:100::20/128 fc00::7e                               0 64600 i
+*= 20c0:a808::/64   fc00::7e                               0 64600 65501 i
+*=                  fc00::7a                               0 64600 65501 i
+*=                  fc00::76                               0 64600 65501 i
+*>                  fc00::72                               0 64600 65501 i
+*= 20c0:a808:0:80::/64
+                    fc00::7e                               0 64600 65501 i
+*=                  fc00::7a                               0 64600 65501 i
+*=                  fc00::76                               0 64600 65501 i
+*>                  fc00::72                               0 64600 65501 i
+*= 20c0:a810::/64   fc00::7e                               0 64600 65502 i
+*=                  fc00::7a                               0 64600 65502 i
+*=                  fc00::76                               0 64600 65502 i
+*>                  fc00::72                               0 64600 65502 i
+*= 20c0:a810:0:80::/64
+                    fc00::7e                               0 64600 65502 i
+*=                  fc00::7a                               0 64600 65502 i
+*=                  fc00::76                               0 64600 65502 i
+*>                  fc00::72                               0 64600 65502 i
+*= 20c0:a818::/64   fc00::7e                               0 64600 65503 i
+*=                  fc00::7a                               0 64600 65503 i
+*=                  fc00::76                               0 64600 65503 i
+*>                  fc00::72                               0 64600 65503 i
+*= 20c0:a818:0:80::/64
+                    fc00::7e                               0 64600 65503 i
+*=                  fc00::7a                               0 64600 65503 i
+*=                  fc00::76                               0 64600 65503 i
+*>                  fc00::72                               0 64600 65503 i
+*= 20c0:a820::/64   fc00::7e                               0 64600 65504 i
+*=                  fc00::7a                               0 64600 65504 i
+*=                  fc00::76                               0 64600 65504 i
+*>                  fc00::72                               0 64600 65504 i
+*= 20c0:a820:0:80::/64
+                    fc00::7e                               0 64600 65504 i
+*=                  fc00::7a                               0 64600 65504 i
+*=                  fc00::76                               0 64600 65504 i
+*>                  fc00::72                               0 64600 65504 i 
+"""
+
+bgp_v6_network_ip_address = \
+"""
+BGP routing table entry for 20c0:a820:0:80::/64
+Paths: (4 available, best #4, table default)
+  Advertised to non peer-group peers:
+  fc00::72 fc00::76 fc00::7a fc00::7e
+  64600 65504
+    fc00::7e from fc00::7e (100.1.0.32)
+    (fe80::1850:e9ff:fef9:27cb) (prefer-global)
+      Origin IGP, valid, external, multipath
+      Community: 5060:12345
+      Last update: Tue Apr 20 05:54:17 2021
+  64600 65504
+    fc00::7a from fc00::7a (100.1.0.31)
+    (fe80::1810:25ff:fe01:c153) (prefer-global)
+      Origin IGP, valid, external, multipath
+      Community: 5060:12345
+      Last update: Tue Apr 20 05:54:17 2021
+  64600 65504
+    fc00::76 from fc00::76 (100.1.0.30)
+    (fe80::80a7:74ff:fee1:d66d) (prefer-global)
+      Origin IGP, valid, external, multipath
+      Community: 5060:12345
+      Last update: Tue Apr 20 05:54:17 2021
+  64600 65504
+    fc00::72 from fc00::72 (100.1.0.29)
+    (fe80::90ec:bcff:fe4b:1e3e) (prefer-global)
+      Origin IGP, valid, external, multipath, best (Router ID)
+      Community: 5060:12345
+      Last update: Tue Apr 20 05:54:16 2021 
+"""
+
+bgp_v6_network_longer_prefixes_error = \
+"""
+The parameter option: "longer-prefixes" only available if passing a network prefix
+EX: 'show ipv6 bgp network fc00:1::/64 longer-prefixes'
+Aborted! 
+"""
+
+bgp_v6_network_longer_prefixes = \
+"""
+BGP table version is 6407, local router ID is 10.1.0.32, vrf id 0
+Default local pref 100, local AS 65100
+Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
+               i internal, r RIB-failure, S Stale, R Removed
+Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
+Origin codes:  i - IGP, e - EGP, ? - incomplete
+
+   Network          Next Hop            Metric LocPrf Weight Path
+*= 20c0:a820:0:80::/64
+                    fc00::7e                               0 64600 65504 i
+*=                  fc00::7a                               0 64600 65504 i
+*=                  fc00::76                               0 64600 65504 i
+*>                  fc00::72                               0 64600 65504 i
+
+Displayed  1 routes and 25602 total paths 
+"""
+
+bgp_v6_network_bestpath = \
+"""
+BGP routing table entry for 20c0:a820:0:80::/64
+Paths: (4 available, best #4, table default)
+  Advertised to non peer-group peers:
+  fc00::72 fc00::76 fc00::7a fc00::7e
+  64600 65504
+    fc00::72 from fc00::72 (100.1.0.29)
+    (fe80::90ec:bcff:fe4b:1e3e) (prefer-global)
+      Origin IGP, valid, external, multipath, best (Router ID)
+      Community: 5060:12345
+      Last update: Tue Apr 20 05:54:15 2021 
+"""
+
+multi_asic_bgp_network_err = \
+"""Error: -n/--namespace option required. provide namespace for list ['asic0', 'asic1']"""
+
+bgp_v4_network_asic0 = \
+"""
+BGP table version is 11256, local router ID is 10.1.0.32, vrf id 0
+Default local pref 100, local AS 65100
+Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
+               i internal, r RIB-failure, S Stale, R Removed
+Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
+Origin codes:  i - IGP, e - EGP, ? - incomplete
+
+   Network          Next Hop            Metric LocPrf Weight Path
+* i0.0.0.0/0        10.1.0.2                      100      0 65200 6666 6667 i
+* i                 10.1.0.0                      100      0 65200 6666 6667 i
+*=                  10.0.0.5                               0 65200 6666 6667 i
+*>                  10.0.0.1                               0 65200 6666 6667 i
+* i8.0.0.0/32       10.1.0.2                 0    100      0 i
+* i                 10.1.0.0                 0    100      0 i
+*                   0.0.0.0                  0         32768 ?
+*>                  0.0.0.0                  0         32768 i
+*=i8.0.0.1/32       10.1.0.2                 0    100      0 i
+*>i                 10.1.0.0                 0    100      0 i
+*=i8.0.0.2/32       10.1.0.2                 0    100      0 i
+*>i                 10.1.0.0                 0    100      0 i
+*=i8.0.0.3/32       10.1.0.2                 0    100      0 i
+*>i                 10.1.0.0                 0    100      0 i
+*>i8.0.0.4/32       10.1.0.0                 0    100      0 i
+*>i8.0.0.5/32       10.1.0.2                 0    100      0 i
+* i10.0.0.0/31      10.1.0.2                 0    100      0 ?
+* i                 10.1.0.0                 0    100      0 ?
+*>                  0.0.0.0                  0         32768 ?
+* i10.0.0.4/31      10.1.0.2                 0    100      0 ?
+* i                 10.1.0.0                 0    100      0 ?
+*>                  0.0.0.0                  0         32768 ?
+*=i10.0.0.8/31      10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.12/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.32/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.34/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.36/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.38/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.40/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.42/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.44/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ? 
+"""
+
+bgp_v4_network_ip_address_asic0 = \
+"""
+ BGP routing table entry for 10.0.0.44/31
+Paths: (2 available, best #2, table default, not advertised outside local AS)
+  Not advertised to any peer
+  Local
+    10.1.0.2 from 10.1.0.2 (8.0.0.5)
+      Origin incomplete, metric 0, localpref 100, valid, internal, multipath
+      Community: local-AS
+      Originator: 8.0.0.5, Cluster list: 8.0.0.5
+      Last update: Thu Apr 22 02:13:31 2021
+
+  Local
+    10.1.0.0 from 10.1.0.0 (8.0.0.4)
+      Origin incomplete, metric 0, localpref 100, valid, internal, multipath, best (Router ID)
+      Community: local-AS
+      Originator: 8.0.0.4, Cluster list: 8.0.0.4
+      Last update: Thu Apr 22 02:13:31 2021
+"""
+bgp_v4_network_bestpath_asic0 = \
+"""
+BGP routing table entry for 10.0.0.44/31
+Paths: (2 available, best #2, table default, not advertised outside local AS)
+  Not advertised to any peer
+  Local
+    10.1.0.0 from 10.1.0.0 (8.0.0.4)
+      Origin incomplete, metric 0, localpref 100, valid, internal, multipath, best (Router ID)
+      Community: local-AS
+      Originator: 8.0.0.4, Cluster list: 8.0.0.4
+      Last update: Thu Apr 22 02:13:30 2021 
+"""
+
+bgp_v6_network_asic0 = \
+"""
+BGP table version is 12849, local router ID is 10.1.0.32, vrf id 0
+Default local pref 100, local AS 65100
+Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
+               i internal, r RIB-failure, S Stale, R Removed
+Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
+Origin codes:  i - IGP, e - EGP, ? - incomplete
+
+   Network          Next Hop            Metric LocPrf Weight Path
+* i::/0             2603:10e2:400:1::1
+                                                  100      0 65200 6666 6667 i
+* i                 2603:10e2:400:1::5
+                                                  100      0 65200 6666 6667 i
+*=                  fc00::6                                0 65200 6666 6667 i
+*>                  fc00::2                                0 65200 6666 6667 i
+* i2064:100::1/128  2603:10e2:400:1::1
+                                                  100      0 65200 i
+* i                 2603:10e2:400:1::5
+                                                  100      0 65200 i
+*>                  fc00::2                                0 65200 i
+* i2064:100::3/128  2603:10e2:400:1::1
+                                                  100      0 65200 i
+* i                 2603:10e2:400:1::5
+                                                  100      0 65200 i
+*>                  fc00::6                                0 65200 i
+*=i2064:100::5/128  2603:10e2:400:1::5
+                                                  100      0 65200 i
+*>i                 2603:10e2:400:1::1
+                                                  100      0 65200 i
+*>i2064:100::7/128  2603:10e2:400:1::1
+                                                  100      0 65200 i
+*=i                 2603:10e2:400:1::5
+                                                  100      0 65200 i
+*>i20c0:a800::/64   2603:10e2:400:1::1
+                                                  100      0 64004 i
+*=i                 2603:10e2:400:1::5
+                                                  100      0 64004 i
+*>i20c0:a800:0:80::/64
+                    2603:10e2:400:1::1
+                                                  100      0 64004 i
+*=i                 2603:10e2:400:1::5
+                                                  100      0 64004 i
+*>i20c0:a808::/64   2603:10e2:400:1::1
+                                                  100      0 64004 i
+*=i                 2603:10e2:400:1::5
+                                                  100      0 64004 i 
+"""
+
+bgp_v6_network_ip_address_asic0 = \
+"""
+BGP routing table entry for 20c0:a808:0:80::/64
+Paths: (2 available, best #1, table default)
+  Advertised to non peer-group peers:
+  fc00::2 fc00::6
+  64004
+    2603:10e2:400:1::1 from 2603:10e2:400:1::1 (8.0.0.4)
+      Origin IGP, localpref 100, valid, internal, multipath, best (Router ID)
+      Community: 8075:8823
+      Originator: 8.0.0.4, Cluster list: 8.0.0.4
+      Last update: Thu Apr 22 02:13:31 2021
+
+  64004
+    2603:10e2:400:1::5 from 2603:10e2:400:1::5 (8.0.0.5)
+      Origin IGP, localpref 100, valid, internal, multipath
+      Community: 8075:8823
+      Originator: 8.0.0.5, Cluster list: 8.0.0.5
+      Last update: Thu Apr 22 02:13:31 2021
+"""
+
+bgp_v6_network_ip_address_asic0_bestpath = \
+"""
+BGP routing table entry for 20c0:a808:0:80::/64
+Paths: (2 available, best #1, table default)
+  Advertised to non peer-group peers:
+  fc00::2 fc00::6
+  64004
+    2603:10e2:400:1::1 from 2603:10e2:400:1::1 (8.0.0.4)
+      Origin IGP, localpref 100, valid, internal, multipath, best (Router ID)
+      Community: 8075:8823
+      Originator: 8.0.0.4, Cluster list: 8.0.0.4
+      Last update: Thu Apr 22 02:13:30 2021
+"""
+
+
+def mock_show_bgp_network_single_asic(request):
+    param = request.param
+    if param == 'bgp_v4_network':
+        return bgp_v4_network
+    elif param == 'bgp_v4_network_ip_address':
+        return bgp_v4_network_ip_address
+    elif param == 'bgp_v4_network_bestpath':
+        return bgp_v4_network_bestpath
+    elif param == 'bgp_v6_network':
+        return bgp_v6_network
+    elif param == 'bgp_v6_network_ip_address':
+        return bgp_v6_network_ip_address
+    elif param == 'bgp_v6_network_longer_prefixes':
+        return bgp_v6_network_longer_prefixes
+    elif param == 'bgp_v6_network_bestpath':
+        return bgp_v6_network_bestpath
+    else:
+        return ""
+
+
+def mock_show_bgp_network_multi_asic(param):
+    if param == "bgp_v4_network_asic0":
+        return bgp_v4_network_asic0
+    elif param == 'bgp_v4_network_ip_address_asic0':
+        return bgp_v4_network_ip_address_asic0
+    elif param == 'bgp_v4_network_bestpath_asic0':
+        return bgp_v4_network_bestpath_asic0
+    if param == "bgp_v6_network_asic0":
+        return bgp_v4_network_asic0
+    elif param == 'bgp_v6_network_ip_address_asic0':
+        return bgp_v4_network_ip_address_asic0
+    elif param == 'bgp_v6_network_bestpath_asic0':
+        return bgp_v4_network_bestpath_asic0
+    else:
+        return ''
+
+
+testData = {
+    'bgp_v4_network': {
+        'args': [],
+        'rc': 0,
+        'rc_output': bgp_v4_network
+    },
+    'bgp_v4_network_ip_address': {
+        'args': [' 193.11.248.128/25'],
+        'rc': 0,
+        'rc_output': bgp_v4_network_ip_address
+    },
+    'bgp_v4_network_bestpath': {
+        'args': [' 193.11.248.128/25', 'bestpath'],
+        'rc': 0,
+        'rc_output': bgp_v4_network_bestpath
+    },
+    'bgp_v4_network_longer_prefixes_error': {
+        'args': [' 193.11.248.128', 'longer-prefixes'],
+        'rc': 2,
+        'rc_err_msg': bgp_v4_network_longer_prefixes_error
+    },
+    'bgp_v6_network': {
+        'args': [],
+        'rc': 0,
+        'rc_output': bgp_v6_network
+    },
+    'bgp_v6_network_ip_address': {
+        'args': [' 20c0:a820:0:80::/64'],
+        'rc': 0,
+        'rc_output': bgp_v6_network_ip_address
+    },
+    'bgp_v6_network_bestpath': {
+        'args': [' 20c0:a820:0:80::/64', 'bestpath'],
+        'rc': 0,
+        'rc_output': bgp_v6_network_bestpath
+    },
+    'bgp_v6_network_longer_prefix_error': {
+        'args': [' 20c0:a820:0:80::', 'longer-prefixes'],
+        'rc': 2,
+        'rc_err_msg': bgp_v6_network_longer_prefixes_error
+    },
+    'bgp_v6_network_longer_prefixes': {
+        'args': [' 20c0:a820:0:80::/64', 'longer-prefixes'],
+        'rc': 0,
+        'rc_err_msg': bgp_v6_network_longer_prefixes
+    },
+}
+
+masicTestData = {
+    'bgp_v4_network': {
+        'args': [],
+        'rc': 2,
+        'rc_err_msg': multi_asic_bgp_network_err
+    },
+    'bgp_v4_network_asic0': {
+        'args': ['-nasic0'],
+        'rc': 0,
+        'rc_output': bgp_v4_network_asic0
+    },
+    'bgp_v4_network_ip_address_asic0': {
+        'args': ['nasic0', '10.0.0.44'],
+        'rc': 0,
+        'rc_output': bgp_v4_network_ip_address_asic0
+    },
+    'bgp_v4_network_bestpath_asic0': {
+        'args': ['-nasic0', '10.0.0.44', 'bestpath'],
+        'rc': 0,
+        'rc_output': bgp_v4_network_bestpath_asic0
+    },
+    'bgp_v6_network': {
+        'args': [],
+        'rc': 2,
+        'rc_err_msg': multi_asic_bgp_network_err
+    },
+    'bgp_v6_network_asic0': {
+        'args': ['-nasic0'],
+        'rc': 0,
+        'rc_output': bgp_v4_network_asic0
+    },
+    'bgp_v6_network_ip_address_asic0': {
+        'args': ['-nasic0', '20c0:a808:0:80::/64'],
+        'rc': 0,
+        'rc_output': bgp_v4_network_ip_address_asic0
+    },
+    'bgp_v6_network_ip_address_asic0_bestpath': {
+        'args': ['-nasic0', '20c0:a808:0:80::/64', 'bestpath'],
+        'rc': 0,
+        'rc_output': bgp_v6_network_ip_address_asic0_bestpath
+    }
+}

--- a/sonic-utilities-tests/bgp_commands_input/bgp_neighbor_test_vector.py
+++ b/sonic-utilities-tests/bgp_commands_input/bgp_neighbor_test_vector.py
@@ -75,13 +75,7 @@ Read thread: on  Write thread: on  FD used: 28
 """
 
 bgp_v4_neighbor_invalid = \
-"""Usage: neighbors [OPTIONS] [IPADDRESS] [[routes|advertised-routes|received-
-                 routes]]
-Try 'neighbors --help' for help.
-
-Error:  Bgp neighbor 20.1.1.1 not configured
-
-"""
+"""Error:  Bgp neighbor 20.1.1.1 not configured"""
 
 bgp_v4_neighbor_invalid_address = \
 """Error: invalid_address is not valid ipv4 address"""
@@ -365,7 +359,7 @@ BGP neighbor is 10.0.0.1, remote AS 65200, local AS 65100, external link
       IPv4 Unicast: RX advertised IPv4 Unicast and received
     Route refresh: advertised and received(new)
     Address Family IPv4 Unicast: advertised and received
-    Hostname Capability: advertised (name: str-nsonic-acs-2,domain name: n/a) not received
+    Hostname Capability: advertised (name: str-n3164-acs-2,domain name: n/a) not received
     Graceful Restart Capabilty: advertised and received
       Remote Restart timer is 300 seconds
       Address families by peer:
@@ -428,7 +422,7 @@ Hostname: sonic
       IPv4 Unicast: RX advertised IPv4 Unicast and received
     Route refresh: advertised and received(old & new)
     Address Family IPv4 Unicast: advertised and received
-    Hostname Capability: advertised (name: str-nsonic-acs-2,domain name: n/a) received (name: str-nsonic-acs-2,domain name: n/a)
+    Hostname Capability: advertised (name: str-n3164-acs-2,domain name: n/a) received (name: str-n3164-acs-2,domain name: n/a)
     Graceful Restart Capabilty: advertised and received
       Remote Restart timer is 240 seconds
       Address families by peer:
@@ -477,7 +471,7 @@ Read thread: on  Write thread: on  FD used: 17
 bgp_v4_neighbors_output_all_asics = bgp_v4_neighbors_output_asic0 + bgp_v4_neighbors_output_asic1
 
 bgp_v6_neighbor_output_warning =\
-"""bgp neighbor 2603:10e2:400:1::2 is present in namespace asic2 not in asic0"""
+"""bgp neighbor 2603:10e2:400:1::2 is present in namespace asic1 not in asic0"""
 
 bgp_v6_neighbors_output_asic0  = \
 """
@@ -494,7 +488,7 @@ bgp_v6_neighbors_output_asic0  = \
       IPv6 Unicast: RX advertised IPv6 Unicast and received
     Route refresh: advertised and received(new)
     Address Family IPv6 Unicast: advertised and received
-    Hostname Capability: advertised (name: str-nsonic-acs-2,domain name: n/a) not received
+    Hostname Capability: advertised (name: str-n3164-acs-2,domain name: n/a) not received
     Graceful Restart Capabilty: advertised and received
       Remote Restart timer is 300 seconds
       Address families by peer:
@@ -545,7 +539,7 @@ bgp_v6_neighbors_output_asic1 = \
 """
  BGP neighbor is 2603:10e2:400:1::2, remote AS 65100, local AS 65100, internal link
  Description: ASIC0
-Hostname: str-nsonic-acs-2
+Hostname: str-n3164-acs-2
  Member of peer-group INTERNAL_PEER_V6 for session parameters
   BGP version 4, remote router ID 10.1.0.32, local router ID 8.0.0.4
   BGP state = Established, up for 13:28:48
@@ -558,7 +552,7 @@ Hostname: str-nsonic-acs-2
       IPv6 Unicast: RX advertised IPv6 Unicast and received
     Route refresh: advertised and received(old & new)
     Address Family IPv6 Unicast: advertised and received
-    Hostname Capability: advertised (name: str-nsonic-acs-2,domain name: n/a) received (name: str-nsonic-acs-2,domain name: n/a)
+    Hostname Capability: advertised (name: str-n3164-acs-2,domain name: n/a) received (name: str-n3164-acs-2,domain name: n/a)
     Graceful Restart Capabilty: advertised and received
       Remote Restart timer is 240 seconds
       Address families by peer:
@@ -605,22 +599,30 @@ BGP Connect Retry Timer in Seconds: 10
 Read thread: on  Write thread: on  FD used: 22
 """
 
-bgp_v6_neighbors_output_all_asics = bgp_v4_neighbors_output_asic0 +\
-     bgp_v4_neighbors_output_asic1
+bgp_v6_neighbors_output_all_asics = bgp_v6_neighbors_output_asic0 +\
+     bgp_v6_neighbors_output_asic1
 
 
-def mock_show_bgp_neighbor_multi_asic(request):
-    if request.param == 'bgp_v4_neighbors_output_all_asics':
-        return bgp_v4_neighbors_output_all_asics
-    if request.param == 'bgp_v4_neighbors_output_asic0':
+def mock_show_bgp_neighbor_multi_asic(param, namespace):
+    if param == 'bgp_v4_neighbors_output_all_asics':
+        if namespace == 'asic0':
+            return bgp_v4_neighbors_output_asic0
+        if namespace == 'asic1':
+            return bgp_v4_neighbors_output_asic1
+    if param == 'bgp_v6_neighbors_output_all_asics':
+        if namespace == 'asic0':
+            return bgp_v6_neighbors_output_asic0
+        if namespace == 'asic1':
+            return bgp_v6_neighbors_output_asic1
+    if param == 'bgp_v4_neighbors_output_asic0':
         return bgp_v4_neighbors_output_asic0
-    if request.param == 'bgp_v4_neighbors_output_asic1':
+    if param == 'bgp_v4_neighbors_output_asic1':
         return bgp_v4_neighbors_output_asic1
-    elif request.param == 'bgp_v6_neighbors_output_all_asics':
+    elif param == 'bgp_v6_neighbors_output_all_asics':
         return bgp_v6_neighbors_output_all_asics
-    if request.param == 'bgp_v6_neighbors_output_asic0':
+    if param == 'bgp_v6_neighbors_output_asic0':
         return bgp_v6_neighbors_output_asic0
-    if request.param == 'bgp_v6_neighbors_output_asic1':
+    if param == 'bgp_v6_neighbors_output_asic1':
         return bgp_v6_neighbors_output_asic1
     else:
         return ""
@@ -649,7 +651,7 @@ testData = {
         'rc': 0,
         'rc_output': bgp_v4_neighbors_output
     },
-    'bgp_v4_neighbor': {
+    'bgp_v4_neighbor_ip_address': {
         'args': ['10.0.0.57'],
         'rc': 0,
         'rc_output': bgp_v4_neighbors_output
@@ -679,7 +681,7 @@ testData = {
         'rc': 0,
         'rc_output': bgp_v6_neighbors_output
     },
-    'bgp_v6_neighbor': {
+    'bgp_v6_neighbor_ip_address': {
         'args': ['fc00::72'],
         'rc': 0,
         'rc_output': bgp_v6_neighbors_output
@@ -699,23 +701,20 @@ testData = {
         'rc': 0,
         'rc_output': bgp_v6_neighbor_output_adv_routes
     },
-    'bgp_v4_neighbor_recv_routes': {
+    'bgp_v6_neighbor_recv_routes': {
         'args': ["fc00::72", "received-routes"],
         'rc': 0,
-        'rc_output': bgp_v4_neighbor_output_recv_routes
-    }
-}
-
-testDataMultiAsic = {
-    'bgp_v4_neighbors' : {
+        'rc_output': bgp_v6_neighbor_output_recv_routes
+    },
+    'bgp_v4_neighbors_multi_asic' : {
         'args': [],
         'rc': 0,
         'rc_output': bgp_v4_neighbors_output_all_asics
     },
     'bgp_v4_neighbors_asic' : {
-        'args': ['-nasic0'],
+        'args': ['-nasic1'],
         'rc': 0,
-        'rc_output': bgp_v4_neighbors_output_asic0
+        'rc_output': bgp_v4_neighbors_output_asic1
     },
     'bgp_v4_neighbors_external' : {
         'args': ['10.0.0.1'],
@@ -727,7 +726,7 @@ testDataMultiAsic = {
         'rc': 0,
         'rc_output': bgp_v4_neighbors_output_asic1
     },
-    ' bgp_v6_neighbors' : {
+    'bgp_v6_neighbors_multi_asic' : {
         'args': [],
         'rc': 0,
         'rc_output': bgp_v6_neighbors_output_all_asics
@@ -748,8 +747,8 @@ testDataMultiAsic = {
         'rc_output': bgp_v6_neighbors_output_asic1
     },
     'bgp_v6_neighbor_warning' : {
-        'args': ['10.1.0.1', '-nasic1'],
-        'rc': 2,
+        'args': ['2603:10e2:400:1::2', '-nasic0'],
+        'rc': 0,
         'rc_warning_msg': bgp_v6_neighbor_output_warning
     },
 

--- a/sonic-utilities-tests/bgp_commands_input/bgp_network_test_vector.py
+++ b/sonic-utilities-tests/bgp_commands_input/bgp_network_test_vector.py
@@ -79,8 +79,7 @@ Paths: (4 available, best #4, table default)
 """
 
 bgp_v4_network_longer_prefixes_error = \
-"""
-The parameter option: "longer-prefixes" only available if passing a network prefix
+"""The parameter option: "longer-prefixes" only available if passing a network prefix
 EX: 'show ip bgp network 10.0.0.0/24 longer-prefixes'
 Aborted!
 """
@@ -187,10 +186,9 @@ Paths: (4 available, best #4, table default)
 """
 
 bgp_v6_network_longer_prefixes_error = \
-"""
-The parameter option: "longer-prefixes" only available if passing a network prefix
+"""The parameter option: "longer-prefixes" only available if passing a network prefix
 EX: 'show ipv6 bgp network fc00:1::/64 longer-prefixes'
-Aborted! 
+Aborted!
 """
 
 bgp_v6_network_longer_prefixes = \
@@ -227,7 +225,7 @@ Paths: (4 available, best #4, table default)
 """
 
 multi_asic_bgp_network_err = \
-"""Error: -n/--namespace option required. provide namespace for list ['asic0', 'asic1']"""
+"""Error: -n/--namespace option required. provide namespace from list ['asic0', 'asic1']"""
 
 bgp_v4_network_asic0 = \
 """
@@ -428,9 +426,9 @@ def mock_show_bgp_network_multi_asic(param):
     if param == "bgp_v6_network_asic0":
         return bgp_v4_network_asic0
     elif param == 'bgp_v6_network_ip_address_asic0':
-        return bgp_v4_network_ip_address_asic0
+        return bgp_v6_network_ip_address_asic0
     elif param == 'bgp_v6_network_bestpath_asic0':
-        return bgp_v4_network_bestpath_asic0
+        return bgp_v6_network_ip_address_asic0_bestpath
     else:
         return ''
 
@@ -453,8 +451,8 @@ testData = {
     },
     'bgp_v4_network_longer_prefixes_error': {
         'args': [' 193.11.248.128', 'longer-prefixes'],
-        'rc': 2,
-        'rc_err_msg': bgp_v4_network_longer_prefixes_error
+        'rc': 1,
+        'rc_output': bgp_v4_network_longer_prefixes_error
     },
     'bgp_v6_network': {
         'args': [],
@@ -471,20 +469,17 @@ testData = {
         'rc': 0,
         'rc_output': bgp_v6_network_bestpath
     },
-    'bgp_v6_network_longer_prefix_error': {
+    'bgp_v6_network_longer_prefixes_error': {
         'args': [' 20c0:a820:0:80::', 'longer-prefixes'],
-        'rc': 2,
-        'rc_err_msg': bgp_v6_network_longer_prefixes_error
+        'rc': 1,
+        'rc_output': bgp_v6_network_longer_prefixes_error
     },
     'bgp_v6_network_longer_prefixes': {
         'args': [' 20c0:a820:0:80::/64', 'longer-prefixes'],
         'rc': 0,
-        'rc_err_msg': bgp_v6_network_longer_prefixes
+        'rc_output': bgp_v6_network_longer_prefixes
     },
-}
-
-masicTestData = {
-    'bgp_v4_network': {
+    'bgp_v4_network_multi_asic': {
         'args': [],
         'rc': 2,
         'rc_err_msg': multi_asic_bgp_network_err
@@ -495,7 +490,7 @@ masicTestData = {
         'rc_output': bgp_v4_network_asic0
     },
     'bgp_v4_network_ip_address_asic0': {
-        'args': ['nasic0', '10.0.0.44'],
+        'args': ['-nasic0', '10.0.0.44'],
         'rc': 0,
         'rc_output': bgp_v4_network_ip_address_asic0
     },
@@ -504,7 +499,7 @@ masicTestData = {
         'rc': 0,
         'rc_output': bgp_v4_network_bestpath_asic0
     },
-    'bgp_v6_network': {
+    'bgp_v6_network_multi_asic': {
         'args': [],
         'rc': 2,
         'rc_err_msg': multi_asic_bgp_network_err
@@ -517,9 +512,9 @@ masicTestData = {
     'bgp_v6_network_ip_address_asic0': {
         'args': ['-nasic0', '20c0:a808:0:80::/64'],
         'rc': 0,
-        'rc_output': bgp_v4_network_ip_address_asic0
+        'rc_output': bgp_v6_network_ip_address_asic0
     },
-    'bgp_v6_network_ip_address_asic0_bestpath': {
+    'bgp_v6_network_bestpath_asic0': {
         'args': ['-nasic0', '20c0:a808:0:80::/64', 'bestpath'],
         'rc': 0,
         'rc_output': bgp_v6_network_ip_address_asic0_bestpath

--- a/sonic-utilities-tests/show_bgp_neighbor_test.py
+++ b/sonic-utilities-tests/show_bgp_neighbor_test.py
@@ -1,0 +1,94 @@
+from imp import reload
+import os
+
+import pytest
+
+from click.testing import CliRunner
+from bgp_commands_input.bgp_neighbor_test_vector import *
+
+def executor( test_vector, show):
+    runner = CliRunner()
+    input = bgp_network_test_vector.testData[test_vector]
+    if test_vector.startswith('bgp_v6'):
+        exec_cmd = show.cli.commands["ipv6"].commands["bgp"].commands["neighbors"]
+    else:
+        exec_cmd = show.cli.commands["ip"].commands["bgp"].commands["neighbors"]
+
+    result = runner.invoke(exec_cmd, input['args'])
+
+    print(result.exit_code)
+    print(result.output)
+
+    if input['rc'] == 0:
+        assert result.exit_code == 0
+    else:
+        assert result.exit_code != input['rc']
+
+    if 'rc_err_msg' in input:
+        output = result.output.strip().split("\n")[-1]
+        assert input['rc_err_msg'] in output
+
+    if 'rc_output' in input:
+        assert result.output == input['rc_output']
+
+    if 'rc_warning_msg' in input:
+        output = result.output.strip().split("\n")[0]
+        assert input['rc_warning_msg'] in output
+
+class TestBgpNeighbors(object):
+
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        from .mock_tables import mock_single_asic
+       reload(mock_tables.mock_single_asic)
+
+    @pytest.mark.parametrize('setup_single_bgp_instance', 
+                [
+                    ('bgp_v4_neighbors_output', 'bgp_v4_neighbors'),
+                    ('bgp_v4_neighbors_output','bgp_v4_neighbors'),
+                    ('bgp_v4_neighbor_invalid_output', 'bgp_v4_neighbor_invalid'),
+                    ('bgp_v4_neighbor_output', 'bgp_v4_neighbor_invalid_address'),
+                    ('bgp_v4_neighbor_output_adv_routes', 'bgp_v4_neighbor_adv_routes'),
+                    ('bgp_v4_neighbor_output_recv_routes', 'bgp_v4_neighbor_recv_routes'),
+                    ('bgp_v6_neighbors_output', 'bgp_v6_neighbors'),
+                    ('bgp_v6_neighbors_output','bgp_v6_neighbors'),
+                    ('bgp_v6_neighbor', 'bgp_v6_neighbor_invalid'),
+                    ('bgp_v6_neighbor', 'bgp_v6_neighbor_invalid_address'),
+                    ('bgp_v6_neighbor_output_adv_routes', 'bgp_v6_neighbor_adv_routes'),
+                    ('bgp_v4_neighbor_output_recv_routes', 'bgp_v6_neighbor_recv_routes'),
+                ],
+                             indirect=['setup_single_bgp_instance'])
+    def test_bgp_networks(self, setup_bgp_commands, test_vector,
+                         setup_single_bgp_instance):
+        show = setup_bgp_commands
+        executor(test_vector, show)
+
+class MultiAsicTestBgpNeighbors(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        from .mock_tables import mock_multi_asic
+        reload(mock_tables.mock_multi_asic)
+
+    @pytest.mark.parametrize('setup_multi_asic_bgp_instance', 
+                [
+                    ('bgp_v4_neighbors_output_all_asics', 'bgp_v4_neighbors'),
+                    ('bgp_v4_neighbors_output_asic0','bgp_v4_neighbors_asic'),
+                    ('bgp_v4_neighbors_output_asic0', 'bgp_v4_neighbors_external'),
+                    ('bgp_v4_neighbors_output_asic1', 'bgp_v4_neighbors_internal'),
+                    ('bgp_v6_neighbor_output_warning', 'bgp_v6_neighbor_warning'),
+                    ('bgp_v6_neighbors_output_asic0', 'bgp_v6_neighbors_asic'),
+                    ('bgp_v6_neighbors_output_asic0','bgp_v6_neighbors_external'),
+                    ('bgp_v6_neighbors_output_asic1', 'bgp_v6_neighbors_internal')
+                ],
+             indirect=['setup_multi_asic_bgp_instance'])
+    def test_bgp_networks(self, setup_bgp_commands, test_vector,
+                         setup_multi_asic_bgp_instance):
+        show = setup_bgp_commands
+        executor(test_vector, show)
+        
+    @classmethod
+    def teardown(cls):
+        from .mock_tables import mock_single_asic
+        reload(mock_tables.mock_single_asic)

--- a/sonic-utilities-tests/show_bgp_neighbor_test.py
+++ b/sonic-utilities-tests/show_bgp_neighbor_test.py
@@ -1,6 +1,4 @@
 from imp import reload
-import os
-
 import pytest
 
 from click.testing import CliRunner

--- a/sonic-utilities-tests/show_bgp_neighbor_test.py
+++ b/sonic-utilities-tests/show_bgp_neighbor_test.py
@@ -4,11 +4,11 @@ import os
 import pytest
 
 from click.testing import CliRunner
-from bgp_commands_input.bgp_neighbor_test_vector import *
+from bgp_commands_input import bgp_neighbor_test_vector
 
 def executor( test_vector, show):
     runner = CliRunner()
-    input = bgp_network_test_vector.testData[test_vector]
+    input = bgp_neighbor_test_vector.testData[test_vector]
     if test_vector.startswith('bgp_v6'):
         exec_cmd = show.cli.commands["ipv6"].commands["bgp"].commands["neighbors"]
     else:
@@ -22,7 +22,7 @@ def executor( test_vector, show):
     if input['rc'] == 0:
         assert result.exit_code == 0
     else:
-        assert result.exit_code != input['rc']
+        assert result.exit_code == input['rc']
 
     if 'rc_err_msg' in input:
         output = result.output.strip().split("\n")[-1]
@@ -40,25 +40,37 @@ class TestBgpNeighbors(object):
     @classmethod
     def setup_class(cls):
         print("SETUP")
-        from .mock_tables import mock_single_asic
-       reload(mock_tables.mock_single_asic)
+        from mock_tables import mock_single_asic
+        reload(mock_single_asic)
+        from mock_tables import dbconnector
+        dbconnector.load_database_config()
 
-    @pytest.mark.parametrize('setup_single_bgp_instance', 
-                [
-                    ('bgp_v4_neighbors_output', 'bgp_v4_neighbors'),
-                    ('bgp_v4_neighbors_output','bgp_v4_neighbors'),
-                    ('bgp_v4_neighbor_invalid_output', 'bgp_v4_neighbor_invalid'),
-                    ('bgp_v4_neighbor_output', 'bgp_v4_neighbor_invalid_address'),
-                    ('bgp_v4_neighbor_output_adv_routes', 'bgp_v4_neighbor_adv_routes'),
-                    ('bgp_v4_neighbor_output_recv_routes', 'bgp_v4_neighbor_recv_routes'),
-                    ('bgp_v6_neighbors_output', 'bgp_v6_neighbors'),
-                    ('bgp_v6_neighbors_output','bgp_v6_neighbors'),
-                    ('bgp_v6_neighbor', 'bgp_v6_neighbor_invalid'),
-                    ('bgp_v6_neighbor', 'bgp_v6_neighbor_invalid_address'),
-                    ('bgp_v6_neighbor_output_adv_routes', 'bgp_v6_neighbor_adv_routes'),
-                    ('bgp_v4_neighbor_output_recv_routes', 'bgp_v6_neighbor_recv_routes'),
-                ],
-                             indirect=['setup_single_bgp_instance'])
+    @pytest.mark.parametrize('setup_single_bgp_instance, test_vector',
+                            [
+                                ('bgp_v4_neighbors_output', 'bgp_v4_neighbors'),
+                                ('bgp_v4_neighbors_output',
+                                    'bgp_v4_neighbor_ip_address'),
+                                ('bgp_v4_neighbor_invalid_neigh',
+                                    'bgp_v4_neighbor_invalid'),
+                                ('bgp_v4_neighbor_invalid_address',
+                                    'bgp_v4_neighbor_invalid_address'),
+                                ('bgp_v4_neighbor_output_adv_routes',
+                                    'bgp_v4_neighbor_adv_routes'),
+                                ('bgp_v4_neighbor_output_recv_routes',
+                                    'bgp_v4_neighbor_recv_routes'),
+                                ('bgp_v6_neighbors_output', 'bgp_v6_neighbors'),
+                                ('bgp_v6_neighbors_output',
+                                    'bgp_v6_neighbor_ip_address'),
+                                ('bgp_v6_neighbor_invalid',
+                                    'bgp_v6_neighbor_invalid'),
+                                ('bgp_v6_neighbor_invalid_address',
+                                    'bgp_v6_neighbor_invalid_address'),
+                                ('bgp_v6_neighbor_output_adv_routes',
+                                    'bgp_v6_neighbor_adv_routes'),
+                                ('bgp_v6_neighbor_output_recv_routes',
+                                    'bgp_v6_neighbor_recv_routes'),
+                            ],
+                            indirect=['setup_single_bgp_instance'])
     def test_bgp_networks(self, setup_bgp_commands, test_vector,
                          setup_single_bgp_instance):
         show = setup_bgp_commands
@@ -68,27 +80,41 @@ class MultiAsicTestBgpNeighbors(object):
     @classmethod
     def setup_class(cls):
         print("SETUP")
-        from .mock_tables import mock_multi_asic
-        reload(mock_tables.mock_multi_asic)
+        from mock_tables import mock_multi_asic
+        reload(mock_multi_asic)
+        from mock_tables import dbconnector
+        dbconnector.load_namespace_config()
 
-    @pytest.mark.parametrize('setup_multi_asic_bgp_instance', 
-                [
-                    ('bgp_v4_neighbors_output_all_asics', 'bgp_v4_neighbors'),
-                    ('bgp_v4_neighbors_output_asic0','bgp_v4_neighbors_asic'),
-                    ('bgp_v4_neighbors_output_asic0', 'bgp_v4_neighbors_external'),
-                    ('bgp_v4_neighbors_output_asic1', 'bgp_v4_neighbors_internal'),
-                    ('bgp_v6_neighbor_output_warning', 'bgp_v6_neighbor_warning'),
-                    ('bgp_v6_neighbors_output_asic0', 'bgp_v6_neighbors_asic'),
-                    ('bgp_v6_neighbors_output_asic0','bgp_v6_neighbors_external'),
-                    ('bgp_v6_neighbors_output_asic1', 'bgp_v6_neighbors_internal')
-                ],
-             indirect=['setup_multi_asic_bgp_instance'])
+    @pytest.mark.parametrize('setup_multi_asic_bgp_instance, test_vector',
+                            [
+                            ('bgp_v4_neighbors_output_all_asics',
+                            'bgp_v4_neighbors_multi_asic'),
+                            ('bgp_v4_neighbors_output_asic1',
+                            'bgp_v4_neighbors_asic'),
+                            ('bgp_v4_neighbors_output_asic1',
+                            'bgp_v4_neighbors_internal'),
+                            ('bgp_v4_neighbors_output_asic0',
+                            'bgp_v4_neighbors_external'),
+                            ('bgp_v6_neighbor_output_warning',
+                            'bgp_v6_neighbor_warning'),
+                            ('bgp_v6_neighbors_output_all_asics',
+                            'bgp_v6_neighbors_multi_asic'),
+                            ('bgp_v6_neighbors_output_asic0',
+                            'bgp_v6_neighbors_asic'),
+                            ('bgp_v6_neighbors_output_asic0',
+                            'bgp_v6_neighbors_external'),
+                            ('bgp_v6_neighbors_output_asic1',
+                            'bgp_v6_neighbors_internal')
+                            ],
+                            indirect=['setup_multi_asic_bgp_instance'])
     def test_bgp_networks(self, setup_bgp_commands, test_vector,
                          setup_multi_asic_bgp_instance):
         show = setup_bgp_commands
         executor(test_vector, show)
         
     @classmethod
-    def teardown(cls):
-        from .mock_tables import mock_single_asic
-        reload(mock_tables.mock_single_asic)
+    def teardown_class(cls):
+        from mock_tables import mock_single_asic
+        reload(mock_single_asic)
+        from mock_tables import dbconnector
+        dbconnector.load_database_config

--- a/sonic-utilities-tests/show_bgp_network_test.py
+++ b/sonic-utilities-tests/show_bgp_network_test.py
@@ -7,7 +7,7 @@ from click.testing import CliRunner
 from bgp_commands_input import bgp_network_test_vector
 
 
-def executor(self, test_vector, show):
+def executor(test_vector, show):
     runner = CliRunner()
     input = bgp_network_test_vector.testData[test_vector]
     if test_vector.startswith('bgp_v6'):
@@ -23,7 +23,7 @@ def executor(self, test_vector, show):
     if input['rc'] == 0:
         assert result.exit_code == 0
     else:
-        assert result.exit_code != input['rc']
+        assert result.exit_code == input['rc']
 
     if 'rc_err_msg' in input:
         output = result.output.strip().split("\n")[-1]
@@ -44,6 +44,8 @@ class TestBgpNetwork(object):
         print("SETUP")
         from mock_tables import mock_single_asic
         reload(mock_single_asic)
+        from mock_tables import dbconnector
+        dbconnector.load_database_config()
 
     @pytest.mark.parametrize(
         'setup_single_bgp_instance, test_vector',
@@ -55,7 +57,7 @@ class TestBgpNetwork(object):
          ('bgp_v4_network_bestpath', 'bgp_v4_network_bestpath'),
          ('bgp_v6_network_longer_prefixes', 'bgp_v6_network_longer_prefixes'),
          ('bgp_v4_network', 'bgp_v4_network_longer_prefixes_error'),
-         ('bgp_v4_network', 'bgp_v6_network_longer_prefixes')],
+         ('bgp_v4_network', 'bgp_v6_network_longer_prefixes_error')],
         indirect=['setup_single_bgp_instance'])
     def test_bgp_network(self, setup_bgp_commands, test_vector,
                          setup_single_bgp_instance):
@@ -70,18 +72,20 @@ class TestMultiAsicBgpNetwork(object):
         print("SETUP")
         from mock_tables import mock_multi_asic
         reload(mock_multi_asic)
+        from mock_tables import dbconnector
+        dbconnector.load_namespace_config()
+
 
     @pytest.mark.parametrize(
         'setup_multi_asic_bgp_instance, test_vector',
-        [('bgp_v4_network', 'bgp_v4_network'),
-         ('bgp_v6_network', 'bgp_v6_network'),
+        [('bgp_v4_network', 'bgp_v4_network_multi_asic'),
+         ('bgp_v6_network', 'bgp_v6_network_multi_asic'),
          ('bgp_v4_network_asic0', 'bgp_v4_network_asic0'),
          ('bgp_v4_network_ip_address_asic0', 'bgp_v4_network_ip_address_asic0'),
          ('bgp_v4_network_bestpath_asic0', 'bgp_v4_network_bestpath_asic0'),
-         ('bgp_v4_network_bestpath', 'bgp_v4_network_bestpath'),
-         ('bgp_v6_network_longer_prefixes', 'bgp_v6_network_longer_prefixes'),
-         ('bgp_v4_network', 'bgp_v4_network_longer_prefixes_error'),
-         ('bgp_v6_network', 'bgp_v6_network_longer_prefixes')],
+        ('bgp_v6_network_asic0', 'bgp_v6_network_asic0'),
+         ('bgp_v6_network_ip_address_asic0', 'bgp_v6_network_ip_address_asic0'),
+         ('bgp_v6_network_bestpath_asic0', 'bgp_v6_network_bestpath_asic0')],
         indirect=['setup_multi_asic_bgp_instance'])
     def test_bgp_network(self, setup_bgp_commands, test_vector,
                          setup_multi_asic_bgp_instance):
@@ -89,6 +93,8 @@ class TestMultiAsicBgpNetwork(object):
         executor(test_vector, show)
 
     @classmethod
-    def teardown(cls):
+    def teardown_class(cls):
         from mock_tables import mock_single_asic
         reload(mock_single_asic)
+        from mock_tables import dbconnector
+        dbconnector.load_namespace_config()

--- a/sonic-utilities-tests/show_bgp_network_test.py
+++ b/sonic-utilities-tests/show_bgp_network_test.py
@@ -1,6 +1,4 @@
 from imp import reload
-import os
-
 import pytest
 
 from click.testing import CliRunner

--- a/sonic-utilities-tests/show_bgp_network_test.py
+++ b/sonic-utilities-tests/show_bgp_network_test.py
@@ -1,0 +1,94 @@
+from imp import reload
+import os
+
+import pytest
+
+from click.testing import CliRunner
+from bgp_commands_input import bgp_network_test_vector
+
+
+def executor(self, test_vector, show):
+    runner = CliRunner()
+    input = bgp_network_test_vector.testData[test_vector]
+    if test_vector.startswith('bgp_v6'):
+        exec_cmd = show.cli.commands["ipv6"].commands["bgp"].commands["network"]
+    else:
+        exec_cmd = show.cli.commands["ip"].commands["bgp"].commands["network"]
+
+    result = runner.invoke(exec_cmd, input['args'])
+
+    print(result.exit_code)
+    print(result.output)
+
+    if input['rc'] == 0:
+        assert result.exit_code == 0
+    else:
+        assert result.exit_code != input['rc']
+
+    if 'rc_err_msg' in input:
+        output = result.output.strip().split("\n")[-1]
+        assert input['rc_err_msg'] in output
+
+    if 'rc_output' in input:
+        assert result.output == input['rc_output']
+
+    if 'rc_warning_msg' in input:
+        output = result.output.strip().split("\n")[0]
+        assert input['rc_warning_msg'] in output
+
+
+class TestBgpNetwork(object):
+
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        from mock_tables import mock_single_asic
+        reload(mock_single_asic)
+
+    @pytest.mark.parametrize(
+        'setup_single_bgp_instance, test_vector',
+        [('bgp_v4_network', 'bgp_v4_network'),
+         ('bgp_v6_network', 'bgp_v6_network'),
+         ('bgp_v4_network_ip_address', 'bgp_v4_network_ip_address'),
+         ('bgp_v6_network_ip_address', 'bgp_v6_network_ip_address'),
+         ('bgp_v6_network_bestpath', 'bgp_v6_network_bestpath'),
+         ('bgp_v4_network_bestpath', 'bgp_v4_network_bestpath'),
+         ('bgp_v6_network_longer_prefixes', 'bgp_v6_network_longer_prefixes'),
+         ('bgp_v4_network', 'bgp_v4_network_longer_prefixes_error'),
+         ('bgp_v4_network', 'bgp_v6_network_longer_prefixes')],
+        indirect=['setup_single_bgp_instance'])
+    def test_bgp_network(self, setup_bgp_commands, test_vector,
+                         setup_single_bgp_instance):
+        show = setup_bgp_commands
+        executor(test_vector, show)
+
+
+class TestMultiAsicBgpNetwork(object):
+
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        from mock_tables import mock_multi_asic
+        reload(mock_multi_asic)
+
+    @pytest.mark.parametrize(
+        'setup_multi_asic_bgp_instance, test_vector',
+        [('bgp_v4_network', 'bgp_v4_network'),
+         ('bgp_v6_network', 'bgp_v6_network'),
+         ('bgp_v4_network_asic0', 'bgp_v4_network_asic0'),
+         ('bgp_v4_network_ip_address_asic0', 'bgp_v4_network_ip_address_asic0'),
+         ('bgp_v4_network_bestpath_asic0', 'bgp_v4_network_bestpath_asic0'),
+         ('bgp_v4_network_bestpath', 'bgp_v4_network_bestpath'),
+         ('bgp_v6_network_longer_prefixes', 'bgp_v6_network_longer_prefixes'),
+         ('bgp_v4_network', 'bgp_v4_network_longer_prefixes_error'),
+         ('bgp_v6_network', 'bgp_v6_network_longer_prefixes')],
+        indirect=['setup_multi_asic_bgp_instance'])
+    def test_bgp_network(self, setup_bgp_commands, test_vector,
+                         setup_multi_asic_bgp_instance):
+        show = setup_bgp_commands
+        executor(test_vector, show)
+
+    @classmethod
+    def teardown(cls):
+        from mock_tables import mock_single_asic
+        reload(mock_single_asic)

--- a/utilities_common/bgp_util.py
+++ b/utilities_common/bgp_util.py
@@ -10,6 +10,32 @@ from sonic_py_common import multi_asic
 from tabulate import tabulate
 from utilities_common import constants
 
+def get_namespace_for_bgp_neighbor(neighbor_ip):
+    namespace_list = multi_asic.get_namespace_list()
+    for namespace in namespace_list:
+        if is_bgp_neigh_present(neighbor_ip, namespace):
+            return namespace
+
+    # neighbor IP not present in any namespace
+    raise ValueError(
+                 ' Bgp neighbor {} not configured'.format(neighbor_ip))
+
+
+def is_bgp_neigh_present(neighbor_ip, namespace=multi_asic.DEFAULT_NAMESPACE):
+    config_db = multi_asic.connect_config_db_for_ns(namespace)
+    #check the internal
+    bgp_session = config_db.get_entry(multi_asic.BGP_NEIGH_CFG_DB_TABLE,
+                                      neighbor_ip)
+    if bgp_session:
+        return True
+
+    bgp_session = config_db.get_entry(
+        multi_asic.BGP_INTERNAL_NEIGH_CFG_DB_TABLE, neighbor_ip)
+    if bgp_session:
+        return True
+    return False
+
+
 
 def is_ipv4_address(ip_address):
     """

--- a/utilities_common/bgp_util.py
+++ b/utilities_common/bgp_util.py
@@ -189,7 +189,7 @@ def run_bgp_command(vtysh_cmd, bgp_namespace=multi_asic.DEFAULT_NAMESPACE):
         output = run_command(cmd, return_cmd=True)
     except Exception:
         ctx = click.get_current_context()
-        ctx.fail("Unable to get summary from bgp".format(bgp_instance_id))
+        ctx.fail("Unable to get summary from bgp {}".format(bgp_instance_id))
 
     return output
 

--- a/utilities_common/multi_asic.py
+++ b/utilities_common/multi_asic.py
@@ -102,6 +102,11 @@ _multi_asic_click_options = [
                  help='Namespace name or all'),
 ]
 
+def multi_asic_namespace_validation_callback(ctx, param, value):
+    if not multi_asic.is_multi_asic:
+        click.echo("-n/--namespace is not available for single asic")
+        ctx.abort()
+    return value
 
 def multi_asic_click_options(func):
     for option in reversed(_multi_asic_click_options):


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This is port of the PR https://github.com/Azure/sonic-utilities/pull/1574 in 201911 branch

This PR is to add support for the commands show ip bgp neighbor and show ip bgp network
Add unit tests for these commands

How I did it
Add change to get the bgp neighbor and network information from each namespace

How to verify it
Check the command works on single and multi asic platforms

UT  results
============================= test session starts ==============================
platform linux2 -- Python 2.7.13, pytest-3.0.6, py-1.4.32, pluggy-0.4.0
rootdir: /sonic/src/sonic-utilities, inifile: pytest.ini
plugins: cov-2.4.0
collected 314 items

sonic-utilities-tests/acl_config_test.py ............
sonic-utilities-tests/acl_loader_test.py .....................
sonic-utilities-tests/aclshow_test.py ..........
sonic-utilities-tests/counterpoll_test.py ...
sonic-utilities-tests/crm_test.py ..................................................
sonic-utilities-tests/db_migrator_test.py ..............................
sonic-utilities-tests/drops_group_test.py .......
sonic-utilities-tests/feature_test.py ...............
sonic-utilities-tests/filter_fdb_entries_test.py ..........
sonic-utilities-tests/intfstat_test.py ........
sonic-utilities-tests/intfutil_test.py .........
sonic-utilities-tests/ip_show_routes_multi_asic_test.py ...............
sonic-utilities-tests/ip_show_routes_test.py ......
sonic-utilities-tests/multi_asic_intfutil_test.py ..........
sonic-utilities-tests/pfcstat_test.py .......
sonic-utilities-tests/pfcwd_test.py ............
sonic-utilities-tests/port2alias_test.py ....
sonic-utilities-tests/portstat_test.py ..................
sonic-utilities-tests/psu_test.py ...
sonic-utilities-tests/sfp_test.py .........
sonic-utilities-tests/show_bgp_neighbor_test.py ............
sonic-utilities-tests/show_bgp_network_test.py .................
sonic-utilities-tests/show_ip_bgp_commands_test.py ...........
sonic-utilities-tests/show_ip_int_test.py ..........
sonic-utilities-tests/sku_create_test.py .....

========================= 314 passed in 65.28 seconds ==========================
make[1]: Leaving directory '/sonic/src/sonic-utilities/deb_dist/sonic-utilities-1.2'
 fakeroot debian/rules binary

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

