### PR TITLE
[202012][Config] Update config command of Kdump.

### DIFF
--- a/config/kdump.py
+++ b/config/kdump.py
@@ -1,44 +1,86 @@
-import os
+import sys
+
 import click
-import utilities_common.cli as clicommon
-from swsssdk import ConfigDBConnector
+from utilities_common.cli import AbbreviationGroup, pass_db
 
-@click.group(cls=clicommon.AbbreviationGroup, name="kdump")
+
+#
+# 'kdump' group ('sudo config kdump ...')
+#
+@click.group(cls=AbbreviationGroup, name="kdump")
 def kdump():
-    """ Configure kdump """
-    if os.geteuid() != 0:
-        exit("Root privileges are required for this operation")
+    """Configure the KDUMP mechanism"""
+    pass
 
-@kdump.command()
-def disable():
-    """Disable kdump operation"""
-    config_db = ConfigDBConnector()
-    if config_db is not None:
-        config_db.connect()
-        config_db.mod_entry("KDUMP", "config", {"enabled": "false"})
 
-@kdump.command()
-def enable():
-    """Enable kdump operation"""
-    config_db = ConfigDBConnector()
-    if config_db is not None:
-        config_db.connect()
-        config_db.mod_entry("KDUMP", "config", {"enabled": "true"})
+def check_kdump_table_existence(kdump_table):
+    """Checks whether the 'KDUMP' table is configured in Config DB.
 
-@kdump.command()
+    Args:
+      kdump_table: A dictionary represents the key-value pair in sub-table
+      of 'KDUMP'.
+
+    Returns:
+      None.
+    """
+    if not kdump_table:
+        click.echo("Unable to retrieve 'KDUMP' table from Config DB.")
+        sys.exit(1)
+
+    if "config" not in kdump_table:
+        click.echo("Unable to retrieve key 'config' from KDUMP table.")
+        sys.exit(2)
+
+
+#
+# 'disable' command ('sudo config kdump disable')
+#
+@kdump.command(name="disable", short_help="Disable the KDUMP mechanism")
+@pass_db
+def kdump_disable(db):
+    """Disable the KDUMP mechanism"""
+    kdump_table = db.cfgdb.get_table("KDUMP")
+    check_kdump_table_existence(kdump_table)
+
+    db.cfgdb.mod_entry("KDUMP", "config", {"enabled": "false"})
+
+
+#
+# 'enable' command ('sudo config kdump enable')
+#
+@kdump.command(name="enable", short_help="Enable the KDUMP mechanism")
+@pass_db
+def kdump_enable(db):
+    """Enable the KDUMP mechanism"""
+    kdump_table = db.cfgdb.get_table("KDUMP")
+    check_kdump_table_existence(kdump_table)
+
+    db.cfgdb.mod_entry("KDUMP", "config", {"enabled": "true"})
+
+
+#
+# 'memory' command ('sudo config kdump memory ...')
+#
+@kdump.command(name="memory", short_help="Configure the memory for KDUMP mechanism")
 @click.argument('kdump_memory', metavar='<kdump_memory>', required=True)
-def memory(kdump_memory):
-    """Set memory allocated for kdump capture kernel"""
-    config_db = ConfigDBConnector()
-    if config_db is not None:
-        config_db.connect()
-        config_db.mod_entry("KDUMP", "config", {"memory": kdump_memory})
+@pass_db
+def kdump_memory(db, kdump_memory):
+    """Reserve memory for kdump capture kernel"""
+    kdump_table = db.cfgdb.get_table("KDUMP")
+    check_kdump_table_existence(kdump_table)
 
-@kdump.command('num-dumps')
+    db.cfgdb.mod_entry("KDUMP", "config", {"memory": kdump_memory})
+
+
+#
+# 'num_dumps' command ('sudo config keump num_dumps ...')
+#
+@kdump.command(name="num_dumps", short_help="Configure the maximum dump files of KDUMP mechanism")
 @click.argument('kdump_num_dumps', metavar='<kdump_num_dumps>', required=True, type=int)
-def num_dumps(kdump_num_dumps):
-    """Set max number of dump files for kdump"""
-    config_db = ConfigDBConnector()
-    if config_db is not None:
-        config_db.connect()
-        config_db.mod_entry("KDUMP", "config", {"num_dumps": kdump_num_dumps})
+@pass_db
+def kdump_num_dumps(db, kdump_num_dumps):
+    """Set maximum number of dump files for kdump"""
+    kdump_table = db.cfgdb.get_table("KDUMP")
+    check_kdump_table_existence(kdump_table)
+
+    db.cfgdb.mod_entry("KDUMP", "config", {"num_dumps": kdump_num_dumps})

