### PR TITLE
[config] support for configuring muxcable to standby mode of operation

### DIFF
--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -233,7 +233,7 @@ def lookup_statedb_and_update_configdb(per_npu_statedb, config_db, port, state_c
     else:
         config_db.set_entry("MUX_CABLE", port, {"state": state_cfg_val,
                                                 "server_ipv4": ipv4_value, "server_ipv6": ipv6_value})
-        if str(state_cfg_val) == 'active' and str(state) != 'active':
+        if (str(state_cfg_val) == 'active' and str(state) != 'active') or (str(state_cfg_val) == 'standby' and str(state) != 'standby'):
             port_status_dict[port] = 'INPROGRESS'
         else:
             port_status_dict[port] = 'OK'
@@ -241,7 +241,7 @@ def lookup_statedb_and_update_configdb(per_npu_statedb, config_db, port, state_c
 
 # 'muxcable' command ("config muxcable mode <port|all> active|auto")
 @muxcable.command()
-@click.argument('state', metavar='<operation_status>', required=True, type=click.Choice(["active", "auto", "manual"]))
+@click.argument('state', metavar='<operation_status>', required=True, type=click.Choice(["active", "auto", "manual", "standby"]))
 @click.argument('port', metavar='<port_name>', required=True, default=None)
 @click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL)
 @clicommon.pass_db

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -1636,6 +1636,11 @@
 	"server_ipv4": "10.1.1.1",
 	"server_ipv6": "fc00::75"
     },
+    "MUX_CABLE|Ethernet16": {
+        "state": "standby",
+	"server_ipv4": "10.1.1.1",
+	"server_ipv6": "fc00::75"
+    },
     "MUX_CABLE|Ethernet28": {
         "state": "manual",
 	"server_ipv4": "10.1.1.1",

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -563,6 +563,9 @@
     "MUX_LINKMGR_TABLE|Ethernet8": {
         "state": "unhealthy"
     },
+    "MUX_LINKMGR_TABLE|Ethernet16": {
+        "state": "healthy"
+    },
     "MUX_LINKMGR_TABLE|Ethernet12": {
         "state": "unhealthy"
     },

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -545,6 +545,9 @@
     "MUX_CABLE_TABLE|Ethernet8": {
         "state": "standby"
     },
+    "MUX_CABLE_TABLE|Ethernet16": {
+        "state": "standby"
+    },
     "MUX_CABLE_TABLE|Ethernet12": {
         "state": "unknown"
     },

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -31,6 +31,7 @@ Ethernet0   active    healthy
 Ethernet4   standby   healthy
 Ethernet8   standby   unhealthy
 Ethernet12  unknown   unhealthy
+Ethernet16  standby   healthy
 Ethernet32  active    healthy
 """
 
@@ -52,6 +53,10 @@ json_data_status_output_expected = """\
         "Ethernet12": {
             "STATUS": "unknown",
             "HEALTH": "unhealthy"
+        },
+        "Ethernet16": {
+            "STATUS": "standby",
+            "HEALTH": "healthy"
         },
         "Ethernet32": {
             "STATUS": "active",
@@ -169,6 +174,7 @@ json_data_config_output_active_expected = """\
     "Ethernet0": "OK",
     "Ethernet4": "INPROGRESS",
     "Ethernet8": "OK",
+    "Ethernet16": "INPROGRESS",
     "Ethernet12": "OK"
 }
 """

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -164,6 +164,7 @@ json_data_config_output_auto_expected = """\
     "Ethernet0": "OK",
     "Ethernet4": "OK",
     "Ethernet8": "OK",
+    "Ethernet16": "OK",
     "Ethernet12": "OK"
 }
 """
@@ -174,7 +175,7 @@ json_data_config_output_active_expected = """\
     "Ethernet0": "OK",
     "Ethernet4": "INPROGRESS",
     "Ethernet8": "OK",
-    "Ethernet16": "OK",
+    "Ethernet16": "INPROGRESS",
     "Ethernet12": "OK"
 }
 """

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -72,6 +72,7 @@ Ethernet0   active   10.2.1.1  e800::46
 Ethernet4   auto     10.3.1.1  e801::46
 Ethernet8   active   10.4.1.1  e802::46
 Ethernet12  active   10.4.1.1  e802::46
+Ethernet16  standby  10.1.1.1  fc00::75
 Ethernet28  manual   10.1.1.1  fc00::75
 Ethernet32  auto     10.1.1.1  fc00::75
 """
@@ -107,6 +108,13 @@ json_data_status_config_output_expected = """\
                 "SERVER": {
                     "IPv4": "10.4.1.1",
                     "IPv6": "e802::46"
+                }
+            },
+            "Ethernet16": {
+                "STATE": "standby",
+                "SERVER": {
+                    "IPv4": "10.1.1.1",
+                    "IPv6": "fc00::75"
                 }
             },
             "Ethernet28": {
@@ -380,6 +388,19 @@ class TestMuxcable(object):
             result = runner.invoke(config.config.commands["muxcable"].commands["mode"], ["manual", "Ethernet8"], obj=db)
 
         assert result.exit_code == 0
+
+    def test_config_muxcable_tabular_port_Ethernet16_standby(self):
+        runner = CliRunner()
+        db = Db()
+
+        with mock.patch('sonic_platform_base.sonic_sfp.sfputilhelper') as patched_util:
+            patched_util.SfpUtilHelper.return_value.get_asic_id_for_logical_port.return_value = 0
+            result = runner.invoke(config.config.commands["muxcable"].commands["mode"], ["standby", "Ethernet16"], obj=db)
+
+        assert result.exit_code == 0
+
+    def test_config_muxcable_mode_auto_json(self):
+        runner = CliRunner()
 
     def test_config_muxcable_mode_auto_json(self):
         runner = CliRunner()

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -401,9 +401,6 @@ class TestMuxcable(object):
 
     def test_config_muxcable_mode_auto_json(self):
         runner = CliRunner()
-
-    def test_config_muxcable_mode_auto_json(self):
-        runner = CliRunner()
         db = Db()
 
         result = runner.invoke(config.config.commands["muxcable"].commands["mode"], ["auto", "all", "--json"], obj=db)

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -174,7 +174,7 @@ json_data_config_output_active_expected = """\
     "Ethernet0": "OK",
     "Ethernet4": "INPROGRESS",
     "Ethernet8": "OK",
-    "Ethernet16": "INPROGRESS",
+    "Ethernet16": "OK",
     "Ethernet12": "OK"
 }
 """


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

#### What I did
This PR adds support for an option to  configure muxcable mode to  a `standby` mode. The standby mode is in addition
to `auto\active\manual` mode. 

The new output would look like this in case an standby arg is passed to the command line

`admin@sonic:~$ sudo config muxcable mode standby Ethernet0`

`admin@sonic:~$ sudo config muxcable mode standby all`


added an option to set muxcable  mode to standby mode, in addition to existing auto/active/manual modes. 

#### How I did it

added the changes in config/muxcable.py and added testcases

#### How to verify it
Ran the unit tests

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

