### PR TITLE
[show] support for show muxcable firmware version of only active banks

### DIFF
--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -823,20 +823,18 @@ def switchmode(port):
             sys.exit(EXIT_FAIL)
 
 
-def get_firmware_dict(physical_port, target, side, mux_info_dict, mux_info_active_dict):
+def get_firmware_dict(physical_port, target, side, mux_info_dict):
 
     import sonic_y_cable.y_cable
     result = sonic_y_cable.y_cable.get_firmware_version(physical_port, target)
 
     if result is not None and isinstance(result, dict):
         mux_info_dict[("version_{}_active".format(side))] = result.get("version_active", None)
-        mux_info_active_dict[("version_{}_active".format(side))] = result.get("version_active", None)
         mux_info_dict[("version_{}_inactive".format(side))] = result.get("version_inactive", None)
         mux_info_dict[("version_{}_next".format(side))] = result.get("version_next", None)
 
     else:
         mux_info_dict[("version_{}_active".format(side))] = "N/A"
-        mux_info_active_dict[("version_{}_active".format(side))] = "N/A"
         mux_info_dict[("version_{}_inactive".format(side))] = "N/A"
         mux_info_dict[("version_{}_next".format(side))] = "N/A"
 
@@ -911,18 +909,24 @@ def version(port, active):
             read_side = sonic_y_cable.y_cable.check_read_side(physical_port)
             if logical_key in y_cable_asic_table_keys:
                 if read_side == 1:
-                    get_firmware_dict(physical_port, 1, "self", mux_info_dict, mux_info_active_dict)
-                    get_firmware_dict(physical_port, 2, "peer", mux_info_dict, mux_info_active_dict)
-                    get_firmware_dict(physical_port, 0, "nic", mux_info_dict, mux_info_active_dict)
+                    get_firmware_dict(physical_port, 1, "self", mux_info_dict)
+                    get_firmware_dict(physical_port, 2, "peer", mux_info_dict)
+                    get_firmware_dict(physical_port, 0, "nic", mux_info_dict)
                     if active is True:
+                        for key in mux_info_dict:
+                            if key.endswith("_active"):
+                                mux_info_active_dict[key] = mux_info_dict[key]
                         click.echo("{}".format(json.dumps(mux_info_active_dict, indent=4)))
                     else:
                         click.echo("{}".format(json.dumps(mux_info_dict, indent=4)))
                 elif read_side == 2:
-                    get_firmware_dict(physical_port, 2, "self", mux_info_dict, mux_info_active_dict)
-                    get_firmware_dict(physical_port, 1, "peer", mux_info_dict, mux_info_active_dict)
-                    get_firmware_dict(physical_port, 0, "nic", mux_info_dict, mux_info_active_dict)
+                    get_firmware_dict(physical_port, 2, "self", mux_info_dict)
+                    get_firmware_dict(physical_port, 1, "peer", mux_info_dict)
+                    get_firmware_dict(physical_port, 0, "nic", mux_info_dict)
                     if active is True:
+                        for key in mux_info_dict:
+                            if key.endswith("_active"):
+                                mux_info_active_dict[key] = mux_info_dict[key]
                         click.echo("{}".format(json.dumps(mux_info_active_dict, indent=4)))
                     else:
                         click.echo("{}".format(json.dumps(mux_info_dict, indent=4)))

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -189,6 +189,14 @@ show_muxcable_firmware_version_expected_output = """\
 }
 """
 
+show_muxcable_firmware_version_active_expected_output = """\
+{
+    "version_self_active": "0.6MS",
+    "version_peer_active": "0.6MS",
+    "version_nic_active": "0.6MS",
+}
+"""
+
 show_muxcable_metrics_expected_output = """\
 PORT       EVENT                         TIME
 ---------  ----------------------------  ---------------------------
@@ -822,6 +830,25 @@ class TestMuxcable(object):
                                ["Ethernet0", "--json"], obj=db)
         assert result.exit_code == 0
         assert result.output == show_muxcable_metrics_expected_output_json
+
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    @mock.patch('sonic_y_cable.y_cable.get_firmware_version', mock.MagicMock(return_value={"version_active": "0.6MS",
+                                                                                           "version_inactive": "0.6MS",
+                                                                                           "version_next": "0.6MS"}))
+    def test_show_muxcable_firmware_active_version(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["firmware"].commands["version"], [
+                               "Ethernet0", "--active"], obj=db)
+        assert result.exit_code == 0
+        assert result.output == show_muxcable_firmware_version_active_expected_output
 
     @classmethod
     def teardown_class(cls):

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -193,7 +193,7 @@ show_muxcable_firmware_version_active_expected_output = """\
 {
     "version_self_active": "0.6MS",
     "version_peer_active": "0.6MS",
-    "version_nic_active": "0.6MS",
+    "version_nic_active": "0.6MS"
 }
 """
 


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

This PR adds support for an option to display firmware version of muxcable of only active banks. 

The new output would look like this in case an active flag is passed to the command line

`admin@STR43-0101-0101-01LT0:~$ show muxcable firmware version Ethernet0 --active`
`{`
    `"version_self_active": "0.7MS",`
    `"version_peer_active": "0.7MS",`
    `"version_nic_active": "0.7MS", `
`}`

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
added an option to display active banks only for display muxcable firmware version

#### How I did it
added the changes in show/muxcable.py and added testcases

#### How to verify it
ran the command on the testbed. 

#### Previous command output (if the output of a command-line utility has changed)
N/A
#### New command output (if the output of a command-line utility has changed)
N/A
