### PR TITLE
[tests]: skip some dynamic port breakout unit tests

### DIFF
--- a/tests/config_dpb_test.py
+++ b/tests/config_dpb_test.py
@@ -467,6 +467,7 @@ class TestConfigDPB(object):
         return
 
     @pytest.mark.usefixtures('mock_func')
+    @pytest.mark.skip(reason="not stable")
     def test_config_breakout_various_modes(self, sonic_db):
         '''
         Test different combination of breakout port.

--- a/tests/config_mgmt_test.py
+++ b/tests/config_mgmt_test.py
@@ -56,6 +56,7 @@ class TestConfigMgmt(TestCase):
             len(out['ACL_TABLE'][k]) == 1
         return
 
+    @pytest.mark.skip(reason="not stable")
     def test_break_out(self):
         # prepare default config
         self.writeJson(portBreakOutConfigDbJson,
@@ -78,6 +79,7 @@ class TestConfigMgmt(TestCase):
         self.dpb_port4_4x25G_2x50G_f_l(curConfig)
         return
 
+    @pytest.mark.skip(reason="not stable")
     def test_shutdownIntf_call(self):
         '''
         Verify that _shutdownIntf() is called with deleted ports while calling

--- a/tests/config_mgmt_test.py
+++ b/tests/config_mgmt_test.py
@@ -4,6 +4,7 @@ from json import dump
 from copy import deepcopy
 from unittest import mock, TestCase
 
+import pytest
 from utilities_common.general import load_module_from_source
 
 # Import file under test i.e., config_mgmt.py


### PR DESCRIPTION
re-enable after fix those tests

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

