### PR TITLE
Add range check on portchannel min-links

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1448,7 +1448,7 @@ def portchannel(ctx, namespace):
 
 @portchannel.command('add')
 @click.argument('portchannel_name', metavar='<portchannel_name>', required=True)
-@click.option('--min-links', default=0, type=int)
+@click.option('--min-links', default=0, type=click.IntRange(0,1024))
 @click.option('--fallback', default='false')
 @click.pass_context
 def add_portchannel(ctx, portchannel_name, min_links, fallback):

--- a/config/main.py
+++ b/config/main.py
@@ -1448,7 +1448,7 @@ def portchannel(ctx, namespace):
 
 @portchannel.command('add')
 @click.argument('portchannel_name', metavar='<portchannel_name>', required=True)
-@click.option('--min-links', default=0, type=click.IntRange(0,1024))
+@click.option('--min-links', default=1, type=click.IntRange(1,1024))
 @click.option('--fallback', default='false')
 @click.pass_context
 def add_portchannel(ctx, portchannel_name, min_links, fallback):


### PR DESCRIPTION
Signed-off-by: Raphael Tryster <raphaelt@nvidia.com>



#### What I did

Restrict the min-links parameter in "config portchannel" to the range 0-1024.
Fixes Azure/sonic-buildimage#6781 in conjunction with https://github.com/Azure/sonic-buildimage/pull/7265/files.


#### How I did it

Changed
@click.option('--min-links', default=0, type=int)
to
@click.option('--min-links', default=0, type=click.IntRange(0,1024))

Note that all these need to be aligned:

the default value
the range enforced here
the limits in libteam
the limits in the yang model

The first two of these are in this PR; the last two are in the other one referred to above. The alignment was performed as follows:

the default value - remained 0
the range enforced here - previously absent, now 0-1024
the limits in libteam - maximum was 255, now 1024
the limits in the yang model - was 1-128, now 0-1024

#### How to verify it

config portchannel add PortChannel0004 --min-links 1024

Command should be accepted.

show interfaces portchannel

Output should show PortChannel0004, no errors on CLI.

config portchannel add PortChannel0005 --min-links 1025

Command should be rejected

show interfaces portchannel

Output should not show PortChannel0005 , no errors on CLI.


#### Previous command output (if the output of a command-line utility has changed)

config portchannel add PortChannel0004 --min-links 1024

show interfaces portchannel

Traceback (most recent call last):
File "/usr/local/bin/show", line 8, in
sys.exit(cli())
File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 764, in call
return self.main(*args, **kwargs)
File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 717, in main
rv = self.invoke(ctx)
File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1137, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1137, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 956, in invoke
return ctx.invoke(self.callback, **ctx.params)
File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 555, in invoke
return callback(*args, **kwargs)
File "/usr/local/lib/python3.7/dist-packages/show/interfaces/portchannel.py", line 165, in portchannel
team.get_teams_info()
File "/usr/local/lib/python3.7/dist-packages/utilities_common/multi_asic.py", line 137, in wrapped_run_on_all_asics
func(self, *args, **kwargs)
File "/usr/local/lib/python3.7/dist-packages/show/interfaces/portchannel.py", line 49, in get_teams_info
self.get_teamshow_result()
File "/usr/local/lib/python3.7/dist-packages/show/interfaces/portchannel.py", line 111, in get_teamshow_result
info['protocol'] += "(A)" if state['runner.active'] == "true" else '(I)'
KeyError: 'runner.active'

config portchannel add PortChannel0005 --min-links 1025

show interfaces portchannel

Traceback (most recent call last):
File "/usr/local/bin/show", line 8, in
sys.exit(cli())
File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 764, in call
return self.main(*args, **kwargs)
File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 717, in main
rv = self.invoke(ctx)
File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1137, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1137, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 956, in invoke
return ctx.invoke(self.callback, **ctx.params)
File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 555, in invoke
return callback(*args, **kwargs)
File "/usr/local/lib/python3.7/dist-packages/show/interfaces/portchannel.py", line 165, in portchannel
team.get_teams_info()
File "/usr/local/lib/python3.7/dist-packages/utilities_common/multi_asic.py", line 137, in wrapped_run_on_all_asics
func(self, *args, **kwargs)
File "/usr/local/lib/python3.7/dist-packages/show/interfaces/portchannel.py", line 49, in get_teams_info
self.get_teamshow_result()
File "/usr/local/lib/python3.7/dist-packages/show/interfaces/portchannel.py", line 111, in get_teamshow_result
info['protocol'] += "(A)" if state['runner.active'] == "true" else '(I)'
KeyError: 'runner.active'

#### New command output (if the output of a command-line utility has changed)

config portchannel add PortChannel0004 --min-links 1024

show interfaces portchannel

No. Team Dev Protocol Ports

0004 PortChannel0004 LACP(A)(Dw) N/A

config portchannel add PortChannel0005 --min-links 1025

Error: Invalid value for "--min-links": 1025 is not in the valid range of 0 to 1024.

show interfaces portchannel

No. Team Dev Protocol Ports

0004 PortChannel0004 LACP(A)(Dw) N/A
