### PR TITLE
Fixed show and config mpls cli bug where invalid interfaces would pas…

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -4026,6 +4026,12 @@ def add(ctx, interface_name):
             ctx.fail("'interface_name' is None!")
 
     table_name = get_interface_table_name(interface_name)
+    if (not interface_name in config_db.get_keys('VLAN_INTERFACE') and
+        not interface_name in config_db.get_keys('INTERFACE') and
+        not interface_name in config_db.get_keys('PORTCHANNEL_INTERFACE') and
+        not interface_name == 'null'):
+            ctx.fail('interface {} doesn`t exist'.format(interface_name))
+    
     if table_name == "":
         ctx.fail("'interface_name' is not valid. Valid names [Ethernet/PortChannel/Vlan]")
     config_db.set_entry(table_name, interface_name, {"mpls": "enable"})
@@ -4046,6 +4052,12 @@ def remove(ctx, interface_name):
             ctx.fail("'interface_name' is None!")
 
     table_name = get_interface_table_name(interface_name)
+    if (not interface_name in config_db.get_keys('VLAN_INTERFACE') and
+        not interface_name in config_db.get_keys('INTERFACE') and
+        not interface_name in config_db.get_keys('PORTCHANNEL_INTERFACE') and
+        not interface_name == 'null'):
+            ctx.fail('interface {} doesn`t exist'.format(interface_name))
+    
     if table_name == "":
         ctx.fail("'interface_name' is not valid. Valid names [Ethernet/PortChannel/Vlan]")
     config_db.set_entry(table_name, interface_name, {"mpls": "disable"})

--- a/config/main.py
+++ b/config/main.py
@@ -4025,13 +4025,9 @@ def add(ctx, interface_name):
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
-    table_name = get_interface_table_name(interface_name)
-    if (not interface_name in config_db.get_keys('VLAN_INTERFACE') and
-        not interface_name in config_db.get_keys('INTERFACE') and
-        not interface_name in config_db.get_keys('PORTCHANNEL_INTERFACE') and
-        not interface_name == 'null'):
-            ctx.fail('interface {} doesn`t exist'.format(interface_name))
-    
+    table_name = get_interface_table_name(interface_name)  
+    if not clicommon.is_interface_in_config_db(config_db, interface_name):
+        ctx.fail('interface {} doesn`t exist'.format(interface_name))
     if table_name == "":
         ctx.fail("'interface_name' is not valid. Valid names [Ethernet/PortChannel/Vlan]")
     config_db.set_entry(table_name, interface_name, {"mpls": "enable"})
@@ -4051,13 +4047,9 @@ def remove(ctx, interface_name):
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
-    table_name = get_interface_table_name(interface_name)
-    if (not interface_name in config_db.get_keys('VLAN_INTERFACE') and
-        not interface_name in config_db.get_keys('INTERFACE') and
-        not interface_name in config_db.get_keys('PORTCHANNEL_INTERFACE') and
-        not interface_name == 'null'):
-            ctx.fail('interface {} doesn`t exist'.format(interface_name))
-    
+    table_name = get_interface_table_name(interface_name) 
+    if not clicommon.is_interface_in_config_db(config_db, interface_name):
+        ctx.fail('interface {} doesn`t exist'.format(interface_name))
     if table_name == "":
         ctx.fail("'interface_name' is not valid. Valid names [Ethernet/PortChannel/Vlan]")
     config_db.set_entry(table_name, interface_name, {"mpls": "disable"})

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -331,7 +331,7 @@ def expected(db, interfacename):
 @click.pass_context
 def mpls(ctx, interfacename, namespace, display):
     """Show Interface MPLS status"""
-       
+     
     #Edge case: Force show frontend interfaces on single asic
     if not (multi_asic.is_multi_asic()):
        if (display == 'frontend' or display == 'all' or display is None):

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -346,9 +346,9 @@ def mpls(ctx, interfacename, namespace, display):
     intfs_data = {}
     intf_found = False
 
-    for ns in range(len(ns_list)):
+    for ns in ns_list:
 
