### PR TITLE
[portconfig] Validate duplicate speed value and interface type value

### DIFF
--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -141,7 +141,12 @@ class portconfig(object):
             supported_speeds_str = self.get_supported_speeds(port)
             if supported_speeds_str:
                 supported_speeds = set(supported_speeds_str.split(','))
-                config_speeds = set(adv_speeds.split(','))
+                config_speed_list = [x.strip() for x in adv_speeds.split(',')]
+                config_speeds = set(config_speed_list)
+                if len(config_speeds) < len(config_speed_list):
+                    print('Invalid speed specified: {}'.format(adv_speeds))
+                    print('Please remove duplicate speed')
+                    exit(1)
                 invalid_speeds = config_speeds - supported_speeds
                 if invalid_speeds:
                     print('Invalid speed specified: {}'.format(','.join(invalid_speeds)))
@@ -164,7 +169,12 @@ class portconfig(object):
             print("Setting adv_interface_types %s on port %s" % (adv_interface_types, port))
         
         if adv_interface_types != 'all':
-            config_interface_types = set(adv_interface_types.split(','))
+            config_interface_type_list = [x.strip() for x in adv_interface_types.split(',')]
+            config_interface_types = set(config_interface_type_list)
+            if len(config_interface_types) < len(config_interface_type_list):
+                print("Invalid interface type specified: {}".format(adv_interface_types))
+                print('Please remove duplicate interface type')
+                exit(1)
             invalid_interface_types = config_interface_types - VALID_INTERFACE_TYPE_SET
             if invalid_interface_types:
                 print("Invalid interface type specified: {}".format(','.join(invalid_interface_types)))

--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -144,8 +144,7 @@ class portconfig(object):
                 config_speed_list = [x.strip() for x in adv_speeds.split(',')]
                 config_speeds = set(config_speed_list)
                 if len(config_speeds) < len(config_speed_list):
-                    print('Invalid speed specified: {}'.format(adv_speeds))
-                    print('Please remove duplicate speed')
+                    print('Invalid speed specified: {}. Please remove duplicate speed'.format(adv_speeds))
                     exit(1)
                 invalid_speeds = config_speeds - supported_speeds
                 if invalid_speeds:
@@ -172,8 +171,7 @@ class portconfig(object):
             config_interface_type_list = [x.strip() for x in adv_interface_types.split(',')]
             config_interface_types = set(config_interface_type_list)
             if len(config_interface_types) < len(config_interface_type_list):
-                print("Invalid interface type specified: {}".format(adv_interface_types))
-                print('Please remove duplicate interface type')
+                print("Invalid interface type specified: {}. Please remove duplicate interface type".format(adv_interface_types))
                 exit(1)
             invalid_interface_types = config_interface_types - VALID_INTERFACE_TYPE_SET
             if invalid_interface_types:

--- a/tests/config_an_test.py
+++ b/tests/config_an_test.py
@@ -50,6 +50,9 @@ class TestConfigInterface(object):
         result = self.basic_check("advertised-speeds", ["Ethernet0", "50000,100000"], ctx, operator.ne)
         assert 'Invalid speed' in result.output
         assert 'Valid speeds:' in result.output
+        result = self.basic_check("advertised-speeds", ["Ethernet0", "50000,50000"], ctx, operator.ne)
+        assert 'Invalid speed' in result.output
+        assert 'duplicate' in result.output
 
     def test_config_type(self, ctx):
         self.basic_check("type", ["Ethernet0", "CR4"], ctx)
@@ -66,6 +69,9 @@ class TestConfigInterface(object):
         result = self.basic_check("advertised-types", ["Ethernet0", "CR4,Invalid"], ctx, operator.ne)
         assert 'Invalid interface type specified' in result.output
         assert 'Valid interface types:' in result.output
+        result = self.basic_check("advertised-types", ["Ethernet0", "CR4,CR4"], ctx, operator.ne)
+        assert 'Invalid interface type specified' in result.output
+        assert 'duplicate' in result.output
         self.basic_check("advertised-types", ["Ethernet0", ""], ctx, operator.ne)
 
     def basic_check(self, command_name, para_list, ctx, op=operator.eq, expect_result=0):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Validate input parameter for command `config interface advertised-speeds` and `config interface advertised-types`, make sure there is no duplicate speeds or types

#### How I did it

Split input speeds/types with "," and check if there is a duplication, if yes, print an error.

#### How to verify it

1. new unit test case
2. manual test

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
```
admin@sonice:$ sudo config interface advertised-speeds Ethernet4 100000,25000,100000
Invalid speed specified: 100000,25000,100000
Please remove duplicate speed
```

```
admin@sonic:$ sudo config interface advertised-types Ethernet4 CR,CR4,CR4
Invalid interface type specified: CR,CR4,CR4
Please remove duplicate interface type
```

