### PR TITLE
[configlet] Python3 compatible syntax for extracting a key from the dict

### DIFF
--- a/scripts/configlet
+++ b/scripts/configlet
@@ -159,7 +159,7 @@ def do_delete(t, k, lst):
 
 def do_operate(op_upd, t, k, lst):
     if lst:
-        if type(lst[lst.keys()[0]]) == dict:
+        if type(lst[next(iter(lst))]) == dict:
             for i in lst:
                 do_operate(op_upd, t, k+(i,), lst[i])
             return


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
Syntax error seen while trying to apply a configlet
Traceback (most recent call last):
  File "/usr/local/bin/configlet", line 212, in <module>
    main()
  File "/usr/local/bin/configlet", line 205, in main
    process_entry (do_update, i)
  File "/usr/local/bin/configlet", line 175, in process_entry
    do_operate(op_upd, t, (), data[t])
  File "/usr/local/bin/configlet", line 162, in do_operate
    if type(lst[lst.keys()[0]]) == dict:
TypeError: 'dict_keys' object is not subscriptable

#### What I did
Use next(iter()) to derive a key from the dict. This is both python2 and python3 compatible

#### How to verify it
Tried applying the json file below using the command 'configlet -j test.json -d'. Configlet was applied successfully. No errors were seen
[
{
"ACL_TABLE": {
"EVERFLOW": {},
"EVERFLOWV6": {}
}
}
]

No unit test exists for this feature currently. Created an issue to track this Azure/sonic-buildimage#8232

