### PR TITLE
[setup.py] Added an option for providing additional arguments to pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ python3 setup.py bdist_wheel
 python3 setup.py test
 ```
 
+#### To pass additional pytest arguments
+
+```
+python3 setup.py test -a "-k 'TestAaa'"
+```
+
 
 ### sonic-utilities-data
 

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,21 @@
 # under scripts/. Consider stop using scripts and use console_scripts instead
 #
 # https://stackoverflow.com/questions/18787036/difference-between-entry-points-console-scripts-and-scripts-in-setup-py
-import fastentrypoints
+import fastentrypoints, sys
 
 from setuptools import setup
+from setuptools.command.test import test as TestCommand
+
+class PyTest(TestCommand):
+    user_options = [("pytest-args=", "a", "Arguments to pass to pytest")]
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.pytest_args = ""
+    def run_tests(self):
+        import shlex
+        import pytest
+        errno = pytest.main(shlex.split(self.pytest_args))
+        sys.exit(errno)
 
 setup(
     name='sonic-utilities',
@@ -213,5 +225,6 @@ setup(
         'Topic :: Utilities',
     ],
     keywords='sonic SONiC utilities command line cli CLI',
+    cmdclass={"pytest": PyTest},
     test_suite='setup.get_test_suite'
 )


### PR DESCRIPTION
Signed-off-by: Vivek Reddy Karri <vkarri@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

Currently, the only option to run unit tests is to use this command, `pytest setup.py test`. This executes all the unit tests even though user only wants to run a few and also no control over pytest arguments

#### What I did
Added an argument '-a' to the pytest setup.py test command which takes in pytest related arguments. 

Essentially, `python3 setup.py test -a "<args>"` translates to `pytest <args>`

#### How I did it

#### How to verify it

```
python3 setup.py test -a "-k 'Test_Aaa'" # To only run the tests under Test_Aaa class

============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.7.3, pytest-3.10.1, py-1.7.0, pluggy-0.8.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /sonic/src/sonic-utilities, inifile: pytest.ini
plugins: pyfakefs-4.4.0, cov-2.6.0
collected 1009 items / 1005 deselected

tests/aaa_test.py::TestAaa::test_show_aaa_default PASSED                                                                                                                                               [ 25%]
tests/aaa_test.py::TestAaa::test_config_aaa_radius PASSED                                                                                                                                              [ 50%]
tests/aaa_test.py::TestAaa::test_config_aaa_radius_local PASSED                                                                                                                                        [ 75%]
tests/aaa_test.py::TestAaa::test_config_aaa_radius_invalid PASSED                                                                                                                                      [100%]

Others:
python3 setup.py test -a "-x'" # To stop at the first failure
python3 setup.py test -a "-x -k 'Test_Aaa'" # Multiple arguments can be given as well
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

