### PR TITLE
Validate input of ```config mirror_session add```

### DIFF
--- a/tests/config_mirror_session_test.py
+++ b/tests/config_mirror_session_test.py
@@ -1,0 +1,130 @@
+import pytest
+import config.main as config
+from unittest import mock
+from click.testing import CliRunner
+
+ERR_MSG_IP_FAILURE = "does not appear to be an IPv4 or IPv6 network"
+ERR_MSG_IP_VERSION_FAILURE = "not a valid IPv4 address"
+ERR_MSG_VALUE_FAILURE = "Invalid value for"
+
+def test_mirror_session_add():
+    runner = CliRunner()
+
+    # Verify invalid src_ip
+    result = runner.invoke(
+            config.config.commands["mirror_session"].commands["add"],
+            ["test_session", "400.1.1.1", "2.2.2.2", "8", "63", "10", "100"])
+    assert result.exit_code != 0
+    assert ERR_MSG_IP_FAILURE in result.stdout
+
+    # Verify invalid dst_ip
+    result = runner.invoke(
+            config.config.commands["mirror_session"].commands["add"],
+            ["test_session", "1.1.1.1", "256.2.2.2", "8", "63", "10", "100"])
+    assert result.exit_code != 0
+    assert ERR_MSG_IP_FAILURE in result.stdout
+
+    # Verify invalid ip version
+    result = runner.invoke(
+            config.config.commands["mirror_session"].commands["add"],
+            ["test_session", "1::1", "2::2", "8", "63", "10", "100"])
+    assert result.exit_code != 0
+    assert ERR_MSG_IP_VERSION_FAILURE in result.stdout
+
+    # Verify invalid dscp
+    result = runner.invoke(
+            config.config.commands["mirror_session"].commands["add"],
+            ["test_session", "1.1.1.1", "2.2.2.2", "65536", "63", "10", "100"])
+    assert result.exit_code != 0
+    assert ERR_MSG_VALUE_FAILURE in result.stdout
+
+    # Verify invalid ttl
+    result = runner.invoke(
+            config.config.commands["mirror_session"].commands["add"],
+            ["test_session", "1.1.1.1", "2.2.2.2", "6", "256", "10", "100"])
+    assert result.exit_code != 0
+    assert ERR_MSG_VALUE_FAILURE in result.stdout
+
+    # Verify invalid gre
+    result = runner.invoke(
+            config.config.commands["mirror_session"].commands["add"],
+            ["test_session", "1.1.1.1", "2.2.2.2", "6", "63", "65536", "100"])
+    assert result.exit_code != 0
+    assert ERR_MSG_VALUE_FAILURE in result.stdout
+
+    # Verify invalid queue
+    result = runner.invoke(
+            config.config.commands["mirror_session"].commands["add"],
+            ["test_session", "1.1.1.1", "2.2.2.2", "6", "63", "65", "65536"])
+    assert result.exit_code != 0
+    assert ERR_MSG_VALUE_FAILURE in result.stdout
+
+    # Positive case
+    with mock.patch('config.main.add_erspan') as mocked:
+        result = runner.invoke(
+                config.config.commands["mirror_session"].commands["add"],
+                ["test_session", "100.1.1.1", "2.2.2.2", "8", "63", "10", "100"])
+        
+        mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, 10, 100, None)
+
+
+
+def test_mirror_session_erspan_add():
+    runner = CliRunner()
+
+    # Verify invalid src_ip
+    result = runner.invoke(
+            config.config.commands["mirror_session"].commands["erspan"].commands["add"],
+            ["test_session", "400.1.1.1", "2.2.2.2", "8", "63", "10", "100"])
+    assert result.exit_code != 0
+    assert ERR_MSG_IP_FAILURE in result.stdout
+
+    # Verify invalid dst_ip
+    result = runner.invoke(
+            config.config.commands["mirror_session"].commands["erspan"].commands["add"],
+            ["test_session", "1.1.1.1", "256.2.2.2", "8", "63", "10", "100"])
+    assert result.exit_code != 0
+    assert ERR_MSG_IP_FAILURE in result.stdout
+
+    # Verify invalid ip version
+    result = runner.invoke(
+            config.config.commands["mirror_session"].commands["erspan"].commands["add"],
+            ["test_session", "1::1", "2::2", "8", "63", "10", "100"])
+    assert result.exit_code != 0
+    assert ERR_MSG_IP_VERSION_FAILURE in result.stdout
+
+    # Verify invalid dscp
+    result = runner.invoke(
+            config.config.commands["mirror_session"].commands["erspan"].commands["add"],
+            ["test_session", "1.1.1.1", "2.2.2.2", "65536", "63", "10", "100"])
+    assert result.exit_code != 0
+    assert ERR_MSG_VALUE_FAILURE in result.stdout
+
+    # Verify invalid ttl
+    result = runner.invoke(
+            config.config.commands["mirror_session"].commands["erspan"].commands["add"],
+            ["test_session", "1.1.1.1", "2.2.2.2", "6", "256", "10", "100"])
+    assert result.exit_code != 0
+    assert ERR_MSG_VALUE_FAILURE in result.stdout
+
+    # Verify invalid gre
+    result = runner.invoke(
+            config.config.commands["mirror_session"].commands["erspan"].commands["add"],
+            ["test_session", "1.1.1.1", "2.2.2.2", "6", "63", "65536", "100"])
+    assert result.exit_code != 0
+    assert ERR_MSG_VALUE_FAILURE in result.stdout
+
+    # Verify invalid queue
+    result = runner.invoke(
+            config.config.commands["mirror_session"].commands["erspan"].commands["add"],
+            ["test_session", "1.1.1.1", "2.2.2.2", "6", "63", "65", "65536"])
+    assert result.exit_code != 0
+    assert ERR_MSG_VALUE_FAILURE in result.stdout
+
+    # Positive case
+    with mock.patch('config.main.add_erspan') as mocked:
+        result = runner.invoke(
+                config.config.commands["mirror_session"].commands["erspan"].commands["add"],
+                ["test_session", "100.1.1.1", "2.2.2.2", "8", "63", "10", "100"])
+        
+        mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, 10, 100, None, None, None)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This PR fixed https://github.com/Azure/sonic-buildimage/issues/7990

Type and value validation is added for CLI ```config mirror_session add```.
The value range is defined below

| Value| Range|
| --- | ----------- |
| src_ip| Invalid IPv4 address |
| dst_ip| Invalid IPv4 address |
|DSCP| [0, 63]|
|TTL|  [0, 255]|
|Queue| [0, 255]|
|GRE_TYPE|[0, 65535]|

#### How I did it
Add a value validation at CLI level.

#### How to verify it
Verified by UT
```
tests/config_mirror_session_test.py::test_mirror_session_add PASSED                                                                                                                                                                                      [ 50%]
tests/config_mirror_session_test.py::test_mirror_session_erspan_add PASSED                                                                                                                                                                               [100%]
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

