### PR TITLE
Fix Aboot breakage sonic-installer due to package migration

### DIFF
--- a/sonic_installer/bootloader/aboot.py
+++ b/sonic_installer/bootloader/aboot.py
@@ -19,6 +19,7 @@ from ..common import (
    HOST_PATH,
    IMAGE_DIR_PREFIX,
    IMAGE_PREFIX,
+   ROOTFS_NAME,
    run_command,
    run_command_or_raise,
 )
@@ -26,18 +27,36 @@ from .bootloader import Bootloader
 
 _secureboot = None
 DEFAULT_SWI_IMAGE = 'sonic.swi'
+KERNEL_CMDLINE_NAME = 'kernel-cmdline'
 
 # For the signature format, see: https://github.com/aristanetworks/swi-tools/tree/master/switools
 SWI_SIG_FILE_NAME = 'swi-signature'
 SWIX_SIG_FILE_NAME = 'swix-signature'
 ISSUERCERT = 'IssuerCert'
 
-def isSecureboot():
+def parse_cmdline(cmdline=None):
+    if cmdline is None:
+        with open('/proc/cmdline') as f:
+            cmdline = f.read()
+
+    data = {}
+    for entry in cmdline.split():
+        idx = entry.find('=')
+        if idx == -1:
+            data[entry] = None
+        else:
+            data[entry[:idx]] = entry[idx+1:]
+    return data
+
+def docker_inram(cmdline=None):
+    cmdline = parse_cmdline(cmdline)
+    return cmdline.get('docker_inram') == 'on'
+
+def is_secureboot():
     global _secureboot
     if _secureboot is None:
-        with open('/proc/cmdline') as f:
-            m = re.search(r"secure_boot_enable=[y1]", f.read())
-        _secureboot = bool(m)
+        cmdline = parse_cmdline()
+        _secureboot = cmdline.get('secure_boot_enable') in ['y', '1']
     return _secureboot
 
 class AbootBootloader(Bootloader):
@@ -70,7 +89,7 @@ class AbootBootloader(Bootloader):
 
     def _swi_image_path(self, image):
         image_dir = image.replace(IMAGE_PREFIX, IMAGE_DIR_PREFIX)
-        if isSecureboot():
+        if is_secureboot():
            return 'flash:%s/sonic.swi' % image_dir
         return 'flash:%s/.sonic-boot.swi' % image_dir
 
@@ -118,6 +137,25 @@ class AbootBootloader(Bootloader):
         subprocess.call(['rm','-rf', image_path])
         click.echo('Image removed')
 
+    def _get_image_cmdline(self, image):
+        image_path = self.get_image_path(image)
+        with open(os.path.join(image_path, KERNEL_CMDLINE_NAME)) as f:
+            return f.read()
+
+    def supports_package_migration(self, image):
+        if is_secureboot():
+            # NOTE: unsafe until migration can guarantee migration safety
+            #       packages need to be signed and verified at boot time.
+            return False
+        cmdline = self._get_image_cmdline(image)
+        if docker_inram(cmdline):
+            # NOTE: the docker_inram feature extracts builtin containers at boot
+            #       time in memory. the use of package manager under these
+            #       circumpstances is not possible without a boot time package
+            #       installation mechanism.
+            return False
+        return True
+
     def get_binary_image_version(self, image_path):
         try:
             version = subprocess.check_output(['/usr/bin/unzip', '-qop', image_path, '.imagehash'], text=True)
@@ -140,7 +178,7 @@ class AbootBootloader(Bootloader):
         return self._verify_secureboot_image(image_path)
 
     def _verify_secureboot_image(self, image_path):
-        if isSecureboot():
+        if is_secureboot():
             cert = self.getCert(image_path)
             return cert is not None
         return True
@@ -188,14 +226,14 @@ class AbootBootloader(Bootloader):
                 return f._fileobj.tell() # pylint: disable=protected-access
 
     @contextmanager
-    def get_path_in_image(self, image_path, path):
-        path_in_image = os.path.join(image_path, path)
-        if os.path.exists(path_in_image) and not isSecureboot():
-            yield path_in_image
+    def get_rootfs_path(self, image_path):
+        path = os.path.join(image_path, ROOTFS_NAME)
+        if os.path.exists(path) and not is_secureboot():
+            yield path
             return
 
         swipath = os.path.join(image_path, DEFAULT_SWI_IMAGE)
