### PR TITLE
[Config] Update config command of kdump

### DIFF
--- a/config/kdump.py
+++ b/config/kdump.py
@@ -1,4 +1,3 @@
-import os
 import sys
 
 import click

--- a/config/kdump.py
+++ b/config/kdump.py
@@ -1,97 +1,90 @@
 import sys
 
 import click
-import utilities_common.cli as clicommon
-from swsscommon.swsscommon import ConfigDBConnector
+from utilities_common.cli import AbbreviationGroup, pass_db
 
 
-@click.group(cls=clicommon.AbbreviationGroup, name="kdump")
+#
+# 'kdump' group ('sudo config kdump ...')
+#
+@click.group(cls=AbbreviationGroup, name="kdump")
 def kdump():
-    """Modify configuration of kdump"""
+    """Configure the KDUMP mechanism"""
     pass
 
+#
+# 'disable' command ('sudo config kdump disable')
+#
+@kdump.command(name="disable", short_help="Disable the KDUMP mechanism")
+@pass_db
+def kdump_disable(db):
+    """Disable the KDUMP mechanism"""
+    kdump_table = db.cfgdb.get_table("KDUMP")
+    if not kdump_table:
+        click.echo("Unable to retrieve 'KDUMP' table from Config DB.")
+        sys.exit(1)
 
-@kdump.command()
-def disable():
-    """Disable kdump feature"""
-    config_db = ConfigDBConnector()
-    if config_db:
-        config_db.connect()
-        kdump_table = config_db.get_table("KDUMP")
-        if not kdump_table:
-            click.echo("Unable to retrieve KDUMP table from CONFIG DB.")
-            sys.exit(1)
+    if "config" not in kdump_table:
+        click.echo("Unable to retrieve key 'config' from KDUMP table.")
+        sys.exit(2)
 
-        if "config" not in kdump_table:
-            click.echo("Unable to retrieve key 'config' from KDUMP table.")
-            sys.exit(2)
+    db.cfgdb.mod_entry("KDUMP", "config", {"enabled": "false"})
 
-        config_db.mod_entry("KDUMP", "config", {"enabled": "false"})
-    else:
-        click.echo("Unable to get an instance of 'ConfigDBConnector'.")
+
+#
+# 'enable' command ('sudo config kdump enable')
+#
+@kdump.command(name="enable", short_help="Enable the KDUMP mechanism")
+@pass_db
+def kdump_enable(db):
+    """Enable the KDUMP mechanism"""
+    kdump_table = db.cfgdb.get_table("KDUMP")
+    if not kdump_table:
+        click.echo("Unable to retrieve KDUMP table from CONFIG DB.")
         sys.exit(3)
 
+    if "config" not in kdump_table:
+        click.echo("Unable to retrieve key 'config' from KDUMP table.")
+        sys.exit(4)
 
-@kdump.command()
-def enable():
-    """Enable kdump feature"""
-    config_db = ConfigDBConnector()
-    if config_db:
-        config_db.connect()
-        kdump_table = config_db.get_table("KDUMP")
-        if not kdump_table:
-            click.echo("Unable to retrieve KDUMP table from CONFIG DB.")
-            sys.exit(4)
+    db.cfgdb.mod_entry("KDUMP", "config", {"enabled": "true"})
 
-        if "config" not in kdump_table:
-            click.echo("Unable to retrieve key 'config' from KDUMP table.")
-            sys.exit(5)
 
-        config_db.mod_entry("KDUMP", "config", {"enabled": "true"})
-    else:
-        click.echo("Unable to get an instance of 'ConfigDBConnector'.")
+#
+# 'memory' command ('sudo config kdump memory ...')
+#
+@kdump.command(name="memory", short_help="Configure the memory for KDUMP mechanism")
+@click.argument('kdump_memory', metavar='<kdump_memory>', required=True)
+@pass_db
+def kdump_memory(db, kdump_memory):
+    """Reserve memory for kdump capture kernel"""
+    kdump_table = db.cfgdb.get_table("KDUMP")
+    if not kdump_table:
+        click.echo("Unable to retrieve KDUMP table from CONFIG DB.")
+        sys.exit(5)
+
+    if "config" not in kdump_table:
+        click.echo("Unable to retrieve key 'config' from KDUMP table.")
         sys.exit(6)
 
