### PR TITLE
Coverage uses top level directory as source

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,6 @@
 [run]
 branch = True
 source = .
+omit =
+    .eggs/*
+    tests/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,3 @@
 [run]
 branch = True
+source = .

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,29 +1,2 @@
 [run]
 branch = True
-source =
-    acl_loader
-    clear
-    config
-    connect
-    consutil
-    counterpoll
-    crm
-    debug
-    fdbutil
-    fwutil
-    pcieutil
-    pddf_fanutil
-    pddf_ledutil
-    pddf_psuutil
-    pddf_thermalutil
-    pfc
-    pfcwd
-    psuutil
-    scripts
-    sfputil
-    show
-    sonic_installer
-    ssdutil
-    undebug
-    utilities_common
-    watchdogutil


### PR DESCRIPTION
#### What I did
Originally, the Azure pipeline "Code Coverage" page will render folder structure wrongly. The first level of folders disappear and all the files in the first level are combined and de-dup. So we lost many main.py, etc.

Fix the coveragerc file so that the rendering will make sense.

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

