### PR TITLE
[config reload] Fix config reload failure due to sonic.target job cancellation

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -686,7 +686,7 @@ def _stop_services():
         pass
 
     click.echo("Stopping SONiC target ...")
-    clicommon.run_command("sudo systemctl stop sonic.target")
+    clicommon.run_command("sudo systemctl stop sonic.target --job-mode replace-irreversibly")
 
 
 def _get_sonic_services():

--- a/config/main.py
+++ b/config/main.py
@@ -706,7 +706,7 @@ def _reset_failed_services():
 
 def _restart_services():
     click.echo("Restarting SONiC target ...")
-    clicommon.run_command("sudo systemctl restart sonic.target")
+    clicommon.run_command("sudo systemctl restart sonic.target --job-mode replace-irreversibly")
 
     try:
         subprocess.check_call("sudo monit status", shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)


### PR DESCRIPTION
Signed-off-by: Vivek Reddy Karri <vkarri@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Fixes https://github.com/Azure/sonic-buildimage/issues/7508

#### How I did it

#### How to verify it

With this change:
```
root@sonic:/home/admin# config reload -y -f
Running command: rm -rf /tmp/dropstat-*
Disabling container monitoring ...
Stopping SONiC target ...
Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/init_cfg.json -j /etc/sonic/config_db.json --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate
Running command: /usr/local/bin/sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t /usr/share/sonic/templates/sonic-environment.j2,/etc/sonic/sonic-environment
Restarting SONiC target ...
Enabling container monitoring ...
Reloading Monit configuration ...
Reinitializing monit daemon

In Paralell:
admin@sonic:~$ sudo systemctl start teamd.service
Failed to start teamd.service: Transaction for teamd.service/start is destructive (radv.service has 'stop' job queued, but 'start' is included in transaction).
See system logs and 'systemctl status teamd.service' for details.
```

Without this Change:
```
root@r-lionfish-16:/home/admin# config reload -y -f
Running command: rm -rf /tmp/dropstat-*
Disabling container monitoring ...
Stopping SONiC target ...
Job for sonic.target canceled.

In Paralell:
admin@sonic:~$ sudo systemctl start teamd.service.
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