-
-@kdump.command()
-@click.argument('kdump_memory', metavar='<kdump_memory>', required=True)
-def memory(kdump_memory):
-    """Reserve memory for kdump capture kernel"""
-    config_db = ConfigDBConnector()
-    if config_db:
-        config_db.connect()
-        kdump_table = config_db.get_table("KDUMP")
-        if not kdump_table:
-            click.echo("Unable to retrieve KDUMP table from CONFIG DB.")
-            sys.exit(7)
-
-        if "config" not in kdump_table:
-            click.echo("Unable to retrieve key 'config' from KDUMP table.")
-            sys.exit(8)
-
-        config_db.mod_entry("KDUMP", "config", {"memory": kdump_memory})
-    else:
-        click.echo("Unable to get an instance of 'ConfigDBConnector'.")
-        sys.exit(9)
+    db.cfgdb.mod_entry("KDUMP", "config", {"memory": kdump_memory})
 
 
-@kdump.command('num-dumps')
+#
+# 'num_dumps' command ('sudo config keump num_dumps ...')
+#
+@kdump.command(name="num_dumps", short_help="Configure the maximum dump files of KDUMP mechanism")
 @click.argument('kdump_num_dumps', metavar='<kdump_num_dumps>', required=True, type=int)
-def num_dumps(kdump_num_dumps):
+@pass_db
+def kdump_num_dumps(db, kdump_num_dumps):
     """Set maximum number of dump files for kdump"""
-    config_db = ConfigDBConnector()
-    if config_db:
-        config_db.connect()
-        kdump_table = config_db.get_table("KDUMP")
-        if not kdump_table:
-            click.echo("Unable to retrieve KDUMP table from CONFIG DB.")
-            sys.exit(10)
+    kdump_table = db.cfgdb.get_table("KDUMP")
+    if not kdump_table:
+        click.echo("Unable to retrieve KDUMP table from CONFIG DB.")
+        sys.exit(7)
 
-        if "config" not in kdump_table:
-            click.echo("Unable to retrieve key 'config' from KDUMP table.")
-            sys.exit(11)
+    if "config" not in kdump_table:
+        click.echo("Unable to retrieve key 'config' from KDUMP table.")
+        sys.exit(8)
 
-        config_db.mod_entry("KDUMP", "config", {"num_dumps": kdump_num_dumps})
-    else:
-        click.echo("Unable to get an instance of 'ConfigDBConnector'.")
-        sys.exit(12)
+    db.cfgdb.mod_entry("KDUMP", "config", {"num_dumps": kdump_num_dumps})

--- a/config/kdump.py
+++ b/config/kdump.py
@@ -1,44 +1,85 @@
 import os
+
 import click
 import utilities_common.cli as clicommon
-from swsscommon.swsscommon import ConfigDBConnector
+from swsssdk import ConfigDBConnector
+
 
 @click.group(cls=clicommon.AbbreviationGroup, name="kdump")
 def kdump():
-    """ Configure kdump """
-    if os.geteuid() != 0:
-        exit("Root privileges are required for this operation")
+    """Modify configuration of kdump"""
+    pass
+
 
 @kdump.command()
 def disable():
-    """Disable kdump operation"""
+    """Disable kdump feature"""
     config_db = ConfigDBConnector()
-    if config_db is not None:
+    if config_db:
         config_db.connect()
+        kdump_table = config_db.get_table("KDUMP")
+        if not kdump_table:
+            click.echo("Unable to retrieve kdump table from CONFIG_DB.")
+            return
+
+        if "config" not in kdump_table:
+            click.echo("Unable retrieve key `config` from kdump table.")
+            return
+
         config_db.mod_entry("KDUMP", "config", {"enabled": "false"})
+
 
 @kdump.command()
 def enable():