-        offset = self._get_swi_file_offset(swipath, path)
+        offset = self._get_swi_file_offset(swipath, ROOTFS_NAME)
         loopdev = subprocess.check_output(['losetup', '-f']).decode('utf8').rstrip()
 
         try:

--- a/sonic_installer/bootloader/bootloader.py
+++ b/sonic_installer/bootloader/bootloader.py
@@ -9,6 +9,7 @@ from ..common import (
    HOST_PATH,
    IMAGE_DIR_PREFIX,
    IMAGE_PREFIX,
+   ROOTFS_NAME,
 )
 
 class Bootloader(object):
@@ -58,6 +59,10 @@ class Bootloader(object):
         image_path = self.get_image_path(image)
         return path.exists(image_path)
 
+    def supports_package_migration(self, image):
+        """tells if the image supports package migration"""
+        return True
+
     @classmethod
     def detect(cls):
         """returns True if the bootloader is in use"""
@@ -70,6 +75,6 @@ class Bootloader(object):
         return image.replace(IMAGE_PREFIX, prefix)
 
     @contextmanager
-    def get_path_in_image(self, image_path, path_in_image):
+    def get_rootfs_path(self, image_path):
         """returns the path to the squashfs"""
-        yield path.join(image_path, path_in_image)
+        yield path.join(image_path, ROOTFS_NAME)


### PR DESCRIPTION
#### Failure cause

Fixes https://github.com/Azure/sonic-buildimage/issues/7566

The `get_rootfs_path` contextmanager was recently repurposed to implement
`get_file_in_image` . It then got used as a function by leveraging some
python complexity to bypass the restrictions coming with the contextmanager construct.
This was a conscious decision to prevent exactly what happened.
The method was then called multiple times to compute relative paths to the image directory.
Simple path joins using `new_image_dir` could have been performed instead.

The `get_rootfs_path` implementation for Aboot bootloaders behaves differently
when a rootfs is extracted or kept within the SWI image. It also behaves differently on secureboot systems.
The updated method was used by providing parameters it was never meant to process.

#### Context around the failure

Over time, the installation and boot process on Aboot has slightly diverged from
the ONIE one. There are 3 scenarios to consider.

1) Regular boot similar to ONIE
This one should just work the same as the filesystem layout is unchanged.

2) docker_inram where dockerfs.tar.gz is extracted in tmpfs at boot
In this scenario the boot is similar to the regular one beside that
`dockerfs.tar.gz` is preserved intact on the flash and not extracted.
By design this does not fit the sonic-package-manager requierements and
the migration should be skipped which is what I did in this review.
In the coming months this boot mode will look closer to `3)` below.

3) Secureboot on Arista devices
In this scenario the SWI image is kept intact and nothing extracted
from it. By ensuring the integrity of the SWI we can guarantee that no
code/data has been tampered with. This mode also relies on
`docker_inram` at the moment.
It could be enhanced when sonic-package-manager can guarantee the
integrity of code and data that is both installed and migrated.

#### Solution provided

The method `get_file_in_image` was reverted to its original meaning
`get_rootfs_path` as there is no point in keeping the new one.
It doesn't have the necessary logic to handle more than the rootfs and
the logic for which it was repurposed can easily be achieved by the following line.
`os.path.join(bootloader.get_image_path(binary_image_name), 'something')`
If this is a desirable helper it should become a method of its own.

A new `Bootloader` method called `support_package_migration` is
introduced to allow the bootloader to skip the package migration based
on the image (e.g docker_inram) or its own configuration (e.g secureboot).
By default all bootloaders enable the package migration.

That change leads to `1)` above running package migration while `2)` and `3)`
skip it.

#### New command output (if the output of a command-line utility has changed)

The temporary error message now becomes a warning message for platforms that do not
support package migration.

```
Command: losetup -d /dev/loop2
Warning: SONiC package migration is not supported for this bootloader/image
Command: sync;sync;sync
```

