### PR TITLE
[minigraph][port_config] Consume port_config.json while loading minigraph

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1441,6 +1441,12 @@ def load_minigraph(db, no_service_restart):
     if os.path.isfile('/etc/sonic/acl.json'):
         clicommon.run_command("acl-loader update full /etc/sonic/acl.json", display_cmd=True)
 
+    # Load port_config.json
+    try:
+        load_port_config(db.cfgdb, '/etc/sonic/port_config.json')
+    except Exception as e:
+        click.secho("Failed to load port_config.json, Error: {}".format(str(e)), fg='magenta')
+
     # generate QoS and Buffer configs
     clicommon.run_command("config qos reload --no-dynamic-buffer", display_cmd=True)
 
@@ -1463,6 +1469,44 @@ def load_minigraph(db, no_service_restart):
         _restart_services()
     click.echo("Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`.")
 
+def load_port_config(config_db, port_config_path):
+    if not os.path.isfile(port_config_path):
+        return
+
+    try:
+        # Load port_config.json
+        port_config_input = read_json_file(port_config_path)
+    except Exception:
+        raise Exception("Bad format: json file broken")
+
+    # Validate if the input is an array
+    if not isinstance(port_config_input, list):
+        raise Exception("Bad format: port_config is not an array")
+    
+    if len(port_config_input) == 0 or 'PORT' not in port_config_input[0]:
+        raise Exception("Bad format: PORT table not exists")
+        
+    port_config = port_config_input[0]['PORT']
+
+    # Ensure all ports are exist
+    port_table = {}
+    for port_name in port_config.keys():
+        port_entry = config_db.get_entry('PORT', port_name)
+        if not port_entry:
+            raise Exception("Port {} is not defined in current device".format(port_name))
+        port_table[port_name] = port_entry
+
+    # Update port state
+    for port_name in port_config.keys():
+        if 'admin_status' not in port_config[port_name]:
+            continue
+        if 'admin_status' in port_table[port_name]:
+            if port_table[port_name]['admin_status'] == port_config[port_name]['admin_status']:
+                continue
+            clicommon.run_command('config interface {} {}'.format(
+                'startup' if port_config[port_name]['admin_status'] == 'up' else 'shutdown',
+                port_name), display_cmd=True)
+    return
 
 #
 # 'hostname' command


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
The port state will be reset to up if user use `config load_minigraph` to recover configurations.
This PR is for supporting consume `port_config.json` while loading minigraph. User can put the stateful `port_config.json` with minigraph file to keep the port state unchanged after reload minigraph.
The `port_config.json` includes a segment of `config_db` PORT table(we called that segment `configlet` as well) and it will be placed on `\etc\sonic\port_config.json`, below is a sample:
```json
[
  {
    "PORT": {
      "Ethernet0": {
        "admin_status": "down"
      },
      "Ethernet4": {
        "admin_status": "up"
      }
    }
  }
]
``` 

This feature will only consume the `port_config.json` when the file is existed in `\etc\sonic\port_config.json`.

Please notice that we do not leverage this feature https://github.com/Azure/sonic-utilities/pull/716 to consume the `port_config.json` due to the configlet might contains multiple fields for an interface such as `mtu`, `speed`, ... however, we just want to consume the `admin_status` here only and there might have some side effects if we update the PORT table only.

#### How I did it
Add code `config load_minigraph` command to let it consume `port_config.json`.

#### How to verify it
Add UTs.
```
tests/config_test.py::TestLoadMinigraph::test_load_minigraph_with_port_config_bad_format PASSED [ 15%]
tests/config_test.py::TestLoadMinigraph::test_load_minigraph_with_port_config_inconsistent_port PASSED [ 16%]
tests/config_test.py::TestLoadMinigraph::test_load_minigraph_with_port_config PASSED [ 16%]
```

