### PR TITLE
Load the  database global_db only once for show cli 

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -10,7 +10,7 @@ import tabulate
 import pyangbind.lib.pybindJSON as pybindJSON
 from natsort import natsorted
 from sonic_py_common import multi_asic
-from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector, SonicDBConfig
+from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
 from utilities_common.general import load_db_config
 
 def info(msg):

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -146,7 +146,7 @@ class AclLoader(object):
 
         # Getting all front asic namespace and correspding config and state DB connector
 
-        namespaces = device_info.get_all_namespaces()
+        namespaces = multi_asic.get_all_namespaces()
         for front_asic_namespaces in namespaces['front_ns']:
             self.per_npu_configdb[front_asic_namespaces] = ConfigDBConnector(use_unix_socket_path=True, namespace=front_asic_namespaces)
             self.per_npu_configdb[front_asic_namespaces].connect()

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -9,7 +9,7 @@ import openconfig_acl
 import tabulate
 import pyangbind.lib.pybindJSON as pybindJSON
 from natsort import natsorted
-from sonic_py_common import device_info, multi_asic
+from sonic_py_common import multi_asic
 from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector, SonicDBConfig
 from utilities_common.general import load_db_config
 

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -11,7 +11,7 @@ import pyangbind.lib.pybindJSON as pybindJSON
 from natsort import natsorted
 from sonic_py_common import device_info, multi_asic
 from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector, SonicDBConfig
-
+from utilities_common.general import load_db_config
 
 def info(msg):
     click.echo(click.style("Info: ", fg='cyan') + click.style(str(msg), fg='green'))
@@ -116,11 +116,8 @@ class AclLoader(object):
         self.rules_db_info = {}
         self.rules_info = {}
 
-        if multi_asic.is_multi_asic():
-            # Load global db config
-            SonicDBConfig.load_sonic_global_db_config()
-        else:
-            SonicDBConfig.initialize()
+        # Load database config files
+        load_db_config()
 
         self.sessions_db_info = {}
         self.configdb = ConfigDBConnector()

--- a/config/main.py
+++ b/config/main.py
@@ -27,6 +27,8 @@ from utilities_common.db import Db
 from utilities_common.intf_filter import parse_interface_in_filter
 from utilities_common import bgp_util
 import utilities_common.cli as clicommon
+from utilities_common.general import load_db_config
+
 from .utils import log
 
 from . import aaa
@@ -946,12 +948,8 @@ def config(ctx):
     except (KeyError, TypeError):
         raise click.Abort()
 
-    # Load the global config file database_global.json once.
-    num_asic = multi_asic.get_num_asics()
-    if num_asic > 1:
-        SonicDBConfig.load_sonic_global_db_config()
-    else:
-        SonicDBConfig.initialize()
+    # Load database config files
+    load_db_config()
 
     if os.geteuid() != 0:
         exit("Root privileges are required for this operation")

--- a/config/main.py
+++ b/config/main.py
@@ -22,7 +22,7 @@ from socket import AF_INET, AF_INET6
 from sonic_py_common import device_info, multi_asic
 from sonic_py_common.interface import get_interface_table_name, get_port_table_name
 from utilities_common import util_base
-from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector, SonicDBConfig
+from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
 from utilities_common.db import Db
 from utilities_common.intf_filter import parse_interface_in_filter
 from utilities_common import bgp_util

--- a/crm/main.py
+++ b/crm/main.py
@@ -3,9 +3,10 @@
 import click
 from swsscommon.swsscommon import ConfigDBConnector, SonicDBConfig
 from tabulate import tabulate
-from utilities_common import multi_asic as multi_asic_util
-from sonic_py_common import multi_asic
 
+from sonic_py_common import multi_asic
+from utilities_common.general import load_db_config
+from utilities_common import multi_asic as multi_asic_util
 class Crm:
     def __init__(self, db=None):
         self.cli_mode = None
@@ -211,13 +212,8 @@ def cli(ctx):
     # Use the db object if given as input.
     db = None if ctx.obj is None else ctx.obj.cfgdb
 
-    # Note: SonicDBConfig may be already initialized in unit test, then skip
-    if not SonicDBConfig.isInit():
-        if multi_asic.is_multi_asic():
-            # Load the global config file database_global.json once.
-            SonicDBConfig.load_sonic_global_db_config()
-        else:
-            SonicDBConfig.initialize()
+    # Load database config files
+    load_db_config()
 
     context = {
         "crm": Crm(db)

--- a/crm/main.py
+++ b/crm/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import click
-from swsscommon.swsscommon import ConfigDBConnector, SonicDBConfig
+from swsscommon.swsscommon import ConfigDBConnector
 from tabulate import tabulate
 
 from sonic_py_common import multi_asic

--- a/scripts/ipintutil
+++ b/scripts/ipintutil
@@ -262,7 +262,7 @@ def main():
     else:
         sys.exit("Invalid argument -a {}".format(args.address_family))
 
-    swsscommon.SonicDBConfig.load_sonic_global_db_config()
+    multi_asic.multi_asic_load_global_db()
     ip_intfs = get_ip_intfs(af, namespace, display)
     display_ip_intfs(ip_intfs)
 

--- a/scripts/ipintutil
+++ b/scripts/ipintutil
@@ -262,7 +262,7 @@ def main():
     else:
         sys.exit("Invalid argument -a {}".format(args.address_family))
 
-    multi_asic.multi_asic_load_global_db()
+    multi_asic.load_db_config()
     ip_intfs = get_ip_intfs(af, namespace, display)
     display_ip_intfs(ip_intfs)
 

--- a/scripts/ipintutil
+++ b/scripts/ipintutil
@@ -12,6 +12,7 @@ from tabulate import tabulate
 from sonic_py_common import multi_asic
 from swsscommon import swsscommon
 from utilities_common import constants
+from utilities_common.general import load_db_config
 from utilities_common import multi_asic as multi_asic_util
 
 
@@ -262,7 +263,7 @@ def main():
     else:
         sys.exit("Invalid argument -a {}".format(args.address_family))
 
-    multi_asic.load_db_config()
+    load_db_config()
     ip_intfs = get_ip_intfs(af, namespace, display)
     display_ip_intfs(ip_intfs)
 

--- a/scripts/lldpshow
+++ b/scripts/lldpshow
@@ -27,6 +27,7 @@ import xml.etree.ElementTree as ET
 
 from sonic_py_common import device_info, multi_asic
 from swsscommon.swsscommon import ConfigDBConnector, SonicDBConfig
+from utilities_common.general import load_db_config
 from tabulate import tabulate
 
 BACKEND_ASIC_INTERFACE_NAME_PREFIX = 'Ethernet-BP'
@@ -48,10 +49,8 @@ class Lldpshow(object):
         # if further capability type is supported like WLAN, can just add the tag definition here
         self.ctags = {'Router': 'R', 'Bridge': 'B'}
 
-        if multi_asic.is_multi_asic():
-            SonicDBConfig.load_sonic_global_db_config()
-        else:
-            SonicDBConfig.initialize()
+        # Load database config files
+        load_db_config()
 
         # For multi-asic platforms we will get only front-panel interface to display
         namespaces = device_info.get_all_namespaces()

--- a/scripts/lldpshow
+++ b/scripts/lldpshow
@@ -25,8 +25,8 @@ import subprocess
 import sys
 import xml.etree.ElementTree as ET
 
-from sonic_py_common import device_info, multi_asic
-from swsscommon.swsscommon import ConfigDBConnector, SonicDBConfig
+from sonic_py_common import device_info
+from swsscommon.swsscommon import ConfigDBConnector
 from utilities_common.general import load_db_config
 from tabulate import tabulate
 

--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -37,7 +37,7 @@ try:
 except KeyError:
     pass
 
-from swsscommon.swsscommon import ConfigDBConnector, SonicDBConfig, SonicV2Connector
+from swsscommon.swsscommon import ConfigDBConnector, SonicV2Connector
 from utilities_common.general import load_db_config
 
 # APPL_DB constants

--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -38,6 +38,7 @@ except KeyError:
     pass
 
 from swsscommon.swsscommon import ConfigDBConnector, SonicDBConfig, SonicV2Connector
+from utilities_common.general import load_db_config
 
 # APPL_DB constants
 PORT_TABLE_NAME = "PORT"
@@ -246,11 +247,8 @@ def main():
                         help = 'port advertised interface types', default=None)
     args = parser.parse_args()
 
-    if args.namespace is not None:
-        SonicDBConfig.load_sonic_global_db_config(namespace=args.namespace)
-    else:
-        SonicDBConfig.initialize()
-
+    # Load database config files
+    load_db_config()
     try:
         port = portconfig(args.verbose, args.port, args.namespace)
         if args.list:

--- a/show/main.py
+++ b/show/main.py
@@ -8,7 +8,7 @@ import click
 import utilities_common.cli as clicommon
 import utilities_common.multi_asic as multi_asic_util
 from natsort import natsorted
-from sonic_py_common import device_info
+from sonic_py_common import device_info, multi_asic
 from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
 from tabulate import tabulate
 from utilities_common import util_base
@@ -149,6 +149,8 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help', '-?'])
 def cli(ctx):
     """SONiC command line - 'show' command"""
 
+    # Load the database global for multi asic platform once
+    multi_asic.load_db_config()
     ctx.obj = Db()
 
 

--- a/show/main.py
+++ b/show/main.py
@@ -14,6 +14,7 @@ from tabulate import tabulate
 from utilities_common import util_base
 from utilities_common.db import Db
 import utilities_common.constants as constants
+from utilities_common.general import load_db_config
 
 from . import acl
 from . import bgp_common
@@ -149,8 +150,8 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help', '-?'])
 def cli(ctx):
     """SONiC command line - 'show' command"""
 
-    # Load the database global for multi asic platform once
-    multi_asic.load_db_config()
+    # Load database config files
+    load_db_config()
     ctx.obj = Db()
 
 

--- a/show/main.py
+++ b/show/main.py
@@ -8,7 +8,7 @@ import click
 import utilities_common.cli as clicommon
 import utilities_common.multi_asic as multi_asic_util
 from natsort import natsorted
-from sonic_py_common import device_info, multi_asic
+from sonic_py_common import device_info
 from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
 from tabulate import tabulate
 from utilities_common import util_base

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -11,6 +11,7 @@ import json
 from natsort import natsorted
 from sonic_py_common import multi_asic
 from utilities_common.db import Db
+from utilities_common.general import load_db_config
 
 VLAN_SUB_INTERFACE_SEPARATOR = '.'
 
@@ -118,6 +119,8 @@ class InterfaceAliasConverter(object):
 
     def __init__(self, db=None):
 
+        # Load database config files
+        load_db_config()
         if db is None:
             self.port_dict = multi_asic.get_port_table()
         else:

--- a/utilities_common/general.py
+++ b/utilities_common/general.py
@@ -2,6 +2,9 @@ import importlib.machinery
 import importlib.util
 import sys
 
