### PR TITLE
[show] fix show muxcable metrics <port> for sorted output

### DIFF
--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -6,6 +6,8 @@ import click
 import re
 import utilities_common.cli as clicommon
 from natsort import natsorted
+from collections import OrderedDict
+from operator import itemgetter
 from sonic_py_common import multi_asic
 from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
 from swsscommon import swsscommon
@@ -1007,7 +1009,8 @@ def metrics(db, port, json_output):
             click.echo("{}".format(json.dumps(metrics_dict[asic_index], indent=4)))
         else:
             print_data = []
-            for key, val in metrics_dict[asic_index].items():
+            ordered_dict = OrderedDict(sorted(metrics_dict[asic_index].items(), key=itemgetter(1)))
+            for key, val in ordered_dict.items():
                 print_port_data = []
                 print_port_data.append(port)
                 print_port_data.append(key)

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -1005,11 +1005,11 @@ def metrics(db, port, json_output):
         metrics_dict[asic_index] = per_npu_statedb[asic_index].get_all(
             per_npu_statedb[asic_index].STATE_DB, 'MUX_METRICS_TABLE|{}'.format(port))
 
+        ordered_dict = OrderedDict(sorted(metrics_dict[asic_index].items(), key=itemgetter(1)))
         if json_output:
-            click.echo("{}".format(json.dumps(metrics_dict[asic_index], indent=4)))
+            click.echo("{}".format(json.dumps(ordered_dict, indent=4)))
         else:
             print_data = []
-            ordered_dict = OrderedDict(sorted(metrics_dict[asic_index].items(), key=itemgetter(1)))
             for key, val in ordered_dict.items():
                 print_port_data = []
                 print_port_data.append(port)

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -217,9 +217,9 @@ Ethernet0  linkmgrd_switch_standby_end   2021-May-13 10:01:15.696728
 show_muxcable_metrics_expected_output_json = """\
 {
     "linkmgrd_switch_active_start": "2021-May-13 10:00:21.420898",
-    "xcvrd_switch_standby_start": "2021-May-13 10:01:15.690835"
+    "xcvrd_switch_standby_start": "2021-May-13 10:01:15.690835",
     "xcvrd_switch_standby_end": "2021-May-13 10:01:15.696051",
-    "linkmgrd_switch_standby_end": "2021-May-13 10:01:15.696728",
+    "linkmgrd_switch_standby_end": "2021-May-13 10:01:15.696728"
 }
 """
 

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -209,17 +209,17 @@ show_muxcable_metrics_expected_output = """\
 PORT       EVENT                         TIME
 ---------  ----------------------------  ---------------------------
 Ethernet0  linkmgrd_switch_active_start  2021-May-13 10:00:21.420898
-Ethernet0  linkmgrd_switch_standby_end   2021-May-13 10:01:15.696728
-Ethernet0  xcvrd_switch_standby_end      2021-May-13 10:01:15.696051
 Ethernet0  xcvrd_switch_standby_start    2021-May-13 10:01:15.690835
+Ethernet0  xcvrd_switch_standby_end      2021-May-13 10:01:15.696051
+Ethernet0  linkmgrd_switch_standby_end   2021-May-13 10:01:15.696728
 """
 
 show_muxcable_metrics_expected_output_json = """\
 {
     "linkmgrd_switch_active_start": "2021-May-13 10:00:21.420898",
-    "linkmgrd_switch_standby_end": "2021-May-13 10:01:15.696728",
-    "xcvrd_switch_standby_end": "2021-May-13 10:01:15.696051",
     "xcvrd_switch_standby_start": "2021-May-13 10:01:15.690835"
+    "xcvrd_switch_standby_end": "2021-May-13 10:01:15.696051",
+    "linkmgrd_switch_standby_end": "2021-May-13 10:01:15.696728",
 }
 """
 


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

This PR fixes the display for show muxcable metrics by sorting the output based on the time of the event. 
This is required for better display.
For example

`admin@str2-7050cx3-acs-12:~$ show mux metrics Ethernet0`
`PORT       EVENT                        TIME`
`---------  ---------------------------  ---------------------------`
`Ethernet0  xcvrd_switch_standby_start   2021-Jul-21 02:03:28.784027`
`Ethernet0  orch_switch_standby_end      2021-Jul-21 02:03:28.788150`
`Ethernet0  linkmgrd_switch_standby_end  2021-Jul-21 02:03:28.790288`


<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
changed the output for muxcable metrics command for sorted time order
#### How I did it
made the changes inside the show/muxcable.py by sorting the output
#### How to verify it
unit-tests
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

