### PR TITLE
[show] add support for muxcable metrics

### DIFF
--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -708,5 +708,11 @@
         "non_fatal|Undefined": "0",
         "non_fatal|UnsupReq": "0",
         "non_fatal|UnxCmplt": "0"
+    },
+    "MUX_METRICS_TABLE|Ethernet0": {
+        "linkmgrd_switch_active_start": "2021-May-13 10:00:21.420898",
+        "linkmgrd_switch_standby_end": "2021-May-13 10:01:15.696728",
+        "xcvrd_switch_standby_end": "2021-05-13 10:01:15.696051",
+        "xcvrd_switch_standby_start": "2021-05-13 10:01:15.690835"
     }
 }

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -712,7 +712,7 @@
     "MUX_METRICS_TABLE|Ethernet0": {
         "linkmgrd_switch_active_start": "2021-May-13 10:00:21.420898",
         "linkmgrd_switch_standby_end": "2021-May-13 10:01:15.696728",
-        "xcvrd_switch_standby_end": "2021-05-13 10:01:15.696051",
-        "xcvrd_switch_standby_start": "2021-05-13 10:01:15.690835"
+        "xcvrd_switch_standby_end": "2021-May-13 10:01:15.696051",
+        "xcvrd_switch_standby_start": "2021-May-13 10:01:15.690835"
     }
 }

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -189,6 +189,23 @@ show_muxcable_firmware_version_expected_output = """\
 }
 """
 
+show_muxcable_metrics_expected_output = """\
+PORT       EVENT                         TIME
+---------  ----------------------------  ---------------------------
+Ethernet0  linkmgrd_switch_active_start  2021-May-13 10:00:21.420898
+Ethernet0  linkmgrd_switch_standby_end   2021-May-13 10:01:15.696728
+Ethernet0  xcvrd_switch_standby_end      2021-05-13 10:01:15.696051
+Ethernet0  xcvrd_switch_standby_start    2021-05-13 10:01:15.690835
+"""
+
+show_muxcable_metrics_expected_output_json = """\
+{
+    "linkmgrd_switch_active_start": "2021-May-13 10:00:21.420898",
+    "linkmgrd_switch_standby_end": "2021-May-13 10:01:15.696728",
+    "xcvrd_switch_standby_end": "2021-05-13 10:01:15.696051",
+    "xcvrd_switch_standby_start": "2021-05-13 10:01:15.690835"
+}
+"""
 
 class TestMuxcable(object):
     @classmethod
@@ -779,6 +796,32 @@ class TestMuxcable(object):
         result = runner.invoke(config.config.commands["muxcable"].commands["firmware"].commands["rollback"], [
                                "Ethernet0"], obj=db)
         assert result.exit_code == 0
+
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    def test_show_muxcable_metrics_port(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["metrics"], [
+                               "Ethernet0"], obj=db)
+        assert result.exit_code == 0
+        assert result.output == show_muxcable_metrics_expected_output
+
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    def test_show_muxcable_metrics_port(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["metrics"], [
+                               "Ethernet0", "--json"], obj=db)
+        assert result.exit_code == 0
+        assert result.output == show_muxcable_metrics_expected_output_json
 
     @classmethod
     def teardown_class(cls):

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -805,8 +805,8 @@ class TestMuxcable(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(show.cli.commands["muxcable"].commands["metrics"], [
-                               "Ethernet0"], obj=db)
+        result = runner.invoke(show.cli.commands["muxcable"].commands["metrics"],
+                               ["Ethernet0"], obj=db)
         assert result.exit_code == 0
         assert result.output == show_muxcable_metrics_expected_output
 
@@ -818,8 +818,8 @@ class TestMuxcable(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(show.cli.commands["muxcable"].commands["metrics"], [
-                               "Ethernet0", "--json"], obj=db)
+        result = runner.invoke(show.cli.commands["muxcable"].commands["metrics"],
+                               ["Ethernet0", "--json"], obj=db)
         assert result.exit_code == 0
         assert result.output == show_muxcable_metrics_expected_output_json
 

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -194,16 +194,16 @@ PORT       EVENT                         TIME
 ---------  ----------------------------  ---------------------------
 Ethernet0  linkmgrd_switch_active_start  2021-May-13 10:00:21.420898
 Ethernet0  linkmgrd_switch_standby_end   2021-May-13 10:01:15.696728
-Ethernet0  xcvrd_switch_standby_end      2021-05-13 10:01:15.696051
-Ethernet0  xcvrd_switch_standby_start    2021-05-13 10:01:15.690835
+Ethernet0  xcvrd_switch_standby_end      2021-May-13 10:01:15.696051
+Ethernet0  xcvrd_switch_standby_start    2021-May-13 10:01:15.690835
 """
 
 show_muxcable_metrics_expected_output_json = """\
 {
     "linkmgrd_switch_active_start": "2021-May-13 10:00:21.420898",
     "linkmgrd_switch_standby_end": "2021-May-13 10:01:15.696728",
-    "xcvrd_switch_standby_end": "2021-05-13 10:01:15.696051",
-    "xcvrd_switch_standby_start": "2021-05-13 10:01:15.690835"
+    "xcvrd_switch_standby_end": "2021-May-13 10:01:15.696051",
+    "xcvrd_switch_standby_start": "2021-May-13 10:01:15.690835"
 }
 """
 


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added support for show muxcable metrics. This essentially records what events came to different modules per se
for toggling the mux from one state to another.
for example 

`admin@sonic$ show muxcable metrics Ethernet0 --json`

`{`
   `"linkmgrd_switch_active_start": "2021-May-13 10:00:21.420898",`
    `"linkmgrd_switch_standby_end": "2021-May-13 10:01:15.696728",`
   ` "linkmgrd_switch_unknown_end": "2021-May-13 10:00:26.123319",`
   ` "xcvrd_switch_standby_end": "2021-May-13 10:01:15.696051",`
   `"xcvrd_switch_standby_start": "2021-May-13 10:01:15.690835"`
`}`

or 

`admin@sonic:$ show muxcable metrics Ethernet0`

`PORT       EVENT                         TIME`
`---------  ----------------------------  ---------------------------`
`Ethernet0  linkmgrd_switch_active_start  2021-May-13 10:00:21.420898`
`Ethernet0  linkmgrd_switch_standby_end   2021-May-13 10:01:15.696728`
`Ethernet0  linkmgrd_switch_unknown_end   2021-May-13 10:00:26.123319`
`Ethernet0  xcvrd_switch_standby_end      2021-May-13 10:01:15.696051`
`Ethernet0  xcvrd_switch_standby_start    2021-May-13 10:01:15.690835`


#### How I did it
added changes in show/muxcable.py by reading and publishing the state DB contents for the corresponding table

#### How to verify it
unit tests are added for verifying. 

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