-    """Enable kdump operation"""
+    """Enable kdump feature"""
     config_db = ConfigDBConnector()
-    if config_db is not None:
+    if config_db:
         config_db.connect()
+        kdump_table = config_db.get_table("KDUMP")
+        if not kdump_table:
+            click.echo("Unable to retrieve kdump table from CONFIG_DB.")
+            return
+
+        if "config" not in kdump_table:
+            click.echo("Unable retrieve key `config` from kdump table.")
+            return
+
         config_db.mod_entry("KDUMP", "config", {"enabled": "true"})
+
 
 @kdump.command()
 @click.argument('kdump_memory', metavar='<kdump_memory>', required=True)
 def memory(kdump_memory):
-    """Set memory allocated for kdump capture kernel"""
+    """Reserve memory for kdump capture kernel"""
     config_db = ConfigDBConnector()
-    if config_db is not None:
+    if config_db:
         config_db.connect()
+        kdump_table = config_db.get_table("KDUMP")
+        if not kdump_table:
+            click.echo("Unable to retrieve kdump table from CONFIG_DB.")
+            return
+
+        if "config" not in kdump_table:
+            click.echo("Unable retrieve key `config` from kdump table.")
+            return
+
         config_db.mod_entry("KDUMP", "config", {"memory": kdump_memory})
+
 
 @kdump.command('num-dumps')
 @click.argument('kdump_num_dumps', metavar='<kdump_num_dumps>', required=True, type=int)
 def num_dumps(kdump_num_dumps):
-    """Set max number of dump files for kdump"""
+    """Set maximum number of dump files for kdump"""
     config_db = ConfigDBConnector()
-    if config_db is not None:
+    if config_db:
         config_db.connect()
+        kdump_table = config_db.get_table("KDUMP")
+        if not kdump_table:
+            click.echo("Unable to retrieve kdump table from CONFIG_DB.")
+            return
+
+        if "config" not in kdump_table:
+            click.echo("Unable retrieve key `config` from kdump table.")
+            return
+
         config_db.mod_entry("KDUMP", "config", {"num_dumps": kdump_num_dumps})

--- a/config/kdump.py
+++ b/config/kdump.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import click
 import utilities_common.cli as clicommon
@@ -18,13 +19,9 @@ def disable():
     if config_db:
         config_db.connect()
         kdump_table = config_db.get_table("KDUMP")
-        if not kdump_table:
-            click.echo("Unable to retrieve kdump table from CONFIG_DB.")
-            return
-
         if "config" not in kdump_table:
-            click.echo("Unable retrieve key `config` from kdump table.")
-            return
+            click.echo("Unable to retrieve key `config` from kdump table.")
+            sys.exit(1)
 
         config_db.mod_entry("KDUMP", "config", {"enabled": "false"})
 
@@ -36,13 +33,9 @@ def enable():
     if config_db:
         config_db.connect()
         kdump_table = config_db.get_table("KDUMP")
-        if not kdump_table:
-            click.echo("Unable to retrieve kdump table from CONFIG_DB.")
-            return
-
         if "config" not in kdump_table:
-            click.echo("Unable retrieve key `config` from kdump table.")
-            return
+            click.echo("Unable to retrieve key `config` from kdump table.")
+            sys.exit(2)
 
         config_db.mod_entry("KDUMP", "config", {"enabled": "true"})
 
@@ -55,13 +48,9 @@ def memory(kdump_memory):
     if config_db:
         config_db.connect()
         kdump_table = config_db.get_table("KDUMP")
-        if not kdump_table:
-            click.echo("Unable to retrieve kdump table from CONFIG_DB.")
-            return
-
         if "config" not in kdump_table:
-            click.echo("Unable retrieve key `config` from kdump table.")
-            return
+            click.echo("Unable to retrieve key `config` from kdump table.")
+            sys.exit(3)
 
         config_db.mod_entry("KDUMP", "config", {"memory": kdump_memory})
 
