### PR TITLE
[sfputil] Expose error status fetched from STATE_DB or platform API to CLI

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -883,7 +883,7 @@ This command displays information for all the interfaces for the transceiver req
 
 - Usage:
   ```
-  show interfaces transceiver (eeprom [-d|--dom] | lpmode | presence) [<interface_name>]
+  show interfaces transceiver (eeprom [-d|--dom] | lpmode | presence | error-status [-h|--fetch-from-hardware]) [<interface_name>]
   ```
 
 - Example (Decode and display information stored on the EEPROM of SFP transceiver connected to Ethernet0):
@@ -937,6 +937,15 @@ This command displays information for all the interfaces for the transceiver req
   -----------  ----------
   Ethernet100  Present
   ```
+
+- Example (Display error status of SFP transceiver connected to Ethernet100):
+  ```
+  admin@sonic:~$ show interfaces transceiver error-status Ethernet100
+  Port         Error Status
+  -----------  --------------
+  Ethernet100  OK
+  ```
+
 Go Back To [Beginning of the document](#) or [Beginning of this section](#basic-show-commands)
 
 ## AAA & TACACS+

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -883,7 +883,7 @@ This command displays information for all the interfaces for the transceiver req
 
 - Usage:
   ```
-  show interfaces transceiver (eeprom [-d|--dom] | lpmode | presence | error-status [-h|--fetch-from-hardware]) [<interface_name>]
+  show interfaces transceiver (eeprom [-d|--dom] | lpmode | presence | error-status [-hw|--fetch-from-hardware]) [<interface_name>]
   ```
 
 - Example (Decode and display information stored on the EEPROM of SFP transceiver connected to Ethernet0):

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -7,10 +7,13 @@
 
 import os
 import sys
+import natsort
 
+import subprocess
 import click
 import sonic_platform
 import sonic_platform_base.sonic_sfp.sfputilhelper
+from swsscommon.swsscommon import SonicV2Connector
 from natsort import natsorted
 from sonic_py_common import device_info, logger, multi_asic
 from tabulate import tabulate
@@ -613,6 +616,133 @@ def presence(port):
             i += 1
 
     click.echo(tabulate(output_table, table_header, tablefmt="simple"))
+
+
+# 'error-status' subcommand
+def fetch_error_status_from_platform_api(port):
+    """Fetch the error status from platform API and return the output as a string
+    Args:
+        port: the port whose error status will be fetched.
+              None represents for all ports.
+    Returns:
+        A string consisting of the error status of each port.
+    """
+    if port is None:
+        logical_port_list = platform_sfputil.logical
+        physical_port_list = None
+        # Create a list containing the logical port names of all ports we're interested in
+        generate_sfp_list_code = \
+            "sfp_list = chassis.get_all_sfps();"
+    else:
+        physical_port_list = logical_port_name_to_physical_port_list(port)
+        logical_port_list = [port]
+        # Create a list containing the logical port names of all ports we're interested in
+        generate_sfp_list_code = \
+            "sfp_list = [chassis.get_sfp(x) for x in {}];".format(physical_port_list)
+
+    # Code to initialize chassis object
+    init_chassis_code = \
+        "import sonic_platform.platform;" \
+        "platform = sonic_platform.platform.Platform();" \
+        "chassis = platform.get_chassis();"
+
+    # Code to fetch the error status
+    get_error_status_code = \
+        "errors=['{}:{}'.format(sfp.index, sfp.get_error_description()) for sfp in sfp_list];" \
+        "print(errors)"
+
+    get_error_status_command = "docker exec pmon python3 -c \"{}{}{}\"".format(
+        init_chassis_code, generate_sfp_list_code, get_error_status_code)
+    # Fetch error status from pmon docker
+    try:
+        output = subprocess.check_output(get_error_status_command, shell=True, universal_newlines=True)
+    except subprocess.CalledProcessError as e:
+        click.abort("Error! Unable to fetch error status for SPF modules. Error code = {}, error messages: {}".format(e.returncode, e.output))
+
+    output_list = output.split('\n')
+    for output_str in output_list:
+        # The output of all SFP error status are a list consisting of element with convention of '<sfp no>:<error status>'
+        # Besides, there can be some logs captured during the platform API executing
+        # So, first of all, we need to skip all the logs until find the output list of SFP error status
+        if output_str[0] == '[' and output_str[-1] == ']':
+            output_list = eval(output_str)
+            break
+
+    output_dict = {}
+    for output in output_list:
+        sfp_index, error_status = output.split(':')
+        output_dict[int(sfp_index)] = error_status
+
+    output = []
+    for logical_port_name in logical_port_list:
+        physical_port_list = logical_port_name_to_physical_port_list(logical_port_name)
+        port_name = get_physical_port_name(logical_port_name, 1, False)
+
+        output.append([port_name, output_dict.get(physical_port_list[0])])
+
+    return output
+
+def fetch_error_status_from_state_db(port, state_db):
+    """Fetch the error status from STATE_DB and return them in a list.
+    Args:
+        port: the port whose error status will be fetched.
+              None represents for all ports.
+    Returns:
+        A list consisting of tuples (port, description) and sorted by port.
+    """
+    status = {}
+    if port:
+        status[port] = state_db.get_all(state_db.STATE_DB, 'TRANSCEIVER_STATUS|{}'.format(port))
+    else:
+        ports = state_db.keys(state_db.STATE_DB, 'TRANSCEIVER_STATUS|*')
+        for key in ports:
+            status[key.split('|')[1]] = state_db.get_all(state_db.STATE_DB, key)
+
+    sorted_ports = natsort.natsorted(status)
+    output = []
+    for port in sorted_ports:
+        statestring = status[port].get('status')
+        description = status[port].get('error')
+        if statestring == '1':
+            description = 'OK'
+        elif statestring == '0':
+            description = 'Unplugged'
+        elif description == 'N/A':
+            description = 'Unknown state: {}'.format(statestring)
+
+        output.append([port, description])
+
+    return output
+
+@show.command()
+@click.option('-p', '--port', metavar='<port_name>', help="Display SFP presence for port <port_name> only")
+@click.option('-h', '--fetch-from-hardware', 'fetch_from_hardware', is_flag=True, default=False, help="Fetch the error status from hardware directly")
+@click.option('-n', '--namespace', default=None, help="Display interfaces for specific namespace")
+def error_status(port, fetch_from_hardware, namespace):
+    """Display error status of SFP transceiver(s)"""
+    logical_port_list = []
+    output_table = []
+    table_header = ["Port", "Error Status"]
+
+    # Create a list containing the logical port names of all ports we're interested in
+    if port and platform_sfputil.is_logical_port(port) == 0:
+        click.echo("Error: invalid port '{}'\n".format(port))
+        click.echo("Valid values for port: {}\n".format(str(platform_sfputil.logical)))
+        sys.exit(ERROR_INVALID_PORT)
+
+    if fetch_from_hardware:
+        output_table = fetch_error_status_from_platform_api(port)
+    else:
+        # Connect to STATE_DB
+        state_db = SonicV2Connector(host='127.0.0.1')
+        if state_db is not None:
+            state_db.connect(state_db.STATE_DB)
+        else:
+            return None
+
+        output_table = fetch_error_status_from_state_db(port, state_db)
+
+    click.echo(tabulate(output_table, table_header, tablefmt='simple'))
 
 
 # 'lpmode' subcommand

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -1,6 +1,7 @@
 import json
 import os
 
+import subprocess
 import click
 import utilities_common.cli as clicommon
 import utilities_common.multi_asic as multi_asic_util
@@ -10,6 +11,7 @@ from sonic_py_common import multi_asic
 from sonic_py_common import device_info
 from swsscommon.swsscommon import ConfigDBConnector
 from portconfig import get_child_ports
+import sonic_platform_base.sonic_sfp.sfputilhelper
 
 from . import portchannel
 from collections import OrderedDict
@@ -394,6 +396,108 @@ def presence(db, interfacename, namespace, verbose):
         cmd += " -n {}".format(namespace)
 
     clicommon.run_command(cmd, display_cmd=verbose)
+
+
+@transceiver.command()
+@click.argument('interfacename', required=False)
+@click.option('--namespace', '-n', 'namespace', default=None, show_default=True,
+              type=click.Choice(multi_asic_util.multi_asic_ns_choices()), help='Namespace name or all')
+@click.option('--verbose', is_flag=True, help="Enable verbose output")
+@clicommon.pass_db
+def error_status(db, interfacename, namespace, verbose):
+    """ Show transceiver error-status """
+    def get_physical_port_name(logical_port, physical_port, ganged):
+        """
+            Returns:
+              port_num if physical
+              logical_port:port_num if logical port and is a ganged port
+              logical_port if logical and not ganged
+        """
+        if logical_port == physical_port:
+            return str(logical_port)
+        elif ganged:
+            return "{}:{} (ganged)".format(logical_port, physical_port)
+        else:
+            return logical_port
+
+    def logical_port_name_to_physical_port_list(port_name):
+        if port_name.startswith("Ethernet"):
+            if platform_sfputil.is_logical_port(port_name):
+                return platform_sfputil.get_logical_to_physical(port_name)
+            else:
+                click.echo("Error: Invalid port '{}'".format(port_name))
+                return None
+        else:
+            return [int(port_name)]
+    port = interfacename
+    logical_port_list = []
+    output_table = []
+    table_header = ["Port", "Error Status"]
+
+    platform_sfputil = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper()
+    port_config_file_path = device_info.get_path_to_port_config_file()
+    platform_sfputil.read_porttab_mappings(port_config_file_path, 0)
+
+    # Code to initialize chassis object
+    init_chassis_code = \
+        "import sonic_platform.platform;" \
+        "platform = sonic_platform.platform.Platform();" \
+        "chassis = platform.get_chassis();"
+
+    # Create a list containing the logical port names of all ports we're interested in
+    if port is None:
+        logical_port_list = platform_sfputil.logical
+
+        # Code to generate SFP object list
+        generate_sfp_list_code = \
+            "sfp_list = chassis.get_all_sfps();"
+    else:
+        if platform_sfputil.is_logical_port(port) == 0:
+            click.echo("Error: invalid port '{}'\n".format(port))
+            click.echo("Valid values for port: {}\n".format(str(platform_sfputil.logical)))
+            sys.exit(ERROR_INVALID_PORT)
+
+        physical_port_list = logical_port_name_to_physical_port_list(port)
+        logical_port_list = [port]
+
+        # Code to generate SFP object list
+        generate_sfp_list_code = \
+            "sfp_list = [chassis.get_sfp({})];".format(physical_port_list[0])
+
+    # Code to fetch the error status
+    get_error_status_code = \
+        "errors=['{}:{}'.format(sfp.index, sfp.get_error_description()) for sfp in sfp_list];" \
+        "print(errors)"
+
+    get_error_status_command = "docker exec pmon python3 -c \"{}{}{}\"".format(
+        init_chassis_code, generate_sfp_list_code, get_error_status_code)
+    # Fetch error status from pmon docker
+    try:
+        output = subprocess.check_output(get_error_status_command, shell=True, universal_newlines=True)
+    except subprocess.CalledProcessError as e:
+        click.abort("Error! Unable to fetch error status for SPF modules. Error code = {}, error messages: {}".format(e.returncode, e.output))
+
+    output_list = output.split('\n')
+    for output_str in output_list:
+        # The output of all SFP error status are a list consisting of element with convention of '<sfp no>:<error status>'
+        # Besides, there can be some logs captured during the platform API executing
+        # So, first of all, we need to skip all the logs until find the output list of SFP error status
+        if output_str[0] == '[' and output_str[-1] == ']':
+            output_list = eval(output_str)
+            break
+
+    output_dict = {}
+    for output in output_list:
+        sfp_index, error_status = output.split(':')
+        output_dict[int(sfp_index)] = error_status
+
+    for logical_port_name in logical_port_list:
+        physical_port_list = logical_port_name_to_physical_port_list(logical_port_name)
+        port_name = get_physical_port_name(logical_port_name, 1, False)
+
+        output_table.append([port_name, output_dict[physical_port_list[0]]])
+
+    click.echo(tabulate(output_table, table_header, tablefmt='simple'))
 
 
 #

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -400,7 +400,7 @@ def presence(db, interfacename, namespace, verbose):
 
 @transceiver.command()
 @click.argument('interfacename', required=False)
-@click.option('--fetch-from-hardware', '-h', 'fetch_from_hardware', is_flag=True, default=False)
+@click.option('--fetch-from-hardware', '-hw', 'fetch_from_hardware', is_flag=True, default=False)
 @click.option('--namespace', '-n', 'namespace', default=None, show_default=True,
               type=click.Choice(multi_asic_util.multi_asic_ns_choices()), help='Namespace name or all')
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
@@ -417,11 +417,8 @@ def error_status(db, interfacename, fetch_from_hardware, namespace, verbose):
 
         cmd += " -p {}".format(interfacename)
 
-    if namespace is not None:
-        cmd += " -n {}".format(namespace)
-
     if fetch_from_hardware:
-        cmd += " -h"
+        cmd += " -hw"
 
     clicommon.run_command(cmd, display_cmd=verbose)
 

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -133,6 +133,22 @@
         "txpowerlowalarm": "-10.5012",
         "txpowerlowwarning": "-7.5007"
     },
+    "TRANSCEIVER_STATUS|Ethernet0": {
+        "status": "67",
+        "error": "Blocking Error|High temperature"
+    },
+    "TRANSCEIVER_STATUS|Ethernet4": {
+        "status": "1",
+        "error": "N/A"
+    },
+    "TRANSCEIVER_STATUS|Ethernet8": {
+        "status": "0",
+        "error": "N/A"
+    },
+    "TRANSCEIVER_STATUS|Ethernet12": {
+        "status": "255",
+        "error": "N/A"
+    },
     "CHASSIS_INFO|chassis 1": {
         "psu_num": "2"
     },

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -2,8 +2,11 @@ import sys
 import os
 from unittest import mock
 
+from .mock_tables import dbconnector
+
 import pytest
 from click.testing import CliRunner
+from utilities_common.db import Db
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
@@ -173,3 +176,16 @@ class TestSfputil(object):
         runner = CliRunner()
         result = runner.invoke(sfputil.cli.commands['version'], [])
         assert result.output.rstrip() == 'sfputil version {}'.format(sfputil.VERSION)
+
+    def test_error_status_from_db(self):
+        db = Db()
+        expected_output = [['Ethernet0', 'Blocking Error|High temperature'],
+                           ['Ethernet4', 'OK'],
+                           ['Ethernet8', 'Unplugged'],
+                           ['Ethernet12', 'Unknown state: 255']]
+        output = sfputil.fetch_error_status_from_state_db(None, db.db)
+        assert output == expected_output
+
+        expected_output_ethernet0 = expected_output[:1]
+        output = sfputil.fetch_error_status_from_state_db('Ethernet0', db.db)
+        assert output == expected_output_eth0

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -188,4 +188,4 @@ class TestSfputil(object):
 
         expected_output_ethernet0 = expected_output[:1]
         output = sfputil.fetch_error_status_from_state_db('Ethernet0', db.db)
-        assert output == expected_output_eth0
+        assert output == expected_output_ethernet0


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Expose error status fetched from STATE_DB or platform API to CLI.
The command is
- `sfputil show error-status [-hw|--fetch-from-hardware] [<interface_name>]`
- and `show interfaces transceiver error-status [-hw|--fetch-from-hardware] [<interface_name>]`

The error status will be fetched from
- `STATE_DB` by default
- hardware via platform API if the parameter `--fetch-from-hardware` is provided.
  In this case, the CLI will call platform API in the pmon docker and format the output.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it

#### How to verify it
Manually test and unit test

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
```
admin@sonic:~$ show interfaces transceiver error-status 
Port         Error Status
-----------  ----------------------------------------------------
Ethernet0    OK
Ethernet4    OK
Ethernet8    Long range for non-Mellanox cable or module
Ethernet12   OK
Ethernet16   OK
Ethernet20   OK
Ethernet24   Blocking EEPROM from being read|High temperature
Ethernet28   OK
Ethernet32   OK
Ethernet36   OK
Ethernet40   OK
Ethernet44   OK
Ethernet48   OK
Ethernet52   OK
Ethernet56   OK
Ethernet60   OK
Ethernet64   OK
Ethernet68   OK
Ethernet72   OK
Ethernet76   OK
Ethernet80   OK
Ethernet84   OK
Ethernet88   Blocking EEPROM from being read|Bus stuck (I2C data or clock shorted)
Ethernet92   OK
Ethernet96   OK
Ethernet100  OK
Ethernet104  OK
Ethernet108  OK
Ethernet112  Long range for non-Mellanox cable or module
Ethernet116  OK
Ethernet120  OK
Ethernet124  OK
admin@sonic:~$ show interfaces transceiver error-status Ethernet100
Port         Error Status
-----------  --------------
Ethernet100  OK
```
