### PR TITLE
[config][interface][speed] Fixed the config interface speed in multi-asic issue

### DIFF
--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -81,7 +81,7 @@ class portconfig(object):
             self.state_db = SonicV2Connector(host='127.0.0.1')
         else:
             self.db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
-            self.state_db = SonicV2Connector(use_unix_socket_path=True, namespace=front_asic_namespaces)
+            self.state_db = SonicV2Connector(use_unix_socket_path=True, namespace=namespace)
         self.db.connect()
         self.state_db.connect(self.state_db.STATE_DB, False)
 


### PR DESCRIPTION


#### What I did

Fix for issue https://github.com/Azure/sonic-buildimage/issues/8308

#### How I did it

"front_asic_namespaces" is not defined. Changed  function Sonic2VConnector() call with the correct argument "namespace". 

#### How to verify it

- Execute the config command to set the interface speed:
**sudo config interface -n asic0 speed Ethernet0 400000**
- No error shown

#### Previous command output (if the output of a command-line utility has changed)

- Previously the command showed the following error.
**name 'front_asic_namespaces' is not defined**

#### New command output (if the output of a command-line utility has changed)

- New output does not show the error