--- a/tests/kdump_test.py
+++ b/tests/kdump_test.py
@@ -1,0 +1,74 @@
+import importlib
+
+from click.testing import CliRunner
+from utilities_common.db import Db
+
+
+class TestKdump(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+
+    def test_config_kdump_disable(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        db = Db()
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["kdump"].commands["disable"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        # Delete the 'KDUMP' table.
+        db.cfgdb.delete_table("KDUMP")
+
+        result = runner.invoke(config.config.commands["kdump"].commands["disable"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 1
+
+    def test_config_kdump_enable(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        db = Db()
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["kdump"].commands["enable"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        # Delete the 'KDUMP' table.
+        db.cfgdb.delete_table("KDUMP")
+
+        result = runner.invoke(config.config.commands["kdump"].commands["enable"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 1
+
+    def test_config_kdump_memory(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        db = Db()
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["kdump"].commands["memory"], ["256MB"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        # Delete the 'KDUMP' table.
+        db.cfgdb.delete_table("KDUMP")
+
+        result = runner.invoke(config.config.commands["kdump"].commands["memory"], ["256MB"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 1
+
+    def test_config_kdump_num_dumps(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        db = Db()
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["kdump"].commands["num_dumps"], ["10"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        # Delete the 'KDUMP' table.
+        db.cfgdb.delete_table("KDUMP")
+
+        result = runner.invoke(config.config.commands["kdump"].commands["num_dumps"], ["10"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 1
+
+    @classmethod
+    def teardown_class(cls):
+        print("TEARDOWN")

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -600,9 +600,9 @@
     "DEBUG_COUNTER_DROP_REASON|DEBUG_2|NO_L3_HEADER": {},
     "DEBUG_COUNTER_DROP_REASON|lowercase_counter|L2_ANY": {},
 	"KDUMP|config": {
-		"enabled": "false",
-		"memory": "256MB".
-		"num_dumps": "3"
+        "enabled": "false",
+        "memory": "256MB",
+        "num_dumps": "3"
 	},
     "FEATURE|bgp": {
         "state": "enabled",

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -599,11 +599,11 @@
     "DEBUG_COUNTER_DROP_REASON|DEBUG_2|IP_HEADER_ERROR": {},
     "DEBUG_COUNTER_DROP_REASON|DEBUG_2|NO_L3_HEADER": {},
     "DEBUG_COUNTER_DROP_REASON|lowercase_counter|L2_ANY": {},
-	"KDUMP|config": {
+    "KDUMP|config": {
         "enabled": "false",
         "memory": "256MB",
         "num_dumps": "3"
-	},
+    },
     "FEATURE|bgp": {
         "state": "enabled",
         "auto_restart": "enabled",

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -28,7 +28,6 @@
         "index": "0",
         "lanes": "25,26,27,28",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -39,7 +38,6 @@
         "index": "1",
         "lanes": "29,30,31,32",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -50,7 +48,6 @@
         "index": "2",
         "lanes": "33,34,35,36",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -61,7 +58,6 @@
         "index": "3",
         "lanes": "37,38,39,40",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -72,7 +68,6 @@
         "index": "4",
         "lanes": "45,46,47,48",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -83,7 +78,6 @@
         "index": "5",
         "lanes": "41,42,43,44",
         "mtu": "9100",
-        "tpid": "0x9200",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -94,7 +88,6 @@
         "index": "6",
         "lanes": "1,2,3,4",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -105,7 +98,6 @@
         "index": "7",
         "lanes": "5,6,7,8",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -116,7 +108,6 @@
         "index": "8",
         "lanes": "13,14,15,16",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -127,7 +118,6 @@
         "index": "9",
         "lanes": "9,10,11,12",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -138,7 +128,6 @@
         "index": "10",
         "lanes": "17,18,19,20",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -149,7 +138,6 @@
         "index": "11",
         "lanes": "21,22,23,24",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -160,7 +148,6 @@
         "index": "12",
         "lanes": "53,54,55,56",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -171,7 +158,6 @@
         "index": "13",
         "lanes": "49,50,51,52",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -182,7 +168,6 @@
         "index": "14",
         "lanes": "57,58,59,60",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -193,7 +178,6 @@
         "index": "15",
         "lanes": "61,62,63,64",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -204,7 +188,6 @@
         "index": "16",
         "lanes": "69,70,71,72",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -215,7 +198,6 @@
         "index": "17",
         "lanes": "65,66,67,68",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -226,7 +208,6 @@
         "index": "18",
         "lanes": "73,74,75,76",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -237,7 +218,6 @@
         "index": "19",
         "lanes": "77,78,79,80",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -248,7 +228,6 @@
         "index": "20",
         "lanes": "109,110,111,112",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -259,7 +238,6 @@
         "index": "21",
         "lanes": "105,106,107,108",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -270,7 +248,6 @@
         "index": "22",
         "lanes": "113,114,115,116",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -281,7 +258,6 @@
         "index": "23",
         "lanes": "117,118,119,120",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -292,7 +268,6 @@
         "index": "24",
         "lanes": "125,126,127,128",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -302,7 +277,6 @@
         "index": "25",
         "lanes": "121,122,123,124",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -312,7 +286,6 @@
         "index": "26",
         "lanes": "81,82,83,84",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -322,7 +295,6 @@
         "index": "27",
         "lanes": "85,86,87,88",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -333,7 +305,6 @@
         "index": "28",
         "lanes": "93,94,95,96",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -344,7 +315,6 @@
         "index": "29",
         "lanes": "89,90,91,92",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -355,7 +325,6 @@
         "index": "30",
         "lanes": "101,102,103,104",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -366,7 +335,6 @@
         "index": "31",
         "lanes": "97,98,99,100",
         "mtu": "9100",
-        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -527,35 +495,30 @@
         "admin_status": "up",
         "members@": "Ethernet32",
         "min_links": "1",
-        "tpid": "0x8100",
         "mtu": "9100"
     },
     "PORTCHANNEL|PortChannel0001": {
         "admin_status": "up",
         "members@": "Ethernet112",
         "min_links": "1",
-        "tpid": "0x8100",
         "mtu": "9100"
     },
     "PORTCHANNEL|PortChannel0002": {
         "admin_status": "up",
         "members@": "Ethernet116",
         "min_links": "1",
-        "tpid": "0x8100",
         "mtu": "9100"
     },
     "PORTCHANNEL|PortChannel0003": {
         "admin_status": "up",
         "members@": "Ethernet120",
         "min_links": "1",
-        "tpid": "0x8100",
         "mtu": "9100"
     },
     "PORTCHANNEL|PortChannel0004": {
         "admin_status": "up",
         "members@": "Ethernet124",
         "min_links": "1",
-        "tpid": "0x8100",
         "mtu": "9100"
     },
     "PORTCHANNEL_MEMBER|PortChannel1001|Ethernet32": {
@@ -636,11 +599,11 @@
     "DEBUG_COUNTER_DROP_REASON|DEBUG_2|IP_HEADER_ERROR": {},
     "DEBUG_COUNTER_DROP_REASON|DEBUG_2|NO_L3_HEADER": {},
     "DEBUG_COUNTER_DROP_REASON|lowercase_counter|L2_ANY": {},
-    "KDUMP|config": {
-        "enabled": "false",
-        "memory": "256MB",
-        "num_dumps": "3"
-    },
+	"KDUMP|config": {
+		"enabled": "false",
+		"memory": "256MB".
+		"num_dumps": "3"
+	},
     "FEATURE|bgp": {
         "state": "enabled",
         "auto_restart": "enabled",
@@ -736,172 +699,6 @@
         "platform": "x86_64-mlnx_msn3800-r0",
         "peer_switch": "sonic-switch",
         "type": "ToRRouter"
-    },
-    "SNMP_COMMUNITY|msft": {
-        "TYPE": "RO"
-    },
-    "SNMP_COMMUNITY|Rainer": {
-        "TYPE": "RW"
-    },
-    "SNMP_USER|test_authpriv_RO_2": {
-        "SNMP_USER_TYPE": "AuthNoPriv",
-        "SNMP_USER_PERMISSION": "RO",
-        "SNMP_USER_AUTH_TYPE": "SHA",
-        "SNMP_USER_AUTH_PASSWORD": "test_authpriv_RO_2_authpass",
-        "SNMP_USER_ENCRYPTION_TYPE": "",
-        "SNMP_USER_ENCRYPTION_PASSWORD": ""
-    },
-    "SNMP_USER|test_authpriv_RO_3": {
-        "SNMP_USER_TYPE": "AuthNoPriv",
-        "SNMP_USER_PERMISSION": "RO",
-        "SNMP_USER_AUTH_TYPE": "HMAC-SHA-2",
-        "SNMP_USER_AUTH_PASSWORD": "test_authpriv_RO_3_authpass",
-        "SNMP_USER_ENCRYPTION_TYPE": "",
-        "SNMP_USER_ENCRYPTION_PASSWORD": ""
-    },
-    "SNMP_USER|test_priv_RW_4": {
-        "SNMP_USER_TYPE": "Priv",
-        "SNMP_USER_PERMISSION": "RW",
-        "SNMP_USER_AUTH_TYPE": "SHA",
-        "SNMP_USER_AUTH_PASSWORD": "test_priv_RW_4_authpass",
-        "SNMP_USER_ENCRYPTION_TYPE": "AES",
-        "SNMP_USER_ENCRYPTION_PASSWORD": "test_priv_RW_4_encrpytpass"
-    },
-    "SNMP_USER|test_priv_RW_3": {
-        "SNMP_USER_TYPE": "Priv",
-        "SNMP_USER_PERMISSION": "RW",
-        "SNMP_USER_AUTH_TYPE": "SHA",
-        "SNMP_USER_AUTH_PASSWORD": "test_priv_RW_3_authpass",
-        "SNMP_USER_ENCRYPTION_TYPE": "DES",
-        "SNMP_USER_ENCRYPTION_PASSWORD": "test_priv_RW_3_encrpytpass"
-    },
-    "SNMP_USER|test_priv_RO_2": {
-        "SNMP_USER_TYPE": "Priv",
-        "SNMP_USER_PERMISSION": "RO",
-        "SNMP_USER_AUTH_TYPE": "MD5",
-        "SNMP_USER_AUTH_PASSWORD": "test_priv_RO_2_authpass",
-        "SNMP_USER_ENCRYPTION_TYPE": "AES",
-        "SNMP_USER_ENCRYPTION_PASSWORD": "test_priv_RO_2_encrpytpass"
-    },
-    "SNMP_USER|test_nopriv_RO_1": {
-        "SNMP_USER_TYPE": "noAuthNoPriv",
-        "SNMP_USER_PERMISSION": "RO",
-        "SNMP_USER_AUTH_TYPE": "",
-        "SNMP_USER_AUTH_PASSWORD": "",
-        "SNMP_USER_ENCRYPTION_TYPE": "",
-        "SNMP_USER_ENCRYPTION_PASSWORD": ""
-    },
-    "SNMP_USER|test_priv_RW_1": {
-        "SNMP_USER_TYPE": "Priv",
-        "SNMP_USER_PERMISSION": "RW",
-        "SNMP_USER_AUTH_TYPE": "MD5",
-        "SNMP_USER_AUTH_PASSWORD": "test_priv_RO_1_authpass",
-        "SNMP_USER_ENCRYPTION_TYPE": "DES",
-        "SNMP_USER_ENCRYPTION_PASSWORD": "test_priv_RW_1_encrpytpass"
-    },
-    "SNMP_USER|test_authpriv_RW_1": {
-        "SNMP_USER_TYPE": "AuthNoPriv",
-        "SNMP_USER_PERMISSION": "RW",
-        "SNMP_USER_AUTH_TYPE": "MD5",
-        "SNMP_USER_AUTH_PASSWORD": "test_authpriv_RW_1_authpass",
-        "SNMP_USER_ENCRYPTION_TYPE": "",
-        "SNMP_USER_ENCRYPTION_PASSWORD": ""
-    },
-    "SNMP_USER|test_priv_RO_6": {
-        "SNMP_USER_TYPE": "Priv",
-        "SNMP_USER_PERMISSION": "RO",
-        "SNMP_USER_AUTH_TYPE": "HMAC-SHA-2",
-        "SNMP_USER_AUTH_PASSWORD": "test_priv_RO_6_authpass",
-        "SNMP_USER_ENCRYPTION_TYPE": "AES",
-        "SNMP_USER_ENCRYPTION_PASSWORD": "test_priv_RO_6_encrpytpass"
-    },
-    "SNMP_USER|test_priv_RO_1": {
-        "SNMP_USER_TYPE": "Priv",
-        "SNMP_USER_PERMISSION": "RO",
-        "SNMP_USER_AUTH_TYPE": "MD5",
-        "SNMP_USER_AUTH_PASSWORD": "test_priv_RO_1_authpass",
-        "SNMP_USER_ENCRYPTION_TYPE": "DES",
-        "SNMP_USER_ENCRYPTION_PASSWORD": "test_priv_RO_1_encrpytpass"
-    },
-    "SNMP_USER|test_priv_RO_5": {
-        "SNMP_USER_TYPE": "Priv",
-        "SNMP_USER_PERMISSION": "RO",
-        "SNMP_USER_AUTH_TYPE": "HMAC-SHA-2",
-        "SNMP_USER_AUTH_PASSWORD": "test_priv_RO_5_authpass",
-        "SNMP_USER_ENCRYPTION_TYPE": "DES",
-        "SNMP_USER_ENCRYPTION_PASSWORD": "test_priv_RO_5_encrpytpass"
-    },
-    "SNMP_USER|test_nopriv_RW_1": {
-        "SNMP_USER_TYPE": "noAuthNoPriv",
-        "SNMP_USER_PERMISSION": "RW",
-        "SNMP_USER_AUTH_TYPE": "",
-        "SNMP_USER_AUTH_PASSWORD": "",
-        "SNMP_USER_ENCRYPTION_TYPE": "",
-        "SNMP_USER_ENCRYPTION_PASSWORD": ""
-    },
-    "SNMP_USER|test_priv_RO_3": {
-        "SNMP_USER_TYPE": "Priv",
-        "SNMP_USER_PERMISSION": "RO",
-        "SNMP_USER_AUTH_TYPE": "SHA",
-        "SNMP_USER_AUTH_PASSWORD": "test_priv_RO_3_authpass",
-        "SNMP_USER_ENCRYPTION_TYPE": "DES",
-        "SNMP_USER_ENCRYPTION_PASSWORD": "test_priv_RO_3_encrpytpass"
-    },
-    "SNMP_USER|test_priv_RW_2": {
-        "SNMP_USER_TYPE": "Priv",
-        "SNMP_USER_PERMISSION": "RW",
-        "SNMP_USER_AUTH_TYPE": "MD5",
-        "SNMP_USER_AUTH_PASSWORD": "test_priv_RO_2_authpass",
-        "SNMP_USER_ENCRYPTION_TYPE": "AES",
-        "SNMP_USER_ENCRYPTION_PASSWORD": "test_priv_RW_2_encrpytpass"
-    },
-    "SNMP_USER|test_authpriv_RW_3": {
-        "SNMP_USER_TYPE": "AuthNoPriv",
-        "SNMP_USER_PERMISSION": "RW",
-        "SNMP_USER_AUTH_TYPE": "HMAC-SHA-2",
-        "SNMP_USER_AUTH_PASSWORD": "test_authpriv_RW_3_authpass",
-        "SNMP_USER_ENCRYPTION_TYPE": "",
-        "SNMP_USER_ENCRYPTION_PASSWORD": ""
-    },
-    "SNMP_USER|test_priv_RW_5": {
-        "SNMP_USER_TYPE": "Priv",
-        "SNMP_USER_PERMISSION": "RW",
-        "SNMP_USER_AUTH_TYPE": "HMAC-SHA-2",
-        "SNMP_USER_AUTH_PASSWORD": "test_priv_RW_5_authpass",
-        "SNMP_USER_ENCRYPTION_TYPE": "DES",
-        "SNMP_USER_ENCRYPTION_PASSWORD": "test_priv_RW_5_encrpytpass"
-    },
-    "SNMP_USER|test_priv_RW_6": {
-        "SNMP_USER_TYPE": "Priv",
-        "SNMP_USER_PERMISSION": "RW",
-        "SNMP_USER_AUTH_TYPE": "HMAC-SHA-2",
-        "SNMP_USER_AUTH_PASSWORD": "test_priv_RW_6_authpass",
-        "SNMP_USER_ENCRYPTION_TYPE": "AES",
-        "SNMP_USER_ENCRYPTION_PASSWORD": "test_priv_RW_6_encrpytpass"
-    },
-    "SNMP_USER|test_authpriv_RW_2": {
-        "SNMP_USER_TYPE": "AuthNoPriv",
-        "SNMP_USER_PERMISSION": "RW",
-        "SNMP_USER_AUTH_TYPE": "SHA",
-        "SNMP_USER_AUTH_PASSWORD": "test_authpriv_RW_2_authpass",
-        "SNMP_USER_ENCRYPTION_TYPE": "",
-        "SNMP_USER_ENCRYPTION_PASSWORD": ""
-    },
-    "SNMP_USER|test_priv_RO_4": {
-        "SNMP_USER_TYPE": "Priv",
-        "SNMP_USER_PERMISSION": "RO",
-        "SNMP_USER_AUTH_TYPE": "SHA",
-        "SNMP_USER_AUTH_PASSWORD": "test_priv_RO_4_authpass",
-        "SNMP_USER_ENCRYPTION_TYPE": "AES",
-        "SNMP_USER_ENCRYPTION_PASSWORD": "test_priv_RO_4_encrpytpass"
-    },
-    "SNMP_USER|test_authpriv_RO_1": {
-        "SNMP_USER_TYPE": "AuthNoPriv",
-        "SNMP_USER_PERMISSION": "RO",
-        "SNMP_USER_AUTH_TYPE": "MD5",
-        "SNMP_USER_AUTH_PASSWORD": "test_authpriv_RO_1_authpass",
-        "SNMP_USER_ENCRYPTION_TYPE": "",
-        "SNMP_USER_ENCRYPTION_PASSWORD": ""
     },
     "DEVICE_NEIGHBOR|Ethernet0": {
         "name": "Servers",
@@ -1708,25 +1505,5 @@
         "wred_red_enable": "true",
         "yellow_drop_probability": "5",
         "red_drop_probability": "5"
-    },
-    "BGP_NEIGHBOR|20.1.1.5": {
-        "rrclient": "0",
-        "name": "T2-Peer",
-        "local_addr": "20.1.1.1",
-        "nhopself": "0",
-        "admin_status": "up",
-        "holdtime": "10",
-        "asn": "65200",
-        "keepalive": "3"
-    },
-    "BGP_NEIGHBOR|30.1.1.5": {
-        "rrclient": "0",
-        "name": "T0-Peer",
-        "local_addr": "30.1.1.1",
-        "nhopself": "0",
-        "admin_status": "up",
-        "holdtime": "10",
-        "asn": "65200",
-        "keepalive": "3"
     }
 }

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -28,6 +28,7 @@
         "index": "0",
         "lanes": "25,26,27,28",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -38,6 +39,7 @@
         "index": "1",
         "lanes": "29,30,31,32",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -48,6 +50,7 @@
         "index": "2",
         "lanes": "33,34,35,36",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -58,6 +61,7 @@
         "index": "3",
         "lanes": "37,38,39,40",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -68,6 +72,7 @@
         "index": "4",
         "lanes": "45,46,47,48",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -78,6 +83,7 @@
         "index": "5",
         "lanes": "41,42,43,44",
         "mtu": "9100",
+        "tpid": "0x9200",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -88,6 +94,7 @@
         "index": "6",
         "lanes": "1,2,3,4",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -98,6 +105,7 @@
         "index": "7",
         "lanes": "5,6,7,8",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -108,6 +116,7 @@
         "index": "8",
         "lanes": "13,14,15,16",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -118,6 +127,7 @@
         "index": "9",
         "lanes": "9,10,11,12",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -128,6 +138,7 @@
         "index": "10",
         "lanes": "17,18,19,20",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -138,6 +149,7 @@
         "index": "11",
         "lanes": "21,22,23,24",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -148,6 +160,7 @@
         "index": "12",
         "lanes": "53,54,55,56",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -158,6 +171,7 @@
         "index": "13",
         "lanes": "49,50,51,52",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -168,6 +182,7 @@
         "index": "14",
         "lanes": "57,58,59,60",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -178,6 +193,7 @@
         "index": "15",
         "lanes": "61,62,63,64",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -188,6 +204,7 @@
         "index": "16",
         "lanes": "69,70,71,72",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -198,6 +215,7 @@
         "index": "17",
         "lanes": "65,66,67,68",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -208,6 +226,7 @@
         "index": "18",
         "lanes": "73,74,75,76",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -218,6 +237,7 @@
         "index": "19",
         "lanes": "77,78,79,80",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -228,6 +248,7 @@
         "index": "20",
         "lanes": "109,110,111,112",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -238,6 +259,7 @@
         "index": "21",
         "lanes": "105,106,107,108",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -248,6 +270,7 @@
         "index": "22",
         "lanes": "113,114,115,116",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -258,6 +281,7 @@
         "index": "23",
         "lanes": "117,118,119,120",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -268,6 +292,7 @@
         "index": "24",
         "lanes": "125,126,127,128",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -277,6 +302,7 @@
         "index": "25",
         "lanes": "121,122,123,124",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -286,6 +312,7 @@
         "index": "26",
         "lanes": "81,82,83,84",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -295,6 +322,7 @@
         "index": "27",
         "lanes": "85,86,87,88",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -305,6 +333,7 @@
         "index": "28",
         "lanes": "93,94,95,96",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -315,6 +344,7 @@
         "index": "29",
         "lanes": "89,90,91,92",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -325,6 +355,7 @@
         "index": "30",
         "lanes": "101,102,103,104",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -335,6 +366,7 @@
         "index": "31",
         "lanes": "97,98,99,100",
         "mtu": "9100",
+        "tpid": "0x8100",
         "pfc_asym": "off",
         "speed": "40000"
     },
@@ -495,30 +527,35 @@
         "admin_status": "up",
         "members@": "Ethernet32",
         "min_links": "1",
+        "tpid": "0x8100",
         "mtu": "9100"
     },
     "PORTCHANNEL|PortChannel0001": {
         "admin_status": "up",
         "members@": "Ethernet112",
         "min_links": "1",
+        "tpid": "0x8100",
         "mtu": "9100"
     },
     "PORTCHANNEL|PortChannel0002": {
         "admin_status": "up",
         "members@": "Ethernet116",
         "min_links": "1",
+        "tpid": "0x8100",
         "mtu": "9100"
     },
     "PORTCHANNEL|PortChannel0003": {
         "admin_status": "up",
         "members@": "Ethernet120",
         "min_links": "1",
+        "tpid": "0x8100",
         "mtu": "9100"
     },
     "PORTCHANNEL|PortChannel0004": {
         "admin_status": "up",
         "members@": "Ethernet124",
         "min_links": "1",
+        "tpid": "0x8100",
         "mtu": "9100"
     },
     "PORTCHANNEL_MEMBER|PortChannel1001|Ethernet32": {
@@ -599,6 +636,11 @@
     "DEBUG_COUNTER_DROP_REASON|DEBUG_2|IP_HEADER_ERROR": {},
     "DEBUG_COUNTER_DROP_REASON|DEBUG_2|NO_L3_HEADER": {},
     "DEBUG_COUNTER_DROP_REASON|lowercase_counter|L2_ANY": {},
+    "KDUMP|config": {
+        "enabled": "false",
+        "memory": "256MB",
+        "num_dumps": "3"
+    },
     "FEATURE|bgp": {
         "state": "enabled",
         "auto_restart": "enabled",
@@ -694,6 +736,172 @@
         "platform": "x86_64-mlnx_msn3800-r0",
         "peer_switch": "sonic-switch",
         "type": "ToRRouter"
+    },
+    "SNMP_COMMUNITY|msft": {
+        "TYPE": "RO"
+    },
+    "SNMP_COMMUNITY|Rainer": {
+        "TYPE": "RW"
+    },
+    "SNMP_USER|test_authpriv_RO_2": {
+        "SNMP_USER_TYPE": "AuthNoPriv",
+        "SNMP_USER_PERMISSION": "RO",
+        "SNMP_USER_AUTH_TYPE": "SHA",
+        "SNMP_USER_AUTH_PASSWORD": "test_authpriv_RO_2_authpass",
+        "SNMP_USER_ENCRYPTION_TYPE": "",
+        "SNMP_USER_ENCRYPTION_PASSWORD": ""
+    },
+    "SNMP_USER|test_authpriv_RO_3": {
+        "SNMP_USER_TYPE": "AuthNoPriv",
+        "SNMP_USER_PERMISSION": "RO",
+        "SNMP_USER_AUTH_TYPE": "HMAC-SHA-2",
+        "SNMP_USER_AUTH_PASSWORD": "test_authpriv_RO_3_authpass",
+        "SNMP_USER_ENCRYPTION_TYPE": "",
+        "SNMP_USER_ENCRYPTION_PASSWORD": ""
+    },
+    "SNMP_USER|test_priv_RW_4": {
+        "SNMP_USER_TYPE": "Priv",
+        "SNMP_USER_PERMISSION": "RW",
+        "SNMP_USER_AUTH_TYPE": "SHA",
+        "SNMP_USER_AUTH_PASSWORD": "test_priv_RW_4_authpass",
+        "SNMP_USER_ENCRYPTION_TYPE": "AES",
+        "SNMP_USER_ENCRYPTION_PASSWORD": "test_priv_RW_4_encrpytpass"
+    },
+    "SNMP_USER|test_priv_RW_3": {
+        "SNMP_USER_TYPE": "Priv",
+        "SNMP_USER_PERMISSION": "RW",
+        "SNMP_USER_AUTH_TYPE": "SHA",
+        "SNMP_USER_AUTH_PASSWORD": "test_priv_RW_3_authpass",
+        "SNMP_USER_ENCRYPTION_TYPE": "DES",
+        "SNMP_USER_ENCRYPTION_PASSWORD": "test_priv_RW_3_encrpytpass"
+    },
+    "SNMP_USER|test_priv_RO_2": {
+        "SNMP_USER_TYPE": "Priv",
+        "SNMP_USER_PERMISSION": "RO",
+        "SNMP_USER_AUTH_TYPE": "MD5",
+        "SNMP_USER_AUTH_PASSWORD": "test_priv_RO_2_authpass",
+        "SNMP_USER_ENCRYPTION_TYPE": "AES",
+        "SNMP_USER_ENCRYPTION_PASSWORD": "test_priv_RO_2_encrpytpass"
+    },
+    "SNMP_USER|test_nopriv_RO_1": {
+        "SNMP_USER_TYPE": "noAuthNoPriv",
+        "SNMP_USER_PERMISSION": "RO",
+        "SNMP_USER_AUTH_TYPE": "",
+        "SNMP_USER_AUTH_PASSWORD": "",
+        "SNMP_USER_ENCRYPTION_TYPE": "",
+        "SNMP_USER_ENCRYPTION_PASSWORD": ""
+    },
+    "SNMP_USER|test_priv_RW_1": {
+        "SNMP_USER_TYPE": "Priv",
+        "SNMP_USER_PERMISSION": "RW",
+        "SNMP_USER_AUTH_TYPE": "MD5",
+        "SNMP_USER_AUTH_PASSWORD": "test_priv_RO_1_authpass",
+        "SNMP_USER_ENCRYPTION_TYPE": "DES",
+        "SNMP_USER_ENCRYPTION_PASSWORD": "test_priv_RW_1_encrpytpass"
+    },
+    "SNMP_USER|test_authpriv_RW_1": {
+        "SNMP_USER_TYPE": "AuthNoPriv",
+        "SNMP_USER_PERMISSION": "RW",
+        "SNMP_USER_AUTH_TYPE": "MD5",
+        "SNMP_USER_AUTH_PASSWORD": "test_authpriv_RW_1_authpass",
+        "SNMP_USER_ENCRYPTION_TYPE": "",
+        "SNMP_USER_ENCRYPTION_PASSWORD": ""
+    },
+    "SNMP_USER|test_priv_RO_6": {
+        "SNMP_USER_TYPE": "Priv",
+        "SNMP_USER_PERMISSION": "RO",
+        "SNMP_USER_AUTH_TYPE": "HMAC-SHA-2",
+        "SNMP_USER_AUTH_PASSWORD": "test_priv_RO_6_authpass",
+        "SNMP_USER_ENCRYPTION_TYPE": "AES",
+        "SNMP_USER_ENCRYPTION_PASSWORD": "test_priv_RO_6_encrpytpass"
+    },
+    "SNMP_USER|test_priv_RO_1": {
+        "SNMP_USER_TYPE": "Priv",
+        "SNMP_USER_PERMISSION": "RO",
+        "SNMP_USER_AUTH_TYPE": "MD5",
+        "SNMP_USER_AUTH_PASSWORD": "test_priv_RO_1_authpass",
+        "SNMP_USER_ENCRYPTION_TYPE": "DES",
+        "SNMP_USER_ENCRYPTION_PASSWORD": "test_priv_RO_1_encrpytpass"
+    },
+    "SNMP_USER|test_priv_RO_5": {
+        "SNMP_USER_TYPE": "Priv",
+        "SNMP_USER_PERMISSION": "RO",
+        "SNMP_USER_AUTH_TYPE": "HMAC-SHA-2",
+        "SNMP_USER_AUTH_PASSWORD": "test_priv_RO_5_authpass",
+        "SNMP_USER_ENCRYPTION_TYPE": "DES",
+        "SNMP_USER_ENCRYPTION_PASSWORD": "test_priv_RO_5_encrpytpass"
+    },
+    "SNMP_USER|test_nopriv_RW_1": {
+        "SNMP_USER_TYPE": "noAuthNoPriv",
+        "SNMP_USER_PERMISSION": "RW",
+        "SNMP_USER_AUTH_TYPE": "",
+        "SNMP_USER_AUTH_PASSWORD": "",
+        "SNMP_USER_ENCRYPTION_TYPE": "",
+        "SNMP_USER_ENCRYPTION_PASSWORD": ""
+    },
+    "SNMP_USER|test_priv_RO_3": {
+        "SNMP_USER_TYPE": "Priv",
+        "SNMP_USER_PERMISSION": "RO",
+        "SNMP_USER_AUTH_TYPE": "SHA",
+        "SNMP_USER_AUTH_PASSWORD": "test_priv_RO_3_authpass",
+        "SNMP_USER_ENCRYPTION_TYPE": "DES",
+        "SNMP_USER_ENCRYPTION_PASSWORD": "test_priv_RO_3_encrpytpass"
+    },
+    "SNMP_USER|test_priv_RW_2": {
+        "SNMP_USER_TYPE": "Priv",
+        "SNMP_USER_PERMISSION": "RW",
+        "SNMP_USER_AUTH_TYPE": "MD5",
+        "SNMP_USER_AUTH_PASSWORD": "test_priv_RO_2_authpass",
+        "SNMP_USER_ENCRYPTION_TYPE": "AES",
+        "SNMP_USER_ENCRYPTION_PASSWORD": "test_priv_RW_2_encrpytpass"
+    },
+    "SNMP_USER|test_authpriv_RW_3": {
+        "SNMP_USER_TYPE": "AuthNoPriv",
+        "SNMP_USER_PERMISSION": "RW",
+        "SNMP_USER_AUTH_TYPE": "HMAC-SHA-2",
+        "SNMP_USER_AUTH_PASSWORD": "test_authpriv_RW_3_authpass",
+        "SNMP_USER_ENCRYPTION_TYPE": "",
+        "SNMP_USER_ENCRYPTION_PASSWORD": ""
+    },
+    "SNMP_USER|test_priv_RW_5": {
+        "SNMP_USER_TYPE": "Priv",
+        "SNMP_USER_PERMISSION": "RW",
+        "SNMP_USER_AUTH_TYPE": "HMAC-SHA-2",
+        "SNMP_USER_AUTH_PASSWORD": "test_priv_RW_5_authpass",
+        "SNMP_USER_ENCRYPTION_TYPE": "DES",
+        "SNMP_USER_ENCRYPTION_PASSWORD": "test_priv_RW_5_encrpytpass"
+    },
+    "SNMP_USER|test_priv_RW_6": {
+        "SNMP_USER_TYPE": "Priv",
+        "SNMP_USER_PERMISSION": "RW",
+        "SNMP_USER_AUTH_TYPE": "HMAC-SHA-2",
+        "SNMP_USER_AUTH_PASSWORD": "test_priv_RW_6_authpass",
+        "SNMP_USER_ENCRYPTION_TYPE": "AES",
+        "SNMP_USER_ENCRYPTION_PASSWORD": "test_priv_RW_6_encrpytpass"
+    },
+    "SNMP_USER|test_authpriv_RW_2": {
+        "SNMP_USER_TYPE": "AuthNoPriv",
+        "SNMP_USER_PERMISSION": "RW",
+        "SNMP_USER_AUTH_TYPE": "SHA",
+        "SNMP_USER_AUTH_PASSWORD": "test_authpriv_RW_2_authpass",
+        "SNMP_USER_ENCRYPTION_TYPE": "",
+        "SNMP_USER_ENCRYPTION_PASSWORD": ""
+    },
+    "SNMP_USER|test_priv_RO_4": {
+        "SNMP_USER_TYPE": "Priv",
+        "SNMP_USER_PERMISSION": "RO",
+        "SNMP_USER_AUTH_TYPE": "SHA",
+        "SNMP_USER_AUTH_PASSWORD": "test_priv_RO_4_authpass",
+        "SNMP_USER_ENCRYPTION_TYPE": "AES",
+        "SNMP_USER_ENCRYPTION_PASSWORD": "test_priv_RO_4_encrpytpass"
+    },
+    "SNMP_USER|test_authpriv_RO_1": {
+        "SNMP_USER_TYPE": "AuthNoPriv",
+        "SNMP_USER_PERMISSION": "RO",
+        "SNMP_USER_AUTH_TYPE": "MD5",
+        "SNMP_USER_AUTH_PASSWORD": "test_authpriv_RO_1_authpass",
+        "SNMP_USER_ENCRYPTION_TYPE": "",
+        "SNMP_USER_ENCRYPTION_PASSWORD": ""
     },
     "DEVICE_NEIGHBOR|Ethernet0": {
         "name": "Servers",
@@ -1500,5 +1708,25 @@
         "wred_red_enable": "true",
         "yellow_drop_probability": "5",
         "red_drop_probability": "5"
+    },
+    "BGP_NEIGHBOR|20.1.1.5": {
+        "rrclient": "0",
+        "name": "T2-Peer",
+        "local_addr": "20.1.1.1",
+        "nhopself": "0",
+        "admin_status": "up",
+        "holdtime": "10",
+        "asn": "65200",
+        "keepalive": "3"
+    },
+    "BGP_NEIGHBOR|30.1.1.5": {
+        "rrclient": "0",
+        "name": "T0-Peer",
+        "local_addr": "30.1.1.1",
+        "nhopself": "0",
+        "admin_status": "up",
+        "holdtime": "10",
+        "asn": "65200",
+        "keepalive": "3"
     }
 }


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
Signed-off-by: Yong Zhao yozhao@microsoft.com

#### What I did
This PR aims to update the config command of Kdump (Linux kernel dump) mechanism.

#### How I did it
Before updating the value of a field in the table of KDUMP, we need decide whether the KDUMP table and corresponding field does exist in the table.

#### How to verify it
I verifies this on device str-msn2700-03 and unit test passed.

    tests/kdump_test.py::TestKdump::test_config_kdump_disable PASSED                                                                                                 
    tests/kdump_test.py::TestKdump::test_config_kdump_enable PASSED                                                                                                  
    tests/kdump_test.py::TestKdump::test_config_kdump_memory PASSED                                                                                                  
    tests/kdump_test.py::TestKdump::test_config_kdump_num_dumps PASSED

