### PR TITLE
[vxlan] remove unnecessary trailing space for show commands

### DIFF
--- a/show/vxlan.py
+++ b/show/vxlan.py
@@ -87,7 +87,7 @@ def interface():
           if vtep_sip is not '0.0.0.0':
              output = '\tVTEP Name : ' + vtepname + ', SIP  : ' + vxlan_table[key]['src_ip']
           else:
-             output = '\tVTEP Name : ' + vtepname 
+             output = '\tVTEP Name : ' + vtepname
 
           click.echo(output)
 
@@ -109,7 +109,7 @@ def interface():
              if len(key1) == 3 and key1[2] == vtep_sip+'/32':
                 loopback = key1[1]
                 break
-         output = '\tSource interface  : ' + loopback 
+         output = '\tSource interface  : ' + loopback
          if vtep_sip != '0.0.0.0':
             click.echo(output)
 
@@ -133,7 +133,7 @@ def vlanvnimap(count):
         vxlan_count = len(vxlan_keys)
 
       output = 'Total count : '
-      output += ('%s \n' % (str(vxlan_count)))
+      output += ('%s\n' % (str(vxlan_count)))
       click.echo(output)
     else:
        vxlan_table = config_db.get_table('VXLAN_TUNNEL_MAP')
@@ -145,7 +145,7 @@ def vlanvnimap(count):
              num += 1
        click.echo(tabulate(body, header, tablefmt="grid"))
        output = 'Total count : '
-       output += ('%s \n' % (str(num)))
+       output += ('%s\n' % (str(num)))
        click.echo(output)
 
 @vxlan.command()
@@ -168,7 +168,7 @@ def vrfvnimap():
               num += 1
     click.echo(tabulate(body, header, tablefmt="grid"))
     output = 'Total count : '
-    output += ('%s \n' % (str(num)))
+    output += ('%s\n' % (str(num)))
     click.echo(output)
 
 @vxlan.command()
@@ -183,7 +183,7 @@ def remotevtep(count):
     header = ['SIP', 'DIP', 'Creation Source', 'OperStatus']
     body = []
     db = SonicV2Connector(host='127.0.0.1')
-    db.connect(db.STATE_DB) 
+    db.connect(db.STATE_DB)
 
     vxlan_keys = db.keys(db.STATE_DB, 'VXLAN_TUNNEL_TABLE|*')
 
@@ -194,9 +194,9 @@ def remotevtep(count):
 
     if (count is not None):
         output = 'Total count : '
-        output += ('%s \n' % (str(vxlan_count)))
+        output += ('%s\n' % (str(vxlan_count)))
         click.echo(output)
-    else: 
+    else:
         num = 0
         if vxlan_keys is not None:
            for key in natsorted(vxlan_keys):
@@ -207,7 +207,7 @@ def remotevtep(count):
                 num += 1
         click.echo(tabulate(body, header, tablefmt="grid"))
         output = 'Total count : '
-        output += ('%s \n' % (str(num)))
+        output += ('%s\n' % (str(num)))
         click.echo(output)
 
 @vxlan.command()
@@ -219,11 +219,11 @@ def remotevni(remote_vtep_ip, count):
     if (remote_vtep_ip != 'all') and (clicommon.is_ipaddress(remote_vtep_ip ) is False):
         click.echo("Remote VTEP IP {} invalid format".format(remote_vtep_ip))
         return
-  
+
     header = ['VLAN', 'RemoteVTEP', 'VNI']
     body = []
     db = SonicV2Connector(host='127.0.0.1')
-    db.connect(db.APPL_DB) 
+    db.connect(db.APPL_DB)
 
     if(remote_vtep_ip == 'all'):
       vxlan_keys = db.keys(db.APPL_DB, 'VXLAN_REMOTE_VNI_TABLE:*')
@@ -237,7 +237,7 @@ def remotevni(remote_vtep_ip, count):
         vxlan_count = len(vxlan_keys)
 
       output = 'Total count : '
-      output += ('%s \n' % (str(vxlan_count)))
+      output += ('%s\n' % (str(vxlan_count)))
       click.echo(output)
     else:
       num = 0