@@ -74,12 +63,8 @@ def num_dumps(kdump_num_dumps):
     if config_db:
         config_db.connect()
         kdump_table = config_db.get_table("KDUMP")
-        if not kdump_table:
-            click.echo("Unable to retrieve kdump table from CONFIG_DB.")
-            return
-
         if "config" not in kdump_table:
-            click.echo("Unable retrieve key `config` from kdump table.")
-            return
+            click.echo("Unable to retrieve key `config` from kdump table.")
+            sys.exit(4)
 
         config_db.mod_entry("KDUMP", "config", {"num_dumps": kdump_num_dumps})

--- a/config/kdump.py
+++ b/config/kdump.py
@@ -2,7 +2,7 @@ import sys
 
 import click
 import utilities_common.cli as clicommon
-from swsssdk import ConfigDBConnector
+from swsscommon.swsscommon import ConfigDBConnector
 
 
 @click.group(cls=clicommon.AbbreviationGroup, name="kdump")
@@ -18,11 +18,18 @@ def disable():
     if config_db:
         config_db.connect()
         kdump_table = config_db.get_table("KDUMP")
-        if "config" not in kdump_table:
-            click.echo("Unable to retrieve key `config` from kdump table.")
+        if not kdump_table:
+            click.echo("Unable to retrieve KDUMP table from CONFIG DB.")
             sys.exit(1)
 
+        if "config" not in kdump_table:
+            click.echo("Unable to retrieve key 'config' from KDUMP table.")
+            sys.exit(2)
+
         config_db.mod_entry("KDUMP", "config", {"enabled": "false"})
+    else:
+        click.echo("Unable to get an instance of 'ConfigDBConnector'.")
+        sys.exit(3)
 
 
 @kdump.command()
@@ -32,11 +39,18 @@ def enable():
     if config_db:
         config_db.connect()
         kdump_table = config_db.get_table("KDUMP")
+        if not kdump_table:
+            click.echo("Unable to retrieve KDUMP table from CONFIG DB.")
+            sys.exit(4)
+
         if "config" not in kdump_table:
-            click.echo("Unable to retrieve key `config` from kdump table.")
-            sys.exit(2)
+            click.echo("Unable to retrieve key 'config' from KDUMP table.")
+            sys.exit(5)
 
         config_db.mod_entry("KDUMP", "config", {"enabled": "true"})
+    else:
+        click.echo("Unable to get an instance of 'ConfigDBConnector'.")
+        sys.exit(6)
 
 
 @kdump.command()
@@ -47,11 +61,18 @@ def memory(kdump_memory):
     if config_db:
         config_db.connect()
         kdump_table = config_db.get_table("KDUMP")
+        if not kdump_table:
+            click.echo("Unable to retrieve KDUMP table from CONFIG DB.")
+            sys.exit(7)
+
         if "config" not in kdump_table:
-            click.echo("Unable to retrieve key `config` from kdump table.")
-            sys.exit(3)
+            click.echo("Unable to retrieve key 'config' from KDUMP table.")
+            sys.exit(8)
 
         config_db.mod_entry("KDUMP", "config", {"memory": kdump_memory})
+    else:
+        click.echo("Unable to get an instance of 'ConfigDBConnector'.")
+        sys.exit(9)
 
 
 @kdump.command('num-dumps')
@@ -62,8 +83,15 @@ def num_dumps(kdump_num_dumps):
     if config_db:
         config_db.connect()
         kdump_table = config_db.get_table("KDUMP")
+        if not kdump_table:
+            click.echo("Unable to retrieve KDUMP table from CONFIG DB.")
+            sys.exit(10)
+
         if "config" not in kdump_table:
-            click.echo("Unable to retrieve key `config` from kdump table.")
-            sys.exit(4)
+            click.echo("Unable to retrieve key 'config' from KDUMP table.")
+            sys.exit(11)
 
         config_db.mod_entry("KDUMP", "config", {"num_dumps": kdump_num_dumps})
+    else:
+        click.echo("Unable to get an instance of 'ConfigDBConnector'.")
+        sys.exit(12)

