### PR TITLE
[202012][fast-reboot] Remove FLEX_COUNTER_TABLE from config_db.json b…

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -20,6 +20,7 @@ PLATFORM=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
 PLATFORM_PLUGIN="${REBOOT_TYPE}_plugin"
 LOG_SSD_HEALTH="/usr/local/bin/log_ssd_health"
 SSD_FW_UPDATE="ssd-fw-upgrade"
+CONFIG_DB_FILE="/etc/sonic/config_db.json"
 TAG_LATEST=yes
 
 # Require 100M available on the hard drive for warm reboot temp files,
@@ -512,7 +513,6 @@ if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
     # Dump the ARP and FDB tables to files also as default routes for both IPv4 and IPv6
     # into /host/fast-reboot
     DUMP_DIR=/host/fast-reboot
-    CONFIG_DB_FILE=/etc/sonic/config_db.json
     mkdir -p $DUMP_DIR
     FAST_REBOOT_DUMP_RC=0
     /usr/local/bin/fast-reboot-dump.py -t $DUMP_DIR || FAST_REBOOT_DUMP_RC=$?
@@ -524,7 +524,7 @@ if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
 
     FILTER_FDB_ENTRIES_RC=0
     # Filter FDB entries using MAC addresses from ARP table
-    /usr/local/bin/filter_fdb_entries -f $DUMP_DIR/fdb.json -a $DUMP_DIR/arp.json -c $CONFIG_DB_FILE || FILTER_FDB_ENTRIES_RC=$?
+    /usr/local/bin/filter_fdb_entries -f $DUMP_DIR/fdb.json -a $DUMP_DIR/arp.json -c ${CONFIG_DB_FILE} || FILTER_FDB_ENTRIES_RC=$?
     if [[ FILTER_FDB_ENTRIES_RC -ne 0 ]]; then
         error "Failed to filter FDb entries. Exit code: $FILTER_FDB_ENTRIES_RC"
         unload_kernel
@@ -677,6 +677,14 @@ if [[ "$sonic_asic_type" = 'broadcom' ]];
 then
   service_name=$(systemctl list-units --plain --no-pager --no-legend --type=service | grep opennsl | cut -f 1 -d' ')
   systemctl stop "$service_name"
+fi
+
+if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
+    # Remove FLEX_COUNTER_TABLE from config_db.json
+    # This is done so that in fast-reboot recovery path, FLEX_COUNTER polling is delayed.
+    # Delayed FLEX_COUNTER polling is an attempt keep dataplane downtime below 30s threshold
+    jq --indent 4  'del(.FLEX_COUNTER_TABLE)' ${CONFIG_DB_FILE} > ${CONFIG_DB_FILE}.new
+    mv ${CONFIG_DB_FILE}.new ${CONFIG_DB_FILE}
 fi
 
 # Update the reboot cause file to reflect that user issued this script


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
Fix https://github.com/Azure/sonic-buildimage/issues/8523

#### What I did
Remove `FLEX_COUNTER_TABLE` from config_db.json before fast-reboot to allow delaying FLEX counter polling after fast-reboot.

Delaying FLEX counter polling is important to keep fastboot dataplane downtime under 30s.

#### How I did it
In the going down path, add a step to modify config_db.json - remove the key:value for `FLEX_COUNTER_TABLE` table.

#### How to verify it

Repro'd the issue in the latest 202012 image.

With the fix, the counter polling is delayed and downtime is back to normal.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

