### PR TITLE
Allow upgrade-docker for macsec container

### DIFF
--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -554,6 +554,7 @@ DOCKER_CONTAINER_LIST = [
     "bgp",
     "dhcp_relay",
     "lldp",
+    "macsec",
     "nat",
     "pmon",
     "radv",


### PR DESCRIPTION
What I did
Updated docker container list to include "macsec" so that sonic_installer upgrade-docker can be used for macsec container.

Why I did it
MACsec support.

How I verified it
System tests on Juniper platform which supports MACsec.

Details if related
N/A