### PR TITLE
Limit pyroute2 version range due to upstream broken

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -179,7 +179,7 @@ setup(
         'pexpect>=4.8.0',
         'poetry-semver>=0.1.0',
         'prettyprinter>=0.18.0',
-        'pyroute2>=0.5.14',
+        'pyroute2>=0.5.14, <0.6.1',
         'requests>=2.25.0',
         'sonic-config-engine',
         'sonic-platform-common',


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
The latest version of pyroute2 introduce breaking change:
```
______________________ ERROR collecting tests/aaa_test.py ______________________
ImportError while importing test module '/__w/1/s/tests/aaa_test.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/__w/1/s/.eggs/pyroute2-0.6.1-py3.7.egg/pyroute2/__init__.py:44: in <module>
    from importlib import metadata
E   ImportError: cannot import name 'metadata' from 'importlib' (/usr/lib/python3.7/importlib/__init__.py)

During handling of the above exception, another exception occurred:
/usr/lib/python3/dist-packages/_pytest/python.py:450: in _importtestmodule
    mod = self.fspath.pyimport(ensuresyspath=importmode)
/usr/lib/python3/dist-packages/py/_path/local.py:668: in pyimport
    __import__(modname)
/usr/lib/python3/dist-packages/_pytest/assertion/rewrite.py:294: in load_module
    six.exec_(co, mod.__dict__)
tests/aaa_test.py:6: in <module>
    from utilities_common.db import Db
utilities_common/db.py:4: in <module>
    from utilities_common.multi_asic import multi_asic_ns_choices
utilities_common/multi_asic.py:6: in <module>
    import pyroute2
/__w/1/s/.eggs/pyroute2-0.6.1-py3.7.egg/pyroute2/__init__.py:46: in <module>
    ???
E   ModuleNotFoundError: No module named 'importlib_metadata'
```

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

