### PR TITLE
[show priority-group drop counters] Remove backup with cached PG drop counters after 'config reload'

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1214,6 +1214,11 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, disable_arp_cach
     if multi_asic.is_multi_asic():
         num_cfg_file += num_asic
 
+    # Remove cached PG drop counters data
+    dropstat_dir_prefix = '/tmp/dropstat'
+    command = "rm -rf {}-*".format(dropstat_dir_prefix)
+    clicommon.run_command(command, display_cmd=True)
+
     # If the user give the filename[s], extract the file names.
     if filename is not None:
         cfg_files = filename.split(',')

--- a/tests/pgdropstat_test.py
+++ b/tests/pgdropstat_test.py
@@ -3,6 +3,7 @@ import sys
 
 import show.main as show
 import clear.main as clear
+import config.main as config
 
 from click.testing import CliRunner
 
@@ -61,6 +62,20 @@ class TestPgDropstat(object):
 
         assert result.exit_code == 0
         assert result.output == show_output
+
+    def test_show_pg_drop_config_reload(self):
+        runner = CliRunner()
+        self.test_show_pg_drop_clear()
+
+        # simulate 'config reload' to provoke counters recalculation (remove  backup from /tmp folder)
+        result = runner.invoke(config.config.commands["reload"], [ "--no_service_restart",  "-y"])
+
+        print(result.exit_code)
+        print(result.output)
+
+        assert result.exit_code == 0
+
+        self.test_show_pg_drop_show()
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
Signed-off-by: Andriy Yurkiv <ayurkiv@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Explanation how show/clear counters works:
- Suppose we got from SDK some count of dropped packets for priority group (№3) per interface (Ehernet4). (for example Ethernet4 PG-3 123 packets)
- Stats can be shown via show priority-group drop counters
Then we run sonic-clear priority-group drop counters. This command will save data "Ethernet4 PG-3 123 packets" to backup. It saved in /tmp/dropstat-{user_id} folder
- When we run show priority-group drop counters again, script will take data from SDK and data saved from backup. In backup it will find 123. In SDK it may still be number 123 for Ethernet4 (like in backup) or bigger (for example 126.)
Our sonic-clear priority-group drop counters command does not change anything in SDK. It just show difference beetwen SDK data and last saved data.
So if in SDK data is 123, show priority-group drop counters will show 0 (123 minus 123) - data is cleared
If in SDK data is bigger than saved 124, or higher show priority-group drop counters will show 1 (124 minus 123)

**FIX**
After config reload all counters drop counters data retrieved from SDK become cleared. All counters become zeros.
In this case show priority-group drop counters will show -123 ( 0 (from SDK) minus 123 (saved backup))
So we don't need backup after config reload

#### How I did it
remove `/tmp/dropstat-{user_id}` folders with counters backup

#### How to verify it
- provoke PG dropped packets (Use QoS test with prf32 topo and RPC image)
- check that counters increased `show priority-group drop counters`
- clear counter via sonic-clear priority-group drop counters
- run `sudo config reload -y`
- check that counters are zeros `show priority-group drop counters`

#### Previous command output (if the output of a command-line utility has changed)
```
       Port    PG0    PG1    PG2    PG3    PG4    PG5    PG6    PG7
-----------  -----  -----  -----  -----  -----  -----  -----  -----
  Ethernet0      0      0      0      0      0      0      0      0
  Ethernet4      0      0      0   -123      0      0      0      0
```

#### New command output (if the output of a command-line utility has changed)
```
       Port    PG0    PG1    PG2    PG3    PG4    PG5    PG6    PG7
-----------  -----  -----  -----  -----  -----  -----  -----  -----
  Ethernet0      0      0      0      0      0      0      0      0
  Ethernet4      0      0      0      0      0      0      0      0
```