--- a/config/kdump.py
+++ b/config/kdump.py
@@ -12,6 +12,26 @@ def kdump():
     """Configure the KDUMP mechanism"""
     pass
 
+
+def check_kdump_table_existence(kdump_table):
+    """Checks whether the 'KDUMP' table is configured in Config DB.
+
+    Args:
+      kdump_table: A dictionary represents the key-value pair in sub-table
+      of 'KDUMP'.
+
+    Returns:
+      None.
+    """
+    if not kdump_table:
+        click.echo("Unable to retrieve 'KDUMP' table from Config DB.")
+        sys.exit(1)
+
+    if "config" not in kdump_table:
+        click.echo("Unable to retrieve key 'config' from KDUMP table.")
+        sys.exit(2)
+
+
 #
 # 'disable' command ('sudo config kdump disable')
 #
@@ -20,13 +40,7 @@ def kdump():
 def kdump_disable(db):
     """Disable the KDUMP mechanism"""
     kdump_table = db.cfgdb.get_table("KDUMP")
-    if not kdump_table:
-        click.echo("Unable to retrieve 'KDUMP' table from Config DB.")
-        sys.exit(1)
-
-    if "config" not in kdump_table:
-        click.echo("Unable to retrieve key 'config' from KDUMP table.")
-        sys.exit(2)
+    check_kdump_table_existence(kdump_table)
 
     db.cfgdb.mod_entry("KDUMP", "config", {"enabled": "false"})
 
@@ -39,13 +53,7 @@ def kdump_disable(db):
 def kdump_enable(db):
     """Enable the KDUMP mechanism"""
     kdump_table = db.cfgdb.get_table("KDUMP")
-    if not kdump_table:
-        click.echo("Unable to retrieve KDUMP table from CONFIG DB.")
-        sys.exit(3)
-
-    if "config" not in kdump_table:
-        click.echo("Unable to retrieve key 'config' from KDUMP table.")
-        sys.exit(4)
+    check_kdump_table_existence(kdump_table)
 
     db.cfgdb.mod_entry("KDUMP", "config", {"enabled": "true"})
 
@@ -59,13 +67,7 @@ def kdump_enable(db):
 def kdump_memory(db, kdump_memory):
     """Reserve memory for kdump capture kernel"""
     kdump_table = db.cfgdb.get_table("KDUMP")
-    if not kdump_table:
-        click.echo("Unable to retrieve KDUMP table from CONFIG DB.")
-        sys.exit(5)
-
-    if "config" not in kdump_table:
-        click.echo("Unable to retrieve key 'config' from KDUMP table.")
-        sys.exit(6)
+    check_kdump_table_existence(kdump_table)
 
     db.cfgdb.mod_entry("KDUMP", "config", {"memory": kdump_memory})
 
@@ -79,12 +81,6 @@ def kdump_memory(db, kdump_memory):
 def kdump_num_dumps(db, kdump_num_dumps):
     """Set maximum number of dump files for kdump"""
     kdump_table = db.cfgdb.get_table("KDUMP")
-    if not kdump_table:
-        click.echo("Unable to retrieve KDUMP table from CONFIG DB.")
-        sys.exit(7)
-
-    if "config" not in kdump_table:
-        click.echo("Unable to retrieve key 'config' from KDUMP table.")
-        sys.exit(8)
+    check_kdump_table_existence(kdump_table)
 
     db.cfgdb.mod_entry("KDUMP", "config", {"num_dumps": kdump_num_dumps})

