### PR TITLE
[show] Allow system with no ports in config db run without errors

### DIFF
--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -127,7 +127,6 @@ class InterfaceAliasConverter(object):
 
 
         if not self.port_dict:
-            click.echo(message="Warning: failed to retrieve PORT table from ConfigDB!", err=True)
             self.port_dict = {}
 
         for port_name in self.port_dict:

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -127,6 +127,7 @@ class InterfaceAliasConverter(object):
 
 
         if not self.port_dict:
+            click.echo(message="Configuration database contains no ports")
             self.port_dict = {}
 
         for port_name in self.port_dict:


### PR DESCRIPTION
What I did
Allow system with no ports in config db run without errors.
This is needed for modular system which should boot properly without line cards.

How I did it
Do not raise warning if ports dictionary is empty.

How to verify it
Run show interfaces status

Previous command output (if the output of a command-line utility has changed)
root@r-leopard-41:/home/admin# show interfaces status
Warning: failed to retrieve PORT table from ConfigDB!
Warning: failed to retrieve PORT table from ConfigDB!
Interface Lanes Speed MTU FEC Alias Vlan Oper Admin Type Asym PFC
*----------- ------- ------- ----- ----- ------- ------ ------ ------- ------ ----------
root@r-leopard-41:/home/admin#

New command output (if the output of a command-line utility has changed)
root@r-leopard-41:/home/admin# show interfaces status
Interface Lanes Speed MTU FEC Alias Vlan Oper Admin Type Asym PFC
*----------- ------- ------- ----- ----- ------- ------ ------ ------- ------ ----------
root@r-leopard-41:/home/admin#

