### PR TITLE
Fix ConfigDBConnector import in pg-drop script

### DIFF
--- a/scripts/pg-drop
+++ b/scripts/pg-drop
@@ -26,7 +26,8 @@ try:
 except KeyError:
     pass
 
-from swsscommon.swsscommon import ConfigDBConnector, SonicV2Connector
+from swsssdk import ConfigDBConnector
+from swsscommon.swsscommon import SonicV2Connector
 
 STATUS_NA = 'N/A'
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
202012 PR tests are failing consistently. The failure is seen in `tests/pgdropstat_test.py` This is a new test that was originally added to master branch, and cherrypicked into 202012 where it started failing.

Related PR: https://github.com/Azure/sonic-utilities/pull/1678

```
2021-08-23T23:50:55.1608995Z =================================== FAILURES ===================================
2021-08-23T23:50:55.1609597Z __________________ TestPgDropstat.test_show_pg_drop_disabled ___________________
2021-08-23T23:50:55.1609973Z 
2021-08-23T23:50:55.1610710Z self = <tests.pgdropstat_test.TestPgDropstat object at 0x7f689981f7f0>
2021-08-23T23:50:55.1611229Z replace_config_db_file = None
2021-08-23T23:50:55.1624925Z 
2021-08-23T23:50:55.1626293Z     def test_show_pg_drop_disabled(self, replace_config_db_file):
2021-08-23T23:50:55.1626874Z         runner = CliRunner()
2021-08-23T23:50:55.1627308Z     
2021-08-23T23:50:55.1628750Z         result = runner.invoke(show.cli.commands["priority-group"].commands["drop"].commands["counters"])
2021-08-23T23:50:55.1629388Z >       assert result.exit_code == 0
2021-08-23T23:50:55.1630728Z E       assert 1 == 0
2021-08-23T23:50:55.1631207Z E        +  where 1 = <Result SystemExit(1)>.exit_code
2021-08-23T23:50:55.1631485Z 
2021-08-23T23:50:55.1632595Z tests/pgdropstat_test.py:61: AssertionError
2021-08-23T23:50:55.1633753Z ---------------------------- Captured stdout setup -----------------------------
2021-08-23T23:50:55.1634187Z SETUP
2021-08-23T23:50:55.1634795Z ----------------------------- Captured stderr call -----------------------------
2021-08-23T23:50:55.1635276Z Traceback (most recent call last):
2021-08-23T23:50:55.1635897Z   File "/__w/1/s/scripts/pg-drop", line 262, in <module>
2021-08-23T23:50:55.1636500Z     main()
2021-08-23T23:50:55.1637067Z   File "/__w/1/s/scripts/pg-drop", line 249, in main
2021-08-23T23:50:55.1637487Z     pgdropstat = PgDropStat()
2021-08-23T23:50:55.1638067Z   File "/__w/1/s/scripts/pg-drop", line 50, in __init__
2021-08-23T23:50:55.1638505Z     self.configdb = ConfigDBConnector()
2021-08-23T23:50:55.1639184Z   File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 1961, in __init__
2021-08-23T23:50:55.1639761Z     super(ConfigDBConnector, self).__init__(use_unix_socket_path = use_unix_socket_path, namespace = namespace)
2021-08-23T23:50:55.1640531Z   File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 1576, in __init__
2021-08-23T23:50:55.1641118Z     super(SonicV2Connector, self).__init__(use_unix_socket_path = use_unix_socket_path, netns = namespace)
2021-08-23T23:50:55.1641661Z TypeError: super(type, obj): obj must be an instance or subtype of type
2021-08-23T23:50:55.1642245Z ____________________ TestPgDropstat.test_show_pg_drop_show _____________________
```

The import mechanism for `ConfigDBConnector ` is incorrect and that fails the PR tests on 202012 branch. The tests succeed on master branch with the original change.
```
2021-08-23T23:50:55.1657204Z ----------------------------- Captured stderr call -----------------------------
2021-08-23T23:50:55.1657678Z Traceback (most recent call last):
2021-08-23T23:50:55.1659116Z   File "/__w/1/s/scripts/pg-drop", line 262, in <module>
2021-08-23T23:50:55.1659555Z     main()
2021-08-23T23:50:55.1660096Z   File "/__w/1/s/scripts/pg-drop", line 249, in main
2021-08-23T23:50:55.1660515Z     pgdropstat = PgDropStat()
2021-08-23T23:50:55.1661104Z   File "/__w/1/s/scripts/pg-drop", line 50, in __init__
2021-08-23T23:50:55.1662374Z     self.configdb = ConfigDBConnector()
2021-08-23T23:50:55.1663359Z   File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 1961, in __init__
2021-08-23T23:50:55.1666325Z     super(ConfigDBConnector, self).__init__(use_unix_socket_path = use_unix_socket_path, namespace = namespace)
2021-08-23T23:50:55.1667593Z   File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 1576, in __init__
2021-08-23T23:50:55.1671490Z     super(SonicV2Connector, self).__init__(use_unix_socket_path = use_unix_socket_path, netns = namespace)
2021-08-23T23:50:55.1672194Z TypeError: super(type, obj): obj must be an instance or subtype of type
2021-08-23T23:50:55.1712428Z ____________________ TestPgDropstat.test_show_pg_drop_clear ____________________
```

#### How I did it
Update `ConfigDBConnector` import from swss-common to swsssdk.

#### How to verify it
PR tests for 202012 target branch are passing now.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

