### PR TITLE
[reboot-cause] Fix reboot cause format

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -710,7 +710,8 @@ fi
 # Update the reboot cause file to reflect that user issued this script
 # Upon next boot, the contents of this file will be used to determine the
 # cause of the previous reboot
-echo "User issued '${REBOOT_SCRIPT_NAME}' command [User: ${REBOOT_USER}, Time: ${REBOOT_TIME}]" > ${REBOOT_CAUSE_FILE}
+echo "{\"cause\":\"${REBOOT_SCRIPT_NAME}\",\"user\":\"${REBOOT_USER}\",\"time\":\"${REBOOT_TIME}\"}" > ${REBOOT_CAUSE_FILE}
+
 
 # Wait until all buffers synced with disk
 sync

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -10,7 +10,7 @@ REBOOT_TIME=$(date)
 VMCORE_FILE=/proc/vmcore
 if [ -e $VMCORE_FILE -a -s $VMCORE_FILE ]; then
         echo "We have a /proc/vmcore, then we just kdump'ed"
-        echo "Kernel Panic [Time: ${REBOOT_TIME}]" > ${REBOOT_CAUSE_FILE}
+        echo "{\"cause\":\"Kernel Panic\",\"time\": \"${REBOOT_TIME}\"}" > ${REBOOT_CAUSE_FILE}
         sync
         PLATFORM=$(grep -oP 'sonic_platform=\K\S+' /proc/cmdline)
         if [ ! -z "${PLATFORM}" -a -x ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT} ]; then
@@ -176,7 +176,7 @@ clear_warm_boot
 # Update the reboot cause file to reflect that user issued 'reboot' command
 # Upon next boot, the contents of this file will be used to determine the
 # cause of the previous reboot
-echo "User issued 'reboot' command [User: ${REBOOT_USER}, Time: ${REBOOT_TIME}]" > ${REBOOT_CAUSE_FILE}
+echo "{\"cause\":\"reboot\",\"user\":\"${REBOOT_USER}\",\"time\": \"${REBOOT_TIME}\"}" > ${REBOOT_CAUSE_FILE}
 sync
 /sbin/fstrim -av
 sleep 3

--- a/scripts/soft-reboot
+++ b/scripts/soft-reboot
@@ -16,7 +16,7 @@ EXIT_NEXT_IMAGE_NOT_EXISTS=4
 VMCORE_FILE=/proc/vmcore
 if [ -e $VMCORE_FILE -a -s $VMCORE_FILE ]; then
         echo "We have a /proc/vmcore, then we just kdump'ed"
-        echo "User issued 'kdump' command [User: kdump, Time: ${REBOOT_TIME}]" > ${REBOOT_CAUSE_FILE}
+        echo "{\"cause\":\"kdump\",\"user\":\"kdump\",\"time\":\"${REBOOT_TIME}\"}" > ${REBOOT_CAUSE_FILE}
         sync
         PLATFORM=$(grep -oP 'sonic_platform=\K\S+' /proc/cmdline)
         if [ ! -z "${PLATFORM}" -a -x ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT} ]; then
@@ -201,7 +201,7 @@ load_kernel
 # Update the reboot cause file to reflect that user issued 'reboot' command
 # Upon next boot, the contents of this file will be used to determine the
 # cause of the previous reboot
-echo "User issued '${REBOOT_SCRIPT_NAME}' command [User: ${REBOOT_USER}, Time: ${REBOOT_TIME}]" > ${REBOOT_CAUSE_FILE}
+echo "{\"cause\":\"${REBOOT_SCRIPT_NAME}\",\"user\":\"${REBOOT_USER}\",\"time\":\"${REBOOT_TIME}\"}" > ${REBOOT_CAUSE_FILE}
 
 sync
 sleep 3

--- a/show/reboot_cause.py
+++ b/show/reboot_cause.py
@@ -8,7 +8,7 @@ from swsscommon.swsscommon import SonicV2Connector
 import utilities_common.cli as clicommon
 
 
-PREVIOUS_REBOOT_CAUSE_FILE_PATH = "/host/reboot-cause/previous-reboot-cause.json"
+PREVIOUS_REBOOT_CAUSE_FILE_PATH = "/host/reboot-cause/reboot-cause.txt"
 
 
 def read_reboot_cause_file():

--- a/tests/reboot_cause_test.py
+++ b/tests/reboot_cause_test.py
@@ -29,7 +29,7 @@ class TestShowRebootCause(object):
         print("SETUP")
         os.environ["UTILITIES_UNIT_TESTING"] = "1"
 
-    # Test 'show reboot-cause' without previous-reboot-cause.json 
+    # Test 'show reboot-cause' without reboot-cause.txt
     def test_reboot_cause_no_history_file(self):
         expected_output = "Unknown\n"
         runner = CliRunner()


### PR DESCRIPTION
Currently reboot-cause recorded by various reboot scripts is not
recognizable by the show reboot-cause command.

Signed-off-by: Xichen Lin <xichenlin@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Changed the format of reboot-cause.txt file.

#### How I did it

#### How to verify it
Tested on switch

#### Previous command output (if the output of a command-line utility has changed)
Unknown

#### New command output (if the output of a command-line utility has changed)
User issued 'reboot' command [User: admin, Time: Thu Oct 22 03:11:08 UTC 2020]

