### PR TITLE
[Mellanox] Remove mstdump from  Mellanox's collect dump script

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -772,13 +772,6 @@ collect_mellanox() {
 
     ${CMD_PREFIX}rm -rf $sai_dump_folder
     ${CMD_PREFIX}docker exec -it syncd rm -rf $sai_dump_folder
-
-    local mst_dump_filename="/tmp/mstdump"
-    local max_dump_count="3"
-    for i in $(seq 1 $max_dump_count); do
-        ${CMD_PREFIX}/usr/bin/mstdump /dev/mst/mt*conf0 > "${mst_dump_filename}${i}"
-        save_file "${mst_dump_filename}${i}" mstdump true
-    done
     
     # Save SDK error dumps
     local sdk_dump_path=`${CMD_PREFIX}docker exec syncd cat /tmp/sai.profile|grep "SAI_DUMP_STORE_PATH"|cut -d = -f2`


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Remove redundant mellanox dumps now that Mellanox SAI is taking care of that.

#### How I did it
Deleted the part related to mstdumps from the generate_script

#### How to verify it
Run 'show techsupport' see we no have mstdump folder but the actual dump available under the saisdk dump

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

