### PR TITLE
[sonic_package_manager] flush file to ensure integrity

### DIFF
--- a/sonic_package_manager/manager.py
+++ b/sonic_package_manager/manager.py
@@ -638,6 +638,7 @@ class PackageManager:
                 with tempfile.NamedTemporaryFile('wb') as file:
                     for chunk in image.save(named=True):
                         file.write(chunk)
+                    file.flush()
 
                     self.install(tarball=file.name)
             else:


### PR DESCRIPTION
…temporary file

Since installation happens inside context manager "with tempfile.NamedTemporaryFile()"
it may be that depending on file size/number of writes the docker image isn't fully written
to the disk. In practice a small test docker image was succesfully migrated but when trying with
larger onces it started to file. This change fixes the issue by adding a flush.

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Fixed corrupted tarfile written.

#### How I did it

Added flie.flush().

#### How to verify it

Perform S2S package migration with a big docker image.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

