### PR TITLE
[config] support for configuring muxcable to manual mode of operation 

### DIFF
--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -73,12 +73,17 @@ def lookup_statedb_and_update_configdb(per_npu_statedb, config_db, port, state_c
     ipv6_value = get_value_for_key_in_config_tbl(config_db, port, "server_ipv6", "MUX_CABLE")
 
     state = get_value_for_key_in_dict(muxcable_statedb_dict, port, "state", "MUX_CABLE_TABLE")
-    if state_cfg_val is not configdb_state:
+
+    if str(state_cfg_val) == str(configdb_state):
+        port_status_dict[port] = 'OK'
+    else:
         config_db.set_entry("MUX_CABLE", port, {"state": state_cfg_val,
                                                 "server_ipv4": ipv4_value, "server_ipv6": ipv6_value})
-        port_status_dict[port] = 'INPROGRESS' if state_cfg_val is 'active' and state is not 'active' else 'OK'
-    else:
-        port_status_dict[port] = 'OK'
+        if str(state_cfg_val) == 'active' and str(state) != 'active':
+            port_status_dict[port] = 'INPROGRESS'
+        else:
+            port_status_dict[port] = 'OK'
+
 
 # 'muxcable' command ("config muxcable mode <port|all> active|auto")
 @muxcable.command()

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -74,7 +74,8 @@ def lookup_statedb_and_update_configdb(per_npu_statedb, config_db, port, state_c
 
     state = get_value_for_key_in_dict(muxcable_statedb_dict, port, "state", "MUX_CABLE_TABLE")
     if state_cfg_val is not configdb_state:
-        config_db.set_entry("MUX_CABLE", port, {"state": state_cfg_val})
+        config_db.set_entry("MUX_CABLE", port, {"state": "active",
+                                                "server_ipv4": ipv4_value, "server_ipv6": ipv6_value})
         port_status_dict[port] = 'INPROGRESS' if state_cfg_val is 'active' and state is not 'active' else 'OK'
     else:
         port_status_dict[port] = 'OK'

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -77,9 +77,9 @@ def lookup_statedb_and_update_configdb(per_npu_statedb, config_db, port, state_c
     if str(state_cfg_val) == str(configdb_state):
         port_status_dict[port] = 'OK'
     else:
-        config_db.set_entry("MUX_CABLE", port, {"state": state_cfg_val,
-                                                "server_ipv4": ipv4_value, "server_ipv6": ipv6_value})
         if str(state_cfg_val) == 'active' and str(state) != 'active':
+            config_db.set_entry("MUX_CABLE", port, {"state": state_cfg_val,
+                                                    "server_ipv4": ipv4_value, "server_ipv6": ipv6_value})
             port_status_dict[port] = 'INPROGRESS'
         else:
             port_status_dict[port] = 'OK'

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -73,40 +73,11 @@ def lookup_statedb_and_update_configdb(per_npu_statedb, config_db, port, state_c
     ipv6_value = get_value_for_key_in_config_tbl(config_db, port, "server_ipv6", "MUX_CABLE")
 
     state = get_value_for_key_in_dict(muxcable_statedb_dict, port, "state", "MUX_CABLE_TABLE")
-    if state in ["active", "standby", "unknown"] and configdb_state in ["active", "manual"]:
-        if state_cfg_val == configdb_state:
-            # status is already active or manual, so nothing to do
-            port_status_dict[port] = 'OK'
-        elif state_cfg_val in ["auto", "manual"]:
-            # display ok and write to cfgdb auto
-            port_status_dict[port] = 'OK'
-            config_db.set_entry("MUX_CABLE", port, {"state": state_cfg_val,
-                                                    "server_ipv4": ipv4_value, "server_ipv6": ipv6_value})
-    elif state == "active" and configdb_state in ["auto", "manual"]:
-        if state_cfg_val == configdb_state:
-            # dont write anything to db, write OK to user
-            port_status_dict[port] = 'OK'
-        elif state_cfg_val in ["active", "manual"]:
-            # make the state active and write back OK
-            config_db.set_entry("MUX_CABLE", port, {"state": state_cfg_val,
-                                                    "server_ipv4": ipv4_value, "server_ipv6": ipv6_value})
-            port_status_dict[port] = 'OK'
-
-    elif state in ["standby", "unknown"] and configdb_state in ["auto", "manual"]:
-        if state_cfg_val == "active":
-            # make the state active
-            config_db.set_entry("MUX_CABLE", port, {"state": "active",
-                                                    "server_ipv4": ipv4_value, "server_ipv6": ipv6_value})
-            port_status_dict[port] = 'INPROGRESS'
-        elif state_cfg_val == configdb_state:
-            # dont write anything to db
-            port_status_dict[port] = 'OK'
-        elif state_cfg_val in ["auto", "manual"]:
-            # make the state what is configured and write back OK
-            config_db.set_entry("MUX_CABLE", port, {"state": state_cfg_val,
-                                                    "server_ipv4": ipv4_value, "server_ipv6": ipv6_value})
-            port_status_dict[port] = 'OK'
-
+    if state_cfg_val is not configdb_state:
+        config_db.set_entry("MUX_CABLE", port, {"state": state_cfg_val})
+        port_status_dict[port] = 'INPROGRESS' if state_cfg_val is 'active' and state is not 'active' else 'OK'
+    else:
+        port_status_dict[port] = 'OK'
 
 # 'muxcable' command ("config muxcable mode <port|all> active|auto")
 @muxcable.command()

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -110,11 +110,11 @@ def lookup_statedb_and_update_configdb(per_npu_statedb, config_db, port, state_c
 
 # 'muxcable' command ("config muxcable mode <port|all> active|auto")
 @muxcable.command()
-@click.argument('state', metavar='<operation_status>', required=True, type=click.Choice(["active", "auto"]))
+@click.argument('state', metavar='<operation_status>', required=True, type=click.Choice(["active", "auto", "manual"]))
 @click.argument('port', metavar='<port_name>', required=True, default=None)
 @click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL)
 def mode(state, port, json_output):
-    """Show muxcable summary information"""
+    """Config muxcable mode"""
 
     port_table_keys = {}
     y_cable_asic_table_keys = {}

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -73,26 +73,26 @@ def lookup_statedb_and_update_configdb(per_npu_statedb, config_db, port, state_c
     ipv6_value = get_value_for_key_in_config_tbl(config_db, port, "server_ipv6", "MUX_CABLE")
 
     state = get_value_for_key_in_dict(muxcable_statedb_dict, port, "state", "MUX_CABLE_TABLE")
-    if (state == "active" and configdb_state == "active") or (state == "standby" and configdb_state == "active") or (state == "unknown" and configdb_state == "active") or (state == "active" and configdb_state == "manual") or (state == "standby" and configdb_state == "manual") or (state == "unknown" and configdb_state == "manual"):
+    if state in ["active", "standby", "unknown"] and configdb_state in ["active", "manual"]:
         if state_cfg_val == configdb_state:
             # status is already active or manual, so nothing to do
             port_status_dict[port] = 'OK'
-        elif state_cfg_val == "auto" or state_cfg_val == "manual":
+        elif state_cfg_val in ["auto", "manual"]:
             # display ok and write to cfgdb auto
             port_status_dict[port] = 'OK'
             config_db.set_entry("MUX_CABLE", port, {"state": state_cfg_val,
                                                     "server_ipv4": ipv4_value, "server_ipv6": ipv6_value})
-    elif state == "active" and configdb_state == "auto" or state == "active" and configdb_state == "manual":
+    elif state == "active" and configdb_state in ["auto", "manual"]:
         if state_cfg_val == configdb_state:
             # dont write anything to db, write OK to user
             port_status_dict[port] = 'OK'
-        elif state_cfg_val == "active" or state_cfg_val == "manual":
+        elif state_cfg_val in ["active", "manual"]:
             # make the state active and write back OK
             config_db.set_entry("MUX_CABLE", port, {"state": state_cfg_val,
                                                     "server_ipv4": ipv4_value, "server_ipv6": ipv6_value})
             port_status_dict[port] = 'OK'
 
-    elif (state == "standby" and configdb_state == "auto") or (state == "unknown" and configdb_state == "auto") or (state == "standby" and configdb_state == "manual") or (state == "unknown" and configdb_state == "manual"):
+    elif state in ["standby", "unknown"] and configdb_state in ["auto", "manual"]:
         if state_cfg_val == "active":
             # make the state active
             config_db.set_entry("MUX_CABLE", port, {"state": "active",
@@ -101,7 +101,7 @@ def lookup_statedb_and_update_configdb(per_npu_statedb, config_db, port, state_c
         elif state_cfg_val == configdb_state:
             # dont write anything to db
             port_status_dict[port] = 'OK'
-        elif state_cfg_val == "manual" or state_cfg_val == "auto":
+        elif state_cfg_val in ["auto", "manual"]:
             # make the state what is configured and write back OK
             config_db.set_entry("MUX_CABLE", port, {"state": state_cfg_val,
                                                     "server_ipv4": ipv4_value, "server_ipv6": ipv6_value})

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -74,7 +74,7 @@ def lookup_statedb_and_update_configdb(per_npu_statedb, config_db, port, state_c
 
     state = get_value_for_key_in_dict(muxcable_statedb_dict, port, "state", "MUX_CABLE_TABLE")
     if state_cfg_val is not configdb_state:
-        config_db.set_entry("MUX_CABLE", port, {"state": "active",
+        config_db.set_entry("MUX_CABLE", port, {"state": state_cfg_val,
                                                 "server_ipv4": ipv4_value, "server_ipv6": ipv6_value})
         port_status_dict[port] = 'INPROGRESS' if state_cfg_val is 'active' and state is not 'active' else 'OK'
     else:

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -77,9 +77,9 @@ def lookup_statedb_and_update_configdb(per_npu_statedb, config_db, port, state_c
     if str(state_cfg_val) == str(configdb_state):
         port_status_dict[port] = 'OK'
     else:
+        config_db.set_entry("MUX_CABLE", port, {"state": state_cfg_val,
+                                                "server_ipv4": ipv4_value, "server_ipv6": ipv6_value})
         if str(state_cfg_val) == 'active' and str(state) != 'active':
-            config_db.set_entry("MUX_CABLE", port, {"state": state_cfg_val,
-                                                    "server_ipv4": ipv4_value, "server_ipv6": ipv6_value})
             port_status_dict[port] = 'INPROGRESS'
         else:
             port_status_dict[port] = 'OK'

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -1540,6 +1540,11 @@
 	"server_ipv4": "10.1.1.1",
 	"server_ipv6": "fc00::75"
     },
+    "MUX_CABLE|Ethernet28": {
+        "state": "manual",
+	"server_ipv4": "10.1.1.1",
+	"server_ipv6": "fc00::75"
+    },
     "MUX_CABLE|Ethernet0": {
         "state": "active",
 	"server_ipv4": "10.2.1.1",

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -72,6 +72,7 @@ Ethernet0   active   10.2.1.1  e800::46
 Ethernet4   auto     10.3.1.1  e801::46
 Ethernet8   active   10.4.1.1  e802::46
 Ethernet12  active   10.4.1.1  e802::46
+Ethernet28  manual   10.1.1.1  fc00::75
 Ethernet32  auto     10.1.1.1  fc00::75
 """
 
@@ -106,6 +107,13 @@ json_data_status_config_output_expected = """\
                 "SERVER": {
                     "IPv4": "10.4.1.1",
                     "IPv6": "e802::46"
+                }
+            },
+            "Ethernet28": {
+                "STATE": "manual",
+                "SERVER": {
+                    "IPv4": "10.1.1.1",
+                    "IPv6": "fc00::75"
                 }
             },
             "Ethernet32": {
@@ -360,6 +368,16 @@ class TestMuxcable(object):
         with mock.patch('sonic_platform_base.sonic_sfp.sfputilhelper') as patched_util:
             patched_util.SfpUtilHelper.return_value.get_asic_id_for_logical_port.return_value = 0
             result = runner.invoke(config.config.commands["muxcable"].commands["mode"], ["auto", "Ethernet8"], obj=db)
+
+        assert result.exit_code == 0
+
+    def test_config_muxcable_tabular_port_Ethernet8_manual(self):
+        runner = CliRunner()
+        db = Db()
+
+        with mock.patch('sonic_platform_base.sonic_sfp.sfputilhelper') as patched_util:
+            patched_util.SfpUtilHelper.return_value.get_asic_id_for_logical_port.return_value = 0
+            result = runner.invoke(config.config.commands["muxcable"].commands["mode"], ["manual", "Ethernet8"], obj=db)
 
         assert result.exit_code == 0
 

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -395,8 +395,6 @@ class TestMuxcable(object):
         db = Db()
 
         result = runner.invoke(config.config.commands["muxcable"].commands["mode"], ["active", "all", "--json"], obj=db)
-        f = open("newfile1", "w")
-        f.write(result.output)
 
         assert result.exit_code == 0
         assert result.output == json_data_config_output_active_expected


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

#### What I did
This PR adds support for an option to  configure muxcable mode to  a `manual` mode. The manual mode is in addition
to `auto\active` mode. 

The new output would look like this in case an active flag is passed to the command line

`admin@sonic:~$ sudo config muxcable mode manual Ethernet0`

`admin@sonic:~$ sudo config muxcable mode manual all`


added an option to set muxcable  mode to manual mode, in addition to existing auto/active modes. 

#### How I did it

added the changes in config/muxcable.py and added testcases

#### How to verify it
Ran the unit tests
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

