### PR TITLE
[Mellanox] Create sniffer folder if it doesn't exist yet

### DIFF
--- a/config/plugins/mlnx.py
+++ b/config/plugins/mlnx.py
@@ -43,6 +43,8 @@ log = logger.Logger(SNIFFER_SYSLOG_IDENTIFIER)
 
 # generate sniffer target file name include a time stamp.
 def sniffer_filename_generate(path, filename_prefix, filename_ext):
+    if not os.path.exists(path):
+        os.makedirs(path)
     time_stamp = time.strftime("%Y%m%d%H%M%S")
     filename = path + filename_prefix + time_stamp + filename_ext
     return filename


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

following the change in PR https://github.com/Azure/sonic-buildimage/pull/7830, the folder needs to be created when the first time enables the sniffer function.

#### How I did it

check whether the path to store the sniffer file is existing or not, if not, create it.

#### How to verify it

run command "config platform mlnx sniffer sdk enable", can see sniffer function can be enabled successfully.

#### Previous command output (if the output of a command-line utility has changed)

N/A

#### New command output (if the output of a command-line utility has changed)

N/A