@@ -254,7 +254,7 @@ def remotevni(remote_vtep_ip, count):
             num += 1
       click.echo(tabulate(body, header, tablefmt="grid"))
       output = 'Total count : '
-      output += ('%s \n' % (str(num)))
+      output += ('%s\n' % (str(num)))
       click.echo(output)
 
 @vxlan.command()
@@ -263,14 +263,14 @@ def remotevni(remote_vtep_ip, count):
 def remotemac(remote_vtep_ip, count):
     """Show MACs pointing to the remote VTEP"""
 
-    if (remote_vtep_ip != 'all') and (clicommon.is_ipaddress(remote_vtep_ip ) is False): 
+    if (remote_vtep_ip != 'all') and (clicommon.is_ipaddress(remote_vtep_ip ) is False):
         click.echo("Remote VTEP IP {} invalid format".format(remote_vtep_ip))
         return
 
     header = ['VLAN', 'MAC', 'RemoteVTEP', 'VNI', 'Type']
     body = []
     db = SonicV2Connector(host='127.0.0.1')
-    db.connect(db.APPL_DB) 
+    db.connect(db.APPL_DB)
 
     vxlan_keys = db.keys(db.APPL_DB, 'VXLAN_FDB_TABLE:*')
 
@@ -281,7 +281,7 @@ def remotemac(remote_vtep_ip, count):
         vxlan_count = len(vxlan_keys)
 
       output = 'Total count : '
-      output += ('%s \n' % (str(vxlan_count)))
+      output += ('%s\n' % (str(vxlan_count)))
       click.echo(output)
     else:
       num = 0
@@ -302,6 +302,6 @@ def remotemac(remote_vtep_ip, count):
       if count is None:
          click.echo(tabulate(body, header, tablefmt="grid"))
       output = 'Total count : '
-      output += ('%s \n' % (str(num)))
+      output += ('%s\n' % (str(num)))
       click.echo(output)
 

--- a/tests/vxlan_test.py
+++ b/tests/vxlan_test.py
@@ -27,7 +27,7 @@ show_vxlan_vlanvnimap_output="""\
 +---------+-------+
 | Vlan200 |   200 |
 +---------+-------+
-Total count : 4 
+Total count : 4
 
 """
 
@@ -37,7 +37,7 @@ show_vxlan_vrfvnimap_output="""\
 +=======+=======+
 | Vrf1  |  1000 |
 +-------+-------+
-Total count : 1 
+Total count : 1
 
 """
 
@@ -52,7 +52,7 @@ show_vxlan_tunnel_output="""\
 +---------+-------------+-------------------+--------------+
 | 1.1.1.1 | 25.25.25.27 | EVPN              | oper_down    |
 +---------+-------------+-------------------+--------------+
-Total count : 3 
+Total count : 3
 
 """
 
@@ -66,7 +66,7 @@ show_vxlan_remotevni_output="""\
 +---------+--------------+-------+
 | Vlan200 | 25.25.25.27  |   200 |
 +---------+--------------+-------+
-Total count : 3 
+Total count : 3
 
 """
 
@@ -76,26 +76,26 @@ show_vxlan_remotevni_specific_output="""\
 +=========+==============+=======+
 | Vlan200 | 25.25.25.27  |   200 |
 +---------+--------------+-------+
-Total count : 1 
+Total count : 1
 
 """
 show_vxlan_vlanvnimap_cnt_output="""\
-Total count : 4 
+Total count : 4
 
 """
 
 show_vxlan_tunnel_cnt_output="""\
-Total count : 3 
+Total count : 3
 
 """
 
 show_vxlan_remotevni_cnt_output="""\
-Total count : 3 
+Total count : 3
 
 """
 
 show_vxlan_remotevni_specific_cnt_output="""\
-Total count : 1 
+Total count : 1
 
 """
 


### PR DESCRIPTION
What I did
Remove the unnecessary trailing space for `Total count : ` in the vxlan show commands, some developers are
used to be enabled the trim space functionality in their editor. These trailing
space are easily to be overlook and cause the unit test fail

Signed-off-by: Gord Chen <gord_chen@edge-core.com>
