### PR TITLE
[sfputil] fix wrong code indent in sfputil

### DIFF
--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -265,14 +265,14 @@ def convert_sfp_info_to_output_string(sfp_info_dict):
             else:
                 output += '{}{}:\n'.format(indent, QSFP_DATA_MAP['specification_compliance'])
 
-            spec_compliance_dict = {}
-            try:
-                spec_compliance_dict = ast.literal_eval(sfp_info_dict['specification_compliance'])
-                sorted_compliance_key_table = natsorted(spec_compliance_dict)
-                for compliance_key in sorted_compliance_key_table:
-                    output += '{}{}: {}\n'.format((indent * 2), compliance_key, spec_compliance_dict[compliance_key])
-            except ValueError as e:
-                output += '{}N/A\n'.format((indent * 2))
+                spec_compliance_dict = {}
+                try:
+                    spec_compliance_dict = ast.literal_eval(sfp_info_dict['specification_compliance'])
+                    sorted_compliance_key_table = natsorted(spec_compliance_dict)
+                    for compliance_key in sorted_compliance_key_table:
+                        output += '{}{}: {}\n'.format((indent * 2), compliance_key, spec_compliance_dict[compliance_key])
+                except ValueError as e:
+                    output += '{}N/A\n'.format((indent * 2))
         else:
             output += '{}{}: {}\n'.format(indent, QSFP_DATA_MAP[key], sfp_info_dict[key])
 


### PR DESCRIPTION
Signed-off-by: Kebo Liu <kebol@nvidia.com>

#### What I did

Wrong code indent cause sfputil go to wrong code branch while handling CMIS cable, result in not able show CMIS cable EEPROM info correctly:

```
root@r-ocelot-07:/home/admin# sfputil show eeprom -p Ethernet8
Traceback (most recent call last):
  File "/usr/local/bin/sfputil", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/sfputil/main.py", line 554, in eeprom
    output += convert_sfp_info_to_output_string(xcvr_info)
  File "/usr/local/lib/python3.7/dist-packages/sfputil/main.py", line 270, in convert_sfp_info_to_output_string
    spec_compliance_dict = ast.literal_eval(sfp_info_dict['specification_compliance'])
  File "/usr/lib/python3.7/ast.py", line 46, in literal_eval
    node_or_string = parse(node_or_string, mode='eval')
  File "/usr/lib/python3.7/ast.py", line 35, in parse
    return compile(source, filename, mode, PyCF_ONLY_AST)
  File "<unknown>", line 1
    Not supported for CMIS cables
                ^
SyntaxError: invalid syntax
```

#### How I did it

Adjust the code indent to have the "spec_compliance_dict" be handled in the correct code branch. CMIS cable EEPROM don't support "spec_compliance_dict" section,  shouldn't go to that code branch, this code branch should only be applicable to SFF cable.

#### How to verify it

run "sfputil show eeprom -p Ethernet{X}" against CMIS cable.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
