### PR TITLE
[sonic-package-manager] remove make_python_identifier

### DIFF
--- a/sonic_package_manager/manager.py
+++ b/sonic_package_manager/manager.py
@@ -140,6 +140,36 @@ def parse_reference_expression(expression):
         return PackageReference.parse(expression)
 
 
+def get_cli_plugin_directory(command: str) -> str:
+    """ Returns a plugins package directory for command group.
+
+    Args:
+        command: SONiC command: "show"/"config"/"clear".
+    Returns:
+        Path to plugins package directory.
+    """
+
+    pkg_loader = pkgutil.get_loader(f'{command}.plugins')
+    if pkg_loader is None:
+        raise PackageManagerError(f'Failed to get plugins path for {command} CLI')
+    plugins_pkg_path = os.path.dirname(pkg_loader.path)
+    return plugins_pkg_path
+
+
+def get_cli_plugin_path(package: Package, command: str) -> str:
+    """ Returns a path where to put CLI plugin code.
+
+    Args:
+        package: Package to generate this path for.
+        command: SONiC command: "show"/"config"/"clear".
+    Returns:
+        Path generated for this package.
+    """
+
+    plugin_module_file = package.name + '.py'
+    return os.path.join(get_cli_plugin_directory(command), plugin_module_file)
+
+
 def validate_package_base_os_constraints(package: Package, sonic_version_info: Dict[str, str]):
     """ Verify that all dependencies on base OS components are met.
     Args:
@@ -930,14 +960,14 @@ class PackageManager:
         image_plugin_path = package.manifest['cli'][command]
         if not image_plugin_path:
             return
-        host_plugin_path = self._get_cli_plugin_path(package, command)
+        host_plugin_path = get_cli_plugin_path(package, command)
         self.docker.extract(package.entry.image_id, image_plugin_path, host_plugin_path)
 
     def _uninstall_cli_plugin(self, package: Package, command: str):
         image_plugin_path = package.manifest['cli'][command]
         if not image_plugin_path:
             return
-        host_plugin_path = self._get_cli_plugin_path(package, command)
+        host_plugin_path = get_cli_plugin_path(package, command)
         if os.path.exists(host_plugin_path):
             os.remove(host_plugin_path)
 

--- a/sonic_package_manager/utils.py
+++ b/sonic_package_manager/utils.py
@@ -6,37 +6,3 @@ import re
 from docker_image.reference import Reference
 
 DockerReference = Reference
-
-
-def make_python_identifier(string):
-    """
-    Takes an arbitrary string and creates a valid Python identifier.
-
-    Identifiers must follow the convention outlined here:
-        https://docs.python.org/2/reference/lexical_analysis.html#identifiers
-    """
-
-    # create a working copy (and make it lowercase, while we're at it)
-    s = string.lower()
-
-    # remove leading and trailing whitespace
-    s = s.strip()
-
-    # Make spaces into underscores
-    s = re.sub('[\\s\\t\\n]+', '_', s)
-
-    # Remove invalid characters
-    s = re.sub('[^0-9a-zA-Z_]', '', s)
-
-    # Remove leading characters until we find a letter or underscore
-    s = re.sub('^[^a-zA-Z_]+', '', s)
-
-    # Check that the string is not a python identifier
-    while s in keyword.kwlist:
-        if re.match(".*?_\d+$", s):
-            i = re.match(".*?_(\d+)$", s).groups()[0]
-            s = s.strip('_'+i) + '_'+str(int(i)+1)
-        else:
-            s += '_1'
-
-    return s

--- a/tests/sonic_package_manager/test_utils.py
+++ b/tests/sonic_package_manager/test_utils.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python
-
-from sonic_package_manager import utils
-
-
-def test_make_python_identifier():
-    assert utils.make_python_identifier('-some-package name').isidentifier()
-    assert utils.make_python_identifier('01 leading digit').isidentifier()


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

It is not needed to make a CLI plugin name with valid python identifier. It is also possible that make_python_identifier will return same filename for two different packages.

#### How I did it

Removed make_python_identifier.

#### How to verify it

Install package with CLI plugin.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

