### PR TITLE
[minigraph][port_config] Use imported config.main and add conditional patch

### DIFF
--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -57,50 +57,54 @@ class TestLoadMinigraph(object):
             assert "\n".join([l.rstrip() for l in result.output.split('\n')]) == load_minigraph_command_output
             assert mock_run_command.call_count == 7
 
-    def test_load_minigraph_with_port_config_bad_format(self, setup_single_broadcom_asic):
+    def test_load_minigraph_with_port_config_bad_format(self, get_cmd_module, setup_single_broadcom_asic):
         with mock.patch(
             "utilities_common.cli.run_command",
             mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command:
+            (config, show) = get_cmd_module
 
             # Not in an array
             port_config = {"PORT": {"Ethernet0": {"admin_status": "up"}}}
-            self.check_port_config(None, port_config, "Failed to load port_config.json, Error: Bad format: port_config is not an array")
+            self.check_port_config(None, config, port_config, "Failed to load port_config.json, Error: Bad format: port_config is not an array")
 
             # No PORT table
             port_config = [{}]
-            self.check_port_config(None, port_config, "Failed to load port_config.json, Error: Bad format: PORT table not exists")
+            self.check_port_config(None, config, port_config, "Failed to load port_config.json, Error: Bad format: PORT table not exists")
 
-    def test_load_minigraph_with_port_config_inconsistent_port(self, setup_single_broadcom_asic):
+    def test_load_minigraph_with_port_config_inconsistent_port(self, get_cmd_module, setup_single_broadcom_asic):
         with mock.patch(
             "utilities_common.cli.run_command",
             mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command:
+            (config, show) = get_cmd_module
+
             db = Db()
             db.cfgdb.set_entry("PORT", "Ethernet1", {"admin_status": "up"})
             port_config = [{"PORT": {"Eth1": {"admin_status": "up"}}}]
-            self.check_port_config(db, port_config, "Failed to load port_config.json, Error: Port Eth1 is not defined in current device")
+            self.check_port_config(db, config, port_config, "Failed to load port_config.json, Error: Port Eth1 is not defined in current device")
 
-    def test_load_minigraph_with_port_config(self, setup_single_broadcom_asic):
+    def test_load_minigraph_with_port_config(self, get_cmd_module, setup_single_broadcom_asic):
         with mock.patch(
             "utilities_common.cli.run_command",
             mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command:
+            (config, show) = get_cmd_module
             db = Db()
 
             # From up to down
             db.cfgdb.set_entry("PORT", "Ethernet0", {"admin_status": "up"})
             port_config = [{"PORT": {"Ethernet0": {"admin_status": "down"}}}]
-            self.check_port_config(db, port_config, "config interface shutdown Ethernet0")
+            self.check_port_config(db, config, port_config, "config interface shutdown Ethernet0")
 
             # From down to up
             db.cfgdb.set_entry("PORT", "Ethernet0", {"admin_status": "down"})
             port_config = [{"PORT": {"Ethernet0": {"admin_status": "up"}}}]
-            self.check_port_config(db, port_config, "config interface startup Ethernet0")
+            self.check_port_config(db, config, port_config, "config interface startup Ethernet0")
 
-    def check_port_config(self, db, port_config, expected_output):
+    def check_port_config(self, db, config, port_config, expected_output):
         def read_json_file_side_effect(filename):
             return port_config
         with mock.patch('config.main.read_json_file', mock.MagicMock(side_effect=read_json_file_side_effect)):
             def is_file_side_effect(filename):
-                return True
+                return True if 'port_config' in filename else False
             with mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)):
                 runner = CliRunner()
                 result = runner.invoke(config.config.commands["load_minigraph"], ["-y"], obj=db)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

We found an issue where UT couldn't pass in old release branch with patch https://github.com/Azure/sonic-utilities/pull/1705 

#### How I did it
To solve this issue, I applied two change in this PR:
- Use imported config.main module since we are not import config.main as config in old release branches
- Add conditional patch since some file were not mocked in old release branches

#### How to verify it
- [x] Test on master
- [x] Test on 202012
- [x] Test on 201911  https://github.com/Azure/sonic-utilities/pull/1725
- [ ] Test on 201811  https://github.com/Azure/sonic-utilities/pull/1726
- [ ] Test on 202106

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

