### PR TITLE
[minigraph][port_config] Consume port_config.json while reloading minigraph

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -47,6 +47,15 @@ asic_type = None
 config_db = None
 multi_asic_cfgdb = None
 
+# Read given JSON file
+def read_json_file(fileName):
+    try:
+        with open(fileName) as f:
+            result = json.load(f)
+    except Exception as e:
+        raise Exception(str(e))
+    return result
+
 class AbbreviationGroup(click.Group):
     """This subclass of click.Group supports abbreviated subgroup/subcommand names
     """
@@ -994,7 +1003,7 @@ def load_minigraph(no_service_restart):
 
     # Load port_config.json
     try:
-        load_port_config(db.cfgdb, '/etc/sonic/port_config.json')
+        load_port_config(config_db, '/etc/sonic/port_config.json')
     except Exception as e:
         click.secho("Failed to load port_config.json, Error: {}".format(str(e)), fg='magenta')
 
@@ -1054,7 +1063,7 @@ def load_port_config(config_db, port_config_path):
         if 'admin_status' in port_table[port_name]:
             if port_table[port_name]['admin_status'] == port_config[port_name]['admin_status']:
                 continue
-            clicommon.run_command('config interface {} {}'.format(
+            run_command('config interface {} {}'.format(
                 'startup' if port_config[port_name]['admin_status'] == 'up' else 'shutdown',
                 port_name), display_cmd=True)
     return

--- a/config/main.py
+++ b/config/main.py
@@ -992,6 +992,12 @@ def load_minigraph(no_service_restart):
     if os.path.isfile('/etc/sonic/acl.json'):
         run_command("acl-loader update full /etc/sonic/acl.json", display_cmd=True)
 
+    # Load port_config.json
+    try:
+        load_port_config(db.cfgdb, '/etc/sonic/port_config.json')
+    except Exception as e:
+        click.secho("Failed to load port_config.json, Error: {}".format(str(e)), fg='magenta')
+
     # generate QoS and Buffer configs
     run_command("config qos reload", display_cmd=True)
 
@@ -1014,6 +1020,44 @@ def load_minigraph(no_service_restart):
         _restart_services()
     click.echo("Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`.")
 
+def load_port_config(config_db, port_config_path):
+    if not os.path.isfile(port_config_path):
+        return
+
+    try:
+        # Load port_config.json
+        port_config_input = read_json_file(port_config_path)
+    except Exception:
+        raise Exception("Bad format: json file broken")
+
+    # Validate if the input is an array
+    if not isinstance(port_config_input, list):
+        raise Exception("Bad format: port_config is not an array")
+    
+    if len(port_config_input) == 0 or 'PORT' not in port_config_input[0]:
+        raise Exception("Bad format: PORT table not exists")
+        
+    port_config = port_config_input[0]['PORT']
+
+    # Ensure all ports are exist
+    port_table = {}
+    for port_name in port_config.keys():
+        port_entry = config_db.get_entry('PORT', port_name)
+        if not port_entry:
+            raise Exception("Port {} is not defined in current device".format(port_name))
+        port_table[port_name] = port_entry
+
+    # Update port state
+    for port_name in port_config.keys():
+        if 'admin_status' not in port_config[port_name]:
+            continue
+        if 'admin_status' in port_table[port_name]:
+            if port_table[port_name]['admin_status'] == port_config[port_name]['admin_status']:
+                continue
+            clicommon.run_command('config interface {} {}'.format(
+                'startup' if port_config[port_name]['admin_status'] == 'up' else 'shutdown',
+                port_name), display_cmd=True)
+    return
 
 #
 # 'hostname' command


### PR DESCRIPTION
Signed-off-by: Jing Kan jika@microsoft.com

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Merge patch of https://github.com/Azure/sonic-utilities/pull/1705
Made additional changes for this branch.

#### How I did it

#### How to verify it

Tested on vSONiC:

Prepare `port_config.json`
```json
[
  {
    "PORT": {
      "Ethernet112": {
        "admin_status": "down"
      },
      "Ethernet116": {
        "admin_status": "up"
      }
    }
  }
]
```

Before
```
admin@vlab-01:~$ show interface status
      Interface            Lanes    Speed    MTU    FEC           Alias             Vlan    Oper    Admin    Type    Asym PFC
---------------  ---------------  -------  -----  -----  --------------  ---------------  ------  -------  ------  ----------
    Ethernet112      93,94,95,96      40G   9100    N/A  fortyGigE0/112  PortChannel0001      up       up     N/A         off
    Ethernet116      89,90,91,92      40G   9100    N/A  fortyGigE0/116  PortChannel0002      up       up     N/A         off
    Ethernet120  101,102,103,104      40G   9100    N/A  fortyGigE0/120  PortChannel0003      up       up     N/A         off
    Ethernet124     97,98,99,100      40G   9100    N/A  fortyGigE0/124  PortChannel0004      up       up     N/A         off
PortChannel0001              N/A      40G   9100    N/A             N/A           routed      up       up     N/A         N/A
PortChannel0002              N/A      40G   9100    N/A             N/A           routed      up       up     N/A         N/A
PortChannel0003              N/A      40G   9100    N/A             N/A           routed      up       up     N/A         N/A
PortChannel0004              N/A      40G   9100    N/A             N/A           routed      up       up     N/A         N/A
admin@vlab-01:~$ show ip bgp sum
Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.57      4  64600       3211       4782         0      0     474  00:00:40             6400  ARISTA01T1
10.0.0.59      4  64600       3211       5256         0      0       0  00:00:40             6400  ARISTA02T1
10.0.0.61      4  64600       3216       5256         0      0       0  00:00:40             6400  ARISTA03T1
10.0.0.63      4  64600       3216       5256         0      0       0  00:00:40             6400  ARISTA04T1

Total number of neighbors 4
```

After `sudo config load_minigraph`
```
admin@vlab-01:/etc/sonic$ show int status
      Interface            Lanes    Speed    MTU    FEC           Alias             Vlan    Oper    Admin    Type    Asym PFC
---------------  ---------------  -------  -----  -----  --------------  ---------------  ------  -------  ------  ----------
    Ethernet112      93,94,95,96      40G   9100    N/A  fortyGigE0/112  PortChannel0001      up     down     N/A         off
    Ethernet116      89,90,91,92      40G   9100    N/A  fortyGigE0/116  PortChannel0002      up       up     N/A         off
    Ethernet120  101,102,103,104      40G   9100    N/A  fortyGigE0/120  PortChannel0003      up       up     N/A         off
    Ethernet124     97,98,99,100      40G   9100    N/A  fortyGigE0/124  PortChannel0004      up       up     N/A         off
PortChannel0001              N/A      40G   9100    N/A             N/A           routed    down       up     N/A         N/A
PortChannel0002              N/A      40G   9100    N/A             N/A           routed      up       up     N/A         N/A
PortChannel0003              N/A      40G   9100    N/A             N/A           routed      up       up     N/A         N/A
PortChannel0004              N/A      40G   9100    N/A             N/A           routed      up       up     N/A         N/A
admin@vlab-01:/etc/sonic$ show ip bgp sum
Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down    State/PfxRcd    NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.57      4  64600          0          0         0      0       0  never      Active          ARISTA01T1
10.0.0.59      4  64600       3207       4791         0      0    1200  00:00:15   6400            ARISTA02T1
10.0.0.61      4  64600       1494        902         0      0    5088  00:00:15   2978            ARISTA03T1
10.0.0.63      4  64600       3208       4802         0      0    1188  00:00:15   6400            ARISTA04T1

Total number of neighbors 4
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

