### PR TITLE
[201911][vnet_route_check] don't hardcode prefix length of /24

### DIFF
--- a/scripts/vnet_route_check.py
+++ b/scripts/vnet_route_check.py
@@ -186,7 +186,9 @@ def filter_out_vnet_ip2me_routes(vnet_routes):
         # rif_attrs[1] - IP prefix and prefix legth
         # IP2ME routes have '/32' prefix length so replace it and add to the list
         if rif_attrs[0] in vnet_intfs:
-            vnet_ip2me_routes.append(rif_attrs[1].replace('/24', '/32'))
+            rif_ip, _ = rif_attrs[1].split('/')
+            ip2me_route = rif_ip + '/32'
+            vnet_ip2me_routes.append(ip2me_route)
 
     for vnet, vnet_attrs in vnet_routes.items():
         for route in vnet_attrs['routes']:
@@ -237,7 +239,7 @@ def get_vnet_routes_from_asic_db():
 
     vnet_vrfs = get_vrf_entries()
     vnet_vrfs_oids = [vnet_vrfs[k] for k in vnet_vrfs]
-    
+
     vnet_intfs = get_vnet_intfs()
 
     vrf_oid_to_vnet_map = {}


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Fix an issue when having /16 prefix on Vlan with vnet:

```
ERR vnet_route_check.py:  {'results': {'missed_in_app_db_routes': {'Vnet3': {'routes': ['172.3.255.254/32']}}}}
```

```
Interface     Master    IPv4 address/mask    Admin/Oper    BGP Neighbor     Neighbor IP
------------  --------  -------------------  ------------  ---------------  -------------
Loopback0               10.1.0.2/32          up/up         N/A              N/A
PortChannel1            10.100.0.16/31       up/up         TGS-SONIC-N2-S1  10.100.0.17
PortChannel2            10.100.0.18/31       up/up         TGS-SONIC-N2-S1  10.100.0.19
PortChannel3            10.100.0.20/31       up/up         TGS-SONIC-N2-S1  10.100.0.21
PortChannel4            10.100.0.22/31       up/up         TGS-SONIC-N2-S1  10.100.0.23
PortChannel5            10.100.0.24/31       up/up         PTR-SONIC-N2-S2  10.100.0.25
PortChannel6            10.100.0.26/31       up/up         PTR-SONIC-N2-S2  10.100.0.27
PortChannel7            10.100.0.28/31       up/up         PTR-SONIC-N2-S2  10.100.0.29
PortChannel8            10.100.0.30/31       up/up         PTR-SONIC-N2-S2  10.100.0.31
Vlan3         Vnet3     172.3.255.254/16     up/up         N/A              N/A
Vlan102                 22.144.1.254/16      up/up         N/A              N/A
docker0                 240.127.1.1/24       up/down       N/A              N/A
eth0                    10.144.253.130/16    up/up         N/A              N/A
lo                      127.0.0.1/8          up/up         N/A              N/A

```

#### How I did it

Avoid hardcoded /24 prefix.

#### How to verify it

Configure Vlan with /16 prefix and sudo vnet_route_check.py.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

