### PR TITLE
Fix build test failure caused by error module name

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from swsssdk import ConfigDBConnector
 
 from .mock_tables import dbconnector
 from . import show_ip_route_common
-import utilities_common.constants as constantsn
+import utilities_common.constants as constants
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
The build is broken for module name error
```
request = <SubRequest 'setup_single_bgp_instance' for <Function 'test_show_ip_route[ip_route]'>>

    @pytest.fixture
    def setup_single_bgp_instance(request):
        import utilities_common.bgp_util as bgp_util
    
        if request.param == 'v4':
            bgp_mocked_json = os.path.join(
                test_path, 'mock_tables', 'ipv4_bgp_summary.json')
        elif request.param == 'v6':
            bgp_mocked_json = os.path.join(
                test_path, 'mock_tables', 'ipv6_bgp_summary.json')
        else:
            bgp_mocked_json = os.path.join(
                test_path, 'mock_tables', 'dummy.json')
    
>       def mock_run_bgp_command(vtysh_cmd, bgp_namespace, vtysh_shell_cmd=constants.RVTYSH_COMMAND):
E       NameError: name 'constants' is not defined
```

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

