### PR TITLE
Fix Unicode issue in ipaddress for python2

### DIFF
--- a/scripts/fast-reboot-dump.py
+++ b/scripts/fast-reboot-dump.py
@@ -13,6 +13,10 @@ import syslog
 import traceback
 import ipaddress
 
+def to_unicode(x):
+  if sys.version_info < (3, 0):
+    return unicode(x)
+  return str(x)
 
 ARP_CHUNK = binascii.unhexlify('08060001080006040001') # defines a part of the packet for ARP Request
 ARP_PAD = binascii.unhexlify('00' * 18)
@@ -96,7 +100,7 @@ def get_map_host_port_id_2_iface_name(asic_db):
         port_id = value['SAI_HOSTIF_ATTR_OBJ_ID']
         iface_name = value['SAI_HOSTIF_ATTR_NAME']
         host_port_id_2_iface[port_id] = iface_name
-    
+
     return host_port_id_2_iface
 
 def get_map_lag_port_id_2_portchannel_name(asic_db, app_db, host_port_id_2_iface):
@@ -274,7 +278,7 @@ def send_garp_nd(neighbor_entries, map_mac_ip_per_vlan):
     # send arp/ndp packets
     for vlan_name, dst_mac, dst_ip in neighbor_entries:
         src_if = map_mac_ip_per_vlan[vlan_name][dst_mac]
-        if ipaddress.ip_interface(dst_ip).ip.version == 4:
+        if ipaddress.ip_interface(to_unicode(dst_ip)).ip.version == 4:
             send_arp(sockets[src_if], src_mac_addrs[src_if], src_ip_addrs[vlan_name], dst_mac, dst_ip)
         else:
             send_ndp(sockets[src_if], src_mac_addrs[src_if], src_ip_addrs[vlan_name], dst_mac, dst_ip)


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This PR is to address the Unicode issue in ```fast-reboot-dump.py``` script in ```201911```. 
There is another PR that addresses same issue in master image #1164 
However, ```builtins``` package is not available in ```201911``` image.

```
Python 2.7.13 (default, Apr 16 2021, 14:02:03) 
[GCC 6.3.0 20170516] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import builtins
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: No module named builtins
``` 
So, I create this PR for 201911 branch to fix the issue in another way.

#### How I did it
Add a custom method to convert ```string``` to ```unicode```.

#### How to verify it
Verified on MSN2700, running ```SONiC.20191130.72```. 
First populate some FDB entry and ARP entry, and then run ```fast-reboot-dump.py``` script. No exception is raised, and we can confirm from ```syslog``` that all entries are dumped.
 
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