-        appl_db = multi_asic.connect_to_all_dbs_for_ns(namespace=ns_list[ns])
+        appl_db = multi_asic.connect_to_all_dbs_for_ns(namespace=ns)
 
         if interfacename is not None:
             interfacename = try_convert_interfacename_from_alias(ctx, interfacename)
@@ -365,26 +365,26 @@ def mpls(ctx, interfacename, namespace, display):
             if (interfacename is not None):
                 if (interfacename != ifname):
                     continue
-                else:
-                    intf_found = True
+                
+                intf_found = True
             
             if (display != "all"):
                 if ("Loopback" in ifname):
                     continue
                 
-                if ifname.startswith("Ethernet") and multi_asic.is_port_internal(ifname, ns_list[ns]):
+                if ifname.startswith("Ethernet") and multi_asic.is_port_internal(ifname, ns):
                     continue
 
-                if ifname.startswith("PortChannel") and multi_asic.is_port_channel_internal(ifname, ns_list[ns]):
+                if ifname.startswith("PortChannel") and multi_asic.is_port_channel_internal(ifname, ns):
                     continue
 
 
             mpls_intf = appl_db.get_all(appl_db.APPL_DB, key)
 
             if 'mpls' not in mpls_intf or mpls_intf['mpls'] == 'disable':
-                intfs_data.update({tokens[1]: 'disable'})
+                intfs_data.update({ifname: 'disable'})
             else:
-                intfs_data.update({tokens[1]: mpls_intf['mpls']}) 
+                intfs_data.update({ifname: mpls_intf['mpls']}) 
     
     # Check if interface is valid
     if (interfacename is not None and not intf_found):

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -354,16 +354,12 @@ def mpls(ctx, interfacename, namespace, display):
 
         if interfacename is not None:
             interfacename = try_convert_interfacename_from_alias(ctx, interfacename)
-            key = "INTF_TABLE:" + str(interfacename)
-            mpls_intf = appl_db.get_all(appl_db.APPL_DB, key)
-            # Check if interface exists on any asic
-            if mpls_intf is None and ns == len(ns_list) - 1:
-                print("Error: Invalid interface. Interface not found!")
-                return
-            elif mpls_intf is None:
+            if not clicommon.is_interface_in_appl_db(appl_db, interfacename) and ns == len(ns_list) - 1:
+                ctx.fail('interface {} doesn`t exist'.format(interfacename))
+            elif not clicommon.is_interface_in_appl_db(appl_db, interfacename):
                 continue
 
-            # Add to interface output table since interface is found, and break
+            mpls_intf = clicommon.get_all_interfaces_with_key(appl_db, "INTF_TABLE:" + str(interfacename))
             if 'mpls' not in mpls_intf or mpls_intf['mpls'] == 'disable':
                 intfs_data.update({interfacename: 'disable'})
             else:
@@ -372,7 +368,7 @@ def mpls(ctx, interfacename, namespace, display):
             break
 
         # Fetching data from appl_db for intfs
-        keys = appl_db.keys(appl_db.APPL_DB, "INTF_TABLE:*")
+        keys = clicommon.get_all_interfaces(appl_db)
         for key in keys if keys else []:
             tokens = key.split(":")
             ifname = tokens[1]

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -331,7 +331,7 @@ def expected(db, interfacename):
 @click.pass_context
 def mpls(ctx, interfacename, namespace, display):
     """Show Interface MPLS status"""
-     
+    
     #Edge case: Force show frontend interfaces on single asic
     if not (multi_asic.is_multi_asic()):
        if (display == 'frontend' or display == 'all' or display is None):

