### PR TITLE
[multi-asic][cli][chassis-db] Avoid connecting to chassis db for cli commands executed from linecard

### DIFF
--- a/utilities_common/db.py
+++ b/utilities_common/db.py
@@ -1,4 +1,4 @@
-from sonic_py_common import multi_asic
+from sonic_py_common import multi_asic, device_info
 from swsscommon.swsscommon import ConfigDBConnector, SonicV2Connector
 from utilities_common import constants
 from utilities_common.multi_asic import multi_asic_ns_choices
@@ -11,7 +11,17 @@ class Db(object):
         self.cfgdb = ConfigDBConnector()
         self.cfgdb.connect()
         self.db = SonicV2Connector(host="127.0.0.1")
-        for db_id in self.db.get_db_list():
+
+        # Skip connecting to chassis databases in line cards
+        db_list = list(self.db.get_db_list())
+        if not device_info.is_voq_supervisor():
+            try:
+                db_list.remove('CHASSIS_APP_DB')
+                db_list.remove('CHASSIS_STATE_DB')
+            except Exception:
+                pass
+
+        for db_id in db_list:
             self.db.connect(db_id)
 
         self.cfgdb_clients[constants.DEFAULT_NAMESPACE] = self.cfgdb

--- a/utilities_common/db.py
+++ b/utilities_common/db.py
@@ -14,7 +14,7 @@ class Db(object):
 
         # Skip connecting to chassis databases in line cards
         db_list = list(self.db.get_db_list())
-        if not device_info.is_voq_supervisor():
+        if not device_info.is_supervisor():
             try:
                 db_list.remove('CHASSIS_APP_DB')
                 db_list.remove('CHASSIS_STATE_DB')


### PR DESCRIPTION



#### What I did

Currently, for all the cli commands, we connect to all databases mentioned in the database_config.json. The database_config.json also includes the databases from chassis redis server from supervisor card. It is unneccessary to connect to databases from chassis redis server when cli commands are executed form linecard. But we need to allow connection to chassis databases when the cli commands are executed from supervisor card. This problem is fixed by this PR

#### How I did it

The constructor of Db() class which is instantiated for every CLI command execution is changed to skip chassis databases from the list of collected databases if the card is not supervisor card. This PR is dependent on sonic-buildimage PR https://github.com/Azure/sonic-buildimage/pull/8065.

#### How to verify it
In voq chassis execute some CLI commands (show, config, etc.) and make sure that commands are executed without any CLI errors no matter whether there is supervisor card or not.

#### Previous command output (if the output of a command-line utility has changed)

No command syntax or outputs changed

#### New command output (if the output of a command-line utility has changed)
N/A
