### PR TITLE
[chassis][route-check]filter out the chassis internal interfaces

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -47,6 +47,7 @@ import signal
 import traceback
 
 from swsscommon import swsscommon
+from utilities_common import chassis
 
 APPL_DB_NAME = 'APPL_DB'
 ASIC_DB_NAME = 'ASIC_DB'
@@ -348,6 +349,9 @@ def filter_out_local_interfaces(keys):
     local_if_lst = {'eth0', 'docker0'}
     local_if_lo = [r'tun0', r'lo', r'Loopback\d+']
 
+    chassis_local_intfs = chassis.get_chassis_local_interfaces()
+    local_if_lst.update(set(chassis_local_intfs))
+    
     db = swsscommon.DBConnector(APPL_DB_NAME, 0)
     tbl = swsscommon.Table(db, 'ROUTE_TABLE')
 

--- a/utilities_common/chassis.py
+++ b/utilities_common/chassis.py
@@ -1,0 +1,18 @@
+import os
+from sonic_py_common import device_info
+
+def get_chassis_local_interfaces():
+    lst = []
+    platform = device_info.get_platform()
+    chassisdb_conf=os.path.join('/usr/share/sonic/device/', platform, "chassisdb.conf")
+    if os.path.exists(chassisdb_conf):
+        lines=[]
+        with open(chassisdb_conf, 'r') as f:
+            lines = f.readlines()
+        for line in lines:
+            line = line.strip()
+            if "chassis_internal_intfs" in line:
+                data = line.split("=")
+                lst = data[1].split(",")
+                return lst
+    return lst


### PR DESCRIPTION
Signed-off-by: mlok <marty.lok@nokia.com>

#### What I did
In the VOQ chassis, the internal interfaces for communication between linecard and supervisor card need to be filtered out for the route check.  Since different vendor may have different number of internal interfaces and names, this PR adds function get_chassis_local_interfaces() to use chassisdb.conf as data file to get a list of internal interfaces and provide them to the filter_out_local_interfaces(). 
 
#### How I did it
1. Add a list of interfaces as a new data field to the /usr/chare/sonic/device/<platform>/chassisdb.conf file.  The keyword is "chassis_internal_intfs"  with comma (,) as a separator. 
```
    chassis_internal_intfs=enp12s0f2,enp5s0f4,enp5s0f4.2
```
2. Define a new function get_chassis_local_interfaces() to check and open /usr/chare/sonic/device/<platform>/chassisdb.conf file to  get a list of internal interface.  If files does't exist or keyword "chassis_internal_intf" is not present, an empty list will be returned.  Otherwise, a list of interface names will be return.

#### How to verify it
1) execute the following CLI command to verify the routecheck status:
```
admin@sonic:~$ sudo monit status
Monit 5.20.0 uptime: 1h 41m

..
..

Program 'routeCheck'
  status                       Status ok
  monitoring status            Monitored
  monitoring mode              active
  on reboot                    start
  last exit value              0
  last output                  -
  data collected               Fri, 03 Sep 2021 23:19:28
..
```
Verify the routeCheck Status should be "Status ok"

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