--- a/tests/mpls_test.py
+++ b/tests/mpls_test.py
@@ -50,6 +50,17 @@ Ethernet-BP0  enable
 Ethernet-BP4  disable
 """
 
+show_interfaces_mpls_output_interface="""\
+Interface    MPLS State
+-----------  ------------
+Ethernet4    enable
+"""
+
+show_interfaces_mpls_masic_output_interface="""\
+Interface    MPLS State
+-----------  ------------
+Ethernet4    disable
+"""
 
 modules_path = os.path.join(os.path.dirname(__file__), "..")
 test_path = os.path.join(modules_path, "tests")
@@ -72,12 +83,27 @@ class TestMpls(object):
 
         result = runner.invoke(
                  config.config.commands["interface"].commands["mpls"].commands["add"],
-                 ["Ethernet8"], obj=obj
+                 ["Ethernet0"], obj=obj
                  )
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
-        assert db.cfgdb.get_entry("INTERFACE", "Ethernet8") == {"mpls": "enable"}
+        assert db.cfgdb.get_entry("INTERFACE", "Ethernet0") == {"mpls": "enable"}
+
+    def test_config_mpls_invalid_add(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db':db.cfgdb}
+
+        result = runner.invoke(
+                 config.config.commands["interface"].commands["mpls"].commands["add"],
+                 ["Ethernet8"], obj=obj
+                 )
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 2
+        assert result.output == """Usage: add [OPTIONS] <interface_name>\nTry "add --help" for help.\n\nError: interface Ethernet8 doesn`t exist\n""" 
+
 
     def test_show_interfaces_mpls_frontend(self):
 
@@ -111,7 +137,41 @@ class TestMpls(object):
         assert result.exit_code == 0
         assert result.output == show_interfaces_mpls_output_frontend
 
+    def test_show_interfaces_mpls_asic_interface(self):
+        runner = CliRunner()
+        result = runner.invoke(
+                 show.cli.commands["interfaces"].commands["mpls"],
+                 ["Ethernet4"]
+                 )
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_interfaces_mpls_output_interface
+    
+    def test_show_interfaces_mpls_asic_invalid_interface(self):
+        runner = CliRunner()
+        result = runner.invoke(
+                 show.cli.commands["interfaces"].commands["mpls"],
+                 ["Ethernet100"]
+                 )
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == "Error: Invalid interface. Interface not found!\n"
+    
     def test_config_mpls_remove(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db':db.cfgdb}
+
+        result = runner.invoke(
+                 config.config.commands["interface"].commands["mpls"].commands["remove"],
+                 ["Ethernet0"], obj=obj
+                 )
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_entry("INTERFACE", "Ethernet0") == {"mpls": "disable"}
+
+    def test_config_mpls_masic_invalid_remove(self):
         runner = CliRunner()
         db = Db()
         obj = {'config_db':db.cfgdb}
@@ -122,8 +182,9 @@ class TestMpls(object):
                  )
         print(result.exit_code)
         print(result.output)
-        assert result.exit_code == 0
-        assert db.cfgdb.get_entry("INTERFACE", "Ethernet8") == {"mpls": "disable"}
+        assert result.exit_code == 2
+        assert result.output == """Usage: remove [OPTIONS] <interface_name>\nTry "remove --help" for help.\n\nError: interface Ethernet8 doesn`t exist\n""" 
+
 
     @classmethod 
     def teardown_class(cls):
@@ -152,12 +213,27 @@ class TestMplsMasic(object):
 
         result = runner.invoke(
                  config.config.commands["interface"].commands["mpls"].commands["add"],
-                 ["Ethernet8"], obj=obj
+                 ["Ethernet0"], obj=obj
                  )
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
-        assert db.cfgdb.get_entry("INTERFACE", "Ethernet8") == {"mpls": "enable"}
+        assert db.cfgdb.get_entry("INTERFACE", "Ethernet0") == {"mpls": "enable"}
+
+
+    def test_config_mpls_masic_invalid_add(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db':db.cfgdb, 'namespace':'asic0'}
+
+        result = runner.invoke(
+                 config.config.commands["interface"].commands["mpls"].commands["add"],
+                 ["Ethernet8"], obj=obj
+                 )
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 2
+        assert result.output == """Usage: add [OPTIONS] <interface_name>\nTry "add --help" for help.\n\nError: interface Ethernet8 doesn`t exist\n""" 
 
 
     def test_show_interfaces_mpls_masic_frontend(self):
@@ -202,7 +278,41 @@ class TestMplsMasic(object):
         assert result.exit_code == 0
         assert result.output == show_interfaces_mpls_masic_output_asic_all
     
+    def test_show_interfaces_mpls_masic_asic_interface(self):
+        runner = CliRunner()
+        result = runner.invoke(
+                 show.cli.commands["interfaces"].commands["mpls"],
+                 ["Ethernet4"]
+                 )
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_interfaces_mpls_masic_output_interface
+    
+    def test_show_interfaces_mpls_masic_asic_invalid_interface(self):
+        runner = CliRunner()
+        result = runner.invoke(
+                 show.cli.commands["interfaces"].commands["mpls"],
+                 ["Ethernet100"]
+                 )
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == "Error: Invalid interface. Interface not found!\n"
+    
     def test_config_mpls_masic_remove(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db':db.cfgdb, 'namespace':'asic0'}
+
+        result = runner.invoke(
+                 config.config.commands["interface"].commands["mpls"].commands["remove"],
+                 ["Ethernet0"], obj=obj
+                 )
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_entry("INTERFACE", "Ethernet0") == {"mpls": "disable"}
+
+    def test_config_mpls_masic_invalid_remove(self):
         runner = CliRunner()
         db = Db()
         obj = {'config_db':db.cfgdb, 'namespace':'asic0'}
@@ -213,8 +323,9 @@ class TestMplsMasic(object):
                  )
         print(result.exit_code)
         print(result.output)
-        assert result.exit_code == 0
-        assert db.cfgdb.get_entry("INTERFACE", "Ethernet8") == {"mpls": "disable"}
+        assert result.exit_code == 2
+        assert result.output == """Usage: remove [OPTIONS] <interface_name>\nTry "remove --help" for help.\n\nError: interface Ethernet8 doesn`t exist\n""" 
+
 
     @classmethod
     def teardown_class(cls):

--- a/tests/mpls_test.py
+++ b/tests/mpls_test.py
@@ -62,6 +62,27 @@ Interface    MPLS State
 Ethernet4    disable
 """
 
