### PR TITLE
[show][config] support for interface alias for muxcable commands

### DIFF
--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -22,7 +22,7 @@ VENDOR_MODEL_REGEX = re.compile(r"CAC\w{3}321P2P\w{2}MS")
 
 # Helper functions
 
-def get_interface_alias(port, db)
+def get_interface_alias(port, db):
 
     if port is not "all" and port is not None:
         alias = port

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -22,6 +22,17 @@ VENDOR_MODEL_REGEX = re.compile(r"CAC\w{3}321P2P\w{2}MS")
 
 # Helper functions
 
+def get_interface_alias(port, db)
+
+    if port is not "all" and port is not None:
+        alias = port
+        iface_alias_converter = clicommon.InterfaceAliasConverter(db)
+        port = iface_alias_converter.alias_to_name(alias)
+        if port is None:
+            click.echo("cannot find port name for alias {}".format(alias))
+            sys.exit(CONFIG_FAIL)
+
+    return port
 
 def get_value_for_key_in_dict(mdict, port, key, table_name):
     value = mdict.get(key, None)
@@ -90,8 +101,11 @@ def lookup_statedb_and_update_configdb(per_npu_statedb, config_db, port, state_c
 @click.argument('state', metavar='<operation_status>', required=True, type=click.Choice(["active", "auto", "manual"]))
 @click.argument('port', metavar='<port_name>', required=True, default=None)
 @click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL)
-def mode(state, port, json_output):
+@clicommon.pass_db
+def mode(db, state, port, json_output):
     """Config muxcable mode"""
+
+    port = get_interface_alias(port, db)
 
     port_table_keys = {}
     y_cable_asic_table_keys = {}
@@ -258,8 +272,11 @@ def hwmode():
 @hwmode.command()
 @click.argument('state', metavar='<operation_status>', required=True, type=click.Choice(["active", "standby"]))
 @click.argument('port', metavar='<port_name>', required=True, default=None)
-def state(state, port):
+@clicommon.pass_db
+def state(db, state, port):
     """Configure the muxcable mux state {active/standby}"""
+
+    port = get_interface_alias(port, db)
 
     per_npu_statedb = {}
     transceiver_table_keys = {}
@@ -457,8 +474,11 @@ def state(state, port):
 @hwmode.command()
 @click.argument('state', metavar='<operation_status>', required=True, type=click.Choice(["auto", "manual"]))
 @click.argument('port', metavar='<port_name>', required=True, default=None)
-def setswitchmode(state, port):
+@clicommon.pass_db
+def setswitchmode(db, state, port):
     """Configure the muxcable mux switching mode {auto/manual}"""
+
+    port = get_interface_alias(port, db)
 
     per_npu_statedb = {}
     transceiver_dict = {}
@@ -701,8 +721,11 @@ def firmware():
 @firmware.command()
 @click.argument('fwfile', metavar='<firmware_file>', required=True)
 @click.argument('port', metavar='<port_name>', required=True, default=None)
-def download(fwfile, port):
+@clicommon.pass_db
+def download(db, fwfile, port):
     """Config muxcable firmware download"""
+
+    port = get_interface_alias(port, db)
 
     per_npu_statedb = {}
     y_cable_asic_table_keys = {}
@@ -751,8 +774,11 @@ def download(fwfile, port):
 
 @firmware.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
-def activate(port):
+@clicommon.pass_db
+def activate(db, port):
     """Config muxcable firmware activate"""
+
+    port = get_interface_alias(port, db)
 
     per_npu_statedb = {}
     y_cable_asic_table_keys = {}
@@ -800,8 +826,11 @@ def activate(port):
 
 @firmware.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
-def rollback(port):
+@clicommon.pass_db
+def rollback(db, port):
     """Config muxcable firmware rollback"""
+
+    port = get_interface_alias(port, db)
 
     port_table_keys = {}
     y_cable_asic_table_keys = {}

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -22,18 +22,6 @@ VENDOR_MODEL_REGEX = re.compile(r"CAC\w{3}321P2P\w{2}MS")
 
 # Helper functions
 
