### PR TITLE
[generic-config-updater] Cropping current/target config before sorting

### DIFF
--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -997,7 +997,10 @@ class PatchSorter:
         current_config = self.config_wrapper.get_config_db_as_json()
         target_config = self.patch_wrapper.simulate_patch(patch, current_config)
 
-        diff = Diff(current_config, target_config)
+        cropped_current_config = self.config_wrapper.crop_tables_without_yang(current_config)
+        cropped_target_config = self.config_wrapper.crop_tables_without_yang(target_config)
+
+        diff = Diff(cropped_current_config, cropped_target_config)
 
         sort_algorithm = self.sort_algorithm_factory.create(algorithm)
         moves = sort_algorithm.sort(diff)


### PR DESCRIPTION
#### What I did
Fixing issue #1830

#### How I did it
Problem we consume the function `loadData` from sonic-yang-mgmt pkg that always crops tables without YANG models from configdb json object. It does it as a side-effect and is not an expected outcome of the function.

The fix here is to crop the current/target tables before doing any sorting, this way gurantee we avoid this bug. I think the better soln is to fix sonic-yang-mgmt pkg. Will look into this more next week.

#### How to verify it
Run the command in the issue, it will result in the expected outcome

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

**TODO: add unit-tests**