### PR TITLE
[PFC] Fix the issue that cannot enable or disable PFC by CLI command.

### DIFF
--- a/pfc/main.py
+++ b/pfc/main.py
@@ -53,13 +53,9 @@ def configPfcPrio(status, interface, priority):
     configdb = ConfigDBConnector()
     configdb.connect()
 
-    if interface not in configdb.get_keys('PORT_QOS_MAP'):
-        click.echo('Cannot find interface {0}'.format(interface))
-        return 
-
     """Current lossless priorities on the interface""" 
     entry = configdb.get_entry('PORT_QOS_MAP', interface)
-    enable_prio = entry.get('pfc_enable').split(',')
+    enable_prio = entry.get('pfc_enable', '').split(',')
     
     """Avoid '' in enable_prio"""
     enable_prio = [x.strip() for x in enable_prio if x.strip()]


### PR DESCRIPTION
- What I do:
  * Fix the issue that cannot enable or disable PFC by CLI command.

- Why I did:
  It's not user freindly for configure PFC enable or disable, if user want to configure PFC by CLI command,  user shall enable  PFC on the interfaces by configuring the table "PORT_QOS_MAP" in json file and issue **sonic-cfggen** command.

- How I verified:
  Verify that user can configure PFC enable or disable on switch by CLI command, need not to configure the table "PORT_QOS_MAP" in json file and issue **sonic-cfggen** command.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

