### PR TITLE
[sfpshow] Gracefully handle improper 'specification_compliance' field

### DIFF
--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -6,6 +6,7 @@
     which accesses the transceiver directly.
 """
 
+import ast
 import os
 import re
 import sys
@@ -273,10 +274,15 @@ class SFPShow(object):
                     output += '{}{}: {}\n'.format(indent, QSFP_DATA_MAP[key], sfp_info_dict[key])
                 else:
                     output += '{}{}:\n'.format(indent, QSFP_DATA_MAP['specification_compliance'])
-                    spefic_compliance_dict = eval(sfp_info_dict['specification_compliance'])
-                    sorted_compliance_key_table = natsorted(spefic_compliance_dict)
-                    for compliance_key in sorted_compliance_key_table:
-                        output += '{}{}: {}\n'.format((indent * 2), compliance_key, spefic_compliance_dict[compliance_key])
+
+                    spec_compliance_dict = {}
+                    try:
+                        spec_compliance_dict = ast.literal_eval(sfp_info_dict['specification_compliance'])
+                        sorted_compliance_key_table = natsorted(spec_compliance_dict)
+                        for compliance_key in sorted_compliance_key_table:
+                            output += '{}{}: {}\n'.format((indent * 2), compliance_key, spec_compliance_dict[compliance_key])
+                    except ValueError as e:
+                        output += '{}N/A\n'.format((indent * 2))
             else:
                 output += '{}{}: {}\n'.format(indent, QSFP_DATA_MAP[key], sfp_info_dict[key])
 


### PR DESCRIPTION
#### What I did

Gracefully handle improper 'specification_compliance' field

#### How I did it

The 'specification_compliance' field of transceiver info is expected to be a string representation of a dictionary. However, there is a chance, upon some kind of platform issue that a vendor's platform API returns something like 'N/A'. In this case, sfpshow would crash. Rather than crash, sfpshow should handle this gracefully and output 'N/A' instead.

#### How to verify it

Run sfpshow on a device where the 'specification_compliance' field of transceiver info is not a string representation of a dictionary.

#### Previous command output (if the output of a command-line utility has changed)

N/A -- sfpshow would crash

#### New command output (if the output of a command-line utility has changed)

```
Ethernet0: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: N/A
        Encoding: N/A
        Extended Identifier: N/A
        Extended RateSelect Compliance: N/A
        Identifier: N/A
        N/A: N/A
        Nominal Bit Rate(100Mbs): N/A
        Specification compliance:
                N/A
        Vendor Date Code(YYYY-MM-DD Lot): N/A
        Vendor Name: N/A
        Vendor OUI: N/A
        Vendor PN: N/A
        Vendor Rev: N/A
        Vendor SN: N/A
```

Related PR: https://github.com/Azure/sonic-platform-daemons/pull/169