### PR TITLE
[config] Adding sanity checks for config reload

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -703,7 +703,7 @@ def _restart_services():
     clicommon.run_command("sudo monit reload")
 
 def _get_delay_timers():
-    out = clicommon.run_command("systemctl list-dependencies delay.target --plain |sed '1d'", return_cmd=True)
+    out = clicommon.run_command("systemctl list-dependencies sonic-delayed.target --plain |sed '1d'", return_cmd=True)
     return [timer.strip() for timer in out.splitlines()]
 
 def _delay_timers_elapsed():

--- a/config/main.py
+++ b/config/main.py
@@ -1234,7 +1234,7 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, disable_arp_cach
             return
 
         if not _swss_ready():
-            click.echo("Orchagent container is not up. Retry later or use -f to avoid system checks")
+            click.echo("SwSS container is not ready. Retry later or use -f to avoid system checks")
             return
 
     if filename is None:

--- a/config/main.py
+++ b/config/main.py
@@ -1226,15 +1226,15 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, disable_arp_cach
     """
     if not force and not no_service_restart:
         if not _system_running():
-            click.echo("System is not up")
+            click.echo("System is not up. Retry later or use -f to avoid system checks")
             return
 
         if not _delay_timers_elapsed():
-            click.echo("Services are not up")
+            click.echo("Relevant services are not up. Retry later or use -f to avoid system checks")
             return
 
         if not _swss_ready():
-            click.echo("SWSS is not ready")
+            click.echo("Orchagent container is not up. Retry later or use -f to avoid system checks")
             return
 
     if filename is None:

--- a/config/main.py
+++ b/config/main.py
@@ -702,6 +702,32 @@ def _restart_services():
     click.echo("Reloading Monit configuration ...")
     clicommon.run_command("sudo monit reload")
 
+def _get_delay_timers():
+    out = clicommon.run_command("systemctl list-dependencies delay.target --plain |sed '1d'", return_cmd=True)
+    return [timer.strip() for timer in out.splitlines()]
+
+def _delay_timers_elapsed():
+    for timer in _get_delay_timers():
+        out = clicommon.run_command("systemctl show {} --property=LastTriggerUSecMonotonic --value".format(timer), return_cmd=True)
+        if out.strip() == "0":
+            return False
+    return True
+
+def _swss_ready():
+    out = clicommon.run_command("systemctl show swss.service --property ActiveState --value", return_cmd=True)
+    if out.strip() != "active":
+        return False
+    out = clicommon.run_command("systemctl show swss.service --property ActiveEnterTimestampMonotonic --value", return_cmd=True)
+    swss_up_time = float(out.strip())/1000000
+    now =  time.monotonic()
+    if (now - swss_up_time > 120):
+        return True
+    else:
+        return False
+
+def _system_running():
+    out = clicommon.run_command("sudo systemctl is-system-running", return_cmd=True)
+    return out.strip() == "running"
 
 def interface_is_in_vlan(vlan_member_table, interface_name):
     """ Check if an interface is in a vlan """
@@ -1191,12 +1217,26 @@ def list_checkpoints(ctx, verbose):
 @click.option('-l', '--load-sysinfo', is_flag=True, help='load system default information (mac, portmap etc) first.')
 @click.option('-n', '--no_service_restart', default=False, is_flag=True, help='Do not restart docker services')
 @click.option('-d', '--disable_arp_cache', default=False, is_flag=True, help='Do not cache ARP table before reloading (applies to dual ToR systems only)')
+@click.option('-f', '--force', default=False, is_flag=True, help='Force config reload without system checks')
 @click.argument('filename', required=False)
 @clicommon.pass_db
-def reload(db, filename, yes, load_sysinfo, no_service_restart, disable_arp_cache):
+def reload(db, filename, yes, load_sysinfo, no_service_restart, disable_arp_cache, force):
     """Clear current configuration and import a previous saved config DB dump file.
        <filename> : Names of configuration file(s) to load, separated by comma with no spaces in between
     """
+    if not force and not no_service_restart:
+        if not _system_running():
+            click.echo("System is not up")
+            return
+
+        if not _delay_timers_elapsed():
+            click.echo("Services are not up")
+            return
+
+        if not _swss_ready():
+            click.echo("SWSS is not ready")
+            return
+
     if filename is None:
         message = 'Clear current config and reload config from the default config file(s) ?'
     else:


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
DO NOT MERGE UNTIL https://github.com/Azure/sonic-buildimage/pull/7846 is merged.

#### What I did
Fixed config reload to add some system sanity checks
    1) To check if the system is in running state
    2) Check if the services which are grouped under delayed target up
    3) Check if swss is running for at least 120 seconds
To force config reload and to avoid these checks an extra option -f/--force is added

#### How I did it
Added the above mentioned checks in config reload flow

#### How to verify it
Perform config reload after reboot, between system up and delayed services up, immediately after another config reload and running two config reload in parallel. In all the cases the config reload should not execute and throw appropriate error messages.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
When system is not up
sonic:~#config reload
System is not up

When delayed services are not up
sonic:~#config reload
Services are not up

When swss is not up for at least 120 seconds
sonic:~# config reload -y
SWSS is not ready
