### PR TITLE
[config][tacacs+] Change tacacs+ minimum timeout value base on specification.

### DIFF
--- a/config/aaa.py
+++ b/config/aaa.py
@@ -94,10 +94,10 @@ tacacs.add_command(default)
 
 
 @click.command()
-@click.argument('second', metavar='<time_second>', type=click.IntRange(0, 60), required=False)
+@click.argument('second', metavar='<time_second>', type=click.IntRange(1, 60), required=False)
 @click.pass_context
 def timeout(ctx, second):
-    """Specify TACACS+ server global timeout <0 - 60>"""
+    """Specify TACACS+ server global timeout <1 - 60>"""
     if ctx.obj == 'default':
         del_table_key('TACPLUS', 'global', 'timeout')
     elif second:


### PR DESCRIPTION
[config][tacacs+] Change tacacs+ minimum timeout value base on specification.

- What I did
    Change the minimum timeout value of TACACS+ to follow the value in specification.

- Why I did it
    The minimum timeout value of tacacs CLI is not the same as
    specification, so modify the CLI to make it follow it.

- How I verified it
   Verified the minimum value is 1 on switch.

Signed-off-by: Po-hong Guo <steven_guo@edge-core.com>