--- a/tests/kdump_test.py
+++ b/tests/kdump_test.py
@@ -1,0 +1,74 @@
+import importlib
+
+from click.testing import CliRunner
+from utilities_common.db import Db
+
+
+class TestKdump(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+
+    def test_config_kdump_disable(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        db = Db()
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["kdump"].commands["disable"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        # Delete the 'KDUMP' table.
+        db.cfgdb.delete_table("KDUMP")
+
+        result = runner.invoke(config.config.commands["kdump"].commands["disable"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 1
+
+    def test_config_kdump_enable(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        db = Db()
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["kdump"].commands["enable"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        # Delete the 'KDUMP' table.
+        db.cfgdb.delete_table("KDUMP")
+
+        result = runner.invoke(config.config.commands["kdump"].commands["enable"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 3
+
+    def test_config_kdump_memory(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        db = Db()
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["kdump"].commands["memory"], ["256MB"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        # Delete the 'KDUMP' table.
+        db.cfgdb.delete_table("KDUMP")
+
+        result = runner.invoke(config.config.commands["kdump"].commands["memory"], ["256MB"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 5
+
+    def test_config_kdump_num_dumps(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        db = Db()
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["kdump"].commands["num_dumps"], ["10"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        # Delete the 'KDUMP' table.
+        db.cfgdb.delete_table("KDUMP")
+
+        result = runner.invoke(config.config.commands["kdump"].commands["num_dumps"], ["10"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 7
+
+    @classmethod
+    def teardown_class(cls):
+        print("TEARDOWN")

--- a/tests/kdump_test.py
+++ b/tests/kdump_test.py
@@ -37,7 +37,7 @@ class TestKdump(object):
 
         result = runner.invoke(config.config.commands["kdump"].commands["enable"], obj=db)
         print(result.exit_code)
-        assert result.exit_code == 3
+        assert result.exit_code == 1
 
     def test_config_kdump_memory(self, get_cmd_module):
         (config, show) = get_cmd_module
@@ -52,7 +52,7 @@ class TestKdump(object):
 
         result = runner.invoke(config.config.commands["kdump"].commands["memory"], ["256MB"], obj=db)
         print(result.exit_code)
-        assert result.exit_code == 5
+        assert result.exit_code == 1
 
     def test_config_kdump_num_dumps(self, get_cmd_module):
         (config, show) = get_cmd_module
@@ -67,7 +67,7 @@ class TestKdump(object):
 
         result = runner.invoke(config.config.commands["kdump"].commands["num_dumps"], ["10"], obj=db)
         print(result.exit_code)
-        assert result.exit_code == 7
+        assert result.exit_code == 1
 
     @classmethod
     def teardown_class(cls):

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -637,9 +637,9 @@
     "DEBUG_COUNTER_DROP_REASON|DEBUG_2|NO_L3_HEADER": {},
     "DEBUG_COUNTER_DROP_REASON|lowercase_counter|L2_ANY": {},
     "KDUMP|config": {
-	"enabled": "false",
-	"memory": "256MB",
-	"num_dumps": "3"
+        "enabled": "false",
+        "memory": "256MB",
+        "num_dumps": "3"
     },
     "FEATURE|bgp": {
         "state": "enabled",

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -636,6 +636,11 @@
     "DEBUG_COUNTER_DROP_REASON|DEBUG_2|IP_HEADER_ERROR": {},
     "DEBUG_COUNTER_DROP_REASON|DEBUG_2|NO_L3_HEADER": {},
     "DEBUG_COUNTER_DROP_REASON|lowercase_counter|L2_ANY": {},
+    "KDUMP|config": {
+	"enabled": "false",
+	"memory": "256MB",
+	"num_dumps": "3"
+    },
     "FEATURE|bgp": {
         "state": "enabled",
         "auto_restart": "enabled",


### PR DESCRIPTION
Signed-off-by: Yong Zhao <yozhao@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This PR aims to update the `config` command of Kdump (Linux kernel dump) mechanism.

#### How I did it
Before updating the value of a field in the table of `KDUMP`, we need decide whether the `KDUMP` table and corresponding field does exist in the table.

#### How to verify it
I verifies this on device `str-msn2700-03` and unit test passed.
        
        tests/kdump_test.py::TestKdump::test_config_kdump_disable PASSED                                                                                                 
        tests/kdump_test.py::TestKdump::test_config_kdump_enable PASSED                                                                                                  
        tests/kdump_test.py::TestKdump::test_config_kdump_memory PASSED                                                                                                  
        tests/kdump_test.py::TestKdump::test_config_kdump_num_dumps PASSED

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

