### PR TITLE
[vnet_route_check] Fix logic for getting VNET routes from ASIC DB

### DIFF
--- a/scripts/vnet_route_check.py
+++ b/scripts/vnet_route_check.py
@@ -266,9 +266,8 @@ def get_vnet_routes_from_asic_db():
         ip_addr = route_attrs[3]
 
         if vrf_oid in vnet_vrfs_oids:
+            vnet_name = vrf_oid_to_vnet_map[vrf_oid]
             if vrf_oid_to_vnet_map[vrf_oid] not in vnet_routes:
-                vnet_name = vrf_oid_to_vnet_map[vrf_oid]
-
                 vnet_routes[vnet_name] = {}
                 vnet_routes[vnet_name]['routes'] = []
                 vnet_routes[vnet_name]['vrf_oid'] = vrf_oid


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixed issue when VNET route check detects some routes as missed they are really configured.

#### How I did it
Fixed logic for getting VNET routes from ASIC DB in order to correctly retrieve all the configured in ASIC DB VNET routes.

#### How to verify it
* Run VNET test from sonic-mgmt
* Run VNET route check script and verify that no missing routes are reported.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

