### PR TITLE
Pcieutil to load the platform api first instead of using common api

### DIFF
--- a/pcieutil/main.py
+++ b/pcieutil/main.py
@@ -54,7 +54,7 @@ def load_platform_pcieutil():
         from sonic_platform.pcie import Pcie
         platform_pcieutil = Pcie(platform_path)
     except ImportError as e:
-        self.log_error("Failed to load platform Pcie module. Error : {}".format(str(e)), True)
+        log.log_warning("Failed to load platform Pcie module. Error : {}, fallback to load Pcie common utility.".format(str(e)), True)
         try:
             from sonic_platform_base.sonic_pcie.pcie_common import PcieUtil
             platform_pcieutil = PcieUtil(platform_path)

--- a/pcieutil/main.py
+++ b/pcieutil/main.py
@@ -49,13 +49,18 @@ def load_platform_pcieutil():
     global platform_path
 
     # Load platform module from source
+    platform_path, _ = device_info.get_paths_to_platform_and_hwsku_dirs()
     try:
-        platform_path, _ = device_info.get_paths_to_platform_and_hwsku_dirs()
-        from sonic_platform_base.sonic_pcie.pcie_common import PcieUtil
-        platform_pcieutil = PcieUtil(platform_path)
+        from sonic_platform.pcie import Pcie
+        platform_pcieutil = Pcie(platform_path)
     except ImportError as e:
-        log.log_error("Failed to load default PcieUtil module. Error : {}".format(str(e)), True)
-        raise e
+        self.log_error("Failed to load platform Pcie module. Error : {}".format(str(e)), True)
+        try:
+            from sonic_platform_base.sonic_pcie.pcie_common import PcieUtil
+            platform_pcieutil = PcieUtil(platform_path)
+        except ImportError as e:
+            log.log_error("Failed to load default PcieUtil module. Error : {}".format(str(e)), True)
+            raise e
 
 
 # ==================== CLI commands and groups ====================


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Pcieutil to load the platform api first instead of using common api
Some platform device with different BIOS version needs more than one pcie configuration to check the pcie devices properly.
Please refer to the platform api support : https://github.com/Azure/sonic-platform-common/pull/195

#### How I did it
Load the platform pcie api first prior to use the common api
#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

