### PR TITLE
disk_check: Script updated to run good in 201811 & 201911

### DIFF
--- a/scripts/disk_check.py
+++ b/scripts/disk_check.py
@@ -64,7 +64,7 @@ def test_writable(dirs):
 
 
 def run_cmd(cmd):
-    proc = subprocess.run(cmd, shell=True, text=True, capture_output=True)
+    proc = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE)
     ret = proc.returncode
     if ret:
         log_err("failed: ret={} cmd={}".format(ret, cmd))
@@ -72,9 +72,9 @@ def run_cmd(cmd):
         log_info("ret={} cmd: {}".format(ret, cmd))
 
     if proc.stdout:
-        log_info("stdout: {}".format(str(proc.stdout)))
+        log_info("stdout: {}".format(proc.stdout.decode("utf-8")))
     if proc.stderr:
-        log_info("stderr: {}".format(str(proc.stderr)))
+        log_info("stderr: {}".format(proc.stderr.decode("utf-8")))
     return ret
 
 
@@ -95,9 +95,15 @@ def do_mnt(dirs):
             return 1
 
     for d in dirs:
+        d_name = get_dname(d)
+        d_upper = os.path.join(UPPER_DIR, d_name)
+        d_work = os.path.join(WORK_DIR, d_name)
+        os.mkdir(d_upper)
+        os.mkdir(d_work)
+
         ret = run_cmd("mount -t overlay overlay_{} -o lowerdir={},"
         "upperdir={},workdir={} {}".format(
-            get_dname(d), d, UPPER_DIR, WORK_DIR, d))
+            d_name, d, d_upper, d_work, d))
         if ret:
             break
 

--- a/scripts/disk_check.py
+++ b/scripts/disk_check.py
@@ -21,6 +21,11 @@ How:
     Monit may be used to invoke it periodically, to help scan & fix and
     report via syslog.
 
+Tidbit:
+    If you would like to test this script, you could simulate a RO disk
+    with the following command. Reboot will revert the effect.
+        sudo bash -c "echo u > /proc/sysrq-trigger"
+
 """
 
 import argparse

--- a/tests/disk_check_test.py
+++ b/tests/disk_check_test.py
@@ -2,6 +2,7 @@ import sys
 import syslog
 from unittest.mock import patch
 import pytest
+import subprocess
 
 sys.path.append("scripts")
 import disk_check
@@ -26,7 +27,7 @@ test_data = {
         "workdir": "/tmp/tmpy",
         "mounts": "overlay_tmpx blahblah",
         "err": "/tmpx is not read-write|READ-ONLY: Mounted ['/tmpx'] to make Read-Write",
-        "cmds": ['mount -t overlay overlay_tmpx -o lowerdir=/tmpx,upperdir=/tmp/tmpx,workdir=/tmp/tmpy /tmpx']
+        "cmds": ['mount -t overlay overlay_tmpx -o lowerdir=/tmpx,upperdir=/tmp/tmpx/tmpx,workdir=/tmp/tmpy/tmpx /tmpx']
     },
     "3": {
         "desc": "Not good as /tmpx is not read-write; mount fail as create of upper fails",
@@ -90,8 +91,11 @@ class proc:
             self.stderr = proc_upd.get("stderr", None)
 
 
-def mock_subproc_run(cmd, shell, text, capture_output):
+def mock_subproc_run(cmd, shell, stdout):
     global cmds
+
+    assert shell == True
+    assert stdout == subprocess.PIPE
 
     upd = (current_tc["proc"][len(cmds)]
             if len(current_tc.get("proc", [])) > len(cmds) else None)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Have independent subdirs for each mounted dir to avoid any collisions of files/dirs by same name.
Adopt for older version of python3

#### How I did it
Changes:
1) Individual subdirs for each dir to be mounted
2) subprocess args made compatible with older version of python3 (tested in version 3.5.3)

#### How to verify it
1) Simulate read-only state
2) Run this script
3) Test ssh via new tacacs user (who had not logged in earlier)

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

