### PR TITLE
Load the database global_db

### DIFF
--- a/utilities_common/multi_asic.py
+++ b/utilities_common/multi_asic.py
@@ -7,6 +7,7 @@ import pyroute2
 from natsort import natsorted
 from sonic_py_common import multi_asic
 from utilities_common import constants
+from utilities_common.general import load_db_config
 
 
 class MultiAsic(object):
@@ -15,6 +16,8 @@ class MultiAsic(object):
         self, display_option=constants.DISPLAY_ALL, namespace_option=None,
         db=None
     ):
+        # Load database config files
+        load_db_config()
         self.namespace_option = namespace_option
         self.display_option = display_option
         self.current_namespace = None


### PR DESCRIPTION
Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Recent change was done to remove call to load database global_db which expects the clients to load global_db.
[https://github.com/Azure/sonic-buildimage/pull/8173]
The load global_db was missing in multi_asic.py which was causing "show interfaces cli" to fail.
While testing on multi-asic VS image:
```
admin@vlab-08:~$ show interfaces status
Traceback (most recent call last):
  File "/usr/local/bin/intfutil", line 701, in <module>
    main()
  File "/usr/local/bin/intfutil", line 687, in main
    interface_stat.display_intf_status()
  File "/usr/local/bin/intfutil", line 376, in display_intf_status
    self.get_intf_status()
  File "/usr/local/lib/python3.7/dist-packages/utilities_common/multi_asic.py", line 133, in wrapped_run_on_all_asics
    ns_list = self.multi_asic.get_ns_list_based_on_options()
  File "/usr/local/lib/python3.7/dist-packages/utilities_common/multi_asic.py", line 59, in get_ns_list_based_on_options
    namespaces = multi_asic.get_all_namespaces()
  File "/usr/local/lib/python3.7/dist-packages/sonic_py_common/multi_asic.py", line 226, in get_all_namespaces
    config_db = connect_config_db_for_ns(namespace)
  File "/usr/local/lib/python3.7/dist-packages/sonic_py_common/multi_asic.py", line 40, in connect_config_db_for_ns
    config_db = swsscommon.ConfigDBConnector(namespace=namespace)
  File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 2076, in __init__
    super(ConfigDBConnector, self).__init__(use_unix_socket_path = use_unix_socket_path, namespace = namespace)
  File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 1698, in __init__
    for db_name in self.get_db_list():
  File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 1634, in get_db_list
    return _swsscommon.SonicV2Connector_Native_get_db_list(self)
RuntimeError: :- validateNamespace: Initialize global DB config using API SonicDBConfig::initializeGlobalConfig
```
#### How I did it
load global_db config in multi_asic.py.
#### How to verify it
Load multi-asic VS image with the fix.
```
admin@vlab-08:~$ show interfaces status
      Interface        Lanes    Speed    MTU    FEC        Alias             Vlan    Oper    Admin    Type    Asym PFC
---------------  -----------  -------  -----  -----  -----------  ---------------  ------  -------  ------  ----------
      Ethernet0      1,2,3,4      40G   9100    N/A  Ethernet1/1  PortChannel0002      up       up     N/A         off
      Ethernet4      5,6,7,8      40G   9100    N/A  Ethernet1/2  PortChannel0002      up       up     N/A         off
      Ethernet8   9,10,11,12      40G   9100    N/A  Ethernet1/3  PortChannel0005      up       up     N/A         off
     Ethernet12  13,14,15,16      40G   9100    N/A  Ethernet1/4  PortChannel0005      up       up     N/A         off
     Ethernet16      1,2,3,4      40G   9100    N/A  Ethernet1/5  PortChannel0001      up       up     N/A         off
     Ethernet20      5,6,7,8      40G   9100    N/A  Ethernet1/6  PortChannel0003      up       up     N/A         off
     Ethernet24   9,10,11,12      40G   9100    N/A  Ethernet1/7  PortChannel0004      up       up     N/A         off
     Ethernet28  13,14,15,16      40G   9100    N/A  Ethernet1/8  PortChannel0006      up       up     N/A         off
PortChannel0001          N/A      40G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel0002          N/A      80G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel0003          N/A      40G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel0004          N/A      40G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel0005          N/A      80G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel0006          N/A      40G   9100    N/A          N/A           routed      up       up     N/A         N/A
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

