### PR TITLE
[Mellanox] Add different dumps files collected by SAI to techsupport

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -758,10 +758,20 @@ enable_logrotate() {
 #  None
 ###############################################################################
 collect_mellanox() {
-    local sai_dump_filename="/tmp/sai_sdk_dump_$(date +"%m_%d_%Y_%I_%M_%p")"
+    local sai_dump_folder="/tmp/saisdkdump"
+    local sai_dump_filename="${sai_dump_folder}/sai_sdk_dump_$(date +"%m_%d_%Y_%I_%M_%p")"
+
+    ${CMD_PREFIX}docker exec -it syncd mkdir -p $sai_dump_folder
     ${CMD_PREFIX}docker exec -it syncd saisdkdump -f $sai_dump_filename
-    ${CMD_PREFIX}docker exec syncd tar Ccf $(dirname $sai_dump_filename) - $(basename $sai_dump_filename) | tar Cxf /tmp/ -
-    save_file $sai_dump_filename sai_sdk_dump true
+
+    copy_from_docker syncd $sai_dump_folder $sai_dump_folder
+    echo "$sai_dump_folder"
+    for file in `ls $sai_dump_folder`; do
+        save_file ${sai_dump_folder}/${file} sai_sdk_dump true 
+    done
+
+    ${CMD_PREFIX}rm -rf $sai_dump_folder
+    ${CMD_PREFIX}docker exec -it syncd rm -rf $sai_dump_folder
 
     local mst_dump_filename="/tmp/mstdump"
     local max_dump_count="3"


### PR DESCRIPTION
This PR depends on https://github.com/Azure/sonic-buildimage/pull/7844
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Enhance the way techsupport collects dumps provided by SAI and do not keep them in the filesystem once the techsupport is created.

#### How I did it
- Create a temporary directory once techsupport script is executed, gather all files SAI dumps created, add them to the tech support and remove the temporary directory and files.
-  Remove direct call to FW trace collection as it is done now by SAI dump

#### How to verify it
Run techsupport, verify newly created files are part of it including mlxtrace which is no longer called directly by the techsupport script.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

