### PR TITLE
[breakout] Fix the check  when port is not present in BREAKOUT_CFG table

### DIFF
--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -203,6 +203,9 @@ def breakout(ctx):
             raise click.Abort()
 
         for port_name in platform_dict:
+            # Check whether port is available in `BREAKOUT_CFG` table or not
+            if  port_name not in cur_brkout_tbl:
+                continue
             cur_brkout_mode = cur_brkout_tbl[port_name]["brkout_mode"]
 
             # Update deafult breakout mode and current breakout mode to platform_dict
@@ -252,7 +255,11 @@ def currrent_mode(ctx, interface):
 
     # Show current Breakout Mode of user prompted interface
     if interface is not None:
-        body.append([interface, str(cur_brkout_tbl[interface]['brkout_mode'])])
+        # Check whether interface is available in `BREAKOUT_CFG` table or not
+        if interface in cur_brkout_tbl:
+            body.append([interface, str(cur_brkout_tbl[interface]['brkout_mode'])])
+        else:
+            body.append([interface, "Not Available"])
         click.echo(tabulate(body, header, tablefmt="grid"))
         return
 

--- a/tests/show_breakout_test.py
+++ b/tests/show_breakout_test.py
@@ -35,6 +35,16 @@ current_mode_intf_output = ''+ \
 +-------------+-------------------------+
 """
 
+# Negetive Test
+# Expected output for 'show breakout current-mode Ethernet60'
+current_mode_intf_output_Ethernet60 = ''+ \
+"""+-------------+-------------------------+
+| Interface   | Current Breakout Mode   |
++=============+=========================+
+| Ethernet60  | Not Available           |
++-------------+-------------------------+
+"""
+
 class TestBreakout(TestCase):
     @classmethod
     def setup_class(cls):
@@ -58,6 +68,12 @@ class TestBreakout(TestCase):
         result = self.runner.invoke(show.cli.commands["interfaces"].commands["breakout"].commands["current-mode"], ["Ethernet0"], obj=self.obj)
         print(sys.stderr, result.output)
         assert result.output == current_mode_intf_output
+
+    # Negetive Test 'show interfaces  breakout current-mode Ethernet60'
+    def test_single_intf_current_mode(self):
+        result = self.runner.invoke(show.cli.commands["interfaces"].commands["breakout"].commands["current-mode"], ["Ethernet60"], obj=self.obj)
+        print(sys.stderr, result.output)
+        assert result.output == current_mode_intf_output_Ethernet60
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
Signed-off-by: Sangita Maity <samaity@linkedin.com>

#### What I did

This PR fixed issue for [show interface breakout](https://github.com/Azure/sonic-buildimage/issues/7957) issue

**Before this fix**
removed `Ethernet60` from breakout_cfg table for unit testing and got the issue
```
 
admin@lnos-x1-a-asw04:~$ sudo redis-cli -n 4 del "BREAKOUT_CFG|Ethernet60"
(integer) 1
admin@lnos-x1-a-asw04:~$ sudo redis-cli -n 4 hgetall "BREAKOUT_CFG|Ethernet60"
(empty array)
admin@lnos-x1-a-asw04:~$ show int breakout
Traceback (most recent call last):
  File "/usr/local/bin/show", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1114, in invoke
    return Command.invoke(self, ctx)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/show/interfaces/__init__.py", line 181, in breakout
    cur_brkout_mode = cur_brkout_tbl[port_name]["brkout_mode"]
KeyError: 'Ethernet60'

```

**After the fix**
```

admin@lnos-x1-a-asw04:~$ show int breakout current-mode Ethernet60
+-------------+-------------------------+
| Interface   | Current Breakout Mode   |
+=============+=========================+
| Ethernet60  | Not Available           |
+-------------+-------------------------+
```
#### How I did it
Gracefully handle the error when port/interface is not present in `BREAKOUT_CFG` table.

#### How to verify it
```
show interface breakout 
show int interface current-mode

```
**_Added unit test case for negetive Test case_**
