### PR TITLE
[sonic-package-manager] stop service explicitelly before uninstalling…

### DIFF
--- a/sonic_package_manager/manager.py
+++ b/sonic_package_manager/manager.py
@@ -435,6 +435,17 @@ class PackageManager:
         # After all checks are passed we proceed to actual uninstallation
 
         try:
+            # Stop and disable the service.
+            # First to make sure we are not uninstalling
+            # package before the service has fully stopped
+            # since "config feature state" command is not blocking.
+            # Second, we make sure the service is in disabled state
+            # so that after reinstall and enablement hostcfgd will enable
+            # it and start it.
+            # TODO: once there is a way to block till hostcfgd will stop
+            # the service, replace it with new approach.
+            self._systemctl_action(package, 'stop')
+            self._systemctl_action(package, 'disable')
             self._uninstall_cli_plugins(package)
             self.service_creator.remove(package)
             self.service_creator.generate_shutdown_sequence_files(


### PR DESCRIPTION
… package

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Fixed an issue with uninstall.
1. When disabling the feature by setting its state to disabled in FEATURE table and then uninstalling it, there is a possibility that service hasn't fully stopped yet.
2. When uninstalling with --force option, and reinstalling the package with --enable option the service does not start.

#### How I did it
Stop and disable service explicitely before uninstalling package.

#### How to verify it

```
sudo spm uninstall cpu-report --force && sudo spm install cpu-report=10.0.0 -v DEBUG -y --enable && docker ps
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

