### PR TITLE
[minigraph][port_config] Consume port_config.json while reloading minigraph

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -50,10 +50,6 @@ def log_warning(msg):
     syslog.syslog(syslog.LOG_WARNING, msg)
     syslog.closelog()
 
-class AbbreviationGroup(click.Group):
-    """This subclass of click.Group supports abbreviated subgroup/subcommand names
-    """
-
 
 def log_error(msg):
     syslog.openlog(SYSLOG_IDENTIFIER)

--- a/config/main.py
+++ b/config/main.py
@@ -22,6 +22,15 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help', '-?'])
 SONIC_CFGGEN_PATH = '/usr/local/bin/sonic-cfggen'
 SYSLOG_IDENTIFIER = "config"
 
+# Read given JSON file
+def read_json_file(fileName):
+    try:
+        with open(fileName) as f:
+            result = json.load(f)
+    except Exception as e:
+        raise Exception(str(e))
+    return result
+
 # ========================== Syslog wrappers ==========================
 
 def log_debug(msg):
@@ -40,6 +49,10 @@ def log_warning(msg):
     syslog.openlog(SYSLOG_IDENTIFIER)
     syslog.syslog(syslog.LOG_WARNING, msg)
     syslog.closelog()
+
+class AbbreviationGroup(click.Group):
+    """This subclass of click.Group supports abbreviated subgroup/subcommand names
+    """
 
 
 def log_error(msg):
@@ -486,7 +499,7 @@ def load_minigraph():
 
     # Load port_config.json
     try:
-        load_port_config(db.cfgdb, '/etc/sonic/port_config.json')
+        load_port_config(config_db, '/etc/sonic/port_config.json')
     except Exception as e:
         click.secho("Failed to load port_config.json, Error: {}".format(str(e)), fg='magenta')
 
@@ -539,7 +552,7 @@ def load_port_config(config_db, port_config_path):
         if 'admin_status' in port_table[port_name]:
             if port_table[port_name]['admin_status'] == port_config[port_name]['admin_status']:
                 continue
-            clicommon.run_command('config interface {} {}'.format(
+            run_command('config interface {} {}'.format(
                 'startup' if port_config[port_name]['admin_status'] == 'up' else 'shutdown',
                 port_name), display_cmd=True)
     return

--- a/config/main.py
+++ b/config/main.py
@@ -483,6 +483,14 @@ def load_minigraph():
         run_command('pfcwd start_default', display_cmd=True)
     if os.path.isfile('/etc/sonic/acl.json'):
         run_command("acl-loader update full /etc/sonic/acl.json", display_cmd=True)
+
+    # Load port_config.json
+    try:
+        load_port_config(db.cfgdb, '/etc/sonic/port_config.json')
+    except Exception as e:
+        click.secho("Failed to load port_config.json, Error: {}".format(str(e)), fg='magenta')
+
+    # generate QoS and Buffer configs
     run_command("config qos reload", display_cmd=True)
 
     # Write latest db version string into db
@@ -497,6 +505,44 @@ def load_minigraph():
     _restart_services()
     click.echo("Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`.")
 
+def load_port_config(config_db, port_config_path):
+    if not os.path.isfile(port_config_path):
+        return
+
+    try:
+        # Load port_config.json
+        port_config_input = read_json_file(port_config_path)
+    except Exception:
+        raise Exception("Bad format: json file broken")
+
+    # Validate if the input is an array
+    if not isinstance(port_config_input, list):
+        raise Exception("Bad format: port_config is not an array")
+    
+    if len(port_config_input) == 0 or 'PORT' not in port_config_input[0]:
+        raise Exception("Bad format: PORT table not exists")
+        
+    port_config = port_config_input[0]['PORT']
+
+    # Ensure all ports are exist
+    port_table = {}
+    for port_name in port_config.keys():
+        port_entry = config_db.get_entry('PORT', port_name)
+        if not port_entry:
+            raise Exception("Port {} is not defined in current device".format(port_name))
+        port_table[port_name] = port_entry
+
+    # Update port state
+    for port_name in port_config.keys():
+        if 'admin_status' not in port_config[port_name]:
+            continue
+        if 'admin_status' in port_table[port_name]:
+            if port_table[port_name]['admin_status'] == port_config[port_name]['admin_status']:
+                continue
+            clicommon.run_command('config interface {} {}'.format(
+                'startup' if port_config[port_name]['admin_status'] == 'up' else 'shutdown',
+                port_name), display_cmd=True)
+    return
 
 #
 # 'portchannel' group ('config portchannel ...')


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Merge patch of #1705
Made additional changes for this branch.

#### How I did it

#### How to verify it

Tested on a Physical DUT with below `port_config.json`
```json
[
	{
		"PORT": {
			"Ethernet48": {
				"admin_status": "down"
			}
		}
	}
]
```

Before
```
admin@str-e1031-acs-3:~$ show int status
      Interface    Lanes    Speed    MTU    Alias             Vlan    Oper    Admin    Type    Asym PFC
---------------  -------  -------  -----  -------  ---------------  ------  -------  ------  ----------
...
     Ethernet48       54      10G   9100    etp49  PortChannel0001      up       up     SFP         off
     Ethernet49       53      10G   9100    etp50  PortChannel0002      up       up     SFP         off
     Ethernet50       56      10G   9100    etp51  PortChannel0003      up       up     SFP         off
     Ethernet51       55      10G   9100    etp52  PortChannel0004      up       up     SFP         off
PortChannel0001      N/A      10G   9100      N/A           routed      up       up     N/A         N/A
PortChannel0002      N/A      10G   9100      N/A           routed      up       up     N/A         N/A
PortChannel0003      N/A      10G   9100      N/A           routed      up       up     N/A         N/A
PortChannel0004      N/A      10G   9100      N/A           routed      up       up     N/A         N/A

admin@str-e1031-acs-3:~$ show ip bgp sum
...
Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
10.0.0.57       4 64600     501     475        0    0    0 00:17:33      902
10.0.0.59       4 64600     501      23        0    0    0 00:17:37      902
10.0.0.61       4 64600     501     475        0    0    0 00:17:34      902
10.0.0.63       4 64600     501     474        0    0    0 00:17:31      902
```

After
```
admin@str-e1031-acs-3:~$ show int status
      Interface    Lanes    Speed    MTU    Alias             Vlan    Oper    Admin    Type    Asym PFC
---------------  -------  -------  -----  -------  ---------------  ------  -------  ------  ----------
...
     Ethernet48       54      10G   9100    etp49  PortChannel0001    down     down     SFP         off
     Ethernet49       53      10G   9100    etp50  PortChannel0002      up       up     SFP         off
     Ethernet50       56      10G   9100    etp51  PortChannel0003      up       up     SFP         off
     Ethernet51       55      10G   9100    etp52  PortChannel0004      up       up     SFP         off
PortChannel0001      N/A      10G   9100      N/A           routed    down       up     N/A         N/A
PortChannel0002      N/A      10G   9100      N/A           routed      up       up     N/A         N/A
PortChannel0003      N/A      10G   9100      N/A           routed      up       up     N/A         N/A
PortChannel0004      N/A      10G   9100      N/A           routed      up       up     N/A         N/A
admin@str-e1031-acs-3:~$ show ip bgp sum
...
10.0.0.57       4 64600       0       0        0    0    0 never    Idle       
10.0.0.59       4 64600     484       6        0    0    0 00:00:30      902
10.0.0.61       4 64600     484     457        0    0    0 00:00:28      902
10.0.0.63       4 64600     484     255        0    0    0 00:00:30      902
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