+invalid_interface_remove_output = """\
+Usage: remove [OPTIONS] <interface_name>
+Try "remove --help" for help.
+
+Error: interface Ethernet8 doesn`t exist
+"""
+
+invalid_interface_add_output = """\
+Usage: add [OPTIONS] <interface_name>
+Try "add --help" for help.
+
+Error: interface Ethernet8 doesn`t exist
+""" 
+ 
+invalid_interface_show_output = """\
+Usage: mpls [OPTIONS] [INTERFACENAME]
+Try "mpls --help" for help.
+
+Error: interface Ethernet100 doesn`t exist
+"""
+ 
 modules_path = os.path.join(os.path.dirname(__file__), "..")
 test_path = os.path.join(modules_path, "tests")
 scripts_path = os.path.join(modules_path, "scripts")
@@ -90,7 +111,7 @@ class TestMpls(object):
         assert result.exit_code == 0
         assert db.cfgdb.get_entry("INTERFACE", "Ethernet0") == {"mpls": "enable"}
 
-    def test_config_mpls_invalid_add(self):
+    def test_config_mpls_invalid_interface_add(self):
         runner = CliRunner()
         db = Db()
         obj = {'config_db':db.cfgdb}
@@ -102,7 +123,7 @@ class TestMpls(object):
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 2
-        assert result.output == """Usage: add [OPTIONS] <interface_name>\nTry "add --help" for help.\n\nError: interface Ethernet8 doesn`t exist\n""" 
+        assert result.output == invalid_interface_add_output
 
 
     def test_show_interfaces_mpls_frontend(self):
@@ -155,7 +176,7 @@ class TestMpls(object):
                  )
         print(result.output)
         assert result.exit_code == 2
-        assert result.output == """Usage: mpls [OPTIONS] [INTERFACENAME]\nTry "mpls --help" for help.\n\nError: interface Ethernet100 doesn`t exist\n""" 
+        assert result.output == invalid_interface_show_output 
     
     def test_config_mpls_remove(self):
         runner = CliRunner()
@@ -171,7 +192,7 @@ class TestMpls(object):
         assert result.exit_code == 0
         assert db.cfgdb.get_entry("INTERFACE", "Ethernet0") == {"mpls": "disable"}
 
