### PR TITLE
[config] Fix adding dev to static route

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -4008,7 +4008,8 @@ def add_route(ctx, command_str):
 
     # If defined intf name, check if it belongs to interface
     if 'ifname' in route:
-        if (not route['ifname'] in config_db.get_keys('VLAN_INTERFACE') and
+        if (not route['ifname'] in config_db.get_keys('VLAN') and
+            not route['ifname'] in config_db.get_keys('VLAN_INTERFACE') and
             not route['ifname'] in config_db.get_keys('INTERFACE') and
             not route['ifname'] in config_db.get_keys('PORTCHANNEL_INTERFACE') and
             not route['ifname'] == 'null'):
@@ -4054,6 +4055,9 @@ def add_route(ctx, command_str):
     # Check if exist entry with key
     keys = config_db.get_keys('STATIC_ROUTE')
     if key in keys:
+        if 'null' in route['ifname']:
+             ctx.fail("this route is already configured on nexthop, remove it before configuring to black hole")
+
         # If exist update current entry
         current_entry = config_db.get_entry('STATIC_ROUTE', key)
 


### PR DESCRIPTION
**What I did**
Change rule for adding dev vlan to route
Update unit tests with ethernet and vlan cases
fixes https://github.com/Azure/sonic-buildimage/issues/7643

Also solved https://github.com/Azure/sonic-utilities/pull/1534#discussion_r628463998 with notifying the user.

**How I did it**
Add a rule for checking vlan in the table, which overrides checking by vlan interface. Since vlan does not have interface entry until an IP address is added to it

**How to verify it**
```
sudo config vlan add 20
sudo config route add prefix 1.2.3.4/32 nexthop dev Vlan20

show ip route
S   1.2.3.4/32 [1/0] is directly connected, Vlan20 inactive, weight 1, 00:21:59
```

#### New command output (if the output of a command-line utility has changed)
If user trying to set blackhole on existing route
"Error: this route is already configured on nexthop, remove it before configuring to black hole"

Signed-off-by: d-dashkov <Dmytro_Dashkov@Jabil.com>
