### PR TITLE
[mlag]fix log print sequence

### DIFF
--- a/config/mclag.py
+++ b/config/mclag.py
@@ -22,7 +22,7 @@ def mclag_ka_session_dep_check(ka, session_tmout):
     """Check if the MCLAG Keepalive timer and session timeout values are multiples of each other and keepalive is < session timeout value 
     """
     if not session_tmout >= ( 3 * ka):
-        return False, "MCLAG Keepalive:{} Session_timeout:{} values not satisfying session_timeout >= (3 * KA) ".format(session_tmout, ka)
+        return False, "MCLAG Keepalive:{} Session_timeout:{} values not satisfying session_timeout >= (3 * KA) ".format(ka, session_tmout)
 
     if session_tmout % ka:
         return False, "MCLAG keepalive:{} Session_timeout:{} Values not satisfying session_timeout should be a multiple of KA".format(ka, session_tmout)


### PR DESCRIPTION
Signed-off-by: pettershao-ragilenetworks <pettershao@ragilenetworks.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
fix error log variable print sequence, otherwise it is confusable 
#### How I did it
change the varible 
#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

before keepalive-interval setting:
```
root@sonic:/home/admin# config mclag 1 keepalive-interval 30
MCLAG Keepalive:15 Session_timeout:30 values not satisfying session_timeout >= (3 * KA)
```
after fixing:
```
root@sonic:/home/admin# config mclag 1 keepalive-interval 30
MCLAG Keepalive:30 Session_timeout:15 values not satisfying session_timeout >= (3 * KA)
```