-    def test_config_mpls_masic_invalid_remove(self):
+    def test_config_mpls_invalid_interface_remove(self):
         runner = CliRunner()
         db = Db()
         obj = {'config_db':db.cfgdb}
@@ -183,7 +204,7 @@ class TestMpls(object):
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 2
-        assert result.output == """Usage: remove [OPTIONS] <interface_name>\nTry "remove --help" for help.\n\nError: interface Ethernet8 doesn`t exist\n""" 
+        assert result.output == invalid_interface_remove_output 
 
 
     @classmethod 
@@ -221,7 +242,7 @@ class TestMplsMasic(object):
         assert db.cfgdb.get_entry("INTERFACE", "Ethernet0") == {"mpls": "enable"}
 
 
-    def test_config_mpls_masic_invalid_add(self):
+    def test_config_mpls_masic_invalid_interface_add(self):
         runner = CliRunner()
         db = Db()
         obj = {'config_db':db.cfgdb, 'namespace':'asic0'}
@@ -233,7 +254,7 @@ class TestMplsMasic(object):
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 2
-        assert result.output == """Usage: add [OPTIONS] <interface_name>\nTry "add --help" for help.\n\nError: interface Ethernet8 doesn`t exist\n""" 
+        assert result.output == invalid_interface_add_output 
 
 
     def test_show_interfaces_mpls_masic_frontend(self):
@@ -296,7 +317,7 @@ class TestMplsMasic(object):
                  )
         print(result.output)
         assert result.exit_code == 2
-        assert result.output == """Usage: mpls [OPTIONS] [INTERFACENAME]\nTry "mpls --help" for help.\n\nError: interface Ethernet100 doesn`t exist\n""" 
+        assert result.output == invalid_interface_show_output 
     
     def test_config_mpls_masic_remove(self):
         runner = CliRunner()
@@ -312,7 +333,7 @@ class TestMplsMasic(object):
         assert result.exit_code == 0
         assert db.cfgdb.get_entry("INTERFACE", "Ethernet0") == {"mpls": "disable"}
 
-    def test_config_mpls_masic_invalid_remove(self):
+    def test_config_mpls_masic_invalid_interface_remove(self):
         runner = CliRunner()
         db = Db()
         obj = {'config_db':db.cfgdb, 'namespace':'asic0'}
@@ -324,7 +345,7 @@ class TestMplsMasic(object):
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 2
-        assert result.output == """Usage: remove [OPTIONS] <interface_name>\nTry "remove --help" for help.\n\nError: interface Ethernet8 doesn`t exist\n""" 
+        assert result.output == invalid_interface_remove_output 
 
 
     @classmethod

--- a/tests/mpls_test.py
+++ b/tests/mpls_test.py
@@ -154,8 +154,8 @@ class TestMpls(object):
                  ["Ethernet100"]
                  )
         print(result.output)
-        assert result.exit_code == 0
-        assert result.output == "Error: Invalid interface. Interface not found!\n"
+        assert result.exit_code == 2
+        assert result.output == """Usage: mpls [OPTIONS] [INTERFACENAME]\nTry "mpls --help" for help.\n\nError: interface Ethernet100 doesn`t exist\n""" 
     
     def test_config_mpls_remove(self):
         runner = CliRunner()
@@ -295,8 +295,8 @@ class TestMplsMasic(object):
                  ["Ethernet100"]
                  )
         print(result.output)
-        assert result.exit_code == 0
-        assert result.output == "Error: Invalid interface. Interface not found!\n"
+        assert result.exit_code == 2
+        assert result.output == """Usage: mpls [OPTIONS] [INTERFACENAME]\nTry "mpls --help" for help.\n\nError: interface Ethernet100 doesn`t exist\n""" 
     
     def test_config_mpls_masic_remove(self):
         runner = CliRunner()

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -587,21 +587,3 @@ def is_interface_in_config_db(config_db, interface_name):
 
     return True
 
