### PR TITLE
Add mock support for swsscommon classes

### DIFF
--- a/tests/mock_tables/dbconnector.py
+++ b/tests/mock_tables/dbconnector.py
@@ -8,7 +8,7 @@ import mockredis
 import redis
 import swsssdk
 from sonic_py_common import multi_asic
-from swsssdk import SonicDBConfig, SonicV2Connector
+from swsssdk import SonicDBConfig, SonicV2Connector, ConfigDBConnector, ConfigDBPipeConnector
 from swsscommon import swsscommon
 
 
@@ -151,3 +151,5 @@ mockredis.MockRedis.config_set = config_set
 redis.StrictRedis = SwssSyncClient
 SonicV2Connector.connect = connect_SonicV2Connector
 swsscommon.SonicV2Connector = SonicV2Connector
+swsscommon.ConfigDBConnector = ConfigDBConnector
+swsscommon.ConfigDBPipeConnector = ConfigDBPipeConnector


### PR DESCRIPTION
#### What I did
This is a partial backport of https://github.com/Azure/sonic-utilities/pull/1392
Only add new mock support in unit test.

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

