### PR TITLE
Use devicelist to check instead of machine.conf

### DIFF
--- a/sonic_installer/bootloader/grub.py
+++ b/sonic_installer/bootloader/grub.py
@@ -18,7 +18,7 @@ from ..common import (
 from .onie import OnieInstallerBootloader
 from .onie import default_sigpipe
 
-MACHINE_CONF = "installer/machine.conf"
+DEVICES_DIR = "installer/devices"
 
 class GrubBootloader(OnieInstallerBootloader):
 
@@ -85,35 +85,29 @@ class GrubBootloader(OnieInstallerBootloader):
         run_command('grub-set-default --boot-directory=' + HOST_PATH + ' 0')
         click.echo('Image removed')
 
+    def platform_in_devices_list(self, platform, image_path):
+        """
+        For those images that don't have devices list builtin, check_output will raise an exception.
+        In this case, we simply return True to make it worked compatible as before.
+        Otherwise, we need to check if platform is inside the supported target devices list.
+        """
+        try:
+            with open(os.devnull, 'w') as fnull:
+                p = subprocess.Popen(["sed", "-e", "1,/^exit_marker$/d", image_path], stdout=subprocess.PIPE, preexec_fn=default_sigpipe)
+                output = subprocess.check_output(["tar", "tf", "-", DEVICES_DIR], stdin=p.stdout, stderr=fnull, preexec_fn=default_sigpipe, text=True)
+                return platform in output
+        except subprocess.CalledProcessError:
+            return True
+
     def verify_image_platform(self, image_path):
         if not os.path.isfile(image_path):
             return False
 
-        # Get running platform's ASIC
-        try:
-            version_info = device_info.get_sonic_version_info()
-            if version_info:
-                asic_type = version_info['asic_type']
-            else:
-                asic_type = None
-        except (KeyError, TypeError) as e:
-            click.echo("Caught an exception: " + str(e))
+        # Get running platform
+        platform = device_info.get_platform()
 
-        # Get installing image's ASIC
-        p1 = subprocess.Popen(["sed", "-e", "1,/^exit_marker$/d", image_path], stdout=subprocess.PIPE, preexec_fn=default_sigpipe)
-        p2 = subprocess.Popen(["tar", "xf", "-", MACHINE_CONF, "-O"], stdin=p1.stdout, stdout=subprocess.PIPE, preexec_fn=default_sigpipe)
-        p3 = subprocess.Popen(["sed", "-n", r"s/^machine=\(.*\)/\1/p"], stdin=p2.stdout, stdout=subprocess.PIPE, preexec_fn=default_sigpipe, text=True)
-
-        stdout = p3.communicate()[0]
-        image_asic = stdout.rstrip('\n')
-
-        # Return false if machine is not found or unexpected issue occur
-        if not image_asic:
-            return False
-
-        if asic_type == image_asic:
-            return True
-        return False
+        # Check if platform is inside image's target platforms
+        return self.platform_in_devices_list(platform, image_path)
 
     @classmethod
     def detect(cls):

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -533,14 +533,14 @@ def install(url, force, skip_platform_check=False, skip_migration=False, skip_pa
             raise click.Abort()
     else:
         # Verify not installing non-secure image in a secure running image
-        if not bootloader.verify_secureboot_image(image_path) and not force:
+        if not force and not bootloader.verify_secureboot_image(image_path):
             echo_and_log("Image file '{}' is of a different type than running image.\n".format(url) +
                 "If you are sure you want to install this image, use -f|--force|--skip-secure-check.\n" +
                 "Aborting...", LOG_ERR)
             raise click.Abort()
 
         # Verify that the binary image is of the same platform type as running platform
-        if not bootloader.verify_image_platform(image_path) and not skip_platform_check:
+        if not skip_platform_check and not bootloader.verify_image_platform(image_path):
             echo_and_log("Image file '{}' is of a different platform type than running platform.\n".format(url) +
                 "If you are sure you want to install this image, use --skip-platform-check.\n" +
                 "Aborting...", LOG_ERR)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Check by devices list instead of machine.conf
#### How I did it
Add a devices list for the same ASIC while build the image
#### How to verify it
Install a bin file which differs the running platform's ASIC. For example;
install sonic-broadcom.bin to mellanox ASIC platform
install sonic-vs.bin to broadcom ASIC platform
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

