### PR TITLE
[CI] sonic-config-engine now depends on SONiC YANG packages

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,10 +70,10 @@ stages:
         set -xe
         sudo pip3 install swsssdk-2.0.1-py3-none-any.whl
         sudo pip3 install sonic_py_common-1.0-py3-none-any.whl
-        sudo pip3 install sonic_config_engine-1.0-py3-none-any.whl
-        sudo pip3 install sonic_platform_common-1.0-py3-none-any.whl
         sudo pip3 install sonic_yang_mgmt-1.0-py3-none-any.whl
         sudo pip3 install sonic_yang_models-1.0-py3-none-any.whl
+        sudo pip3 install sonic_config_engine-1.0-py3-none-any.whl
+        sudo pip3 install sonic_platform_common-1.0-py3-none-any.whl
       workingDirectory: $(Pipeline.Workspace)/target/python-wheels/
       displayName: 'Install Python dependencies'
 


### PR DESCRIPTION
sonic-config-engine now depends on sonic-yang-mgmt and sonic-yang-models, so we now need to install them before we install sonic-config-engine as part of continuous integration to get the CI working again