### PR TITLE
platform pre-check for reboot in 202012 branch

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -3,6 +3,7 @@ DEVPATH="/usr/share/sonic/device"
 PLAT_REBOOT="platform_reboot"
 PLATFORM_UPDATE_REBOOT_CAUSE="platform_update_reboot_cause"
 REBOOT_CAUSE_FILE="/host/reboot-cause/reboot-cause.txt"
+PLATFORM_REBOOT_PRE_CHECK="platform_reboot_pre_check"
 REBOOT_TIME=$(date)
 
 # Reboot immediately if we run the kdump capture kernel
@@ -120,6 +121,11 @@ function reboot_pre_check()
         VERBOSE=yes debug "Filesystem might be read-only or full ..."
     fi
     rm ${filename}
+
+    if [ -x ${DEVPATH}/${PLATFORM}/${PLATFORM_REBOOT_PRE_CHECK} ]; then
+        ${DEVPATH}/${PLATFORM}/${PLATFORM_REBOOT_PRE_CHECK}
+        [[ $? -ne 0 ]] && exit $?
+    fi
 
     # Verify the next image by sonic-installer
     local message=$(sonic-installer verify-next-image 2>&1)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
- Added platform pre check support in reboot script.
- Checking platform based changes before stopping dockers and sonic services.
- Porting changes in 202012 branch.

#### How I did it
On branch reboot_pre_check_202012
Changes not staged for commit:
(use "git add ..." to update what will be committed)
(use "git checkout -- ..." to discard changes in working directory)

    modified:   scripts/reboot
    
#### How to verify it
- Write a platform pre check script(platform_reboot_pre_check) and place it in /usr/share/sonic/device/<HWSKU>/ directory.
- If the script exit with status 0, reboot will be proceeded.
- If script exit with non-zero status, the reboot script gets stopped.
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

