### PR TITLE
[show] fix `show version`

### DIFF
--- a/show/platform.py
+++ b/show/platform.py
@@ -23,7 +23,7 @@ def get_chassis_info():
     for k in required_keys:
         if chassis_info.get(k, '') in failed_vals:
             if platform_chassis is None:
-                import platform
+                import sonic_platform
                 platform_chassis = sonic_platform.platform.Platform().get_chassis()
             try:
                 chassis_info[k] = getattr(platform_chassis, "get_".format(k))()


### PR DESCRIPTION

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix `NameError` from `show version`.
```
admin@str2-7050cx3-acs-02:~$ show version
Traceback (most recent call last):
  File "/usr/local/bin/show", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/show/main.py", line 960, in version
    chassis_info = platform.get_chassis_info()
  File "/usr/local/lib/python3.7/dist-packages/show/platform.py", line 27, in get_chassis_info
    platform_chassis = sonic_platform.platform.Platform().get_chassis()
NameError: name 'sonic_platform' is not defined
```

#### How I did it
Import `sonic_platform` before using `sonic_platform`.

#### How to verify it
```
admin@str2-7050cx3-acs-02:~$ show version

SONiC Software Version: SONiC.master.20303-a069cb0b1
Distribution: Debian 10.9
Kernel: 4.19.0-12-2-amd64
Build commit: a069cb0b1
Build date: Fri Jun 18 12:43:04 UTC 2021
Built by: AzDevOps@sonic-build-workers-000EBT

Platform: x86_64-arista_7050cx3_32s
HwSKU: Arista-7050CX3-32S-C32
ASIC: broadcom
ASIC Count: 1
Serial Number: JPE20424995
Model Number: DCS-7050CX3-32S-SSD
Hardware Revision: N/A
Uptime: 16:02:04 up  8:26,  2 users,  load average: 1.31, 1.34, 1.43
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