+from sonic_py_common.multi_asic import is_multi_asic
+from swsscommon import swsscommon
+
 def load_module_from_source(module_name, file_path):
     """
     This function will load the Python source file specified by <file_path>
@@ -15,3 +18,16 @@ def load_module_from_source(module_name, file_path):
     sys.modules[module_name] = module
 
     return module
+
+def load_db_config():
+    '''
+    Load the correct database config file:
+     - database_global.json for multi asic
+     - database_config.json for single asic
+    '''
+    if is_multi_asic():
+        if not swsscommon.SonicDBConfig.isGlobalInit():
+            swsscommon.SonicDBConfig.load_sonic_global_db_config()
+    else:
+        if not swsscommon.SonicDBConfig.isInit():
+            swsscommon.SonicDBConfig.load_sonic_db_config()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Introduce a new function `load_db_config()`. This function will load the global database file or database config file based on the platform. 

This change depends on https://github.com/Azure/sonic-buildimage/pull/8173

#### How I did it

#### How to verify it
UT results
```
============================= test session starts ==============================
platform linux -- Python 3.7.3, pytest-3.10.1, py-1.7.0, pluggy-0.8.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /sonic/src/sonic-utilities, inifile: pytest.ini
plugins: pyfakefs-4.5.0, cov-2.6.0
collecting ... collected 1052 items

tests/aaa_test.py::TestAaa::test_show_aaa_default PASSED                 [  0%]
tests/aaa_test.py::TestAaa::test_config_aaa_radius PASSED                [  0%]
tests/aaa_test.py::TestAaa::test_config_aaa_radius_local PASSED          [  0%]
tests/aaa_test.py::TestAaa::test_config_aaa_radius_invalid PASSED        [  0%]
tests/acl_config_test.py::TestConfigAcl::test_expand_vlan PASSED         [  0%]
tests/acl_config_test.py::TestConfigAcl::test_expand_lag PASSED          [  0%]
tests/acl_config_test.py::TestConfigAcl::test_expand_physical_interface PASSED [  0%]
tests/acl_config_test.py::TestConfigAcl::test_expand_empty_vlan PASSED   [  0%]
tests/acl_config_test.py::TestConfigAcl::test_parse_table_with_vlan_expansion PASSED [  0%]
tests/acl_config_test.py::TestConfigAcl::test_parse_table_with_vlan_and_duplicates PASSED [  0%]
tests/acl_config_test.py::TestConfigAcl::test_parse_table_with_empty_vlan PASSED [  1%]
tests/acl_config_test.py::TestConfigAcl::test_parse_table_with_invalid_ports PASSED [  1%]
tests/acl_config_test.py::TestConfigAcl::test_parse_table_with_empty_ports PASSED [  1%]
tests/acl_config_test.py::TestConfigAcl::test_acl_add_table_nonexistent_port PASSED [  1%]
tests/acl_config_test.py::TestConfigAcl::test_acl_add_table_empty_string_port_list PASSED [  1%]
tests/acl_config_test.py::TestConfigAcl::test_acl_add_table_empty_vlan PASSED [  1%]
tests/acl_loader_test.py::TestAclLoader::test_acl_empty PASSED           [  1%]
tests/acl_loader_test.py::TestAclLoader::test_valid PASSED               [  1%]
tests/acl_loader_test.py::TestAclLoader::test_invalid PASSED             [  1%]
tests/acl_loader_test.py::TestAclLoader::test_validate_mirror_action PASSED [  1%]
tests/acl_loader_test.py::TestAclLoader::test_vlan_id_translation PASSED [  1%]
tests/acl_loader_test.py::TestAclLoader::test_vlan_id_lower_bound PASSED [  2%]
tests/acl_loader_test.py::TestAclLoader::test_vlan_id_upper_bound PASSED [  2%]
tests/acl_loader_test.py::TestAclLoader::test_vlan_id_not_a_number PASSED [  2%]
tests/acl_loader_test.py::TestAclLoader::test_ethertype_translation PASSED [  2%]
tests/acl_loader_test.py::TestAclLoader::test_icmp_translation PASSED    [  2%]
tests/acl_loader_test.py::TestAclLoader::test_icmpv6_translation PASSED  [  2%]
tests/acl_loader_test.py::TestAclLoader::test_ingress_default_deny_rule PASSED [  2%]
tests/acl_loader_test.py::TestAclLoader::test_egress_no_default_deny_rule PASSED [  2%]
tests/acl_loader_test.py::TestAclLoader::test_icmp_type_lower_bound PASSED [  2%]
tests/acl_loader_test.py::TestAclLoader::test_icmp_type_upper_bound PASSED [  2%]
tests/acl_loader_test.py::TestAclLoader::test_icmp_type_not_a_number PASSED [  3%]
tests/acl_loader_test.py::TestAclLoader::test_icmp_code_lower_bound PASSED [  3%]
tests/acl_loader_test.py::TestAclLoader::test_icmp_code_upper_bound PASSED [  3%]
tests/acl_loader_test.py::TestAclLoader::test_icmp_code_not_a_number PASSED [  3%]
tests/acl_loader_test.py::TestAclLoader::test_icmp_fields_with_non_icmp_protocol PASSED [  3%]
tests/acl_loader_test.py::TestAclLoader::test_icmp_fields_with_non_tcp_protocol PASSED [  3%]
tests/aclshow_test.py::test_default PASSED                               [  3%]
tests/aclshow_test.py::test_all PASSED                                   [  3%]
tests/aclshow_test.py::test_rule1_dataacl PASSED                         [  3%]
tests/aclshow_test.py::test_rule05_all PASSED                            [  3%]
tests/aclshow_test.py::test_rule0 PASSED                                 [  3%]
tests/aclshow_test.py::test_rule10_lowercase_priority PASSED             [  4%]
tests/aclshow_test.py::test_rule4_rule6_verbose PASSED                   [  4%]
tests/aclshow_test.py::test_everflow PASSED                              [  4%]
tests/aclshow_test.py::test_dataacl PASSED                               [  4%]
tests/aclshow_test.py::test_clear PASSED                                 [  4%]
tests/aclshow_test.py::test_all_after_clear PASSED                       [  4%]
tests/bgp_commands_test.py::TestBgpCommands::test_bgp_summary_v4[v4] PASSED [  4%]
tests/bgp_commands_test.py::TestBgpCommands::test_bgp_summary_v6[v6] PASSED [  4%]
tests/bgp_commands_test.py::TestBgpCommands::test_bgp_summary_error[ ] PASSED [  4%]
tests/buffer_test.py::TestBuffer::test_config_buffer_profile_headroom PASSED [  4%]
tests/buffer_test.py::TestBuffer::test_config_buffer_profile_dynamic_th PASSED [  5%]
tests/buffer_test.py::TestBuffer::test_config_buffer_profile_add_existing PASSED [  5%]
tests/buffer_test.py::TestBuffer::test_config_buffer_profile_set_non_existing PASSED [  5%]
tests/buffer_test.py::TestBuffer::test_config_buffer_profile_add_headroom_to_dynamic_profile PASSED [  5%]
tests/buffer_test.py::TestBuffer::test_config_buffer_profile_add_no_xon PASSED [  5%]
tests/buffer_test.py::TestBuffer::test_config_buffer_profile_add_no_param PASSED [  5%]
tests/buffer_test.py::TestBuffer::test_config_buffer_profile_multiple_or_none_default_buffer_param_in_database PASSED [  5%]
tests/buffer_test.py::TestBuffer::test_config_shp_size_negative PASSED   [  5%]
tests/buffer_test.py::TestBuffer::test_config_shp_ratio PASSED           [  5%]
tests/buffer_test.py::TestBuffer::test_config_shp_ratio_negative PASSED  [  5%]
tests/buffer_test.py::TestBuffer::test_config_buffer_profile_headroom_toggle_shp PASSED [  5%]
tests/buffer_test.py::TestBuffer::test_show_buffer_configuration PASSED  [  6%]
tests/buffer_test.py::TestBuffer::test_show_buffer_information PASSED    [  6%]
tests/chassis_modules_test.py::TestChassisModules::test_show_and_verify_output PASSED [  6%]
tests/chassis_modules_test.py::TestChassisModules::test_show_all_count_lines PASSED [  6%]
tests/chassis_modules_test.py::TestChassisModules::test_show_single_count_lines PASSED [  6%]
tests/chassis_modules_test.py::TestChassisModules::test_show_module_down PASSED [  6%]
tests/chassis_modules_test.py::TestChassisModules::test_show_incorrect_command PASSED [  6%]
tests/chassis_modules_test.py::TestChassisModules::test_show_incorrect_module PASSED [  6%]
tests/chassis_modules_test.py::TestChassisModules::test_config_shutdown_module PASSED [  6%]
tests/chassis_modules_test.py::TestChassisModules::test_config_startup_module PASSED [  6%]
tests/chassis_modules_test.py::TestChassisModules::test_config_incorrect_module PASSED [  7%]
tests/chassis_modules_test.py::TestChassisModules::test_show_and_verify_midplane_output PASSED [  7%]
tests/chassis_modules_test.py::TestChassisModules::test_midplane_show_all_count_lines PASSED [  7%]
tests/chassis_modules_test.py::TestChassisModules::test_midplane_show_single_count_lines PASSED [  7%]
tests/chassis_modules_test.py::TestChassisModules::test_midplane_show_module_down PASSED [  7%]
tests/chassis_modules_test.py::TestChassisModules::test_midplane_show_incorrect_module PASSED [  7%]
tests/config_an_test.py::TestConfigInterface::test_config_autoneg PASSED [  7%]
tests/config_an_test.py::TestConfigInterface::test_config_speed PASSED   [  7%]
tests/config_an_test.py::TestConfigInterface::test_config_adv_speeds PASSED [  7%]
tests/config_an_test.py::TestConfigInterface::test_config_type PASSED    [  7%]
tests/config_an_test.py::TestConfigInterface::test_config_adv_types PASSED [  7%]
tests/config_dpb_test.py::TestConfigDPB::test_get_breakout_options PASSED [  8%]
tests/config_dpb_test.py::TestConfigDPB::test_config_breakout_extra_table_warning PASSED [  8%]
tests/config_dpb_test.py::TestConfigDPB::test_config_breakout_verbose PASSED [  8%]
tests/config_dpb_test.py::TestConfigDPB::test_config_breakout_negative_cases PASSED [  8%]
tests/config_dpb_test.py::TestConfigDPB::test_config_breakout_various_modes SKIPPED [  8%]
tests/config_int_ip_test.py::TestIntIp::test_config_int_ip_rem[ip_route_for_int_ip] PASSED [  8%]
tests/config_int_ip_test.py::TestIntIp::test_config_int_ip_rem_static[ip_route_for_int_ip] PASSED [  8%]
tests/config_int_ip_test.py::TestIntIpMultiasic::test_config_int_ip_rem_static_multiasic[ip_route_for_int_ip] PASSED [  8%]
tests/config_mgmt_test.py::TestConfigMgmt::test_break_out SKIPPED        [  8%]
tests/config_mgmt_test.py::TestConfigMgmt::test_config_validation PASSED [  8%]
tests/config_mgmt_test.py::TestConfigMgmt::test_search_keys PASSED       [  9%]
tests/config_mgmt_test.py::TestConfigMgmt::test_shutdownIntf_call SKIPPED [  9%]
tests/config_mgmt_test.py::TestConfigMgmt::test_table_without_yang PASSED [  9%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_community_add_new_community_ro PASSED [  9%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_community_add_new_community_rw PASSED [  9%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_community_add_new_community_with_invalid_type PASSED [  9%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_community_add_invalid_community_over_32_characters PASSED [  9%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_community_add_invalid_community_with_excluded_special_characters PASSED [  9%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_community_add_existing_community PASSED [  9%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_community_del_existing_community PASSED [  9%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_community_del_non_existing_community PASSED [  9%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_community_replace_existing_community_with_new_community PASSED [ 10%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_community_replace_existing_community_non_existing_community PASSED [ 10%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_community_replace_new_community_already_exists PASSED [ 10%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_community_replace_with_invalid_new_community_bad_symbol PASSED [ 10%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_community_replace_with_invalid_new_community_over_32_chars PASSED [ 10%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_contact_del_without_contact_redis PASSED [ 10%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_contact_modify_without_contact_redis PASSED [ 10%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_contact_add_del_new_contact PASSED [ 10%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_contact_add_with_existing_contact PASSED [ 10%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_contact_add_invalid_email PASSED [ 10%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_contact_del_new_contact_when_contact_exists PASSED [ 11%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_contact_del_with_existing_contact PASSED [ 11%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_contact_modify_email_with_existing_contact PASSED [ 11%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_contact_modify_contact_and_email_with_existing_entry PASSED [ 11%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_contact_modify_existing_contact_with_invalid_email PASSED [ 11%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_contact_modify_new_contact_with_invalid_email PASSED [ 11%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_location_add_exiting_location_with_same_location_already_existing PASSED [ 11%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_location_add_new_location_with_location_already_existing PASSED [ 11%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_location_del_with_existing_location PASSED [ 11%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_location_del_new_location_with_location_already_existing PASSED [ 11%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_location_modify_with_same_location PASSED [ 11%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_location_modify_without_redis PASSED [ 12%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_location_modify_without_existing_location PASSED [ 12%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_invalid_user_name_over_32_characters PASSED [ 12%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_excluded_special_characters_in_username PASSED [ 12%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_existing_user PASSED [ 12%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_invalid_user_type PASSED [ 12%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_invalid_permission_type PASSED [ 12%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_user_type_noauthnopriv_with_unnecessary_auth_type PASSED [ 12%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_user_type_authnopriv_missing_auth_type PASSED [ 12%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_user_type_authnopriv_missing_auth_password PASSED [ 12%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_user_type_authnopriv_with_unnecessary_encrypt_type PASSED [ 13%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_user_type_priv_missing_auth_type PASSED [ 13%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_user_type_priv_missing_auth_password PASSED [ 13%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_user_type_priv_missing_encrypt_type PASSED [ 13%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_user_type_priv_invalid_encrypt_password_over_64_characters PASSED [ 13%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_user_type_priv_invalid_encrypt_password_excluded_special_characters PASSED [ 13%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_user_type_priv_invalid_encrypt_password_not_long_enough PASSED [ 13%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_invalid_auth_type PASSED [ 13%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_missing_auth_password PASSED [ 13%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_invalid_encrypt_type PASSED [ 13%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_missing_encrypt_password PASSED [ 13%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_user_already_existing PASSED [ 14%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_valid_user_priv_ro_md5_des PASSED [ 14%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_valid_user_priv_ro_md5_aes PASSED [ 14%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_valid_user_priv_ro_sha_des PASSED [ 14%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_valid_user_priv_ro_sha_aes PASSED [ 14%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_valid_user_priv_ro_hmac_sha_2_des PASSED [ 14%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_valid_user_priv_ro_hmac_sha_2_aes PASSED [ 14%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_valid_user_priv_rw_md5_des PASSED [ 14%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_valid_user_priv_rw_md5_aes PASSED [ 14%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_valid_user_priv_rw_sha_des PASSED [ 14%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_valid_user_priv_rw_sha_aes PASSED [ 15%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_valid_user_priv_rw_hmac_sha_2_des PASSED [ 15%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_add_valid_user_priv_rw_hmac_sha_2_aes PASSED [ 15%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_del_valid_user PASSED [ 15%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_config_snmp_user_del_invalid_user PASSED [ 15%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_is_valid_email[test@contoso] PASSED [ 15%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_is_valid_email[test.contoso.com] PASSED [ 15%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_is_valid_email[testcontoso@com] PASSED [ 15%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_is_valid_email[123_%contoso.com] PASSED [ 15%]
tests/config_snmp_test.py::TestSNMPConfigCommands::test_is_valid_email[mytest@contoso.comm] PASSED [ 15%]
tests/config_test.py::TestLoadMinigraph::test_load_minigraph PASSED      [ 15%]
tests/config_test.py::TestConfigQos::test_qos_reload_single PASSED       [ 16%]
tests/config_test.py::TestConfigQosMasic::test_qos_reload_masic PASSED   [ 16%]
tests/config_test.py::TestGenericUpdateCommands::test_apply_patch__all_optional_params_non_default__non_default_values_used PASSED [ 16%]
tests/config_test.py::TestGenericUpdateCommands::test_apply_patch__exception_thrown__error_displayed_error_code_returned PASSED [ 16%]
tests/config_test.py::TestGenericUpdateCommands::test_apply_patch__help__gets_help_msg PASSED [ 16%]
tests/config_test.py::TestGenericUpdateCommands::test_apply_patch__no_params__get_required_params_error_msg PASSED [ 16%]
tests/config_test.py::TestGenericUpdateCommands::test_apply_patch__only_required_params__default_values_used_for_optional_params PASSED [ 16%]
tests/config_test.py::TestGenericUpdateCommands::test_apply_patch__optional_parameters_passed_correctly PASSED [ 16%]
tests/config_test.py::TestGenericUpdateCommands::test_checkpoint__all_optional_params_non_default__non_default_values_used PASSED [ 16%]
tests/config_test.py::TestGenericUpdateCommands::test_checkpoint__exception_thrown__error_displayed_error_code_returned PASSED [ 16%]
tests/config_test.py::TestGenericUpdateCommands::test_checkpoint__help__gets_help_msg PASSED [ 17%]
tests/config_test.py::TestGenericUpdateCommands::test_checkpoint__no_params__get_required_params_error_msg PASSED [ 17%]
tests/config_test.py::TestGenericUpdateCommands::test_checkpoint__only_required_params__default_values_used_for_optional_params PASSED [ 17%]
tests/config_test.py::TestGenericUpdateCommands::test_checkpoint__optional_parameters_passed_correctly PASSED [ 17%]
tests/config_test.py::TestGenericUpdateCommands::test_delete_checkpoint__all_optional_params_non_default__non_default_values_used PASSED [ 17%]
tests/config_test.py::TestGenericUpdateCommands::test_delete_checkpoint__exception_thrown__error_displayed_error_code_returned PASSED [ 17%]
tests/config_test.py::TestGenericUpdateCommands::test_delete_checkpoint__help__gets_help_msg PASSED [ 17%]
tests/config_test.py::TestGenericUpdateCommands::test_delete_checkpoint__no_params__get_required_params_error_msg PASSED [ 17%]
tests/config_test.py::TestGenericUpdateCommands::test_delete_checkpoint__only_required_params__default_values_used_for_optional_params PASSED [ 17%]
tests/config_test.py::TestGenericUpdateCommands::test_delete_checkpoint__optional_parameters_passed_correctly PASSED [ 17%]
tests/config_test.py::TestGenericUpdateCommands::test_list_checkpoints__all_optional_params_non_default__non_default_values_used PASSED [ 17%]
tests/config_test.py::TestGenericUpdateCommands::test_list_checkpoints__exception_thrown__error_displayed_error_code_returned PASSED [ 18%]
tests/config_test.py::TestGenericUpdateCommands::test_list_checkpoints__help__gets_help_msg PASSED [ 18%]
tests/config_test.py::TestGenericUpdateCommands::test_list_checkpoints__optional_parameters_passed_correctly PASSED [ 18%]
tests/config_test.py::TestGenericUpdateCommands::test_replace__all_optional_params_non_default__non_default_values_used PASSED [ 18%]
tests/config_test.py::TestGenericUpdateCommands::test_replace__exception_thrown__error_displayed_error_code_returned PASSED [ 18%]
tests/config_test.py::TestGenericUpdateCommands::test_replace__help__gets_help_msg PASSED [ 18%]
tests/config_test.py::TestGenericUpdateCommands::test_replace__no_params__get_required_params_error_msg PASSED [ 18%]
tests/config_test.py::TestGenericUpdateCommands::test_replace__only_required_params__default_values_used_for_optional_params PASSED [ 18%]
tests/config_test.py::TestGenericUpdateCommands::test_replace__optional_parameters_passed_correctly PASSED [ 18%]
tests/config_test.py::TestGenericUpdateCommands::test_rollback__all_optional_params_non_default__non_default_values_used PASSED [ 18%]
tests/config_test.py::TestGenericUpdateCommands::test_rollback__exception_thrown__error_displayed_error_code_returned PASSED [ 19%]
tests/config_test.py::TestGenericUpdateCommands::test_rollback__help__gets_help_msg PASSED [ 19%]
tests/config_test.py::TestGenericUpdateCommands::test_rollback__no_params__get_required_params_error_msg PASSED [ 19%]
tests/config_test.py::TestGenericUpdateCommands::test_rollback__only_required_params__default_values_used_for_optional_params PASSED [ 19%]
tests/config_test.py::TestGenericUpdateCommands::test_rollback__optional_parameters_passed_correctly PASSED [ 19%]
tests/console_test.py::TestConfigConsoleCommands::test_enable_console_switch PASSED [ 19%]
tests/console_test.py::TestConfigConsoleCommands::test_disable_console_switch PASSED [ 19%]
tests/console_test.py::TestConfigConsoleCommands::test_console_add_exists PASSED [ 19%]
tests/console_test.py::TestConfigConsoleCommands::test_console_add_no_baud PASSED [ 19%]
tests/console_test.py::TestConfigConsoleCommands::test_console_add_name_conflict PASSED [ 19%]
tests/console_test.py::TestConfigConsoleCommands::test_console_add_success PASSED [ 19%]
tests/console_test.py::TestConfigConsoleCommands::test_console_del_non_exists PASSED [ 20%]
tests/console_test.py::TestConfigConsoleCommands::test_console_del_success PASSED [ 20%]
tests/console_test.py::TestConfigConsoleCommands::test_update_console_remote_device_name_non_exists PASSED [ 20%]
tests/console_test.py::TestConfigConsoleCommands::test_update_console_remote_device_name_conflict PASSED [ 20%]
tests/console_test.py::TestConfigConsoleCommands::test_update_console_remote_device_name_existing_and_same PASSED [ 20%]
tests/console_test.py::TestConfigConsoleCommands::test_update_console_remote_device_name_reset PASSED [ 20%]
tests/console_test.py::TestConfigConsoleCommands::test_update_console_remote_device_name_success PASSED [ 20%]
tests/console_test.py::TestConfigConsoleCommands::test_update_console_baud_no_change PASSED [ 20%]
tests/console_test.py::TestConfigConsoleCommands::test_update_console_baud_non_exists PASSED [ 20%]
tests/console_test.py::TestConfigConsoleCommands::test_update_console_baud_success PASSED [ 20%]
tests/console_test.py::TestConfigConsoleCommands::test_update_console_flow_control_no_change PASSED [ 21%]
tests/console_test.py::TestConfigConsoleCommands::test_update_console_flow_control_non_exists PASSED [ 21%]
tests/console_test.py::TestConfigConsoleCommands::test_update_console_flow_control_success PASSED [ 21%]
tests/console_test.py::TestConsutilLib::test_console_port_provider_get_all_configured_only_empty PASSED [ 21%]
tests/console_test.py::TestConsutilLib::test_console_port_provider_get_all_configured_only_nonempty PASSED [ 21%]
tests/console_test.py::TestConsutilLib::test_console_port_provider_get_all_with_ttys PASSED [ 21%]
tests/console_test.py::TestConsutilLib::test_console_port_provider_get_line_success PASSED [ 21%]
tests/console_test.py::TestConsutilLib::test_console_port_provider_get_line_not_found PASSED [ 21%]
tests/console_test.py::TestConsutilLib::test_console_port_provider_get_line_by_device_success PASSED [ 21%]
tests/console_test.py::TestConsutilLib::test_console_port_provider_get_line_by_device_not_found PASSED [ 21%]
tests/console_test.py::TestConsutilLib::test_console_port_info_refresh_without_session PASSED [ 21%]
tests/console_test.py::TestConsutilLib::test_console_port_info_refresh_without_session_idle PASSED [ 22%]
tests/console_test.py::TestConsutilLib::test_console_port_info_refresh_with_session PASSED [ 22%]
tests/console_test.py::TestConsutilLib::test_console_port_info_refresh_with_session_line_mismatch PASSED [ 22%]
tests/console_test.py::TestConsutilLib::test_console_port_info_refresh_with_session_process_ended PASSED [ 22%]
tests/console_test.py::TestConsutilLib::test_console_port_info_connect_state_busy PASSED [ 22%]
tests/console_test.py::TestConsutilLib::test_console_port_info_connect_invalid_config PASSED [ 22%]
tests/console_test.py::TestConsutilLib::test_console_port_info_connect_device_busy PASSED [ 22%]
tests/console_test.py::TestConsutilLib::test_console_port_info_connect_connection_fail PASSED [ 22%]
tests/console_test.py::TestConsutilLib::test_console_port_info_connect_success PASSED [ 22%]
tests/console_test.py::TestConsutilLib::test_console_port_info_clear_session_line_not_busy PASSED [ 22%]
tests/console_test.py::TestConsutilLib::test_console_port_info_clear_session_with_state_db PASSED [ 23%]
tests/console_test.py::TestConsutilLib::test_console_port_info_clear_session_with_existing_session PASSED [ 23%]
tests/console_test.py::TestConsutilLib::test_sys_info_provider_init_device_prefix_plugin_nonexists PASSED [ 23%]
tests/console_test.py::TestConsutilLib::test_sys_info_provider_init_device_prefix_plugin PASSED [ 23%]
tests/console_test.py::TestConsutilLib::test_sys_info_provider_list_console_ttys PASSED [ 23%]
tests/console_test.py::TestConsutilLib::test_sys_info_provider_list_console_ttys_device_not_exists PASSED [ 23%]
tests/console_test.py::TestConsutilLib::test_sys_info_provider_list_active_console_processes PASSED [ 23%]
tests/console_test.py::TestConsutilLib::test_sys_info_provider_get_active_console_process_info_exists PASSED [ 23%]
tests/console_test.py::TestConsutilLib::test_sys_info_provider_get_active_console_process_info_nonexists PASSED [ 23%]
tests/console_test.py::TestConsutil::test_consutil_feature_disabled_null_config PASSED [ 23%]
tests/console_test.py::TestConsutil::test_consutil_feature_disabled_config PASSED [ 23%]
tests/console_test.py::TestConsutil::test_consutil_feature_enabled PASSED [ 24%]
tests/console_test.py::TestConsutilShow::test_show PASSED                [ 24%]
tests/console_test.py::TestConsutilShow::test_show_stale_idle_to_busy PASSED [ 24%]
tests/console_test.py::TestConsutilShow::test_show_stale_busy_to_idle PASSED [ 24%]
tests/console_test.py::TestConsutilConnect::test_connect_target_nonexists PASSED [ 24%]
tests/console_test.py::TestConsutilConnect::test_connect_line_busy PASSED [ 24%]
tests/console_test.py::TestConsutilConnect::test_connect_no_baud PASSED  [ 24%]
tests/console_test.py::TestConsutilConnect::test_connect_picocom_err PASSED [ 24%]
tests/console_test.py::TestConsutilConnect::test_connect_success PASSED  [ 24%]
tests/console_test.py::TestConsutilClear::test_clear_without_root PASSED [ 24%]
tests/console_test.py::TestConsutilClear::test_clear_line_not_found PASSED [ 25%]
tests/console_test.py::TestConsutilClear::test_clear_idle PASSED         [ 25%]
tests/console_test.py::TestConsutilClear::test_clear_success PASSED      [ 25%]
tests/counterpoll_test.py::TestCounterpoll::test_show PASSED             [ 25%]
tests/counterpoll_test.py::TestCounterpoll::test_port_buffer_drop_interval PASSED [ 25%]
tests/counterpoll_test.py::TestCounterpoll::test_port_buffer_drop_interval_too_short PASSED [ 25%]
tests/counterpoll_test.py::TestCounterpoll::test_pg_drop_interval_too_long PASSED [ 25%]
tests/counterpoll_test.py::TestCounterpoll::test_update_counter_config_db_status[disable] PASSED [ 25%]
tests/counterpoll_test.py::TestCounterpoll::test_update_counter_config_db_status[enable] PASSED [ 25%]
tests/counterpoll_test.py::TestCounterpoll::test_update_pg_drop_status[disable] PASSED [ 25%]
tests/counterpoll_test.py::TestCounterpoll::test_update_pg_drop_status[enable] PASSED [ 25%]
tests/counterpoll_test.py::TestCounterpoll::test_update_pg_drop_interval PASSED [ 26%]
tests/crm_test.py::TestCrm::test_crm_show_summary PASSED                 [ 26%]
tests/crm_test.py::TestCrm::test_crm_show_thresholds_acl_group PASSED    [ 26%]
tests/crm_test.py::TestCrm::test_crm_show_thresholds_acl_table PASSED    [ 26%]
tests/crm_test.py::TestCrm::test_crm_show_thresholds_all PASSED          [ 26%]
tests/crm_test.py::TestCrm::test_crm_show_thresholds_fdb PASSED          [ 26%]
tests/crm_test.py::TestCrm::test_crm_show_thresholds_ipv4_neighbor PASSED [ 26%]
tests/crm_test.py::TestCrm::test_crm_show_thresholds_ipv4_nexthop PASSED [ 26%]
tests/crm_test.py::TestCrm::test_crm_show_thresholds_ipv4_route PASSED   [ 26%]
tests/crm_test.py::TestCrm::test_crm_show_thresholds_ipv6_neighbor PASSED [ 26%]
tests/crm_test.py::TestCrm::test_crm_show_thresholds_ipv6_nexthop PASSED [ 26%]
tests/crm_test.py::TestCrm::test_crm_show_thresholds_ipv6_route PASSED   [ 27%]
tests/crm_test.py::TestCrm::test_crm_show_thresholds_nexthop_group_member PASSED [ 27%]
tests/crm_test.py::TestCrm::test_crm_show_thresholds_nexthop_group_object PASSED [ 27%]
tests/crm_test.py::TestCrm::test_crm_show_thresholds_snat PASSED         [ 27%]
tests/crm_test.py::TestCrm::test_crm_show_thresholds_dnat PASSED         [ 27%]
tests/crm_test.py::TestCrm::test_crm_show_thresholds_ipmc PASSED         [ 27%]
tests/crm_test.py::TestCrm::test_crm_show_resources_acl_group PASSED     [ 27%]
tests/crm_test.py::TestCrm::test_crm_show_resources_acl_table PASSED     [ 27%]
tests/crm_test.py::TestCrm::test_crm_show_resources_all PASSED           [ 27%]
tests/crm_test.py::TestCrm::test_crm_show_resources_fdb PASSED           [ 27%]
tests/crm_test.py::TestCrm::test_crm_show_resources_ipv4_neighbor PASSED [ 28%]
tests/crm_test.py::TestCrm::test_crm_show_resources_ipv4_nexthop PASSED  [ 28%]
tests/crm_test.py::TestCrm::test_crm_show_resources_ipv4_route PASSED    [ 28%]
tests/crm_test.py::TestCrm::test_crm_show_resources_ipv6_route PASSED    [ 28%]
tests/crm_test.py::TestCrm::test_crm_show_resources_ipv6_neighbor PASSED [ 28%]
tests/crm_test.py::TestCrm::test_crm_show_resources_ipv6_nexthop PASSED  [ 28%]
tests/crm_test.py::TestCrm::test_crm_show_resources_nexthop_group_member PASSED [ 28%]
tests/crm_test.py::TestCrm::test_crm_show_resources_nexthop PASSED       [ 28%]
tests/crm_test.py::TestCrm::test_crm_show_resources_snat PASSED          [ 28%]
tests/crm_test.py::TestCrm::test_crm_show_resources_dnat PASSED          [ 28%]
tests/crm_test.py::TestCrm::test_crm_show_resources_ipmc PASSED          [ 28%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_show_summary PASSED        [ 29%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_show_thresholds_acl_group PASSED [ 29%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_show_thresholds_acl_table PASSED [ 29%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_show_thresholds_all PASSED [ 29%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_show_thresholds_fdb PASSED [ 29%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_show_thresholds_ipv4_neighbor PASSED [ 29%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_show_thresholds_ipv4_nexthop PASSED [ 29%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_show_thresholds_ipv4_route PASSED [ 29%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_show_thresholds_ipv6_neighbor PASSED [ 29%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_show_thresholds_ipv6_nexthop PASSED [ 29%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_show_thresholds_ipv6_route PASSED [ 30%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_show_thresholds_nexthop_group_member PASSED [ 30%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_show_thresholds_nexthop_group_object PASSED [ 30%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_show_thresholds_snat PASSED [ 30%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_show_thresholds_dnat PASSED [ 30%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_show_thresholds_ipmc PASSED [ 30%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_multi_asic_show_resources_acl_group PASSED [ 30%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_multi_asic_show_resources_acl_table PASSED [ 30%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_multi_asic_show_resources_all PASSED [ 30%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_multi_asic_show_resources_fdb PASSED [ 30%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_multi_asic_show_resources_ipv4_neighbor PASSED [ 30%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_multi_asic_show_resources_ipv4_nexthop PASSED [ 31%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_multi_asic_show_resources_ipv4_route PASSED [ 31%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_multi_asic_show_resources_ipv6_route PASSED [ 31%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_multi_asic_show_resources_ipv6_neighbor PASSED [ 31%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_multi_asic_show_resources_ipv6_nexthop PASSED [ 31%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_multi_asic_show_resources_nexthop_group_member PASSED [ 31%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_multi_asic_show_resources_nexthop PASSED [ 31%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_multi_asic_show_resources_snat PASSED [ 31%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_multi_asic_show_resources_dnat PASSED [ 31%]
tests/crm_test.py::TestCrmMultiAsic::test_crm_multi_asic_show_resources_ipmc PASSED [ 31%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_negative_cold_reboot[empty-config] PASSED [ 32%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_negative_cold_reboot[non-default-config] PASSED [ 32%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_negative_cold_reboot[non-default-xoff] PASSED [ 32%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_negative_cold_reboot[non-default-lossless-profile-in-pg] PASSED [ 32%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_negative_cold_reboot[non-default-lossy-profile-in-pg] PASSED [ 32%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_negative_cold_reboot[non-default-pg] PASSED [ 32%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t0-sku_version0] PASSED [ 32%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t0-sku_version1] PASSED [ 32%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t0-sku_version2] PASSED [ 32%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t0-sku_version3] PASSED [ 32%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t0-sku_version4] PASSED [ 32%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t0-sku_version5] PASSED [ 33%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t0-sku_version6] PASSED [ 33%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t0-sku_version7] PASSED [ 33%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t0-sku_version8] PASSED [ 33%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t0-sku_version9] PASSED [ 33%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t0-sku_version10] PASSED [ 33%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t0-sku_version11] PASSED [ 33%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t0-sku_version12] PASSED [ 33%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t0-sku_version13] PASSED [ 33%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t0-sku_version14] PASSED [ 33%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t1-sku_version0] PASSED [ 34%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t1-sku_version1] PASSED [ 34%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t1-sku_version2] PASSED [ 34%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t1-sku_version3] PASSED [ 34%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t1-sku_version4] PASSED [ 34%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t1-sku_version5] PASSED [ 34%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t1-sku_version6] PASSED [ 34%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t1-sku_version7] PASSED [ 34%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t1-sku_version8] PASSED [ 34%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t1-sku_version9] PASSED [ 34%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t1-sku_version10] PASSED [ 34%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t1-sku_version11] PASSED [ 35%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t1-sku_version12] PASSED [ 35%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t1-sku_version13] PASSED [ 35%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_cold_reboot[t1-sku_version14] PASSED [ 35%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t0-ACS-MSN2700] PASSED [ 35%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t0-Mellanox-SN2700] PASSED [ 35%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t0-Mellanox-SN2700-Single-Pool] PASSED [ 35%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t0-Mellanox-SN2700-C28D8] PASSED [ 35%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t0-Mellanox-SN2700-C28D8-Single-Pool] PASSED [ 35%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t0-Mellanox-SN2700-D48C8] PASSED [ 35%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t0-Mellanox-SN2700-D48C8-Single-Pool] PASSED [ 36%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t0-Mellanox-SN2700-D40C8S8] PASSED [ 36%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t0-ACS-MSN3700] PASSED [ 36%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t0-ACS-MSN3800] PASSED [ 36%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t0-Mellanox-SN3800-C64] PASSED [ 36%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t0-Mellanox-SN3800-D112C8] PASSED [ 36%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t0-Mellanox-SN3800-D24C52] PASSED [ 36%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t0-Mellanox-SN3800-D28C50] PASSED [ 36%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t0-ACS-MSN4700] PASSED [ 36%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t1-ACS-MSN2700] PASSED [ 36%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t1-Mellanox-SN2700] PASSED [ 36%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t1-Mellanox-SN2700-Single-Pool] PASSED [ 37%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t1-Mellanox-SN2700-C28D8] PASSED [ 37%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t1-Mellanox-SN2700-C28D8-Single-Pool] PASSED [ 37%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t1-Mellanox-SN2700-D48C8] PASSED [ 37%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t1-Mellanox-SN2700-D48C8-Single-Pool] PASSED [ 37%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t1-Mellanox-SN2700-D40C8S8] PASSED [ 37%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t1-ACS-MSN3700] PASSED [ 37%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t1-ACS-MSN3800] PASSED [ 37%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t1-Mellanox-SN3800-C64] PASSED [ 37%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t1-Mellanox-SN3800-D112C8] PASSED [ 37%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t1-Mellanox-SN3800-D24C52] PASSED [ 38%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t1-Mellanox-SN3800-D28C50] PASSED [ 38%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_for_warm_reboot[t1-ACS-MSN4700] PASSED [ 38%]
tests/db_migrator_test.py::TestMellanoxBufferMigrator::test_mellanox_buffer_migrator_negative_nondefault_for_warm_reboot PASSED [ 38%]
tests/db_migrator_test.py::TestAutoNegMigrator::test_port_autoneg_migrator PASSED [ 38%]
tests/db_migrator_test.py::TestInitConfigMigrator::test_init_config_feature_migration PASSED [ 38%]
tests/db_migrator_test.py::TestLacpKeyMigrator::test_lacp_key_migrator PASSED [ 38%]
tests/decode_syseeprom_test.py::TestDecodeSyseeprom::test_print_eeprom_dict PASSED [ 38%]
tests/decode_syseeprom_test.py::TestDecodeSyseeprom::test_read_eeprom_from_db PASSED [ 38%]
tests/decode_syseeprom_test.py::TestDecodeSyseeprom::test_get_tlv_value_from_db PASSED [ 38%]
tests/decode_syseeprom_test.py::TestDecodeSyseeprom::test_print_mgmt_mac_db PASSED [ 38%]
tests/decode_syseeprom_test.py::TestDecodeSyseeprom::test_print_serial PASSED [ 39%]
tests/decode_syseeprom_test.py::TestDecodeSyseeprom::test_print_model PASSED [ 39%]
tests/disk_check_test.py::TestDiskCheck::test_readonly PASSED            [ 39%]
tests/drops_group_test.py::TestDropCounters::test_show_capabilities PASSED [ 39%]
tests/drops_group_test.py::TestDropCounters::test_show_configuration PASSED [ 39%]
tests/drops_group_test.py::TestDropCounters::test_show_configuration_with_group PASSED [ 39%]
tests/drops_group_test.py::TestDropCounters::test_show_counts PASSED     [ 39%]
tests/drops_group_test.py::TestDropCounters::test_show_counts_with_group PASSED [ 39%]
tests/drops_group_test.py::TestDropCounters::test_show_counts_with_type PASSED [ 39%]
tests/drops_group_test.py::TestDropCounters::test_show_counts_with_clear PASSED [ 39%]
tests/ecn_test.py::TestEcnConfig::test_ecn_show_config PASSED            [ 40%]
tests/ecn_test.py::TestEcnConfig::test_ecn_config_gmin PASSED            [ 40%]
tests/ecn_test.py::TestEcnConfig::test_ecn_config_gmax PASSED            [ 40%]
tests/ecn_test.py::TestEcnConfig::test_ecn_config_ymin PASSED            [ 40%]
tests/ecn_test.py::TestEcnConfig::test_ecn_config_ymax PASSED            [ 40%]
tests/ecn_test.py::TestEcnConfig::test_ecn_config_rmin PASSED            [ 40%]
tests/ecn_test.py::TestEcnConfig::test_ecn_config_rmax PASSED            [ 40%]
tests/ecn_test.py::TestEcnConfig::test_ecn_config_gdrop PASSED           [ 40%]
tests/ecn_test.py::TestEcnConfig::test_ecn_config_ydrop PASSED           [ 40%]
tests/ecn_test.py::TestEcnConfig::test_ecn_config_rdrop PASSED           [ 40%]
tests/ecn_test.py::TestEcnConfig::test_ecn_config_multi_set PASSED       [ 40%]
tests/ecn_test.py::TestEcnConfig::test_ecn_config_gmin_gmax_invalid PASSED [ 41%]
tests/ecn_test.py::TestEcnConfig::test_ecn_config_ymin_ymax_invalid PASSED [ 41%]
tests/ecn_test.py::TestEcnConfig::test_ecn_config_rmin_rmax_invalid PASSED [ 41%]
tests/ecn_test.py::TestEcnConfig::test_ecn_config_rmax_invalid PASSED    [ 41%]
tests/ecn_test.py::TestEcnConfig::test_ecn_config_rdrop_invalid PASSED   [ 41%]
tests/fan_test.py::TestFan::test_show_platform_fan PASSED                [ 41%]
tests/fast_reboot_dump_test.py::TestFastRebootDump::test_generate_fdb_entries_vlan_portcahnnel_member PASSED [ 41%]
tests/fdbshow_test.py::TestFdbshow::test_show_mac_def_vlan PASSED        [ 41%]
tests/fdbshow_test.py::TestFdbshow::test_show_mac PASSED                 [ 41%]
tests/fdbshow_test.py::TestFdbshow::test_show_mac_port_vlan PASSED       [ 41%]
tests/fdbshow_test.py::TestFdbshow::test_show_mac_no_port PASSED         [ 42%]
tests/fdbshow_test.py::TestFdbshow::test_show_mac_no_vlan PASSED         [ 42%]
tests/fdbshow_test.py::TestFdbshow::test_show_mac_no_fdb PASSED          [ 42%]
tests/fdbshow_test.py::TestFdbshow::test_show_mac_no_bridge PASSED       [ 42%]
tests/fdbshow_test.py::TestFdbshow::test_show_fetch_except PASSED        [ 42%]
tests/feature_test.py::TestFeature::test_show_feature_status_no_kube_status PASSED [ 42%]
tests/feature_test.py::TestFeature::test_show_feature_status PASSED      [ 42%]
tests/feature_test.py::TestFeature::test_show_feature_config PASSED      [ 42%]
tests/feature_test.py::TestFeature::test_show_feature_status_abbrev_cmd PASSED [ 42%]
tests/feature_test.py::TestFeature::test_show_bgp_feature_status PASSED  [ 42%]
tests/feature_test.py::TestFeature::test_show_unknown_feature_status PASSED [ 42%]
tests/feature_test.py::TestFeature::test_show_feature_autorestart PASSED [ 43%]
tests/feature_test.py::TestFeature::test_fail_autorestart PASSED         [ 43%]
tests/feature_test.py::TestFeature::test_show_bgp_autorestart_status PASSED [ 43%]
tests/feature_test.py::TestFeature::test_show_unknown_autorestart_status PASSED [ 43%]
tests/feature_test.py::TestFeature::test_config_bgp_feature_state PASSED [ 43%]
tests/feature_test.py::TestFeature::test_config_snmp_feature_owner PASSED [ 43%]
tests/feature_test.py::TestFeature::test_config_unknown_feature_owner PASSED [ 43%]
tests/feature_test.py::TestFeature::test_config_snmp_feature_fallback PASSED [ 43%]
tests/feature_test.py::TestFeature::test_config_bgp_autorestart PASSED   [ 43%]
tests/feature_test.py::TestFeature::test_config_database_feature_state PASSED [ 43%]
tests/feature_test.py::TestFeature::test_config_database_feature_autorestart PASSED [ 44%]
tests/feature_test.py::TestFeature::test_config_unknown_feature PASSED   [ 44%]
tests/feature_test.py::TestFeatureMultiAsic::test_config_bgp_feature_inconsistent_state PASSED [ 44%]
tests/feature_test.py::TestFeatureMultiAsic::test_config_bgp_feature_inconsistent_autorestart PASSED [ 44%]
tests/feature_test.py::TestFeatureMultiAsic::test_config_bgp_feature_consistent_state PASSED [ 44%]
tests/feature_test.py::TestFeatureMultiAsic::test_config_bgp_feature_consistent_autorestart PASSED [ 44%]
tests/fgnhg_test.py::TestFineGrainedNexthopGroup::test_show_fgnhg_hash_view PASSED [ 44%]
tests/fgnhg_test.py::TestFineGrainedNexthopGroup::test_show_fgnhgv4_hash_view PASSED [ 44%]
tests/fgnhg_test.py::TestFineGrainedNexthopGroup::test_show_fgnhgv6_hash_view PASSED [ 44%]
tests/fgnhg_test.py::TestFineGrainedNexthopGroup::test_show_fgnhg_active_hops PASSED [ 44%]
tests/fgnhg_test.py::TestFineGrainedNexthopGroup::test_show_fgnhgv4_active_hops PASSED [ 44%]
tests/fgnhg_test.py::TestFineGrainedNexthopGroup::test_show_fgnhgv6_active_hops PASSED [ 45%]
tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData0] PASSED [ 45%]
tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData1] PASSED [ 45%]
tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData2] PASSED [ 45%]
tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData3] PASSED [ 45%]
tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData4] PASSED [ 45%]
tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData5] PASSED [ 45%]
tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData6] PASSED [ 45%]
tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData7] PASSED [ 45%]
tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData8] PASSED [ 45%]
tests/filter_fdb_entries_test.py::TestFilterFdbEntries::testFilterFdbEntries[testData9] PASSED [ 46%]
tests/gearbox_test.py::TestGearbox::test_gearbox_interfaces_status_validation PASSED [ 46%]
tests/gearbox_test.py::TestGearbox::test_gearbox_phys_status_validation PASSED [ 46%]
tests/interfaces_test.py::TestInterfaces::test_show_interfaces PASSED    [ 46%]
tests/interfaces_test.py::TestInterfaces::test_show_interfaces_alias PASSED [ 46%]
tests/interfaces_test.py::TestInterfaces::test_show_interfaces_alias_Ethernet0 PASSED [ 46%]
tests/interfaces_test.py::TestInterfaces::test_show_interfaces_alias_etp1 PASSED [ 46%]
tests/interfaces_test.py::TestInterfaces::test_show_interfaces_alias_invalid_name PASSED [ 46%]
tests/interfaces_test.py::TestInterfaces::test_show_interfaces_naming_mode_default PASSED [ 46%]
tests/interfaces_test.py::TestInterfaces::test_show_interfaces_naming_mode_alias PASSED [ 46%]
tests/interfaces_test.py::TestInterfaces::test_show_interfaces_neighbor_expected PASSED [ 46%]
tests/interfaces_test.py::TestInterfaces::test_show_interfaces_neighbor_expected_t1 PASSED [ 47%]
tests/interfaces_test.py::TestInterfaces::test_show_interfaces_neighbor_expected_Ethernet112 PASSED [ 47%]
tests/interfaces_test.py::TestInterfaces::test_show_interfaces_neighbor_expected_t1_Ethernet0 PASSED [ 47%]
tests/interfaces_test.py::TestInterfaces::test_show_interfaces_neighbor_expected_etp29 PASSED [ 47%]
tests/interfaces_test.py::TestInterfaces::test_show_interfaces_neighbor_expected_t1_Ethernet1_1 PASSED [ 47%]
tests/interfaces_test.py::TestInterfaces::test_show_interfaces_neighbor_expected_Ethernet0 PASSED [ 47%]
tests/interfaces_test.py::TestInterfaces::test_show_interfaces_portchannel PASSED [ 47%]
tests/interfaces_test.py::TestInterfaces::test_show_interfaces_portchannel_in_alias_mode PASSED [ 47%]
tests/intfstat_test.py::TestIntfstat::test_no_param PASSED               [ 47%]
tests/intfstat_test.py::TestIntfstat::test_verbose PASSED                [ 47%]
tests/intfstat_test.py::TestIntfstat::test_period PASSED                 [ 48%]
tests/intfstat_test.py::TestIntfstat::test_period_single_interface PASSED [ 48%]
tests/intfstat_test.py::TestIntfstat::test_single_intfs PASSED           [ 48%]
tests/intfstat_test.py::TestIntfstat::test_clear_single_intfs PASSED     [ 48%]
tests/intfstat_test.py::TestIntfstat::test_clear PASSED                  [ 48%]
tests/intfstat_test.py::TestIntfstat::test_alias_mode PASSED             [ 48%]
tests/intfutil_test.py::TestIntfutil::test_intf_status PASSED            [ 48%]
tests/intfutil_test.py::TestIntfutil::test_intf_status_Ethernet32 PASSED [ 48%]
tests/intfutil_test.py::TestIntfutil::test_intf_status_etp9 PASSED       [ 48%]
tests/intfutil_test.py::TestIntfutil::test_intf_status_verbose PASSED    [ 48%]
tests/intfutil_test.py::TestIntfutil::test_show_interfaces_autoneg_status PASSED [ 48%]
tests/intfutil_test.py::TestIntfutil::test_show_interfaces_autoneg_status_Ethernet0 PASSED [ 49%]
tests/intfutil_test.py::TestIntfutil::test_show_interfaces_autoneg_status_etp9_in_alias_mode PASSED [ 49%]
tests/intfutil_test.py::TestIntfutil::test_show_interfaces_description PASSED [ 49%]
tests/intfutil_test.py::TestIntfutil::test_show_interfaces_description_Ethernet0 PASSED [ 49%]
tests/intfutil_test.py::TestIntfutil::test_show_interfaces_description_Ethernet0_verbose PASSED [ 49%]
tests/intfutil_test.py::TestIntfutil::test_show_interfaces_description_etp33_in_alias_mode PASSED [ 49%]
tests/intfutil_test.py::TestIntfutil::test_show_interfaces_description_etp9_in_alias_mode PASSED [ 49%]
tests/intfutil_test.py::TestIntfutil::test_single_subintf_status PASSED  [ 49%]
tests/intfutil_test.py::TestIntfutil::test_single_subintf_status_alias_mode PASSED [ 49%]
tests/intfutil_test.py::TestIntfutil::test_single_subintf_status_alias_mode_verbose PASSED [ 49%]
tests/intfutil_test.py::TestIntfutil::test_single_subintf_status_verbose PASSED [ 50%]
tests/intfutil_test.py::TestIntfutil::test_subintf_status PASSED         [ 50%]
tests/intfutil_test.py::TestIntfutil::test_subintf_status_verbose PASSED [ 50%]
tests/ip_config_test.py::TestConfigIP::test_add_del_interface_valid_ipv4 PASSED [ 50%]
tests/ip_config_test.py::TestConfigIP::test_add_interface_invalid_ipv4 PASSED [ 50%]
tests/ip_config_test.py::TestConfigIP::test_add_interface_ipv4_invalid_mask PASSED [ 50%]
tests/ip_config_test.py::TestConfigIP::test_add_del_interface_ipv4_with_leading_zeros PASSED [ 50%]
tests/ip_config_test.py::TestConfigIP::test_add_del_interface_valid_ipv6 PASSED [ 50%]
tests/ip_config_test.py::TestConfigIP::test_add_interface_invalid_ipv6 PASSED [ 50%]
tests/ip_config_test.py::TestConfigIP::test_add_interface_ipv6_invalid_mask PASSED [ 50%]
tests/ip_config_test.py::TestConfigIP::test_add_del_interface_ipv6_with_leading_zeros PASSED [ 50%]
tests/ip_config_test.py::TestConfigIP::test_add_del_interface_shortened_ipv6_with_leading_zeros PASSED [ 51%]
tests/ip_show_routes_multi_asic_test.py::TestMultiAiscShowIpRouteDisplayAllCommands::test_show_multi_asic_ip_route_front_end[ip_route] PASSED [ 51%]
tests/ip_show_routes_multi_asic_test.py::TestMultiAiscShowIpRouteDisplayAllCommands::test_show_multi_asic_ip_route_all[ip_route] PASSED [ 51%]
tests/ip_show_routes_multi_asic_test.py::TestMultiAiscShowIpRouteDisplayAllCommands::test_show_multi_asic_ip_route_specific[ip_specific_route] PASSED [ 51%]
tests/ip_show_routes_multi_asic_test.py::TestMultiAiscShowIpRouteDisplayAllCommands::test_show_multi_asic_ip_route_specific_on_1_asic[ip_specific_route_on_1_asic] PASSED [ 51%]
tests/ip_show_routes_multi_asic_test.py::TestMultiAiscShowIpRouteDisplayAllCommands::test_show_multi_asic_ip_route_specific_recursive_route[ip_specific_recursive_route] PASSED [ 51%]
tests/ip_show_routes_multi_asic_test.py::TestMultiAiscShowIpRouteDisplayAllCommands::test_show_multi_asic_ipv6_route_specific[ipv6_specific_route] PASSED [ 51%]
tests/ip_show_routes_multi_asic_test.py::TestMultiAiscShowIpRouteDisplayAllCommands::test_show_imulti_asic_ipv6_route_err[ipv6_route_err] PASSED [ 51%]
tests/ip_show_routes_multi_asic_test.py::TestMultiAiscShowIpRouteDisplayAllCommands::test_show_multi_asic_ip_route_namespace_option_err[ip_route] PASSED [ 51%]
tests/ip_show_routes_multi_asic_test.py::TestMultiAiscShowIpRouteDisplayAllCommands::test_show_multi_asic_ip_route_display_option_err[ip_route] PASSED [ 51%]
tests/ip_show_routes_multi_asic_test.py::TestMultiAiscShowIpRouteDisplayAllCommands::test_show_multi_asic_ipv6_route_all_namespace[ipv6_route] PASSED [ 51%]
tests/ip_show_routes_multi_asic_test.py::TestMultiAiscShowIpRouteDisplayAllCommands::test_show_multi_asic_ipv6_route_single_namespace[ipv6_route] PASSED [ 52%]
tests/ip_show_routes_multi_asic_test.py::TestMultiAiscShowIpRouteDisplayAllCommands::test_show_multi_asic_ipv6_route_specific_route_json[ipv6_specific_route] PASSED [ 52%]
tests/ip_show_routes_multi_asic_test.py::TestMultiAiscShowIpRouteDisplayAllCommands::test_show_multi_asic_ip_route_special_route[ip_special_route] PASSED [ 52%]
tests/ip_show_routes_multi_asic_test.py::TestMultiAiscShowIpRouteDisplayAllCommands::test_show_multi_asic_ip_route_empty_route[ip_empty_route] PASSED [ 52%]
tests/ip_show_routes_multi_asic_test.py::TestMultiAiscShowIpRouteDisplayAllCommands::test_show_multi_asic_ip_route_summay[ip_route_summary] PASSED [ 52%]
tests/ip_show_routes_test.py::TestShowIpRouteCommands::test_show_ip_route[ip_route] PASSED [ 52%]
tests/ip_show_routes_test.py::TestShowIpRouteCommands::test_show_specific_ip_route[ip_specific_route] PASSED [ 52%]
tests/ip_show_routes_test.py::TestShowIpRouteCommands::test_show_special_ip_route[ip_special_route] PASSED [ 52%]
tests/ip_show_routes_test.py::TestShowIpRouteCommands::test_show_specific_ipv6_route_json[ipv6_specific_route] PASSED [ 52%]
tests/ip_show_routes_test.py::TestShowIpRouteCommands::test_show_ipv6_route[ipv6_route] PASSED [ 52%]
tests/ip_show_routes_test.py::TestShowIpRouteCommands::test_show_ipv6_route_err[ipv6_route_err] PASSED [ 53%]
tests/kube_test.py::TestKube::test_kube_server PASSED                    [ 53%]
tests/kube_test.py::TestKube::test_no_kube_server PASSED                 [ 53%]
tests/kube_test.py::TestKube::test_kube_server_status PASSED             [ 53%]
tests/kube_test.py::TestKube::test_set_server_ip PASSED                  [ 53%]
tests/kube_test.py::TestKube::test_set_server_invalid_port PASSED        [ 53%]
tests/kube_test.py::TestKube::test_set_insecure PASSED                   [ 53%]
tests/kube_test.py::TestKube::test_set_disable PASSED                    [ 53%]
tests/kube_test.py::TestKube::test_set_port PASSED                       [ 53%]
tests/kube_test.py::TestKube::test_kube_labels PASSED                    [ 53%]
tests/kube_test.py::TestKube::test_set_kube_labels PASSED                [ 53%]
tests/multi_asic_intfutil_test.py::TestInterfacesMultiAsic::test_multi_asic_interface_status_all PASSED [ 54%]
tests/multi_asic_intfutil_test.py::TestInterfacesMultiAsic::test_multi_asic_interface_status PASSED [ 54%]
tests/multi_asic_intfutil_test.py::TestInterfacesMultiAsic::test_multi_asic_interface_status_asic0_all PASSED [ 54%]
tests/multi_asic_intfutil_test.py::TestInterfacesMultiAsic::test_multi_asic_interface_status_asic0 PASSED [ 54%]
tests/multi_asic_intfutil_test.py::TestInterfacesMultiAsic::test_multi_asic_interface_desc PASSED [ 54%]
tests/multi_asic_intfutil_test.py::TestInterfacesMultiAsic::test_multi_asic_interface_desc_all PASSED [ 54%]
tests/multi_asic_intfutil_test.py::TestInterfacesMultiAsic::test_multi_asic_interface_asic0 PASSED [ 54%]
tests/multi_asic_intfutil_test.py::TestInterfacesMultiAsic::test_multi_asic_interface_desc_asic0_all PASSED [ 54%]
tests/multi_asic_intfutil_test.py::TestInterfacesMultiAsic::test_invalid_asic_name PASSED [ 54%]
tests/muxcable_test.py::TestMuxcable::test_muxcable_status PASSED        [ 54%]
tests/muxcable_test.py::TestMuxcable::test_muxcable_status_json PASSED   [ 55%]
tests/muxcable_test.py::TestMuxcable::test_muxcable_status_config PASSED [ 55%]
tests/muxcable_test.py::TestMuxcable::test_muxcable_status_config_json PASSED [ 55%]
tests/muxcable_test.py::TestMuxcable::test_muxcable_config_json_with_incorrect_port PASSED [ 55%]
tests/muxcable_test.py::TestMuxcable::test_muxcable_status_json_with_correct_port PASSED [ 55%]
tests/muxcable_test.py::TestMuxcable::test_muxcable_status_json_port_incorrect_index PASSED [ 55%]
tests/muxcable_test.py::TestMuxcable::test_muxcable_status_with_patch PASSED [ 55%]
tests/muxcable_test.py::TestMuxcable::test_muxcable_status_json_with_incorrect_port PASSED [ 55%]
tests/muxcable_test.py::TestMuxcable::test_muxcable_config_with_correct_port PASSED [ 55%]
tests/muxcable_test.py::TestMuxcable::test_muxcable_config_json_with_correct_port PASSED [ 55%]
tests/muxcable_test.py::TestMuxcable::test_muxcable_config_json_port_with_incorrect_index PASSED [ 55%]
tests/muxcable_test.py::TestMuxcable::test_muxcable_config_json_with_incorrect_port_patch PASSED [ 56%]
tests/muxcable_test.py::TestMuxcable::test_muxcable_status_json_port_eth0 PASSED [ 56%]
tests/muxcable_test.py::TestMuxcable::test_config_muxcable_tabular_port_Ethernet8_active PASSED [ 56%]
tests/muxcable_test.py::TestMuxcable::test_config_muxcable_tabular_port_Ethernet8_auto PASSED [ 56%]
tests/muxcable_test.py::TestMuxcable::test_config_muxcable_tabular_port_Ethernet8_manual PASSED [ 56%]
tests/muxcable_test.py::TestMuxcable::test_config_muxcable_mode_auto_json PASSED [ 56%]
tests/muxcable_test.py::TestMuxcable::test_config_muxcable_mode_active_json PASSED [ 56%]
tests/muxcable_test.py::TestMuxcable::test_config_muxcable_json_port_auto_Ethernet0 PASSED [ 56%]
tests/muxcable_test.py::TestMuxcable::test_config_muxcable_json_port_active_Ethernet0 PASSED [ 56%]
tests/muxcable_test.py::TestMuxcable::test_config_muxcable_mode_auto_tabular PASSED [ 56%]
tests/muxcable_test.py::TestMuxcable::test_config_muxcable_mode_active_tabular PASSED [ 57%]
tests/muxcable_test.py::TestMuxcable::test_config_muxcable_tabular_port PASSED [ 57%]
tests/muxcable_test.py::TestMuxcable::test_config_muxcable_tabular_port_Ethernet4_active PASSED [ 57%]
tests/muxcable_test.py::TestMuxcable::test_config_muxcable_tabular_port_Ethernet4_auto PASSED [ 57%]
tests/muxcable_test.py::TestMuxcable::test_config_muxcable_tabular_port_with_incorrect_index PASSED [ 57%]
tests/muxcable_test.py::TestMuxcable::test_config_muxcable_tabular_port_with_incorrect_port_index PASSED [ 57%]
tests/muxcable_test.py::TestMuxcable::test_config_muxcable_tabular_port_with_incorrect_port PASSED [ 57%]
tests/muxcable_test.py::TestMuxcable::test_show_muxcable_eye_info PASSED [ 57%]
tests/muxcable_test.py::TestMuxcable::test_show_muxcable_ber_info PASSED [ 57%]
tests/muxcable_test.py::TestMuxcable::test_config_muxcable_enable_prbs PASSED [ 57%]
tests/muxcable_test.py::TestMuxcable::test_config_muxcable_enable_loopback PASSED [ 57%]
tests/muxcable_test.py::TestMuxcable::test_config_muxcable_disble_prbs PASSED [ 58%]
tests/muxcable_test.py::TestMuxcable::test_config_muxcable_disable_loopback PASSED [ 58%]
tests/muxcable_test.py::TestMuxcable::test_show_muxcable_cableinfo PASSED [ 58%]
tests/muxcable_test.py::TestMuxcable::test_show_muxcable_cableinfo_incorrect_port PASSED [ 58%]
tests/muxcable_test.py::TestMuxcable::test_show_muxcable_cableinfo_incorrect_port_return_value PASSED [ 58%]
tests/muxcable_test.py::TestMuxcable::test_show_muxcable_cableinfo_incorrect_logical_port_return_value PASSED [ 58%]
tests/muxcable_test.py::TestMuxcable::test_show_muxcable_hwmode_muxdirection_port_active PASSED [ 58%]
tests/muxcable_test.py::TestMuxcable::test_show_muxcable_hwmode_muxdirection_active PASSED [ 58%]
tests/muxcable_test.py::TestMuxcable::test_show_muxcable_hwmode_muxdirection_port_standby PASSED [ 58%]
tests/muxcable_test.py::TestMuxcable::test_show_muxcable_hwmode_muxdirection_standby PASSED [ 58%]
tests/muxcable_test.py::TestMuxcable::test_config_muxcable_hwmode_state_port_active PASSED [ 59%]
tests/muxcable_test.py::TestMuxcable::test_config_muxcable_hwmode_state_active PASSED [ 59%]
tests/muxcable_test.py::TestMuxcable::test_config_muxcable_hwmode_state_port_standby PASSED [ 59%]
tests/muxcable_test.py::TestMuxcable::test_config_muxcable_hwmode_state_standby PASSED [ 59%]
tests/muxcable_test.py::TestMuxcable::test_show_muxcable_firmware_version PASSED [ 59%]
tests/muxcable_test.py::TestMuxcable::test_config_muxcable_download_firmware PASSED [ 59%]
tests/muxcable_test.py::TestMuxcable::test_config_muxcable_activate_firmware PASSED [ 59%]
tests/muxcable_test.py::TestMuxcable::test_config_muxcable_rollback_firmware PASSED [ 59%]
tests/muxcable_test.py::TestMuxcable::test_show_muxcable_metrics_port PASSED [ 59%]
tests/muxcable_test.py::TestMuxcable::test_show_muxcable_firmware_active_version PASSED [ 59%]
tests/neighbor_advertiser_test.py::TestNeighborAdvertiser::test_neighbor_advertiser_slice PASSED [ 59%]
tests/neighbor_advertiser_test.py::TestNeighborAdvertiser::test_set_vxlan PASSED [ 60%]
tests/pcieutil_test.py::TestPcieUtil::test_aer_all PASSED                [ 60%]
tests/pcieutil_test.py::TestPcieUtil::test_aer_correctable PASSED        [ 60%]
tests/pcieutil_test.py::TestPcieUtil::test_aer_fatal PASSED              [ 60%]
tests/pcieutil_test.py::TestPcieUtil::test_aer_non_fatal PASSED          [ 60%]
tests/pcieutil_test.py::TestPcieUtil::test_aer_option_verbose PASSED     [ 60%]
tests/pcieutil_test.py::TestPcieUtil::test_aer_option_device PASSED      [ 60%]
tests/pfcstat_test.py::TestPfcstat::test_pfc_counters PASSED             [ 60%]
tests/pfcstat_test.py::TestPfcstat::test_pfc_clear PASSED                [ 60%]
tests/pfcstat_test.py::TestMultiAsicPfcstat::test_pfc_counters_all PASSED [ 60%]
tests/pfcstat_test.py::TestMultiAsicPfcstat::test_pfc_counters_frontend PASSED [ 61%]
tests/pfcstat_test.py::TestMultiAsicPfcstat::test_pfc_counters_asic PASSED [ 61%]
tests/pfcstat_test.py::TestMultiAsicPfcstat::test_pfc_counters_asic_all PASSED [ 61%]
tests/pfcstat_test.py::TestMultiAsicPfcstat::test_masic_pfc_clear PASSED [ 61%]
tests/pfcwd_test.py::TestPfcwd::test_pfcwd_show_config PASSED            [ 61%]
tests/pfcwd_test.py::TestPfcwd::test_pfcwd_show_config_single_port PASSED [ 61%]
tests/pfcwd_test.py::TestPfcwd::test_pfcwd_show_config_multi_port PASSED [ 61%]
tests/pfcwd_test.py::TestPfcwd::test_pfcwd_show_config_invalid_port PASSED [ 61%]
tests/pfcwd_test.py::TestPfcwd::test_pfcwd_show_stats PASSED             [ 61%]
tests/pfcwd_test.py::TestPfcwd::test_pfcwd_show_stats_single_queue PASSED [ 61%]
tests/pfcwd_test.py::TestPfcwd::test_pfcwd_show_stats_multi_queue PASSED [ 61%]
tests/pfcwd_test.py::TestPfcwd::test_pfcwd_show_stats_invalid_queue PASSED [ 62%]
tests/pfcwd_test.py::TestPfcwd::test_pfcwd_start_ports_valid PASSED      [ 62%]
tests/pfcwd_test.py::TestPfcwd::test_pfcwd_start_actions PASSED          [ 62%]
tests/pfcwd_test.py::TestPfcwd::test_pfcwd_pfc_not_enabled PASSED        [ 62%]
tests/pfcwd_test.py::TestPfcwd::test_pfcwd_start_ports_invalid PASSED    [ 62%]
tests/pfcwd_test.py::TestMultiAsicPfcwdShow::test_pfcwd_stats_all PASSED [ 62%]
tests/pfcwd_test.py::TestMultiAsicPfcwdShow::test_pfcwd_stats_with_queues PASSED [ 62%]
tests/pfcwd_test.py::TestMultiAsicPfcwdShow::test_pfcwd_config_all PASSED [ 62%]
tests/pfcwd_test.py::TestMultiAsicPfcwdShow::test_pfcwd_config_with_ports PASSED [ 62%]
tests/pfcwd_test.py::TestMultiAsicPfcwdShow::test_pfcwd_start_ports_masic_valid PASSED [ 62%]
tests/pfcwd_test.py::TestMultiAsicPfcwdShow::test_pfcwd_start_actions_masic PASSED [ 63%]
tests/pfcwd_test.py::TestMultiAsicPfcwdShow::test_pfcwd_start_ports_masic_invalid PASSED [ 63%]
tests/pfcwd_test.py::TestMultiAsicPfcwdShow::test_pfcwd_pfc_not_enabled_masic PASSED [ 63%]
tests/pgdropstat_test.py::TestPgDropstat::test_show_pg_drop_show PASSED  [ 63%]
tests/pgdropstat_test.py::TestPgDropstat::test_show_pg_drop_clear PASSED [ 63%]
tests/port2alias_test.py::TestPort2Alias::test_translate_line_empty_ports PASSED [ 63%]
tests/port2alias_test.py::TestPort2Alias::test_translate_line_multiple_words PASSED [ 63%]
tests/port2alias_test.py::TestPort2Alias::test_translate_line_single_word PASSED [ 63%]
tests/port2alias_test.py::TestPort2Alias::test_translate_line_with_symbol PASSED [ 63%]
tests/portchannel_test.py::TestPortChannel::test_add_portchannel_with_invalid_name PASSED [ 63%]
tests/portchannel_test.py::TestPortChannel::test_delete_portchannel_with_invalid_name PASSED [ 63%]
tests/portchannel_test.py::TestPortChannel::test_add_existing_portchannel_again PASSED [ 64%]
tests/portchannel_test.py::TestPortChannel::test_delete_non_existing_portchannel PASSED [ 64%]
tests/portchannel_test.py::TestPortChannel::test_add_portchannel_member_with_invalid_name PASSED [ 64%]
tests/portchannel_test.py::TestPortChannel::test_delete_portchannel_member_with_invalid_name PASSED [ 64%]
tests/portchannel_test.py::TestPortChannel::test_add_non_existing_portchannel_member PASSED [ 64%]
tests/portchannel_test.py::TestPortChannel::test_delete_non_existing_portchannel_member PASSED [ 64%]
tests/portchannel_test.py::TestPortChannel::test_add_portchannel_member_which_has_ipaddress PASSED [ 64%]
tests/portchannel_test.py::TestPortChannel::test_add_portchannel_member_which_is_member_of_vlan PASSED [ 64%]
tests/portchannel_test.py::TestPortChannel::test_add_portchannel_member_which_is_member_of_another_po PASSED [ 64%]
tests/portchannel_test.py::TestPortChannel::test_delete_portchannel_member_which_is_member_of_another_po PASSED [ 64%]
tests/portstat_test.py::TestPortStat::test_show_intf_counters PASSED     [ 65%]
tests/portstat_test.py::TestPortStat::test_show_intf_counters_ethernet4 PASSED [ 65%]
tests/portstat_test.py::TestPortStat::test_show_intf_counters_all PASSED [ 65%]
tests/portstat_test.py::TestPortStat::test_show_intf_counters_period PASSED [ 65%]
tests/portstat_test.py::TestPortStat::test_show_intf_counters_detailed PASSED [ 65%]
tests/portstat_test.py::TestPortStat::test_clear_intf_counters PASSED    [ 65%]
tests/portstat_test.py::TestMultiAsicPortStat::test_multi_show_intf_counters PASSED [ 65%]
tests/portstat_test.py::TestMultiAsicPortStat::test_multi_show_intf_counters_all PASSED [ 65%]
tests/portstat_test.py::TestMultiAsicPortStat::test_multi_show_intf_counters_asic PASSED [ 65%]
tests/portstat_test.py::TestMultiAsicPortStat::test_multi_show_intf_counters_asic_all PASSED [ 65%]
tests/portstat_test.py::TestMultiAsicPortStat::test_multi_show_external_intf_counters_printall PASSED [ 65%]
tests/portstat_test.py::TestMultiAsicPortStat::test_multi_show_intf_counters_printall PASSED [ 66%]
tests/portstat_test.py::TestMultiAsicPortStat::test_multi_show_intf_counters_printall_asic PASSED [ 66%]
tests/portstat_test.py::TestMultiAsicPortStat::test_multi_show_intf_counters_printall_asic_all PASSED [ 66%]
tests/portstat_test.py::TestMultiAsicPortStat::test_multi_show_intf_counters_period PASSED [ 66%]
tests/portstat_test.py::TestMultiAsicPortStat::test_multi_show_intf_counters_period_all PASSED [ 66%]
tests/portstat_test.py::TestMultiAsicPortStat::test_multi_show_intf_counters_period_asic PASSED [ 66%]
tests/portstat_test.py::TestMultiAsicPortStat::test_multi_show_intf_counters_period_asic_all PASSED [ 66%]
tests/portstat_test.py::TestMultiAsicPortStat::test_multi_asic_clear_intf_counters PASSED [ 66%]
tests/portstat_test.py::TestMultiAsicPortStat::test_multi_asic_invalid_asic PASSED [ 66%]
tests/psushow_test.py::TestPsushow::test_get_psu_status_list PASSED      [ 66%]
tests/psushow_test.py::TestPsushow::test_status_table PASSED             [ 67%]
tests/psushow_test.py::TestPsushow::test_status_json PASSED              [ 67%]
tests/psushow_test.py::TestPsushow::test_version PASSED                  [ 67%]
tests/psuutil_test.py::TestPsuutil::test_version PASSED                  [ 67%]
tests/queue_counter_test.py::TestQueue::test_queue_counters PASSED       [ 67%]
tests/queue_counter_test.py::TestQueue::test_queue_counters_port PASSED  [ 67%]
tests/queue_counter_test.py::TestQueue::test_queue_counters_json PASSED  [ 67%]
tests/queue_counter_test.py::TestQueue::test_queue_counters_port_json PASSED [ 67%]
tests/radius_test.py::TestRadius::test_show_radius_default PASSED        [ 67%]
tests/radius_test.py::TestRadius::test_config_radius_server PASSED       [ 67%]
tests/radius_test.py::TestRadius::test_config_radius_server_invalidkey PASSED [ 67%]
tests/radius_test.py::TestRadius::test_config_radius_nasip_invalid PASSED [ 68%]
tests/radius_test.py::TestRadius::test_config_radius_sourceip_invalid PASSED [ 68%]
tests/radius_test.py::TestRadius::test_config_radius_authtype PASSED     [ 68%]
tests/reboot_cause_test.py::TestShowRebootCause::test_reboot_cause_no_history_file PASSED [ 68%]
tests/reboot_cause_test.py::TestShowRebootCause::test_reboot_cause_user PASSED [ 68%]
tests/reboot_cause_test.py::TestShowRebootCause::test_reboot_cause_non_user PASSED [ 68%]
tests/reboot_cause_test.py::TestShowRebootCause::test_reboot_cause_history PASSED [ 68%]
tests/route_check_test.py::TestRouteCheck::test_server PASSED            [ 68%]
tests/sflow_test.py::TestShowSflow::test_show_sflow PASSED               [ 68%]
tests/sflow_test.py::TestShowSflow::test_show_sflow_intf PASSED          [ 68%]
tests/sflow_test.py::TestShowSflow::test_config_sflow_disable_enable PASSED [ 69%]
tests/sflow_test.py::TestShowSflow::test_config_sflow_agent_id PASSED    [ 69%]
tests/sflow_test.py::TestShowSflow::test_config_sflow_collector PASSED   [ 69%]
tests/sflow_test.py::TestShowSflow::test_config_sflow_polling_interval PASSED [ 69%]
tests/sflow_test.py::TestShowSflow::test_config_sflow_intf_enable_disable PASSED [ 69%]
tests/sflow_test.py::TestShowSflow::test_config_sflow_intf_sample_rate PASSED [ 69%]
tests/sflow_test.py::TestShowSflow::test_config_disable_all_intf PASSED  [ 69%]
tests/sflow_test.py::TestShowSflow::test_config_enable_all_intf PASSED   [ 69%]
tests/sflow_test.py::TestShowSflow::test_config_sflow_intf_sample_rate_default PASSED [ 69%]
tests/sfp_test.py::TestSFP::test_sfp_presence PASSED                     [ 69%]
tests/sfp_test.py::TestSFP::test_sfp_eeprom_with_dom PASSED              [ 69%]
tests/sfp_test.py::TestSFP::test_qsfp_dd_eeprom_with_dom PASSED          [ 70%]
tests/sfp_test.py::TestSFP::test_sfp_eeprom PASSED                       [ 70%]
tests/sfp_test.py::TestSFP::test_qsfp_dd_eeprom PASSED                   [ 70%]
tests/sfp_test.py::Test_multiAsic_SFP::test_sfp_presence_with_ns PASSED  [ 70%]
tests/sfp_test.py::Test_multiAsic_SFP::test_sfp_presence_all PASSED      [ 70%]
tests/sfp_test.py::Test_multiAsic_SFP::test_sfp_eeprom_with_dom_with_ns PASSED [ 70%]
tests/sfp_test.py::Test_multiAsic_SFP::test_sfp_eeprom_with_ns PASSED    [ 70%]
tests/sfp_test.py::Test_multiAsic_SFP::test_sfp_eeprom_all PASSED        [ 70%]
tests/sfp_test.py::Test_multiAsic_SFP::test_sfp_eeprom_dom_all PASSED    [ 70%]
tests/sfputil_test.py::TestSfputil::test_format_dict_value_to_string PASSED [ 70%]
tests/sfputil_test.py::TestSfputil::test_convert_sfp_info_to_output_string PASSED [ 71%]
tests/sfputil_test.py::TestSfputil::test_convert_dom_to_output_string PASSED [ 71%]
tests/sfputil_test.py::TestSfputil::test_get_physical_port_name PASSED   [ 71%]
tests/sfputil_test.py::TestSfputil::test_version PASSED                  [ 71%]
tests/sfputil_test.py::TestSfputil::test_error_status_from_db PASSED     [ 71%]
tests/show_bgp_neighbor_test.py::TestBgpNeighbors::test_bgp_neighbors[bgp_v4_neighbors_output-bgp_v4_neighbors] PASSED [ 71%]
tests/show_bgp_neighbor_test.py::TestBgpNeighbors::test_bgp_neighbors[bgp_v4_neighbors_output-bgp_v4_neighbor_ip_address] PASSED [ 71%]
tests/show_bgp_neighbor_test.py::TestBgpNeighbors::test_bgp_neighbors[bgp_v4_neighbor_invalid_neigh-bgp_v4_neighbor_invalid] PASSED [ 71%]
tests/show_bgp_neighbor_test.py::TestBgpNeighbors::test_bgp_neighbors[bgp_v4_neighbor_invalid_address-bgp_v4_neighbor_invalid_address] PASSED [ 71%]
tests/show_bgp_neighbor_test.py::TestBgpNeighbors::test_bgp_neighbors[bgp_v4_neighbor_output_adv_routes-bgp_v4_neighbor_adv_routes] PASSED [ 71%]
tests/show_bgp_neighbor_test.py::TestBgpNeighbors::test_bgp_neighbors[bgp_v4_neighbor_output_recv_routes-bgp_v4_neighbor_recv_routes] PASSED [ 71%]
tests/show_bgp_neighbor_test.py::TestBgpNeighbors::test_bgp_neighbors[bgp_v6_neighbors_output-bgp_v6_neighbors] PASSED [ 72%]
tests/show_bgp_neighbor_test.py::TestBgpNeighbors::test_bgp_neighbors[bgp_v6_neighbors_output-bgp_v6_neighbor_ip_address] PASSED [ 72%]
tests/show_bgp_neighbor_test.py::TestBgpNeighbors::test_bgp_neighbors[bgp_v6_neighbor_invalid-bgp_v6_neighbor_invalid] PASSED [ 72%]
tests/show_bgp_neighbor_test.py::TestBgpNeighbors::test_bgp_neighbors[bgp_v6_neighbor_invalid_address-bgp_v6_neighbor_invalid_address] PASSED [ 72%]
tests/show_bgp_neighbor_test.py::TestBgpNeighbors::test_bgp_neighbors[bgp_v6_neighbor_output_adv_routes-bgp_v6_neighbor_adv_routes] PASSED [ 72%]
tests/show_bgp_neighbor_test.py::TestBgpNeighbors::test_bgp_neighbors[bgp_v6_neighbor_output_recv_routes-bgp_v6_neighbor_recv_routes] PASSED [ 72%]
tests/show_bgp_neighbor_test.py::TestBgpNeighborsMultiAsic::test_bgp_neighbors[bgp_v4_neighbors_output_all_asics-bgp_v4_neighbors_multi_asic] PASSED [ 72%]
tests/show_bgp_neighbor_test.py::TestBgpNeighborsMultiAsic::test_bgp_neighbors[bgp_v4_neighbors_output_asic1-bgp_v4_neighbors_asic] PASSED [ 72%]
tests/show_bgp_neighbor_test.py::TestBgpNeighborsMultiAsic::test_bgp_neighbors[bgp_v4_neighbors_output_asic1-bgp_v4_neighbors_internal] PASSED [ 72%]
tests/show_bgp_neighbor_test.py::TestBgpNeighborsMultiAsic::test_bgp_neighbors[bgp_v4_neighbors_output_asic0-bgp_v4_neighbors_external] PASSED [ 72%]
tests/show_bgp_neighbor_test.py::TestBgpNeighborsMultiAsic::test_bgp_neighbors[bgp_v6_neighbor_output_warning-bgp_v6_neighbor_warning] PASSED [ 73%]
tests/show_bgp_neighbor_test.py::TestBgpNeighborsMultiAsic::test_bgp_neighbors[bgp_v6_neighbors_output_all_asics-bgp_v6_neighbors_multi_asic] PASSED [ 73%]
tests/show_bgp_neighbor_test.py::TestBgpNeighborsMultiAsic::test_bgp_neighbors[bgp_v6_neighbors_output_asic0-bgp_v6_neighbors_asic] PASSED [ 73%]
tests/show_bgp_neighbor_test.py::TestBgpNeighborsMultiAsic::test_bgp_neighbors[bgp_v6_neighbors_output_asic0-bgp_v6_neighbors_external] PASSED [ 73%]
tests/show_bgp_neighbor_test.py::TestBgpNeighborsMultiAsic::test_bgp_neighbors[bgp_v6_neighbors_output_asic1-bgp_v6_neighbors_internal] PASSED [ 73%]
tests/show_bgp_network_test.py::TestBgpNetwork::test_bgp_network[bgp_v4_network-bgp_v4_network] PASSED [ 73%]
tests/show_bgp_network_test.py::TestBgpNetwork::test_bgp_network[bgp_v6_network-bgp_v6_network] PASSED [ 73%]
tests/show_bgp_network_test.py::TestBgpNetwork::test_bgp_network[bgp_v4_network_ip_address-bgp_v4_network_ip_address] PASSED [ 73%]
tests/show_bgp_network_test.py::TestBgpNetwork::test_bgp_network[bgp_v6_network_ip_address-bgp_v6_network_ip_address] PASSED [ 73%]
tests/show_bgp_network_test.py::TestBgpNetwork::test_bgp_network[bgp_v6_network_bestpath-bgp_v6_network_bestpath] PASSED [ 73%]
tests/show_bgp_network_test.py::TestBgpNetwork::test_bgp_network[bgp_v4_network_bestpath-bgp_v4_network_bestpath] PASSED [ 73%]
tests/show_bgp_network_test.py::TestBgpNetwork::test_bgp_network[bgp_v6_network_longer_prefixes-bgp_v6_network_longer_prefixes] PASSED [ 74%]
tests/show_bgp_network_test.py::TestBgpNetwork::test_bgp_network[bgp_v4_network-bgp_v4_network_longer_prefixes_error] PASSED [ 74%]
tests/show_bgp_network_test.py::TestBgpNetwork::test_bgp_network[bgp_v4_network-bgp_v6_network_longer_prefixes_error] PASSED [ 74%]
tests/show_bgp_network_test.py::TestMultiAsicBgpNetwork::test_bgp_network[bgp_v4_network-bgp_v4_network_multi_asic] PASSED [ 74%]
tests/show_bgp_network_test.py::TestMultiAsicBgpNetwork::test_bgp_network[bgp_v6_network-bgp_v6_network_multi_asic] PASSED [ 74%]
tests/show_bgp_network_test.py::TestMultiAsicBgpNetwork::test_bgp_network[bgp_v4_network_asic0-bgp_v4_network_asic0] PASSED [ 74%]
tests/show_bgp_network_test.py::TestMultiAsicBgpNetwork::test_bgp_network[bgp_v4_network_ip_address_asic0-bgp_v4_network_ip_address_asic0] PASSED [ 74%]
tests/show_bgp_network_test.py::TestMultiAsicBgpNetwork::test_bgp_network[bgp_v4_network_bestpath_asic0-bgp_v4_network_bestpath_asic0] PASSED [ 74%]
tests/show_bgp_network_test.py::TestMultiAsicBgpNetwork::test_bgp_network[bgp_v6_network_asic0-bgp_v6_network_asic0] PASSED [ 74%]
tests/show_bgp_network_test.py::TestMultiAsicBgpNetwork::test_bgp_network[bgp_v6_network_ip_address_asic0-bgp_v6_network_ip_address_asic0] PASSED [ 74%]
tests/show_bgp_network_test.py::TestMultiAsicBgpNetwork::test_bgp_network[bgp_v6_network_bestpath_asic0-bgp_v6_network_bestpath_asic0] PASSED [ 75%]
tests/show_breakout_test.py::TestBreakout::test_all_intf_current_mode PASSED [ 75%]
tests/show_breakout_test.py::TestBreakout::test_single_intf_current_mode PASSED [ 75%]
tests/show_ip_int_test.py::TestShowIpInt::test_show_ip_intf_v4 PASSED    [ 75%]
tests/show_ip_int_test.py::TestShowIpInt::test_show_ip_intf_v6 PASSED    [ 75%]
tests/show_ip_int_test.py::TestShowIpInt::test_show_intf_invalid_af_option PASSED [ 75%]
tests/show_ip_int_test.py::TestMultiAsicShowIpInt::test_show_ip_intf_v4 PASSED [ 75%]
tests/show_ip_int_test.py::TestMultiAsicShowIpInt::test_show_ip_intf_v4_asic0 PASSED [ 75%]
tests/show_ip_int_test.py::TestMultiAsicShowIpInt::test_show_ip_intf_v4_all PASSED [ 75%]
tests/show_ip_int_test.py::TestMultiAsicShowIpInt::test_show_ip_intf_v6 PASSED [ 75%]
tests/show_ip_int_test.py::TestMultiAsicShowIpInt::test_show_ip_intf_v6_asic0 PASSED [ 75%]
tests/show_ip_int_test.py::TestMultiAsicShowIpInt::test_show_ip_intf_v6_all PASSED [ 76%]
tests/show_ip_int_test.py::TestMultiAsicShowIpInt::test_show_intf_invalid_af_option PASSED [ 76%]
tests/show_platform_test.py::TestShowPlatform::test_summary PASSED       [ 76%]
tests/show_platform_test.py::TestShowPlatformPsu::test_all_psus PASSED   [ 76%]
tests/show_platform_test.py::TestShowPlatformPsu::test_all_psus_json PASSED [ 76%]
tests/show_platform_test.py::TestShowPlatformPsu::test_single_psu PASSED [ 76%]
tests/show_platform_test.py::TestShowPlatformPsu::test_single_psu_json PASSED [ 76%]
tests/show_platform_test.py::TestShowPlatformPsu::test_verbose PASSED    [ 76%]
tests/show_snmp_test.py::TestSNMPShowCommands::test_show_run_snmp_location_tabular PASSED [ 76%]
tests/show_snmp_test.py::TestSNMPShowCommands::test_show_run_snmp_location_json PASSED [ 76%]
tests/show_snmp_test.py::TestSNMPShowCommands::test_show_run_snmp_location_json_bad_key PASSED [ 76%]
tests/show_snmp_test.py::TestSNMPShowCommands::test_show_run_snmp_location_bad_key PASSED [ 77%]
tests/show_snmp_test.py::TestSNMPShowCommands::test_show_run_snmp_contact_tabular PASSED [ 77%]
tests/show_snmp_test.py::TestSNMPShowCommands::test_show_run_snmp_contact_json PASSED [ 77%]
tests/show_snmp_test.py::TestSNMPShowCommands::test_show_run_snmp_contact_json_bad_key PASSED [ 77%]
tests/show_snmp_test.py::TestSNMPShowCommands::test_show_run_snmp_contact_tabular_bad_key PASSED [ 77%]
tests/show_snmp_test.py::TestSNMPShowCommands::test_show_run_snmp_community_tabular PASSED [ 77%]
tests/show_snmp_test.py::TestSNMPShowCommands::test_show_run_snmp_community_json PASSED [ 77%]
tests/show_snmp_test.py::TestSNMPShowCommands::test_show_run_snmp_user_tabular PASSED [ 77%]
tests/show_snmp_test.py::TestSNMPShowCommands::test_show_run_snmp_user_json PASSED [ 77%]
tests/show_snmp_test.py::TestSNMPShowCommands::test_show_run_snmp_user_json_bad_key PASSED [ 77%]
tests/show_snmp_test.py::TestSNMPShowCommands::test_show_run_snmp_tabular PASSED [ 78%]
tests/sku_create_test.py::TestSkuCreate::test_sku_from_xml_file PASSED   [ 78%]
tests/sku_create_test.py::TestSkuCreate::test_sku_from_minigraph_file PASSED [ 78%]
tests/sku_create_test.py::TestSkuCreate::test_sku_from_config_db_file PASSED [ 78%]
tests/sku_create_test.py::TestSkuCreate::test_sku_port_split PASSED      [ 78%]
tests/sku_create_test.py::TestSkuCreate::test_sku_port_unsplit PASSED    [ 78%]
tests/static_routes_test.py::TestStaticRoutes::test_simple_static_route PASSED [ 78%]
tests/static_routes_test.py::TestStaticRoutes::test_static_route_invalid_prefix_ip PASSED [ 78%]
tests/static_routes_test.py::TestStaticRoutes::test_static_route_invalid_nexthop_ip PASSED [ 78%]
tests/static_routes_test.py::TestStaticRoutes::test_vrf_static_route PASSED [ 78%]
tests/static_routes_test.py::TestStaticRoutes::test_dest_vrf_static_route PASSED [ 78%]
tests/static_routes_test.py::TestStaticRoutes::test_multiple_nexthops_with_vrf_static_route PASSED [ 79%]
tests/static_routes_test.py::TestStaticRoutes::test_multiple_nexthops_static_route PASSED [ 79%]
tests/static_routes_test.py::TestStaticRoutes::test_static_route_miss_prefix PASSED [ 79%]
tests/static_routes_test.py::TestStaticRoutes::test_static_route_miss_nexthop PASSED [ 79%]
tests/static_routes_test.py::TestStaticRoutes::test_static_route_ECMP_nexthop PASSED [ 79%]
tests/static_routes_test.py::TestStaticRoutes::test_static_route_ECMP_nexthop_with_vrf PASSED [ 79%]
tests/static_routes_test.py::TestStaticRoutes::test_static_route_ECMP_mixed_nextfop PASSED [ 79%]
tests/static_routes_test.py::TestStaticRoutes::test_del_nonexist_key_static_route PASSED [ 79%]
tests/static_routes_test.py::TestStaticRoutes::test_del_nonexist_entry_static_route PASSED [ 79%]
tests/static_routes_test.py::TestStaticRoutes::test_del_entire_ECMP_static_route PASSED [ 79%]
tests/synchronous_mode_test.py::TestSynchronousMode::test_synchronous_mode PASSED [ 80%]
tests/system_health_test.py::TestHealth::test_health_summary PASSED      [ 80%]
tests/system_health_test.py::TestHealth::test_health_monitor PASSED      [ 80%]
tests/system_health_test.py::TestHealth::test_health_detail PASSED       [ 80%]
tests/tpid_test.py::TestTpid::test_tpid_config_bad_tpid PASSED           [ 80%]
tests/tpid_test.py::TestTpid::test_tpid_config_lag_mbr PASSED            [ 80%]
tests/tpid_test.py::TestTpid::test_tpid_add_lag_mbr_with_non_default_tpid PASSED [ 80%]
tests/tpid_test.py::TestTpid::test_tpid_config_port_interface PASSED     [ 80%]
tests/tpid_test.py::TestTpid::test_tpid_config_portchannel_interface PASSED [ 80%]
tests/tpid_test.py::TestTpid::test_show_tpid PASSED                      [ 80%]
tests/tpid_test.py::TestTpid::test_show_tpid_ethernet0 PASSED            [ 80%]
tests/vlan_test.py::TestVlan::test_show_vlan PASSED                      [ 81%]
tests/vlan_test.py::TestVlan::test_show_vlan_brief PASSED                [ 81%]
tests/vlan_test.py::TestVlan::test_show_vlan_brief_verbose PASSED        [ 81%]
tests/vlan_test.py::TestVlan::test_show_vlan_brief_in_alias_mode PASSED  [ 81%]
tests/vlan_test.py::TestVlan::test_show_vlan_brief_explicit_proxy_arp_disable PASSED [ 81%]
tests/vlan_test.py::TestVlan::test_show_vlan_config PASSED               [ 81%]
tests/vlan_test.py::TestVlan::test_show_vlan_config_in_alias_mode PASSED [ 81%]
tests/vlan_test.py::TestVlan::test_config_vlan_add_vlan_with_invalid_vlanid PASSED [ 81%]
tests/vlan_test.py::TestVlan::test_config_vlan_add_vlan_with_exist_vlanid PASSED [ 81%]
tests/vlan_test.py::TestVlan::test_config_vlan_del_vlan_with_invalid_vlanid PASSED [ 81%]
tests/vlan_test.py::TestVlan::test_config_vlan_del_vlan_with_nonexist_vlanid PASSED [ 82%]
tests/vlan_test.py::TestVlan::test_config_vlan_add_member_with_invalid_vlanid PASSED [ 82%]
tests/vlan_test.py::TestVlan::test_config_vlan_add_member_with_nonexist_vlanid PASSED [ 82%]
tests/vlan_test.py::TestVlan::test_config_vlan_add_exist_port_member PASSED [ 82%]
tests/vlan_test.py::TestVlan::test_config_vlan_add_nonexist_port_member PASSED [ 82%]
tests/vlan_test.py::TestVlan::test_config_vlan_add_nonexist_portchannel_member PASSED [ 82%]
tests/vlan_test.py::TestVlan::test_config_vlan_add_portchannel_member PASSED [ 82%]
tests/vlan_test.py::TestVlan::test_config_vlan_add_rif_portchannel_member PASSED [ 82%]
tests/vlan_test.py::TestVlan::test_config_vlan_del_vlan PASSED           [ 82%]
tests/vlan_test.py::TestVlan::test_config_vlan_del_nonexist_vlan_member PASSED [ 82%]
tests/vlan_test.py::TestVlan::test_config_add_del_vlan_and_vlan_member PASSED [ 82%]
tests/vlan_test.py::TestVlan::test_config_add_del_vlan_and_vlan_member_in_alias_mode PASSED [ 83%]
tests/vlan_test.py::TestVlan::test_config_vlan_proxy_arp_with_nonexist_vlan_intf_table PASSED [ 83%]
tests/vlan_test.py::TestVlan::test_config_vlan_proxy_arp_with_nonexist_vlan_intf PASSED [ 83%]
tests/vlan_test.py::TestVlan::test_config_vlan_proxy_arp_enable PASSED   [ 83%]
tests/vlan_test.py::TestVlan::test_config_vlan_proxy_arp_disable PASSED  [ 83%]
tests/vlan_test.py::TestVlan::test_config_2_untagged_vlan_on_same_interface PASSED [ 83%]
tests/vlan_test.py::TestVlan::test_config_set_router_port_on_member_interface PASSED [ 83%]
tests/vlan_test.py::TestVlan::test_config_vlan_add_member_of_portchannel PASSED [ 83%]
tests/vnet_route_check_test.py::TestVnetRouteCheck::test_vnet_route_check PASSED [ 83%]
tests/vxlan_test.py::TestVxlan::test_show_vxlan_interface PASSED         [ 83%]
tests/vxlan_test.py::TestVxlan::test_show_vxlan_vlanvnimap PASSED        [ 84%]
tests/vxlan_test.py::TestVxlan::test_show_vxlan_vrfvnimap PASSED         [ 84%]
tests/vxlan_test.py::TestVxlan::test_show_vxlan_tunnel PASSED            [ 84%]
tests/vxlan_test.py::TestVxlan::test_show_vxlan_remotevni PASSED         [ 84%]
tests/vxlan_test.py::TestVxlan::test_show_vxlan_remotevni_specific PASSED [ 84%]
tests/vxlan_test.py::TestVxlan::test_show_vxlan_vlanvnimap_cnt PASSED    [ 84%]
tests/vxlan_test.py::TestVxlan::test_show_vxlan_tunnel_cnt PASSED        [ 84%]
tests/vxlan_test.py::TestVxlan::test_show_vxlan_remotevni_cnt PASSED     [ 84%]
tests/vxlan_test.py::TestVxlan::test_show_vxlan_remotevni_specific_cnt PASSED [ 84%]
tests/vxlan_test.py::TestVxlan::test_config_vxlan_add PASSED             [ 84%]
tests/watermarkstat_test.py::TestWatermarkstat::test_show_pg_shared_wm PASSED [ 84%]
tests/watermarkstat_test.py::TestWatermarkstat::test_show_pg_headroom_wm PASSED [ 85%]
tests/watermarkstat_test.py::TestWatermarkstat::test_show_queue_unicast_wm PASSED [ 85%]
tests/watermarkstat_test.py::TestWatermarkstat::test_show_queue_multicast_wm PASSED [ 85%]
tests/watermarkstat_test.py::TestWatermarkstat::test_show_queue_all_wm PASSED [ 85%]
tests/watermarkstat_test.py::TestWatermarkstat::test_show_buffer_pool_wm PASSED [ 85%]
tests/watermarkstat_test.py::TestWatermarkstat::test_show_headroom_pool_wm PASSED [ 85%]
tests/watermarkstat_test.py::TestWatermarkstat::test_show_pg_shared_peristent_wm PASSED [ 85%]
tests/watermarkstat_test.py::TestWatermarkstat::test_show_pg_headroom_persistent_wm PASSED [ 85%]
tests/watermarkstat_test.py::TestWatermarkstat::test_show_queue_unicast_persistent_wm PASSED [ 85%]
tests/watermarkstat_test.py::TestWatermarkstat::test_show_queue_multicast_persistent_wm PASSED [ 85%]
tests/watermarkstat_test.py::TestWatermarkstat::test_show_queue_all_persistent_wm PASSED [ 86%]
tests/watermarkstat_test.py::TestWatermarkstat::test_show_buffer_pool_persistent_wm PASSED [ 86%]
tests/watermarkstat_test.py::TestWatermarkstat::test_show_headroom_pool_persistent_wm PASSED [ 86%]
tests/generic_config_updater/generic_updater_test.py::TestPatchApplier::test_apply__invalid_config_db__failure PASSED [ 86%]
tests/generic_config_updater/generic_updater_test.py::TestPatchApplier::test_apply__invalid_patch_updating_tables_without_yang_models__failure PASSED [ 86%]
tests/generic_config_updater/generic_updater_test.py::TestPatchApplier::test_apply__json_not_fully_updated__failure PASSED [ 86%]
tests/generic_config_updater/generic_updater_test.py::TestPatchApplier::test_apply__no_errors__update_successful PASSED [ 86%]
tests/generic_config_updater/generic_updater_test.py::TestConfigReplacer::test_replace__invalid_config_db__failure PASSED [ 86%]
tests/generic_config_updater/generic_updater_test.py::TestConfigReplacer::test_replace__json_not_fully_updated__failure PASSED [ 86%]
tests/generic_config_updater/generic_updater_test.py::TestConfigReplacer::test_replace__no_errors__update_successful PASSED [ 86%]
tests/generic_config_updater/generic_updater_test.py::TestFileSystemConfigRollbacker::test_checkpoint__checkpoints_dir_does_not_exist__checkpoint_created PASSED [ 86%]
tests/generic_config_updater/generic_updater_test.py::TestFileSystemConfigRollbacker::test_checkpoint__checkpoints_dir_exists__checkpoint_created PASSED [ 87%]
tests/generic_config_updater/generic_updater_test.py::TestFileSystemConfigRollbacker::test_checkpoint__config_not_valid__failure PASSED [ 87%]
tests/generic_config_updater/generic_updater_test.py::TestFileSystemConfigRollbacker::test_delete_checkpoint__checkpoint_does_not_exist__failure PASSED [ 87%]
tests/generic_config_updater/generic_updater_test.py::TestFileSystemConfigRollbacker::test_delete_checkpoint__checkpoint_exist__success PASSED [ 87%]
tests/generic_config_updater/generic_updater_test.py::TestFileSystemConfigRollbacker::test_list_checkpoints__checkpoints_dir_does_not_exist__empty_list PASSED [ 87%]
tests/generic_config_updater/generic_updater_test.py::TestFileSystemConfigRollbacker::test_list_checkpoints__checkpoints_dir_exist_but_no_files__empty_list PASSED [ 87%]
tests/generic_config_updater/generic_updater_test.py::TestFileSystemConfigRollbacker::test_list_checkpoints__checkpoints_dir_has_multiple_files__multiple_files PASSED [ 87%]
tests/generic_config_updater/generic_updater_test.py::TestFileSystemConfigRollbacker::test_list_checkpoints__checkpoints_names_have_special_characters__multiple_files PASSED [ 87%]
tests/generic_config_updater/generic_updater_test.py::TestFileSystemConfigRollbacker::test_multiple_operations PASSED [ 87%]
tests/generic_config_updater/generic_updater_test.py::TestFileSystemConfigRollbacker::test_rollback__checkpoint_does_not_exist__failure PASSED [ 87%]
tests/generic_config_updater/generic_updater_test.py::TestFileSystemConfigRollbacker::test_rollback__no_errors__success PASSED [ 88%]
tests/generic_config_updater/generic_updater_test.py::TestGenericUpdateFactory::test_create_config_replacer__different_options PASSED [ 88%]
tests/generic_config_updater/generic_updater_test.py::TestGenericUpdateFactory::test_create_config_replacer__invalid_config_format__failure PASSED [ 88%]
tests/generic_config_updater/generic_updater_test.py::TestGenericUpdateFactory::test_create_config_rollbacker__different_options PASSED [ 88%]
tests/generic_config_updater/generic_updater_test.py::TestGenericUpdateFactory::test_create_patch_applier__different_options PASSED [ 88%]
tests/generic_config_updater/generic_updater_test.py::TestGenericUpdateFactory::test_create_patch_applier__invalid_config_format__failure PASSED [ 88%]
tests/generic_config_updater/generic_updater_test.py::TestGenericUpdater::test_apply_patch__creates_applier_and_apply PASSED [ 88%]
tests/generic_config_updater/generic_updater_test.py::TestGenericUpdater::test_checkpoint__creates_rollbacker_and_checkpoint PASSED [ 88%]
tests/generic_config_updater/generic_updater_test.py::TestGenericUpdater::test_delete_checkpoint__creates_rollbacker_and_deletes_checkpoint PASSED [ 88%]
tests/generic_config_updater/generic_updater_test.py::TestGenericUpdater::test_list_checkpoints__creates_rollbacker_and_list_checkpoints PASSED [ 88%]
tests/generic_config_updater/generic_updater_test.py::TestGenericUpdater::test_replace__creates_replacer_and_replace PASSED [ 88%]
tests/generic_config_updater/generic_updater_test.py::TestGenericUpdater::test_rollback__creates_rollbacker_and_rollback PASSED [ 89%]
tests/generic_config_updater/generic_updater_test.py::TestDecorator::test_apply__calls_decorated_applier PASSED [ 89%]
tests/generic_config_updater/generic_updater_test.py::TestDecorator::test_checkpoint__calls_decorated_rollbacker PASSED [ 89%]
tests/generic_config_updater/generic_updater_test.py::TestDecorator::test_delete_checkpoint__calls_decorated_rollbacker PASSED [ 89%]
tests/generic_config_updater/generic_updater_test.py::TestDecorator::test_list_checkpoints__calls_decorated_rollbacker PASSED [ 89%]
tests/generic_config_updater/generic_updater_test.py::TestDecorator::test_replace__calls_decorated_replacer PASSED [ 89%]
tests/generic_config_updater/generic_updater_test.py::TestDecorator::test_rollback__calls_decorated_rollbacker PASSED [ 89%]
tests/generic_config_updater/generic_updater_test.py::TestSonicYangDecorator::test_apply__converts_to_config_db_and_calls_decorated_class PASSED [ 89%]
tests/generic_config_updater/generic_updater_test.py::TestSonicYangDecorator::test_replace__converts_to_config_db_and_calls_decorated_class PASSED [ 89%]
tests/generic_config_updater/generic_updater_test.py::TestConfigLockDecorator::test_apply__lock_config PASSED [ 89%]
tests/generic_config_updater/generic_updater_test.py::TestConfigLockDecorator::test_checkpoint__lock_config PASSED [ 90%]
tests/generic_config_updater/generic_updater_test.py::TestConfigLockDecorator::test_replace__lock_config PASSED [ 90%]
tests/generic_config_updater/generic_updater_test.py::TestConfigLockDecorator::test_rollback__lock_config PASSED [ 90%]
tests/generic_config_updater/gu_common_test.py::TestConfigWrapper::test_convert_config_db_to_sonic_yang__empty_config_db__returns_empty_sonic_yang PASSED [ 90%]
tests/generic_config_updater/gu_common_test.py::TestConfigWrapper::test_convert_config_db_to_sonic_yang__non_empty_config_db__returns_sonic_yang_as_json PASSED [ 90%]
tests/generic_config_updater/gu_common_test.py::TestConfigWrapper::test_convert_sonic_yang_to_config_db__empty_sonic_yang__returns_empty_config_db PASSED [ 90%]
tests/generic_config_updater/gu_common_test.py::TestConfigWrapper::test_convert_sonic_yang_to_config_db__non_empty_sonic_yang__returns_config_db_as_json PASSED [ 90%]
tests/generic_config_updater/gu_common_test.py::TestConfigWrapper::test_convert_sonic_yang_to_config_db__table_name_with_unexpected_colons__returns_config_db_as_json PASSED [ 90%]
tests/generic_config_updater/gu_common_test.py::TestConfigWrapper::test_convert_sonic_yang_to_config_db__table_name_without_colons__returns_config_db_as_json PASSED [ 90%]
tests/generic_config_updater/gu_common_test.py::TestConfigWrapper::test_crop_tables_without_yang__returns_cropped_config_db_as_json PASSED [ 90%]
tests/generic_config_updater/gu_common_test.py::TestConfigWrapper::test_ctor__default_values_set PASSED [ 90%]
tests/generic_config_updater/gu_common_test.py::TestConfigWrapper::test_get_sonic_yang_as_json__returns_sonic_yang_as_json PASSED [ 91%]
tests/generic_config_updater/gu_common_test.py::TestConfigWrapper::test_validate_config_db_config__invalid_config__returns_false PASSED [ 91%]
tests/generic_config_updater/gu_common_test.py::TestConfigWrapper::test_validate_config_db_config__valid_config__returns_true PASSED [ 91%]
tests/generic_config_updater/gu_common_test.py::TestConfigWrapper::test_validate_sonic_yang_config__invvalid_config__returns_false PASSED [ 91%]
tests/generic_config_updater/gu_common_test.py::TestConfigWrapper::test_validate_sonic_yang_config__valid_config__returns_true PASSED [ 91%]
tests/generic_config_updater/gu_common_test.py::TestPatchWrapper::test_convert_config_db_patch_to_sonic_yang_patch__empty_patch__returns_empty_patch PASSED [ 91%]
tests/generic_config_updater/gu_common_test.py::TestPatchWrapper::test_convert_config_db_patch_to_sonic_yang_patch__invalid_config_db_patch__failure PASSED [ 91%]
tests/generic_config_updater/gu_common_test.py::TestPatchWrapper::test_convert_config_db_patch_to_sonic_yang_patch__multiple_operations_patch__returns_sonic_yang_patch PASSED [ 91%]
tests/generic_config_updater/gu_common_test.py::TestPatchWrapper::test_convert_config_db_patch_to_sonic_yang_patch__single_operation_patch__returns_sonic_yang_patch PASSED [ 91%]
tests/generic_config_updater/gu_common_test.py::TestPatchWrapper::test_convert_sonic_yang_patch_to_config_db_patch__empty_patch__returns_empty_patch PASSED [ 91%]
tests/generic_config_updater/gu_common_test.py::TestPatchWrapper::test_convert_sonic_yang_patch_to_config_db_patch__multiple_operations_patch__returns_config_db_patch PASSED [ 92%]
tests/generic_config_updater/gu_common_test.py::TestPatchWrapper::test_convert_sonic_yang_patch_to_config_db_patch__single_operation_patch__returns_config_db_patch PASSED [ 92%]
tests/generic_config_updater/gu_common_test.py::TestPatchWrapper::test_generate_patch__diff__non_empty_patch PASSED [ 92%]
tests/generic_config_updater/gu_common_test.py::TestPatchWrapper::test_generate_patch__no_diff__empty_patch PASSED [ 92%]
tests/generic_config_updater/gu_common_test.py::TestPatchWrapper::test_same_patch__diff__returns_false PASSED [ 92%]
tests/generic_config_updater/gu_common_test.py::TestPatchWrapper::test_same_patch__no_diff__returns_true PASSED [ 92%]
tests/generic_config_updater/gu_common_test.py::TestPatchWrapper::test_simulate_patch__empty_patch__no_changes PASSED [ 92%]
tests/generic_config_updater/gu_common_test.py::TestPatchWrapper::test_simulate_patch__non_empty_patch__changes_applied PASSED [ 92%]
tests/generic_config_updater/gu_common_test.py::TestPatchWrapper::test_validate_config_db_patch_has_yang_models__table_with_yang_model__returns_true PASSED [ 92%]
tests/generic_config_updater/gu_common_test.py::TestPatchWrapper::test_validate_config_db_patch_has_yang_models__table_without_yang_model__returns_false PASSED [ 92%]
tests/sonic_package_manager/test_cli.py::test_show_changelog PASSED      [ 92%]
tests/sonic_package_manager/test_cli.py::test_show_changelog_no_changelog PASSED [ 93%]
tests/sonic_package_manager/test_constraint.py::test_constraint PASSED   [ 93%]
tests/sonic_package_manager/test_constraint.py::test_constraint_range PASSED [ 93%]
tests/sonic_package_manager/test_constraint.py::test_constraint_strict PASSED [ 93%]
tests/sonic_package_manager/test_constraint.py::test_constraint_match PASSED [ 93%]
tests/sonic_package_manager/test_constraint.py::test_constraint_multiple PASSED [ 93%]
tests/sonic_package_manager/test_constraint.py::test_constraint_only_name PASSED [ 93%]
tests/sonic_package_manager/test_constraint.py::test_constraint_from_dict PASSED [ 93%]
tests/sonic_package_manager/test_constraint.py::test_version_to_tag PASSED [ 93%]
tests/sonic_package_manager/test_constraint.py::test_tag_to_version PASSED [ 93%]
tests/sonic_package_manager/test_database.py::test_database_get_package PASSED [ 94%]
tests/sonic_package_manager/test_database.py::test_database_get_package_not_builtin PASSED [ 94%]
tests/sonic_package_manager/test_database.py::test_database_get_package_not_existing PASSED [ 94%]
tests/sonic_package_manager/test_database.py::test_database_add_package PASSED [ 94%]
tests/sonic_package_manager/test_database.py::test_database_add_package_existing PASSED [ 94%]
tests/sonic_package_manager/test_database.py::test_database_update_package PASSED [ 94%]
tests/sonic_package_manager/test_database.py::test_database_update_package_non_existing PASSED [ 94%]
tests/sonic_package_manager/test_database.py::test_database_remove_package PASSED [ 94%]
tests/sonic_package_manager/test_database.py::test_database_remove_package_non_existing PASSED [ 94%]
tests/sonic_package_manager/test_database.py::test_database_remove_package_installed PASSED [ 94%]
tests/sonic_package_manager/test_database.py::test_database_remove_package_built_in PASSED [ 94%]
tests/sonic_package_manager/test_manager.py::test_installation_not_installed PASSED [ 95%]
tests/sonic_package_manager/test_manager.py::test_installation_already_installed PASSED [ 95%]
tests/sonic_package_manager/test_manager.py::test_installation_dependencies PASSED [ 95%]
tests/sonic_package_manager/test_manager.py::test_installation_dependencies_missing_package PASSED [ 95%]
tests/sonic_package_manager/test_manager.py::test_installation_dependencies_satisfied PASSED [ 95%]
tests/sonic_package_manager/test_manager.py::test_installation_components_dependencies_satisfied PASSED [ 95%]
tests/sonic_package_manager/test_manager.py::test_installation_components_dependencies_not_satisfied PASSED [ 95%]
tests/sonic_package_manager/test_manager.py::test_installation_components_dependencies_implicit PASSED [ 95%]
tests/sonic_package_manager/test_manager.py::test_installation_components_dependencies_explicitely_allowed PASSED [ 95%]
tests/sonic_package_manager/test_manager.py::test_installation_breaks PASSED [ 95%]
tests/sonic_package_manager/test_manager.py::test_installation_breaks_missing_package PASSED [ 96%]
tests/sonic_package_manager/test_manager.py::test_installation_breaks_not_installed_package PASSED [ 96%]
tests/sonic_package_manager/test_manager.py::test_installation_base_os_constraint PASSED [ 96%]
tests/sonic_package_manager/test_manager.py::test_installation_base_os_constraint_satisfied PASSED [ 96%]
tests/sonic_package_manager/test_manager.py::test_installation_cli_plugin PASSED [ 96%]
tests/sonic_package_manager/test_manager.py::test_installation_cli_plugin_skipped PASSED [ 96%]
tests/sonic_package_manager/test_manager.py::test_installation_cli_plugin_is_mandatory_but_skipped PASSED [ 96%]
tests/sonic_package_manager/test_manager.py::test_installation PASSED    [ 96%]
tests/sonic_package_manager/test_manager.py::test_installation_using_reference PASSED [ 96%]
tests/sonic_package_manager/test_manager.py::test_manager_installation_tag PASSED [ 96%]
tests/sonic_package_manager/test_manager.py::test_installation_from_file PASSED [ 96%]
tests/sonic_package_manager/test_manager.py::test_installation_from_registry PASSED [ 97%]
tests/sonic_package_manager/test_manager.py::test_installation_from_registry_using_digest PASSED [ 97%]
tests/sonic_package_manager/test_manager.py::test_installation_from_file_known_package PASSED [ 97%]
tests/sonic_package_manager/test_manager.py::test_installation_from_file_unknown_package PASSED [ 97%]
tests/sonic_package_manager/test_manager.py::test_upgrade_from_file_known_package PASSED [ 97%]
tests/sonic_package_manager/test_manager.py::test_installation_non_default_owner PASSED [ 97%]
tests/sonic_package_manager/test_manager.py::test_installation_enabled PASSED [ 97%]
tests/sonic_package_manager/test_manager.py::test_installation_fault PASSED [ 97%]
tests/sonic_package_manager/test_manager.py::test_manager_installation_version_range PASSED [ 97%]
tests/sonic_package_manager/test_manager.py::test_manager_upgrade PASSED [ 97%]
tests/sonic_package_manager/test_manager.py::test_manager_package_reset PASSED [ 98%]
tests/sonic_package_manager/test_manager.py::test_manager_migration PASSED [ 98%]
tests/sonic_package_manager/test_manifest.py::test_manifest_v1_defaults PASSED [ 98%]
tests/sonic_package_manager/test_manifest.py::test_manifest_v1_invalid_version PASSED [ 98%]
tests/sonic_package_manager/test_manifest.py::test_manifest_v1_invalid_package_constraint PASSED [ 98%]
tests/sonic_package_manager/test_manifest.py::test_manifest_v1_service_spec PASSED [ 98%]
tests/sonic_package_manager/test_manifest.py::test_manifest_v1_mounts PASSED [ 98%]
tests/sonic_package_manager/test_manifest.py::test_manifest_v1_mounts_invalid PASSED [ 98%]
tests/sonic_package_manager/test_manifest.py::test_manifest_v1_unmarshal PASSED [ 98%]
tests/sonic_package_manager/test_metadata.py::test_metadata_resolver_local PASSED [ 98%]
tests/sonic_package_manager/test_metadata.py::test_metadata_resolver_remote PASSED [ 98%]
tests/sonic_package_manager/test_reference.py::test_reference PASSED     [ 99%]
tests/sonic_package_manager/test_reference.py::test_reference_invalid PASSED [ 99%]
tests/sonic_package_manager/test_registry.py::test_get_registry_for PASSED [ 99%]
tests/sonic_package_manager/test_service_creator.py::test_service_creator PASSED [ 99%]
tests/sonic_package_manager/test_service_creator.py::test_service_creator_with_timer_unit PASSED [ 99%]
tests/sonic_package_manager/test_service_creator.py::test_service_creator_with_debug_dump PASSED [ 99%]
tests/sonic_package_manager/test_service_creator.py::test_service_creator_initial_config PASSED [ 99%]
tests/sonic_package_manager/test_service_creator.py::test_feature_registration PASSED [ 99%]
tests/sonic_package_manager/test_service_creator.py::test_feature_registration_with_timer PASSED [ 99%]
tests/sonic_package_manager/test_service_creator.py::test_feature_registration_with_non_default_owner PASSED [ 99%]
tests/sonic_package_manager/test_utils.py::test_make_python_identifier PASSED [100%]

------- generated xml file: /sonic/src/sonic-utilities/test-results.xml --------

----------- coverage: platform linux, python 3.7.3-final-0 -----------
Name                                          Stmts   Miss Branch BrPart  Cover
-------------------------------------------------------------------------------
acl_loader/__init__.py                            0      0      0      0   100%
acl_loader/main.py                              586    273    270     35    47%
clear/__init__.py                                 0      0      0      0   100%
clear/bgp_frr_v6.py                              44     44     12      0     0%
clear/bgp_quagga_v4.py                           44     44     12      0     0%
clear/bgp_quagga_v6.py                           44     44     12      0     0%
clear/main.py                                   211    121     48      7    38%
clear/plugins/__init__.py                         0      0      0      0   100%
config/__init__.py                                0      0      0      0   100%
config/aaa.py                                   345    164    164     24    43%
config/chassis_modules.py                        18      1      2      0    95%
config/config_mgmt.py                           361    236    124      8    32%
config/console.py                               110      1     28      0    99%
config/feature.py                                59      1     22      0    99%
config/kdump.py                                  29     18     10      0    28%
config/kube.py                                   65      2      8      0    97%
config/main.py                                 3368   1554   1399    172    49%
config/muxcable.py                              534    241    244     55    49%
config/nat.py                                   677    569    344      0    11%
config/plugins/__init__.py                        0      0      0      0   100%
config/plugins/mlnx.py                          131     87     36      1    28%
config/utils.py                                   3      0      0      0   100%
config/vlan.py                                  115     10     52      6    90%
config/vxlan.py                                 202     57    104     46    65%
connect/__init__.py                               0      0      0      0   100%
connect/main.py                                  56     56     16      0     0%
consutil/__init__.py                              0      0      0      0   100%
consutil/lib.py                                 232      7     58      2    97%
consutil/main.py                                 75      3     16      1    96%
counterpoll/__init__.py                           0      0      0      0   100%
counterpoll/main.py                             197     88     34     12    53%
crm/__init__.py                                   0      0      0      0   100%
crm/main.py                                     371     24    108     25    89%
debug/__init__.py                                 0      0      0      0   100%
debug/main.py                                   153    153     26      0     0%
fdbutil/__init__.py                               0      0      0      0   100%
fdbutil/filter_fdb_entries.py                    79      7     30      4    88%
fwutil/__init__.py                                5      5      0      0     0%
fwutil/lib.py                                   469    469    200      0     0%
fwutil/log.py                                    45     45      4      0     0%
fwutil/main.py                                  243    243     68      0     0%
pcieutil/__init__.py                              0      0      0      0   100%
pcieutil/main.py                                165     64     54      8    62%
pddf_fanutil/__init__.py                          0      0      0      0   100%
pddf_fanutil/main.py                            112    112     44      0     0%
pddf_ledutil/__init__.py                          0      0      0      0   100%
pddf_ledutil/main.py                             43     43     12      0     0%
pddf_psuutil/__init__.py                          0      0      0      0   100%
pddf_psuutil/main.py                            128    128     50      0     0%
pddf_thermalutil/__init__.py                      0      0      0      0   100%
pddf_thermalutil/main.py                         77     77     32      0     0%
pfc/__init__.py                                   0      0      0      0   100%
pfc/main.py                                      93     93     26      0     0%
pfcwd/__init__.py                                 0      0      0      0   100%
pfcwd/main.py                                   291     79    112     12    67%
psuutil/__init__.py                               0      0      0      0   100%
psuutil/main.py                                  80     59     14      1    23%
scripts/aclshow                                 127     13     60      4    89%
scripts/db_migrator.py                          369     78    154     36    76%
scripts/decode-syseeprom                        172     81     53     10    48%
scripts/disk_check.py                            87      6     36      7    89%
scripts/dropconfig                              219    104    112     15    45%
scripts/dropstat                                222     21     86     17    88%
scripts/dump_nat_entries.py                      12     12      4      0     0%
scripts/ecnconfig                               234     58    130     26    70%
scripts/fanshow                                  63     10     18      6    80%
scripts/fast-reboot-dump.py                     250    120     66     10    49%
scripts/fdbshow                                  92      0     38      0   100%
scripts/gearboxutil                             131     21     44     14    78%
scripts/intfstat                                195     42     72     13    75%
scripts/intfutil                                408     20    180     30    91%
scripts/ipintutil                               172     15     64     10    89%
scripts/mellanox_buffer_migrator.py             250     16    126     14    92%
scripts/mmuconfig                               119     29     54      7    71%
scripts/neighbor_advertiser                     332    170    114      9    44%
scripts/pfcstat                                 157     23     52      8    84%
scripts/pg-drop                                 149     22     46     12    83%
scripts/port2alias                               32      5     14      1    83%
scripts/portconfig                              203     31     96     25    79%
scripts/portstat                                309     54    108     25    79%
scripts/psushow                                  86      8     30      7    87%
scripts/queuestat                               239     77     88     16    65%
scripts/route_check.py                          269      6    104     17    94%
scripts/sfpshow                                 211     34     56      6    85%
scripts/sonic_sku_create.py                     626    151    234     57    73%
scripts/update_json.py                           35     35      8      0     0%
scripts/vnet_route_check.py                     183     17     94     15    87%
scripts/watermarkstat                           188     30     64     17    81%
sfputil/__init__.py                               0      0      0      0   100%
sfputil/main.py                                 413    264    140      6    33%
show/__init__.py                                  0      0      0      0   100%
show/acl.py                                      21     11      6      0    37%
show/bgp_common.py                              275     10    180     11    95%
show/bgp_frr_v4.py                               58      2     20      1    96%
show/bgp_frr_v6.py                               57      1     18      1    97%
show/bgp_quagga_v4.py                            22     22      4      0     0%
show/bgp_quagga_v6.py                            17     17      0      0     0%
show/chassis_modules.py                          73      7     22      4    88%
show/dropcounters.py                             25      1      6      0    97%
show/feature.py                                 105      1     40      1    99%
show/fgnhg.py                                   124      1     68      0    99%
show/gearbox.py                                  14      3      0      0    79%
show/interfaces/__init__.py                     322     99    108     15    66%
show/interfaces/portchannel.py                  102      6     36      6    91%
show/kdump.py                                    59     47     28      0    14%
show/kube.py                                     41      2     10      0    96%
show/main.py                                    885    381    235     20    52%
show/muxcable.py                                657    240    266     60    58%
show/nat.py                                      56     34      4      0    37%
show/platform.py                                 80     35     16      1    52%
show/plugins/__init__.py                          0      0      0      0   100%
show/plugins/mlnx.py                             85     62     22      0    23%
show/processes.py                                16      7      0      0    56%
show/reboot_cause.py                             62      7     18      6    84%
show/sflow.py                                    59      5     18      5    87%
show/system_health.py                           179     46     88     18    72%
show/vlan.py                                    103      2     40      0    99%
show/vnet.py                                    180    164     56      0     7%
show/vxlan.py                                   225     89     88     18    56%
show/warm_restart.py                             93     84     34      0     7%
sonic_installer/__init__.py                       0      0      0      0   100%
sonic_installer/bootloader/__init__.py            9      9      4      0     0%
sonic_installer/bootloader/aboot.py             178    178     42      0     0%
sonic_installer/bootloader/bootloader.py         37     37      0      0     0%
sonic_installer/bootloader/grub.py               60     60     10      0     0%
sonic_installer/bootloader/onie.py               27     27      2      0     0%
sonic_installer/bootloader/uboot.py              61     61     18      0     0%
sonic_installer/common.py                        25     25      4      0     0%
sonic_installer/exception.py                      2      2      0      0     0%
sonic_installer/main.py                         480    480    152      0     0%
ssdutil/__init__.py                               0      0      0      0   100%
ssdutil/main.py                                  50     50      8      0     0%
undebug/__init__.py                               0      0      0      0   100%
undebug/main.py                                 153    153     26      0     0%
utilities_common/__init__.py                      0      0      0      0   100%
utilities_common/bgp_util.py                    198     58     58      4    65%
utilities_common/cli.py                         333    104    196     24    63%
utilities_common/constants.py                    10      0      0      0   100%
utilities_common/db.py                           23      2      6      0    93%
utilities_common/general.py                      10      0      0      0   100%
utilities_common/intf_filter.py                  30     18     20      1    34%
utilities_common/multi_asic.py                   97     17     44      3    79%
utilities_common/netstat.py                      37     11     18      6    62%
utilities_common/platform_sfputil_helper.py      36     26      6      0    24%
utilities_common/util_base.py                    49     23      8      1    51%
watchdogutil/__init__.py                          0      0      0      0   100%
watchdogutil/main.py                             54     54     16      0     0%
-------------------------------------------------------------------------------
TOTAL                                         22368   9576   8409   1065    54%
Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml

=============================== warnings summary ===============================
tests/acl_loader_test.py::TestAclLoader::()::test_valid
  /usr/local/lib/python3.7/dist-packages/pyangbind/lib/yangtypes.py:375: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    class TypedList(collections.MutableSequence):

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============= 1049 passed, 3 skipped, 1 warnings in 244.95 seconds =============
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

