### PR TITLE
[watermarkstat] Fix for error in processing empty array from couters db

### DIFF
--- a/scripts/watermarkstat
+++ b/scripts/watermarkstat
@@ -232,7 +232,7 @@ class Watermarkstat(object):
             idx = int(idx_func(obj_id))
             pos = idx - self.min_idx
             counter_data = self.counters_db.get(self.counters_db.COUNTERS_DB, full_table_id, watermark)
-            if counter_data is None:
+            if counter_data is None or counter_data == '':
                 fields[pos] = STATUS_NA
             elif fields[pos] != STATUS_NA:
                 fields[pos] = str(int(counter_data))


### PR DESCRIPTION
#### What I did

With swsscommon, the get operations return NULL ('') if there are no entries in any table. But the existing code for handling counters values in the case of absence of entries assumes that the get operations return 'None', which was the case with swsssdk. This was causing problem for watermark counters show cli commands. This PR fixes this issue.

#### How I did it

For PG_WATERMARK_STAT_COUNTER SAI does not support SAI_INGRESS_PRIORITY_GROUP_STAT_XOFF_ROOM_WATERMARK_BYTES and SAI_INGRESS_PRIORITY_GROUP_STAT_SHARED_WATERMARK_BYTES. So there are no objects in the counters db. With swsscommon, in the absence of objects, an empty string ('') is returned instead of 'None'. The code expecting 'None' tries to convert the empty string to integer and throws error. This is fixed by adding check for empty string in addition to 'None'.

#### How to verify it

- In VOQ chassis, run the command **show priority-group persistent-watermark headroom** command.
- There should not be any failure with traceback of **ValueError: invalid literal for int() with base 10: ''** in file **/usr/local/bin/watermarkstat**

#### Previous command output (if the output of a command-line utility has changed)

- No output change for any command line utilities

#### New command output (if the output of a command-line utility has changed)

- No output change for any command line utilities