### PR TITLE
Improve `config` error handling on version_info

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -950,8 +950,12 @@ def config(ctx):
 
     try:
         version_info = device_info.get_sonic_version_info()
-        asic_type = version_info['asic_type']
-    except (KeyError, TypeError):
+        if version_info:
+            asic_type = version_info['asic_type']
+        else:
+            asic_type = None
+    except (KeyError, TypeError) as e:
+        print("Caught an exception: " + str(e))
         raise click.Abort()
 
     # Load database config files


### PR DESCRIPTION
#### What I did
`get_sonic_version_info()` may return `None` if `/etc/sonic/sonic_version.yml` does not exist. Previously the `config` exit without any useful information.

Some `config` subcommands do not depend on sonic version info, we should allow them to run.

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

