### PR TITLE
[supervisor][show][interfaces]Fixed show interfaces command shows warning on Supervisor card

### DIFF
--- a/tests/interfaces_test.py
+++ b/tests/interfaces_test.py
@@ -2,6 +2,7 @@ import os
 import traceback
 
 from click.testing import CliRunner
+from unittest import mock
 
 import show.main as show
 
@@ -292,7 +293,30 @@ class TestInterfaces(object):
         traceback.print_tb(result.exc_info[2])
         assert result.exit_code == 0
         assert result.output == show_interfaces_portchannel_in_alias_mode_output
-
+        
+    @mock.patch('sonic_py_common.multi_asic.get_port_table', mock.MagicMock(return_value={}))
+    def test_supervisor_show_interfaces_alias_etp1_with_waring(self):
+        runner = CliRunner()
+        os.environ['SONIC_CLI_IFACE_MODE'] = "alias"
+        result = runner.invoke(show.cli.commands["interfaces"].commands["alias"], ["etp1"])
+        os.environ['SONIC_CLI_IFACE_MODE'] = "default"
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Configuration database contains no ports" in result.output
+        
+    @mock.patch('sonic_py_common.multi_asic.get_port_table', mock.MagicMock(return_value={}))
+    @mock.patch('sonic_py_common.device_info.is_supervisor', mock.MagicMock(return_value=True))
+    def test_supervisor_show_interfaces_alias_etp1_without_waring(self):
+        runner = CliRunner()
+        os.environ['SONIC_CLI_IFACE_MODE'] = "alias"
+        result = runner.invoke(show.cli.commands["interfaces"].commands["alias"], ["etp1"])
+        os.environ['SONIC_CLI_IFACE_MODE'] = "default"
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Configuration database contains no ports" not in result.output
+        
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -10,7 +10,7 @@ import json
 import netaddr
 
 from natsort import natsorted
-from sonic_py_common import multi_asic
+from sonic_py_common import multi_asic, device_info
 from utilities_common.db import Db
 from utilities_common.general import load_db_config
 
@@ -131,7 +131,8 @@ class InterfaceAliasConverter(object):
 
 
         if not self.port_dict:
-            click.echo(message="Configuration database contains no ports")
+            if not device_info.is_supervisor():
+                click.echo(message="Configuration database contains no ports")
             self.port_dict = {}
 
         for port_name in self.port_dict:


### PR DESCRIPTION
#### What I did
Fixed https://github.com/Azure/sonic-buildimage/issues/8521

#### How I did it
Before displaying the warning message, call device_info.is_supervisor() function to check if it is supervisor card, don't display the warning message.

#### How to verify it

1) Running the image on supervisor card
2) Execute the CLI "show interfaces status"
3) No warning should be seen.
```
admin@supervisor:~$ show interfaces status
  Interface    Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin    Type    Asym PFC
  -----------  -------  -------  -----  -----  -------  ------  ------  -------  ------  ---------
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

