### PR TITLE
fix the show ip bgp network command

### DIFF
--- a/show/bgp_frr_v4.py
+++ b/show/bgp_frr_v4.py
@@ -97,7 +97,7 @@ def neighbors(ipaddress, info_type, namespace):
                 show_default=True,
                 required=True if multi_asic.is_multi_asic is True else False,
                 help='Namespace name or all',
-                default=None,
+                default=multi_asic.DEFAULT_NAMESPACE,
                 callback=multi_asic_util.multi_asic_namespace_validation_callback)
 def network(ipaddress, info_type, namespace):
     """Show IP (IPv4) BGP network"""

--- a/show/bgp_frr_v6.py
+++ b/show/bgp_frr_v6.py
@@ -96,7 +96,7 @@ def neighbors(ipaddress, info_type, namespace):
                 show_default=True,
                 required=True if multi_asic.is_multi_asic is True else False,
                 help='Namespace name or all',
-                default=None,
+                default=multi_asic.DEFAULT_NAMESPACE,
                 callback=multi_asic_util.multi_asic_namespace_validation_callback)
 def network(ipaddress, info_type, namespace):
     """Show BGP ipv6 network"""


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix the issue https://github.com/Azure/sonic-buildimage/issues/7935

#### How I did it
Add the default namespace option to `DEFAULT_NAMESPACE` instead of `None`
#### How to verify it
Run the command on VS
`show ip bgp network` and `show ipv6 bgp network`

```
admin@vlab-01:~$ show ip bgp network  -h
Usage: show ip bgp network [OPTIONS] [<ipv4-address>|<ipv4-prefix>]
                           [bestpath|json|longer-prefixes|multipath]

  Show IP (IPv4) BGP network

Options:
  -n, --namespace TEXT  Namespace name or all  [default: ]
  -h, -?, --help        Show this message and exit.
admin@vlab-01:~$ show ip bgp network | more

BGP table version is 6405, local router ID is 10.1.0.32, vrf id 0
Default local pref 100, local AS 65100
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete

   Network          Next Hop            Metric LocPrf Weight Path
*= 0.0.0.0/0        10.0.0.61                              0 64600 65534 6666 6667 i
*=                  10.0.0.63                              0 64600 65534 6666 6667 i
*>                  10.0.0.57                              0 64600 65534 6666 6667 i
*=                  10.0.0.59                              0 64600 65534 6666 6667 i
*> 10.1.0.32/32     0.0.0.0                  0         32768 i
*> 100.1.0.29/32    10.0.0.57                              0 64600 i
*> 100.1.0.30/32    10.0.0.59                              0 64600 i
admin@vlab-01:~$ show ip bgp network 100.1.0.30/32

BGP routing table entry for 100.1.0.30/32
Paths: (1 available, best #1, table default)
  Advertised to non peer-group peers:
  10.0.0.57 10.0.0.59 10.0.0.61 10.0.0.63
  64600
    10.0.0.59 from 10.0.0.59 (100.1.0.30)
      Origin IGP, valid, external, best (First path received)
      Community: 5060:12345
      Last update: Tue Jul 27 22:20:03 2021
```

```
admin@vlab-01:~$ show ipv6 bgp network | more
BGP table version is 6407, local router ID is 10.1.0.32, vrf id 0
Default local pref 100, local AS 65100
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete

   Network          Next Hop            Metric LocPrf Weight Path
*= ::/0             fc00::7a                               0 64600 65534 6666 6667 i
*=                  fc00::7e                               0 64600 65534 6666 6667 i
*>                  fc00::72                               0 64600 65534 6666 6667 i
*=                  fc00::76                               0 64600 65534 6666 6667 i
*> 2064:100::1d/128 fc00::72                               0 64600 i
*> 2064:100::1e/128 fc00::76                               0 64600 i
*> 2064:100::1f/128 fc00::7a                               0 64600 i
*> 2064:100::20/128 fc00::7e                               0 64600 i


admin@vlab-01:~$ show ipv6 bgp network 2064:100::20/128
BGP routing table entry for 2064:100::20/128
Paths: (1 available, best #1, table default)
  Advertised to non peer-group peers:
  fc00::72 fc00::76 fc00::7a fc00::7e
  64600
    fc00::7e from fc00::7e (100.1.0.32)
    (fe80::cde:f4ff:feff:c74e) (prefer-global)
      Origin IGP, valid, external, best (First path received)
      Community: 5060:12345
      Last update: Tue Jul 27 22:20:07 2021
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

