### PR TITLE
[intfutil]Let speed 100M/2.5G can be correct displayed.

### DIFF
--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -138,12 +138,28 @@ def appl_db_port_status_get(appl_db, intf_name, status_type):
     if status is None:
         return "N/A"
     if status_type == PORT_SPEED and status != "N/A":
-        status = '{}G'.format(status[:-3])
+        if (len(status) < len('1000')):
+            status += 'M'
+        else:
+            if (status.rpartition('000')[1] != '000'):
+                status = status[:-3] + '.' + status[-3:]
+                status = status.rstrip('0') + 'G'
+            else:
+                status = '{}G'.format(status[:-3])
     elif status_type == PORT_ADV_SPEEDS and status != "N/A" and status != "all":
         speed_list = status.split(',')
         new_speed_list = []
         for s in natsorted(speed_list):
-            new_speed_list.append('{}G'.format(s[:-3]))
+            if (len(s) < len('1000')):
+                s += 'M'
+                new_speed_list.append(s)
+            else:
+                if (s.rpartition('000')[1] != '000'):
+                    s = s[:-3] + '.' + s[-3:]
+                    s = s.rstrip('0') + 'G'
+                    new_speed_list.append(s)
+                else:
+                    new_speed_list.append('{}G'.format(s[:-3]))
         status = ','.join(new_speed_list)
     return status
 
@@ -261,7 +277,14 @@ def po_speed_dict(po_int_dict, appl_db):
                     # If no speed was returned, append None without format
                     po_list.append(None)
                 else:
-                    interface_speed = '{}G'.format(interface_speed[:-3])
+                    if len(interface_speed) < len('1000'):
+                        interface_speed += 'M'
+                    else:
+                        if interface_speed.rpartition('000')[1] != '000':
+                            interface_speed = interface_speed[:-3] + '.' +interface_speed[-3:]
+                            interface_speed = interface_speed.rstrip('0') + 'G'
+                        else:
+                            interface_speed = '{}G'.format(interface_speed[:-3])
                     po_list.append(interface_speed)
             elif len(value) > 1:
                 for intf in value:
@@ -270,7 +293,14 @@ def po_speed_dict(po_int_dict, appl_db):
                     agg_speed_list.append(temp_speed)
                     interface_speed = sum(agg_speed_list)
                     interface_speed = str(interface_speed)
-                    interface_speed = '{}G'.format(interface_speed[:-3])
+                    if len(interface_speed) < len('1000'):
+                        interface_speed += 'M'
+                    else:
+                        if interface_speed.rpartition('000')[1] != '000':
+                            interface_speed = interface_speed[:-3] + '.' +interface_speed[-3:]
+                            interface_speed = interface_speed.rstrip('0') + 'G'
+                        else:
+                            interface_speed = '{}G'.format(interface_speed[:-3])
                 po_list.append(interface_speed)
             po_speed_dict = dict(po_list[i:i+2] for i in range(0, len(po_list), 2))
         return po_speed_dict


### PR DESCRIPTION
Parse the speed string:
The speed string length < len('1000'), display speed by unit 'M'
else display speed by unit 'G'

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Let speed 100M/2.5G can be correct displayed

#### How I did it
Parse the speed string:
The speed string length < len('1000'), display speed by unit 'M'
else display speed by 'G'

#### How to verify it
Real device verification.

Verify by the CLI cmd 'show interfaces status' output on the port which is configure with speed 100M
100M shall be shown in the Speed field

Verify by the CLI cmd 'show interfaces status' output on the port which is configured with speed 2.5G
2.5G shall be shown in the Speed field.
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

