### PR TITLE
[config reload]: fix the condition for checking if system is starting

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -43,7 +43,7 @@ from . import vlan
 from . import vxlan
 from . import plugins
 from .config_mgmt import ConfigMgmtDPB
-from . import mclag 
+from . import mclag
 
 # mock masic APIs for unit test
 try:
@@ -727,9 +727,9 @@ def _swss_ready():
     else:
         return False
 
-def _system_running():
+def _is_system_starting():
     out = clicommon.run_command("sudo systemctl is-system-running", return_cmd=True)
-    return out.strip() == "running"
+    return out.strip() == "starting"
 
 def interface_is_in_vlan(vlan_member_table, interface_name):
     """ Check if an interface is in a vlan """
@@ -1233,7 +1233,7 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, disable_arp_cach
        <filename> : Names of configuration file(s) to load, separated by comma with no spaces in between
     """
     if not force and not no_service_restart:
-        if not _system_running():
+        if _is_system_starting():
             click.echo("System is not up. Retry later or use -f to avoid system checks")
             return
 
@@ -1491,10 +1491,10 @@ def load_port_config(config_db, port_config_path):
     # Validate if the input is an array
     if not isinstance(port_config_input, list):
         raise Exception("Bad format: port_config is not an array")
-    
+
     if len(port_config_input) == 0 or 'PORT' not in port_config_input[0]:
         raise Exception("Bad format: PORT table not exists")
-        
+
     port_config = port_config_input[0]['PORT']
 
     # Ensure all ports are exist


### PR DESCRIPTION
When systemd services finished, the systemd status could running
or degraded. Therefore, compare system status with starting directly.

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
When systemd services finished, the systemd status could running
or degraded. Therefore, compare system status with starting directly.

Here is what is happening on kvm switch. Some services cannot be started.
Then, the system state is in degraded state.

```
admin@ARISTA01T1:~$ systemctl is-system-running
starting
admin@ARISTA01T1:~$ systemctl is-system-running
degraded
```
#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