-def get_interface_alias(port, db):
-
-    if port is not "all" and port is not None:
-        alias = port
-        iface_alias_converter = clicommon.InterfaceAliasConverter(db)
-        port = iface_alias_converter.alias_to_name(alias)
-        if port is None:
-            click.echo("cannot find port name for alias {}".format(alias))
-            sys.exit(CONFIG_FAIL)
-
-    return port
-
 def get_value_for_key_in_dict(mdict, port, key, table_name):
     value = mdict.get(key, None)
     if value is None:
@@ -105,7 +93,7 @@ def lookup_statedb_and_update_configdb(per_npu_statedb, config_db, port, state_c
 def mode(db, state, port, json_output):
     """Config muxcable mode"""
 
-    port = get_interface_alias(port, db)
+    port = platform_sfputil_helper.get_interface_alias(port, db)
 
     port_table_keys = {}
     y_cable_asic_table_keys = {}
@@ -276,7 +264,7 @@ def hwmode():
 def state(db, state, port):
     """Configure the muxcable mux state {active/standby}"""
 
-    port = get_interface_alias(port, db)
+    port = platform_sfputil_helper.get_interface_alias(port, db)
 
     per_npu_statedb = {}
     transceiver_table_keys = {}
@@ -478,7 +466,7 @@ def state(db, state, port):
 def setswitchmode(db, state, port):
     """Configure the muxcable mux switching mode {auto/manual}"""
 
-    port = get_interface_alias(port, db)
+    port = platform_sfputil_helper.get_interface_alias(port, db)
 
     per_npu_statedb = {}
     transceiver_dict = {}
@@ -725,7 +713,7 @@ def firmware():
 def download(db, fwfile, port):
     """Config muxcable firmware download"""
 
-    port = get_interface_alias(port, db)
+    port = platform_sfputil_helper.get_interface_alias(port, db)
 
     per_npu_statedb = {}
     y_cable_asic_table_keys = {}
@@ -778,7 +766,7 @@ def download(db, fwfile, port):
 def activate(db, port):
     """Config muxcable firmware activate"""
 
-    port = get_interface_alias(port, db)
+    port = platform_sfputil_helper.get_interface_alias(port, db)
 
     per_npu_statedb = {}
     y_cable_asic_table_keys = {}
@@ -830,7 +818,7 @@ def activate(db, port):
 def rollback(db, port):
     """Config muxcable firmware rollback"""
 
-    port = get_interface_alias(port, db)
+    port = platform_sfputil_helper.get_interface_alias(port, db)
 
     port_table_keys = {}
     y_cable_asic_table_keys = {}

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -27,6 +27,18 @@ VENDOR_NAME = "Credo"
 VENDOR_MODEL_REGEX = re.compile(r"CAC\w{3}321P2P\w{2}MS")
 
 
+def get_interface_alias(port, db)
+
+    if port is not "all" and port is not None:
+        alias = port
+        iface_alias_converter = clicommon.InterfaceAliasConverter(db)
+        port = iface_alias_converter.alias_to_name(alias)
+        if port is None:
+            click.echo("cannot find port name for alias {}".format(alias))
+            sys.exit(STATUS_FAIL)
+
+    return port
+
 #
 # 'muxcable' command ("show muxcable")
 #
@@ -129,8 +141,11 @@ def create_json_dump_per_port_config(port_status_dict, per_npu_configdb, asic_id
 @muxcable.command()
 @click.argument('port', required=False, default=None)
 @click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
-def status(port, json_output):
+@clicommon.pass_db
+def status(db, port, json_output):
     """Show muxcable status information"""
+
+    port = get_interface_alias(port, db)
 
     port_table_keys = {}
     port_health_table_keys = {}
@@ -239,8 +254,11 @@ def status(port, json_output):
 @muxcable.command()
 @click.argument('port', required=False, default=None)
 @click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
-def config(port, json_output):
+@clicommon.pass_db
+def config(db, port, json_output):
     """Show muxcable config information"""
+
+    port = get_interface_alias(port, db)
 
     port_mux_tbl_keys = {}
     asic_start_idx = None
@@ -407,8 +425,11 @@ def eyeinfo(port, target):
 
 @muxcable.command()
 @click.argument('port', required=True, default=None)
-def cableinfo(port):
+@clicommon.pass_db
+def cableinfo(db, port):
     """Show muxcable cable information"""
+
+    port = get_interface_alias(port, db)
 
     if platform_sfputil is not None:
         physical_port_list = platform_sfputil_helper.logical_port_name_to_physical_port_list(port)
@@ -444,8 +465,11 @@ def hwmode():
 
 @hwmode.command()
 @click.argument('port', metavar='<port_name>', required=False, default=None)
-def muxdirection(port):
+@clicommon.pass_db
+def muxdirection(db, port):
     """Shows the current direction of the muxcable {active/standy}"""
+
+    port = get_interface_alias(port, db)
 
     per_npu_statedb = {}
     transceiver_table_keys = {}
@@ -649,8 +673,10 @@ def muxdirection(port):
 
 @hwmode.command()
 @click.argument('port', metavar='<port_name>', required=False, default=None)
-def switchmode(port):
+def switchmode(db, port):
     """Shows the current switching mode of the muxcable {auto/manual}"""
+
+    port = get_interface_alias(port, db)
 
     per_npu_statedb = {}
     transceiver_dict = {}
@@ -848,8 +874,11 @@ def firmware():
 @firmware.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
 @click.option('--active', 'active', required=False, is_flag=True, type=click.BOOL, help="display the firmware version of only active bank within MCU's")
-def version(port, active):
+@clicommon.pass_db
+def version(db, port, active):
     """Show muxcable firmware version"""
+
+    port = get_interface_alias(port, db)
 
     port_table_keys = {}
     y_cable_asic_table_keys = {}
@@ -940,11 +969,15 @@ def version(port, active):
         else:
             click.echo("there is not a valid asic table for this asic_index".format(asic_index))
 
+
 @muxcable.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
 @click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
-def metrics(port, json_output):
+@clicommon.pass_db
+def metrics(db, port, json_output):
     """Show muxcable metrics <port>"""
+
+    port = get_interface_alias(port, db)
 
     metrics_table_keys = {}
     per_npu_statedb = {}
@@ -980,7 +1013,6 @@ def metrics(port, json_output):
                 asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
                 if asic_index is None:
                     click.echo("Got invalid asic index for port {}, cant retreive mux status".format(port))
-
 
         metrics_dict[asic_index] = per_npu_statedb[asic_index].get_all(
             per_npu_statedb[asic_index].STATE_DB, 'MUX_METRICS_TABLE|{}'.format(port))

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -27,7 +27,7 @@ VENDOR_NAME = "Credo"
 VENDOR_MODEL_REGEX = re.compile(r"CAC\w{3}321P2P\w{2}MS")
 
 
-def get_interface_alias(port, db)
+def get_interface_alias(port, db):
 
     if port is not "all" and port is not None:
         alias = port

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -26,20 +26,6 @@ STATUS_SUCCESSFUL = 0
 VENDOR_NAME = "Credo"
 VENDOR_MODEL_REGEX = re.compile(r"CAC\w{3}321P2P\w{2}MS")
 
-
-def get_interface_alias(port, db):
-
-    if port is not "all" and port is not None:
-        alias = port
-        iface_alias_converter = clicommon.InterfaceAliasConverter(db)
-        port = iface_alias_converter.alias_to_name(alias)
-        if port is None:
-            click.echo("cannot find port name for alias {}".format(alias))
-            sys.exit(STATUS_FAIL)
-
-    return port
-
-#
 # 'muxcable' command ("show muxcable")
 #
 
@@ -145,7 +131,7 @@ def create_json_dump_per_port_config(port_status_dict, per_npu_configdb, asic_id
 def status(db, port, json_output):
     """Show muxcable status information"""
 
-    port = get_interface_alias(port, db)
+    port = platform_sfputil_helper.get_interface_alias(port, db)
 
     port_table_keys = {}
     port_health_table_keys = {}
@@ -258,7 +244,7 @@ def status(db, port, json_output):
 def config(db, port, json_output):
     """Show muxcable config information"""
 
-    port = get_interface_alias(port, db)
+    port = platform_sfputil_helper.get_interface_alias(port, db)
 
     port_mux_tbl_keys = {}
     asic_start_idx = None
@@ -429,7 +415,7 @@ def eyeinfo(port, target):
 def cableinfo(db, port):
     """Show muxcable cable information"""
 
-    port = get_interface_alias(port, db)
+    port = platform_sfputil_helper.get_interface_alias(port, db)
 
     if platform_sfputil is not None:
         physical_port_list = platform_sfputil_helper.logical_port_name_to_physical_port_list(port)
@@ -469,7 +455,7 @@ def hwmode():
 def muxdirection(db, port):
     """Shows the current direction of the muxcable {active/standy}"""
 
-    port = get_interface_alias(port, db)
+    port = platform_sfputil_helper.get_interface_alias(port, db)
 
     per_npu_statedb = {}
     transceiver_table_keys = {}
@@ -676,7 +662,7 @@ def muxdirection(db, port):
 def switchmode(db, port):
     """Shows the current switching mode of the muxcable {auto/manual}"""
 
-    port = get_interface_alias(port, db)
+    port = platform_sfputil_helper.get_interface_alias(port, db)
 
     per_npu_statedb = {}
     transceiver_dict = {}
@@ -878,7 +864,7 @@ def firmware():
 def version(db, port, active):
     """Show muxcable firmware version"""
 
-    port = get_interface_alias(port, db)
+    port = platform_sfputil_helper.get_interface_alias(port, db)
 
     port_table_keys = {}
     y_cable_asic_table_keys = {}
@@ -977,7 +963,7 @@ def version(db, port, active):
 def metrics(db, port, json_output):
     """Show muxcable metrics <port>"""
 
-    port = get_interface_alias(port, db)
+    port = platform_sfputil_helper.get_interface_alias(port, db)
 
     metrics_table_keys = {}
     per_npu_statedb = {}

--- a/utilities_common/platform_sfputil_helper.py
+++ b/utilities_common/platform_sfputil_helper.py
@@ -1,6 +1,8 @@
 import sys
 
 import click
+
+from . import cli as clicommon
 from sonic_py_common import multi_asic, device_info
 
 platform_sfputil = None
@@ -64,3 +66,17 @@ def get_asic_id_for_logical_port(port):
 def get_physical_to_logical():
 
     return platform_sfputil.physical_to_logical
+
+
+def get_interface_alias(port, db):
+
+    if port is not "all" and port is not None:
+        alias = port
+        iface_alias_converter = clicommon.InterfaceAliasConverter(db)
+        port = iface_alias_converter.alias_to_name(alias)
+        if port is None:
+            click.echo("cannot find port name for alias {}".format(alias))
+            sys.exit(1)
+
+    return port
+


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
this PR adds support for interface alias support for muxcable commands. Basically for other OS's there could be a different scheme of interface naming which will be now be supported by muxcable commands as well.

#### How I did it
Added the changes in muxcable.py in show and config . 

#### How to verify it
add unit-tests as well as run on a Arista-7050cx3 switch.

#### Previous command output (if the output of a command-line utility has changed)


#### New command output (if the output of a command-line utility has changed)
```
admin@str2-7050cx3-acs-04:/usr$ show mux cableinfo Ethernet15/1
Vendor    Model
--------  ----------------
Credo     CACL2X321P2PA1MS
admin@str2-7050cx3-acs-04:/usr$ show mux hwmode muxdirection Ethernet13/1
Port        Direction
----------  -----------
Ethernet48  standby
```

