### PR TITLE
[config]: Use mod_entry when editing VLAN_INTERFACE

### DIFF
--- a/config/vlan.py
+++ b/config/vlan.py
@@ -92,7 +92,7 @@ def config_proxy_arp(db, vid, mode):
     if not clicommon.is_valid_vlan_interface(db.cfgdb, vlan):
         ctx.fail("Interface {} does not exist".format(vlan))
 
-    db.cfgdb.set_entry('VLAN_INTERFACE', vlan, {"proxy_arp": mode})
+    db.cfgdb.mod_entry('VLAN_INTERFACE', vlan, {"proxy_arp": mode})
     click.echo('Proxy ARP setting saved to ConfigDB')
     restart_ndppd()
 #


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Replace `set_entry` with `mod_entry` when setting the `proxy_arp` value for a VLAN.

Using `set_entry` will delete any other fields set for the key used, which is not desirable.

#### How I did it

#### How to verify it
Add some field to `VLAN_INTERFACE|Vlan1000`, then run `config vlan proxy_arp 1000 enabled`. Confirm with `sonic-db-cli` that the extra field is still present after the command runs.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

