### PR TITLE
Add --skip-platform-check option for sonic_installer when image mismatch

### DIFF
--- a/sonic_installer/bootloader/aboot.py
+++ b/sonic_installer/bootloader/aboot.py
@@ -164,6 +164,9 @@ class AbootBootloader(Bootloader):
         return IMAGE_PREFIX + version.strip()
 
     def verify_binary_image(self, image_path):
+        return os.path.isfile(image_path)
+
+    def verify_secureboot_image(self, image_path):
         try:
             subprocess.check_call(['/usr/bin/unzip', '-tq', image_path])
             return self._verify_secureboot_image(image_path)

--- a/sonic_installer/bootloader/aboot.py
+++ b/sonic_installer/bootloader/aboot.py
@@ -163,7 +163,7 @@ class AbootBootloader(Bootloader):
             return None
         return IMAGE_PREFIX + version.strip()
 
-    def verify_binary_image(self, image_path):
+    def verify_image_platform(self, image_path):
         return os.path.isfile(image_path)
 
     def verify_secureboot_image(self, image_path):

--- a/sonic_installer/bootloader/bootloader.py
+++ b/sonic_installer/bootloader/bootloader.py
@@ -49,12 +49,12 @@ class Bootloader(object):
         """returns the version of the image"""
         raise NotImplementedError
 
-    def verify_binary_image(self, image_path):
-        """verify that the image is supported by the bootloader"""
+    def verify_image_platform(self, image_path):
+        """verify that the image is of the same platform than running platform"""
         raise NotImplementedError
 
     def verify_secureboot_image(self, image_path):
-        """verify that the image is secureboot"""
+        """verify that the image is secure running image"""
         raise NotImplementedError
 
     def verify_next_image(self):

--- a/sonic_installer/bootloader/bootloader.py
+++ b/sonic_installer/bootloader/bootloader.py
@@ -53,6 +53,10 @@ class Bootloader(object):
         """verify that the image is supported by the bootloader"""
         raise NotImplementedError
 
+    def verify_secureboot_image(self, image_path):
+        """verify that the image is secureboot"""
+        raise NotImplementedError
+
     def verify_next_image(self):
         """verify the next image for reboot"""
         image = self.get_next_image()

--- a/sonic_installer/bootloader/grub.py
+++ b/sonic_installer/bootloader/grub.py
@@ -98,7 +98,6 @@ class GrubBootloader(OnieInstallerBootloader):
                 asic_type = None
         except (KeyError, TypeError) as e:
             click.echo("Caught an exception: " + str(e))
-        # click.echo('Get running platform ASIC... %s' % asic_type)
 
         # Get installing image's ASIC
         p1 = subprocess.Popen(["sed", "-e", "1,/^exit_marker$/d", image_path], stdout=subprocess.PIPE, preexec_fn=default_sigpipe)
@@ -106,11 +105,9 @@ class GrubBootloader(OnieInstallerBootloader):
         p3 = subprocess.Popen(["sed", "-n", r"s/^machine=\(.*\)/\1/p"], stdin=p2.stdout, stdout=subprocess.PIPE, preexec_fn=default_sigpipe, text=True)
 
         stdout = p3.communicate()[0]
-        p3.wait()
         image_asic = stdout.rstrip('\n')
-        # click.echo('Get installing images ASIC... %s' % image_asic)
 
-        # Backword compatibility if IMAGE_ASIC not set in install.sh
+        # Return true if machine is not found
         if not image_asic:
             return True
 

--- a/sonic_installer/bootloader/grub.py
+++ b/sonic_installer/bootloader/grub.py
@@ -102,6 +102,10 @@ class GrubBootloader(OnieInstallerBootloader):
         image_asic = stdout.rstrip('\n')
         # click.echo('Get installing images ASIC... %s' % image_asic)
 
+        # Backword compatibility if IMAGE_ASIC not set in install.sh
+        if not image_asic:
+            return True
+
         if asic_type == image_asic:
             return True
         return False

--- a/sonic_installer/bootloader/grub.py
+++ b/sonic_installer/bootloader/grub.py
@@ -8,6 +8,7 @@ import subprocess
 
 import click
 