KVM SONiC test:
Before
```
admin@vlab-01:/etc/sonic$ show interface status
      Interface            Lanes    Speed    MTU    FEC           Alias             Vlan    Oper    Admin    Type    Asym PFC
---------------  ---------------  -------  -----  -----  --------------  ---------------  ------  -------  ------  ----------
    Ethernet112      93,94,95,96      40G   9100    N/A  fortyGigE0/112  PortChannel0001      up       up     N/A         off
    Ethernet116      89,90,91,92      40G   9100    N/A  fortyGigE0/116  PortChannel0002      up       up     N/A         off
    Ethernet120  101,102,103,104      40G   9100    N/A  fortyGigE0/120  PortChannel0003      up       up     N/A         off
    Ethernet124     97,98,99,100      40G   9100    N/A  fortyGigE0/124  PortChannel0004      up       up     N/A         off

admin@vlab-01:/etc/sonic$ show ip bgp sum
Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.57      4  64600      22731      24480         0      0       0  16:16:49             6400  ARISTA01T1
10.0.0.59      4  64600      22752      24480         0      0       0  16:16:48             6400  ARISTA02T1
10.0.0.61      4  64600      22744      24480         0      0       0  16:16:48             6400  ARISTA03T1
10.0.0.63      4  64600      22736      24480         0      0       0  16:16:48             6400  ARISTA04T1

Total number of neighbors 4
```

Prepare `port_config.json` with below content:
```json
[
  {
    "PORT": {
      "Ethernet112": {
        "admin_status": "down"
      },
      "Ethernet116": {
        "admin_status": "up"
      }
    }
  }
]
```

After `config load_minigraph`:
```
admin@vlab-01:/etc/sonic$ show interface status
      Interface            Lanes    Speed    MTU    FEC           Alias             Vlan    Oper    Admin    Type    Asym PFC
---------------  ---------------  -------  -----  -----  --------------  ---------------  ------  -------  ------  ----------
    Ethernet112      93,94,95,96      40G   9100    N/A  fortyGigE0/112  PortChannel0001    down     down     N/A         off
    Ethernet116      89,90,91,92      40G   9100    N/A  fortyGigE0/116  PortChannel0002      up       up     N/A         off
    Ethernet120  101,102,103,104      40G   9100    N/A  fortyGigE0/120  PortChannel0003      up       up     N/A         off
    Ethernet124     97,98,99,100      40G   9100    N/A  fortyGigE0/124  PortChannel0004      up       up     N/A         off

admin@vlab-01:/etc/sonic$ show ip bgp sum
Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down    State/PfxRcd    NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.57      4  64600          0          0         0      0       0  never      Active          ARISTA01T1
10.0.0.59      4  64600       3222       7664         0      0       0  00:00:59   6400            ARISTA02T1
10.0.0.61      4  64600       3223       7664         0      0       0  00:00:58   6400            ARISTA03T1
10.0.0.63      4  64600       3222       7664         0      0       0  00:00:59   6400            ARISTA04T1
```

Remove `port_config.json` and run `config load_minigraph` again:
```
admin@vlab-01:/etc/sonic$ show interface status
      Interface            Lanes    Speed    MTU    FEC           Alias             Vlan    Oper    Admin    Type    Asym PFC
---------------  ---------------  -------  -----  -----  --------------  ---------------  ------  -------  ------  ----------
    Ethernet112      93,94,95,96      40G   9100    N/A  fortyGigE0/112  PortChannel0001      up       up     N/A         off
    Ethernet116      89,90,91,92      40G   9100    N/A  fortyGigE0/116  PortChannel0002      up       up     N/A         off
    Ethernet120  101,102,103,104      40G   9100    N/A  fortyGigE0/120  PortChannel0003      up       up     N/A         off
    Ethernet124     97,98,99,100      40G   9100    N/A  fortyGigE0/124  PortChannel0004      up       up     N/A         off

admin@vlab-01:/etc/sonic$ show ip bgp sum
Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.57      4  64600       3274       8396         0      0       0  00:03:30             6400  ARISTA01T1
10.0.0.59      4  64600       3274      13103         0      0       0  00:03:31             6400  ARISTA02T1
10.0.0.61      4  64600       3274      13104         0      0       0  00:03:31             6400  ARISTA03T1
10.0.0.63      4  64600       4884       9839         0      0       0  00:03:18             6400  ARISTA04T1

Total number of neighbors 4
```

#### Previous command output (if the output of a command-line utility has changed)
N/A

#### New command output (if the output of a command-line utility has changed)
N/A