-def is_interface_in_appl_db(appl_db, interface_name):
-    """ Check if an interface is in APPL DB """
-    key = "INTF_TABLE:" + str(interface_name)
-    interfaces = appl_db.get_all(appl_db.APPL_DB, key)
-
-    if interfaces is None:
-        return False
-
-    return True
-
-def get_all_interfaces(appl_db):
-    """ Return a list of all interfaces, present in APP DB """
-    return appl_db.keys(appl_db.APPL_DB, "INTF_TABLE:*")
-
-def get_all_interfaces_with_key(appl_db, key):
-    """ Return a list of interfaces given a key """
-    return appl_db.get_all(appl_db.APPL_DB, key)
-

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -576,3 +576,32 @@ def interface_is_untagged_member(db, interface_name):
             if (val['tagging_mode'] == 'untagged'):
                 return True
     return False
+
+def is_interface_in_config_db(config_db, interface_name):
+    """ Check if an interface is in CONFIG DB """
+    if (not interface_name in config_db.get_keys('VLAN_INTERFACE') and
+        not interface_name in config_db.get_keys('INTERFACE') and
+        not interface_name in config_db.get_keys('PORTCHANNEL_INTERFACE') and
+        not interface_name == 'null'):
+            return False
+
+    return True
+
+def is_interface_in_appl_db(appl_db, interface_name):
+    """ Check if an interface is in APPL DB """
+    key = "INTF_TABLE:" + str(interface_name)
+    interfaces = appl_db.get_all(appl_db.APPL_DB, key)
+
+    if interfaces is None:
+        return False
+
+    return True
+
+def get_all_interfaces(appl_db):
+    """ Return a list of all interfaces, present in APP DB """
+    return appl_db.keys(appl_db.APPL_DB, "INTF_TABLE:*")
+
+def get_all_interfaces_with_key(appl_db, key):
+    """ Return a list of interfaces given a key """
+    return appl_db.get_all(appl_db.APPL_DB, key)
+


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Added bug fixes for MPLS CLI commands where mpls show and config commands would allow invalid interfaces to be passed into the command, without displaying an error. No longer require the "-d all" flag to show internal interfaces too, when a specific interface is asked to "show". Also added respective unit tests to check out the errors, and test the expected output. 

#### How I did it

Modified the config/main.py to add logic to detect invalid interfaces by comparing against PORTCHANNEL_INTERFACES, INTERFACE, and VLAN_INTERFACE. Similarly added logic in show/interfaces in __init__.py to detect invalid interfaces by comparing interfaces across all ASICs. 

#### How to verify it

Type the following commands into the CLI, and see the output:

"show interfaces mpls $VALIDPORTCHANNEL" -> should output a table format of whether that interface has MPLS enabled or not. Notice the "d-all" flag is not required here, an internal interface will also be displayed when called. 

"show interfaces mpls $INVALID_PORTCHANNEL" -> produces an error as invalid interface

"sudo config interface -n $QASIC# mpls add $INVALID_PORTCHANNEL" -> produces an error as invalid interface

#### Previous command output (if the output of a command-line utility has changed)

For configuring an invalid interface in an ASIC:
"""
admin@vlab-07:~$ sudo config interface -n asic2 mpls add PortChannel4011
"""

No error is produced, which it should produce. 

For showing an invalid interface in an ASIC:
"""
admin@vlab-07: show interfaces mpls PortChannel4001
Interface                 MPLS State
---------------       ------------
"""

An error should be produced, which it is not. 


#### New command output (if the output of a command-line utility has changed)

For configuring an invalid interface in an ASIC:
"""
admin@vlab-07:~$ sudo config interface -n asic2 mpls add PortChannel4011
Usage: config interface mpls add [OPTIONS] <interface_name>
Try "config interface mpls add -h" for help.

Error: interface PortChannel4011 doesn`t exist
"""

For showing an invalid interface in an ASIC:
"""
admin@vlab-07:~$ show interfaces mpls PortChannel3007
Error: Invalid interface. Interface not found.
"""

Valid show mpls interface:
"""
admin@vlab-07: show interfaces mpls PortChannel4001
Interface                 MPLS State
---------------       ------------
PortChannel4001   enable
"""

Notice the "-d all" flag is not required. Internal interfaces are also displayed when trying to show a specific interface. 