+from sonic_py_common import device_info
 from ..common import (
    HOST_PATH,
    IMAGE_DIR_PREFIX,
@@ -82,14 +83,19 @@ class GrubBootloader(OnieInstallerBootloader):
         run_command('grub-set-default --boot-directory=' + HOST_PATH + ' 0')
         click.echo('Image removed')
 
-    def verify_binary_image(self, image_path):
+    def verify_image_platform(self, image_path):
         if not os.path.isfile(image_path):
             return False
 
         # Get running platform's ASIC
-        sonic_version_yml = open('/etc/sonic/sonic_version.yml', 'r')
-        asic_type = re.search(r"asic_type: (\S+)", sonic_version_yml.read()).group(1)
-        sonic_version_yml.close()
+        try:
+            version_info = device_info.get_sonic_version_info()
+            if version_info:
+                asic_type = version_info['asic_type']
+            else:
+                asic_type = None
+        except (KeyError, TypeError) as e:
+            click.echo("Caught an exception: " + str(e))
         # click.echo('Get running platform ASIC... %s' % asic_type)
 
         # Get installing image's ASIC

--- a/sonic_installer/bootloader/grub.py
+++ b/sonic_installer/bootloader/grub.py
@@ -107,9 +107,9 @@ class GrubBootloader(OnieInstallerBootloader):
         stdout = p3.communicate()[0]
         image_asic = stdout.rstrip('\n')
 
-        # Return true if machine is not found
+        # Return false if machine is not found or unexpected issue occur
         if not image_asic:
-            return True
+            return False
 
         if asic_type == image_asic:
             return True

--- a/sonic_installer/bootloader/grub.py
+++ b/sonic_installer/bootloader/grub.py
@@ -18,6 +18,8 @@ from ..common import (
 from .onie import OnieInstallerBootloader
 from .onie import default_sigpipe
 
+MACHINE_CONF = "installer/machine.conf"
+
 class GrubBootloader(OnieInstallerBootloader):
 
     NAME = 'grub'
@@ -99,9 +101,9 @@ class GrubBootloader(OnieInstallerBootloader):
         # click.echo('Get running platform ASIC... %s' % asic_type)
 
         # Get installing image's ASIC
-        p1 = subprocess.Popen(["cat", "-v", image_path], stdout=subprocess.PIPE, preexec_fn=default_sigpipe)
-        p2 = subprocess.Popen(["grep", "-m 1", "^image_asic"], stdin=p1.stdout, stdout=subprocess.PIPE, preexec_fn=default_sigpipe)
-        p3 = subprocess.Popen(["sed", "-n", r"s/^image_asic=\"\(.*\)\"$/\1/p"], stdin=p2.stdout, stdout=subprocess.PIPE, preexec_fn=default_sigpipe, text=True)
+        p1 = subprocess.Popen(["sed", "-e", "1,/^exit_marker$/d", image_path], stdout=subprocess.PIPE, preexec_fn=default_sigpipe)
+        p2 = subprocess.Popen(["tar", "xf", "-", MACHINE_CONF, "-O"], stdin=p1.stdout, stdout=subprocess.PIPE, preexec_fn=default_sigpipe)
+        p3 = subprocess.Popen(["sed", "-n", r"s/^machine=\(.*\)/\1/p"], stdin=p2.stdout, stdout=subprocess.PIPE, preexec_fn=default_sigpipe, text=True)
 
         stdout = p3.communicate()[0]
         p3.wait()

--- a/sonic_installer/bootloader/onie.py
+++ b/sonic_installer/bootloader/onie.py
@@ -44,5 +44,5 @@ class OnieInstallerBootloader(Bootloader): # pylint: disable=abstract-method
 
         return IMAGE_PREFIX + version_num
 
-    def verify_binary_image(self, image_path):
+    def verify_secureboot_image(self, image_path):
         return os.path.isfile(image_path)

--- a/sonic_installer/bootloader/uboot.py
+++ b/sonic_installer/bootloader/uboot.py
@@ -77,7 +77,7 @@ class UbootBootloader(OnieInstallerBootloader):
         subprocess.call(['rm','-rf', HOST_PATH + '/' + image_dir])
         click.echo('Done')
 
-    def verify_binary_image(self, image_path):
+    def verify_image_platform(self, image_path):
         return os.path.isfile(image_path)
 
     @classmethod

--- a/sonic_installer/bootloader/uboot.py
+++ b/sonic_installer/bootloader/uboot.py
@@ -77,6 +77,9 @@ class UbootBootloader(OnieInstallerBootloader):
         subprocess.call(['rm','-rf', HOST_PATH + '/' + image_dir])
         click.echo('Done')
 
+    def verify_binary_image(self, image_path):
+        return os.path.isfile(image_path)
+
     @classmethod
     def detect(cls):
         arch = platform.machine()

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -534,12 +534,12 @@ def install(url, force, skip_platform_check=False, skip_migration=False, skip_pa
     else:
         # Verify not installing non-secure image in a secure running image
         if not bootloader.verify_secureboot_image(image_path) and not force:
-            echo_and_log("Image file '{}' is of a non-secure type than secure running image.\n".format(url) +
+            echo_and_log("Image file '{}' is of a different type than running image.\n".format(url) +
                 "If you are sure you want to install this image, use -f|--force|--skip-secure-check.\n" +
                 "Aborting...", LOG_ERR)
             raise click.Abort()
 
-        # Verify that the binary image is of the same platform type than running platform
+        # Verify that the binary image is of the same platform type as running platform
         if not bootloader.verify_image_platform(image_path) and not skip_platform_check:
             echo_and_log("Image file '{}' is of a different platform type than running platform.\n".format(url) +
                 "If you are sure you want to install this image, use --skip-platform-check.\n" +

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -480,10 +480,10 @@ def sonic_installer():
 @sonic_installer.command('install')
 @click.option('-y', '--yes', is_flag=True, callback=abort_if_false,
               expose_value=False, prompt='New image will be installed, continue?')
-@click.option('--force_secureboot', is_flag=True,
-              help="Force installation of an image of a type which is not secureboot")
-@click.option('-f', '--force_install', is_flag=True,
-              help="Force installation of an image of a type which differs from that of the current running image")
+@click.option('-f', '--force', '--skip-secure-check', is_flag=True,
+              help="Force installation of an image of a non-secure type than secure running image")
+@click.option('--skip-platform-check', is_flag=True,
+              help="Force installation of an image of a type which is not of the same platform")
 @click.option('--skip_migration', is_flag=True,
               help="Do not migrate current configuration to the newly installed image")
 @click.option('--skip-package-migration', is_flag=True,
@@ -502,7 +502,7 @@ def sonic_installer():
               cls=clicommon.MutuallyExclusiveOption, mutually_exclusive=['skip_setup_swap'],
               callback=validate_positive_int)
 @click.argument('url')
-def install(url, force_secureboot, force_install=False, skip_migration=False, skip_package_migration=False,
+def install(url, force, skip_platform_check=False, skip_migration=False, skip_package_migration=False,
             skip_setup_swap=False, swap_mem_size=None, total_mem_threshold=None, available_mem_threshold=None):
     """ Install image from local binary or URL"""
     bootloader = get_bootloader()
@@ -532,17 +532,17 @@ def install(url, force_secureboot, force_install=False, skip_migration=False, sk
             echo_and_log('Error: Failed to set image as default', LOG_ERR)
             raise click.Abort()
     else:
-        # Verify that the binary image is secureboot
-        if not bootloader.verify_secureboot_image(image_path) and not force_secureboot:
-            echo_and_log("Image file '{}' is not a secureboot image.\n".format(url) +
-                "If you are sure you want to install this image, use --force_secureboot.\n" +
+        # Verify not installing non-secure image in a secure running image
+        if not bootloader.verify_secureboot_image(image_path) and not force:
+            echo_and_log("Image file '{}' is of a non-secure type than secure running image.\n".format(url) +
+                "If you are sure you want to install this image, use -f|--force|--skip-secure-check.\n" +
                 "Aborting...", LOG_ERR)
             raise click.Abort()
 
-        # Verify that the binary image is of the same type as the running image
-        if not bootloader.verify_binary_image(image_path) and not force_install:
-            echo_and_log("Image file '{}' is of a different type than running image.\n".format(url) +
-                "If you are sure you want to install this image, use -f|--force_install.\n" +
+        # Verify that the binary image is of the same platform type than running platform
+        if not bootloader.verify_image_platform(image_path) and not skip_platform_check:
+            echo_and_log("Image file '{}' is of a different platform type than running platform.\n".format(url) +
+                "If you are sure you want to install this image, use --skip-platform-check.\n" +
                 "Aborting...", LOG_ERR)
             raise click.Abort()
 

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -480,7 +480,9 @@ def sonic_installer():
 @sonic_installer.command('install')
 @click.option('-y', '--yes', is_flag=True, callback=abort_if_false,
               expose_value=False, prompt='New image will be installed, continue?')
-@click.option('-f', '--force', is_flag=True,
+@click.option('--force_secureboot', is_flag=True,
+              help="Force installation of an image of a type which is not secureboot")
+@click.option('-f', '--force_install', is_flag=True,
               help="Force installation of an image of a type which differs from that of the current running image")
 @click.option('--skip_migration', is_flag=True,
               help="Do not migrate current configuration to the newly installed image")
@@ -500,7 +502,7 @@ def sonic_installer():
               cls=clicommon.MutuallyExclusiveOption, mutually_exclusive=['skip_setup_swap'],
               callback=validate_positive_int)
 @click.argument('url')
-def install(url, force, skip_migration=False, skip_package_migration=False,
+def install(url, force_secureboot, force_install=False, skip_migration=False, skip_package_migration=False,
             skip_setup_swap=False, swap_mem_size=None, total_mem_threshold=None, available_mem_threshold=None):
     """ Install image from local binary or URL"""
     bootloader = get_bootloader()
@@ -530,10 +532,17 @@ def install(url, force, skip_migration=False, skip_package_migration=False,
             echo_and_log('Error: Failed to set image as default', LOG_ERR)
             raise click.Abort()
     else:
+        # Verify that the binary image is secureboot
+        if not bootloader.verify_secureboot_image(image_path) and not force_secureboot:
+            echo_and_log("Image file '{}' is not a secureboot image.\n".format(url) +
+                "If you are sure you want to install this image, use --force_secureboot.\n" +
+                "Aborting...", LOG_ERR)
+            raise click.Abort()
+
         # Verify that the binary image is of the same type as the running image
-        if not bootloader.verify_binary_image(image_path) and not force:
+        if not bootloader.verify_binary_image(image_path) and not force_install:
             echo_and_log("Image file '{}' is of a different type than running image.\n".format(url) +
-                "If you are sure you want to install this image, use -f|--force.\n" +
+                "If you are sure you want to install this image, use -f|--force_install.\n" +
                 "Aborting...", LOG_ERR)
             raise click.Abort()
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add --skip-platform-check option for sonic_installer; tune up comment for secureboot
#### How I did it
Add --skip-platform-check option for sonic_installer
#### How to verify it
Install a bin file which differs the running platform's ASIC. For example;
install sonic-broadcom.bin to mellanox ASIC platform
install sonic-vs.bin to broadcom ASIC platform
#### Previous command output (if the output of a command-line utility has changed)
sudo sonic-installer install --help
Usage: sonic-installer install [OPTIONS] URL

  Install image from local binary or URL

Options:
  -y, --yes
  -f, --force_install       Force installation of an image of a type which
                            differs from that of the current running image
  --skip_migration          Do not migrate current configuration to the newly
                            installed image
  --skip-package-migration  Do not migrate current packages to the newly
                            installed image
  --help                    Show this message and exit.

#### New command output (if the output of a command-line utility has changed)
sudo sonic-installer install --help
Usage: sonic-installer install [OPTIONS] URL

  Install image from local binary or URL

Options:
   -y, --yes
   -f, --force, --skip-secure-check
                                  Force installation of an image of a non-
                                  secure type than secure running image
  --skip-platform-check           Force installation of an image of a type
                                  which is not of the same platform
  --skip_migration                Do not migrate current configuration to the
                                  newly installed image
  --skip-package-migration        Do not migrate current packages to the newly
                                  installed image
 --help                    Show this message and exit.


