### PR TITLE
[config] config reload needs to handle exceptions while stopping sonic target

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -663,6 +663,17 @@ def _get_disabled_services_list(config_db):
 
     return disabled_services_list
 
+def _stop_all_services():
+    # stop all other services
+    for s in _get_sonic_services():
+        try:
+            clicommon.run_command("sudo systemctl stop {}".format(s))
+        except:
+            click.echo("Error encountered while stopping service {}. Continuing..".format(s))
+    try:
+        clicommon.run_command("sudo systemctl stop swss")
+    except:
+        click.echo("Error encountered while stopping swss.service. Continuing..")
 
 def _stop_services():
     try:
@@ -673,8 +684,11 @@ def _stop_services():
         pass
 
     click.echo("Stopping SONiC target ...")
-    clicommon.run_command("sudo systemctl stop sonic.target")
-
+    try:
+        clicommon.run_command("sudo systemctl stop sonic.target")
+    except:
+        click.echo("Failed to stop sonic.target. Stopping all services individually.")
+        _stop_all_services()
 
 def _get_sonic_services():
     out = clicommon.run_command("systemctl list-dependencies --plain sonic.target | sed '1d'", return_cmd=True)

--- a/config/main.py
+++ b/config/main.py
@@ -668,11 +668,11 @@ def _stop_all_services():
     for s in _get_sonic_services():
         try:
             clicommon.run_command("sudo systemctl stop {}".format(s))
-        except subprocess.CalledProcessError as err:
+        except SystemExit as err:
             click.echo("Error encountered while stopping service {}. Continuing..".format(s))
     try:
         clicommon.run_command("sudo systemctl stop swss")
-    except subprocess.CalledProcessError as err:
+    except SystemExit as err:
         click.echo("Error encountered while stopping swss.service. Continuing..")
 
 def _stop_services():
@@ -686,7 +686,7 @@ def _stop_services():
     click.echo("Stopping SONiC target ...")
     try:
         clicommon.run_command("sudo systemctl stop sonic.target")
-    except subprocess.CalledProcessError as err:
+    except SystemExit as err:
         click.echo("Failed to stop sonic.target. Stopping all services individually.")
         _stop_all_services()
 

--- a/config/main.py
+++ b/config/main.py
@@ -668,11 +668,11 @@ def _stop_all_services():
     for s in _get_sonic_services():
         try:
             clicommon.run_command("sudo systemctl stop {}".format(s))
-        except:
+        except subprocess.CalledProcessError as err:
             click.echo("Error encountered while stopping service {}. Continuing..".format(s))
     try:
         clicommon.run_command("sudo systemctl stop swss")
-    except:
+    except subprocess.CalledProcessError as err:
         click.echo("Error encountered while stopping swss.service. Continuing..")
 
 def _stop_services():
@@ -686,7 +686,7 @@ def _stop_services():
     click.echo("Stopping SONiC target ...")
     try:
         clicommon.run_command("sudo systemctl stop sonic.target")
-    except:
+    except subprocess.CalledProcessError as err:
         click.echo("Failed to stop sonic.target. Stopping all services individually.")
         _stop_all_services()
 

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -495,7 +495,7 @@ def run_command_in_alias_mode(command):
         sys.exit(rc)
 
 
-def run_command(command, display_cmd=False, ignore_error=False, return_cmd=False, interactive_mode=False):
+def run_command(command, display_cmd=False, ignore_error=False, return_cmd=False, interactive_mode=False, return_err=False):
     """
     Run bash command. Default behavior is to print output to stdout. If the command returns a non-zero
     return code, the function will exit with that return code.
@@ -506,6 +506,7 @@ def run_command(command, display_cmd=False, ignore_error=False, return_cmd=False
         return_cmd: Boolean; If true, the function will return the output, ignoring any non-zero return code
         interactive_mode: Boolean; If true, it will treat the process as a long-running process which may generate
                           multiple lines of output over time
+        return_err: Boolean; If true, the function will return the stdout, stderr and non-zero return code of the command
     """
 
     if display_cmd == True:
@@ -517,7 +518,7 @@ def run_command(command, display_cmd=False, ignore_error=False, return_cmd=False
         run_command_in_alias_mode(command)
         sys.exit(0)
 
-    proc = subprocess.Popen(command, shell=True, text=True, stdout=subprocess.PIPE)
+    proc = subprocess.Popen(command, shell=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE if return_err else None)
 
     if return_cmd:
         output = proc.communicate()[0]
@@ -528,6 +529,9 @@ def run_command(command, display_cmd=False, ignore_error=False, return_cmd=False
 
         if len(out) > 0:
             click.echo(out.rstrip('\n'))
+
+        if return_err:
+            return (out, err, proc.returncode)
 
         if proc.returncode != 0 and not ignore_error:
             sys.exit(proc.returncode)


### PR DESCRIPTION
The below error is seen when a 'config reload' operation is performed
while the sonic.target is starting during system startup or a prior config
reload command.

Job for sonic.target canceled.

Fixes# https://github.com/Azure/sonic-buildimage/issues/7508
fixes #7508
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This error can be ignored if we can try to stop all the services associated
with sonic.target individually. Any processes which did not stop, will be
restarted as part of the "systemctl restart sonic.target" command.

#### How I did it
If sonic.target fails to stop, find all individual services which are part of sonic.target and stop them. All exceptions
are handled, logged and passed. The restart operation on sonic.target will ensure that the services are stopped and
started if they were not stopped earlier.

#### How to verify it
Use ZTP to push a configuration file. Also verified using ZTP unit tests.

root@sonic:/usr/lib/ztp/tests# pytest-3 -v -x -k test_configdb-json.py
============================= test session starts ==============================
platform linux -- Python 3.7.3, pytest-3.10.1, py-1.7.0, pluggy-0.8.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /usr/lib/ztp/tests, inifile:
collected 199 items / 192 deselected

test_configdb-json.py::TestClass::test_constructor_wrong_type PASSED     [ 14%]
test_configdb-json.py::TestClass::test_input_nfound PASSED               [ 28%]
test_configdb-json.py::TestClass::test_invalid_input PASSED              [ 42%]
test_configdb-json.py::TestClass::test_input_no_section PASSED           [ 57%]
test_configdb-json.py::TestClass::test_json_config_nvalid PASSED         [ 71%]
test_configdb-json.py::TestClass::test_json_config_valid_load PASSED     [ 85%]
test_configdb-json.py::TestClass::test_json_config_valid_reload PASSED   [100%]

================== 7 passed, 192 deselected in 40.48 seconds ===================
root@sonic:/usr/lib/ztp/tests#

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

