### PR TITLE
[show][platform] Revise chassis info fallback to only fall back on pmon crash

### DIFF
--- a/show/platform.py
+++ b/show/platform.py
@@ -21,16 +21,18 @@ def get_chassis_info():
 
     def try_get(platform, attr, fallback):
         try:
-            return getattr(platform, "get_{}".format(attr))()
+            if platform["chassis"] is None:
+                import sonic_platform
+                platform["chassis"] = sonic_platform.platform.Platform().get_chassis()
+            return getattr(platform["chassis"], "get_{}".format(attr))()
         except Exception:
             return 'N/A'
 
     chassis_info = device_info.get_chassis_info()
 
     if all(v is None for k, v in chassis_info.items()):
-        import sonic_platform
-        platform_chassis = sonic_platform.platform.Platform().get_chassis()
-        chassis_info = {k:try_get(platform_chassis, k, "N/A") for k in keys}
+        platform_cache = {"chassis": None}
+        chassis_info = {k:try_get(platform_cache, k, "N/A") for k in keys}
 
     return chassis_info
 


### PR DESCRIPTION
#### What I did

Changed the behavior of the `get_chassis_info()` function which is used by `show version` and `show platform summary` to report the serial / model / revision of the switch to only attempt to call the platform API if pmon completely failed to provision STATE_DB with CHASSIS_INFO

#### How I did it

Altered `get_chassis_info()` according to the above behavior. See changelog for details. 

#### How to verify it

Verify `show platform summary` and `show version` correctly report chassis info.

Delete the `CHASSIS_INFO` table from `STATE_DB`

Verify `show platform summary` and `show version` still correctly report the info. 
