### PR TITLE
[dhcp_relay] Update CLI reference document and add a new API for ip address type

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -2225,33 +2225,43 @@ This sub-section of commands is used to add or remove the DHCP Relay Destination
 
 **config vlan dhcp_relay add**
 
-This command is used to add a DHCP Relay Destination IP address to the a VLAN.  Note that more that one DHCP Relay Destination IP address can be added on a VLAN interface.
+This command is used to add a DHCP Relay Destination IP address or multiple IP addresses to a VLAN.  Note that more than one DHCP Relay Destination IP address can be added on a VLAN interface.
 
 - Usage:
   ```
-  config vlan dhcp_relay add <vlan_id> <dhcp_relay_destination_ip>
+  config vlan dhcp_relay add <vlan_id> <dhcp_relay_destination_ips>
   ```
 
 - Example:
   ```
   admin@sonic:~$ sudo config vlan dhcp_relay add 1000 7.7.7.7
-  Added DHCP relay destination address 7.7.7.7 to Vlan1000
+  Added DHCP relay destination address ['7.7.7.7'] to Vlan1000
+  Restarting DHCP relay service...
+  ```
+  ```
+  admin@sonic:~$ sudo config vlan dhcp_relay add 1000 7.7.7.7 1.1.1.1
+  Added DHCP relay destination address ['7.7.7.7', '1.1.1.1'] to Vlan1000
   Restarting DHCP relay service...
   ```
 
 **config vlan dhcp_relay delete**
 
-This command is used to delete a configured DHCP Relay Destination IP address from a VLAN interface.
+This command is used to delete a configured DHCP Relay Destination IP address or multiple IP addresses from a VLAN interface.
 
 - Usage:
   ```
-  config vlan dhcp_relay del <vlan-id> <dhcp_relay_destination_ip>
+  config vlan dhcp_relay del <vlan-id> <dhcp_relay_destination_ips>
   ```
 
 - Example:
   ```
   admin@sonic:~$ sudo config vlan dhcp_relay del 1000 7.7.7.7
   Removed DHCP relay destination address 7.7.7.7 from Vlan1000
+  Restarting DHCP relay service...
+  ```
+  ```
+  admin@sonic:~$ sudo config vlan dhcp_relay del 1000 7.7.7.7 1.1.1.1
+  Removed DHCP relay destination address ('7.7.7.7', '1.1.1.1') from Vlan1000
   Restarting DHCP relay service...
   ```
 

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -7,6 +7,7 @@ import sys
 
 import click
 import json
+import netaddr
 
 from natsort import natsorted
 from sonic_py_common import multi_asic
@@ -200,6 +201,17 @@ def is_ipaddress(val):
         return False
     return True
 
+def ipaddress_type(val):
+    """ Return the IP address type """
+    if not val:
+        return None
+
+    try:
+        ip_version = netaddr.IPAddress(str(val))
+    except netaddr.core.AddrFormatError:
+        return None
+
+    return ip_version.version
 
 def is_ip_prefix_in_key(key):
     '''


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Update CLI reference document following PR : https://github.com/Azure/sonic-buildimage/pull/8211
Add a new API on utilities_common to get IP type.

#### How I did it
- Update doc/Command-Reference.md with new DHCP CLI.
- Add ipaddress_type API to utilities_common/cli.py

#### How to verify it
- Build an image with PR https://github.com/Azure/sonic-buildimage/pull/8211 and this PR.
- Run DHCP CLI commands
