### PR TITLE
[202012] [pfcwd] Fix the return code in invalid case

### DIFF
--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -244,7 +244,7 @@ class PfcwdCli(object):
             click.echo("Failed to run command, invalid options:")
             for opt in invalid_ports:
                 click.echo(opt)
-            exit()
+            exit(1)
         self.start_cmd(action, restoration_time, ports, detection_time)
 
 

--- a/tests/pfcwd_test.py
+++ b/tests/pfcwd_test.py
@@ -255,7 +255,7 @@ class TestPfcwd(object):
             obj=db
         )
         print(result.output)
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         assert result.output == pfcwd_show_start_config_output_fail
 
     @classmethod
@@ -447,7 +447,7 @@ class TestMultiAsicPfcwdShow(object):
             obj=db
         )
         print(result.output)
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         assert result.output == show_pfc_config_start_fail
 
         # get config after the command, config shouldn't change


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
Backport #1691

#### What I did
Set the correct return code when pfcwd command is specified with invalid options