### PR TITLE
[config reload] Removed replace irreversibly job-mode for sonic.target restart

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -706,7 +706,7 @@ def _reset_failed_services():
 
 def _restart_services():
     click.echo("Restarting SONiC target ...")
-    clicommon.run_command("sudo systemctl restart sonic.target --job-mode replace-irreversibly")
+    clicommon.run_command("sudo systemctl restart sonic.target")
 
     try:
         subprocess.check_call("sudo monit status", shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)


### PR DESCRIPTION
Signed-off-by: Vivek Reddy Karri <vkarri@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

As discussed in this PR https://github.com/Azure/sonic-utilities/pull/1814#discussion_r708225104, only the stop.job should have job-mode set to replace irreversibly.

Otherwise,  simultaneous config reloads in the quick succession, can lead to the behavior.

Although ,when the restart job (and all the other dependent jobs) are finished and is taken out of systemd's job queue, the next stop job will not be cancelled. 

```
admin@sonic:~$ sudo systemctl restart sonic.target --job-mode replace-irreversibly
admin@sonic:~$ sudo systemctl stop sonic.target --job-mode replace-irreversibly (Ran Immediately)
Failed to stop sonic.target: Transaction for sonic.target/stop is destructive (ntp-config.service has 'start' job queued, but 'stop' is included in transaction).
See system logs and 'systemctl status sonic.target' for details.
(After all the dependent jobs of restart sonic.target  are done, it works)
admin@sonic:~$ sudo systemctl stop sonic.target --job-mode replace-irreversibly
admin@sonic:
```

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

