### PR TITLE
[ci]: Support PR coverage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,6 +91,14 @@ stages:
         python3 setup.py test
       displayName: 'Test Python 3'
 
+    - script: |
+        sudo pip3 install diff-cover
+        target_branch=$(System.PullRequest.TargetBranch)
+        compare_branch=origin/${target_branch#refs/heads/}
+        diff-cover coverage.xml --compare-branch=$compare_branch
+      condition: eq(variables['Build.Reason'], 'PullRequest')
+      displayName: "Diff coverage"
+
     - task: PublishTestResults@2
       inputs:
         testResultsFiles: '$(System.DefaultWorkingDirectory)/test-results.xml'


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Support PR coverage, It will print PR coverage in the AZP.
The output log will be collected by subsequent pipelines to generate Pull Request coverage reports.
And if a branch wants to enforce the coverage rate, we can simply and "--fail-under SCORE" in the cover-diff command, see detail in https://diff-cover.readthedocs.io/en/latest/README.html

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

