### PR TITLE
[portstat] check TX/RX utilization calculation correctness

### DIFF
--- a/tests/mock_tables/counters_db.json
+++ b/tests/mock_tables/counters_db.json
@@ -467,10 +467,10 @@
             "SAI_ROUTER_INTERFACE_STAT_OUT_PACKETS": "0"
     },
     "RATES:oid:0x1000000000012": {
-            "RX_BPS": "0",
-            "RX_PPS": "0",
-            "TX_BPS": "0",
-            "TX_PPS": "0"
+            "RX_BPS": "2.e9",
+            "RX_PPS": "247.e3",
+            "TX_BPS": "1.5e9",
+            "TX_PPS": "183.e3"
     },
     "RATES:oid:0x1000000000013": {
             "RX_BPS": "204800",

--- a/tests/portstat_test.py
+++ b/tests/portstat_test.py
@@ -12,11 +12,11 @@ modules_path = os.path.dirname(root_path)
 scripts_path = os.path.join(modules_path, "scripts")
 
 intf_counters_before_clear = """\
-    IFACE    STATE    RX_OK        RX_BPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR    TX_OK       TX_BPS    TX_UTIL    TX_ERR    TX_DRP    TX_OVR
----------  -------  -------  ------------  ---------  --------  --------  --------  -------  -----------  ---------  --------  --------  --------
-Ethernet0        D        8      0.00 B/s      0.00%        10       100       N/A       10     0.00 B/s      0.00%       N/A       N/A       N/A
-Ethernet4      N/A        4   204.80 KB/s        N/A         0     1,000       N/A       40  204.85 KB/s        N/A       N/A       N/A       N/A
-Ethernet8      N/A        6  1350.00 KB/s        N/A       100        10       N/A       60   13.37 MB/s        N/A       N/A       N/A       N/A
+    IFACE    STATE    RX_OK        RX_BPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR    TX_OK        TX_BPS    TX_UTIL    TX_ERR    TX_DRP    TX_OVR
+---------  -------  -------  ------------  ---------  --------  --------  --------  -------  ------------  ---------  --------  --------  --------
+Ethernet0        D        8  2000.00 MB/s     64.00%        10       100       N/A       10  1500.00 MB/s     48.00%       N/A       N/A       N/A
+Ethernet4      N/A        4   204.80 KB/s        N/A         0     1,000       N/A       40   204.85 KB/s        N/A       N/A       N/A       N/A
+Ethernet8      N/A        6  1350.00 KB/s        N/A       100        10       N/A       60    13.37 MB/s        N/A       N/A       N/A       N/A
 """
 
 intf_counters_ethernet4 = """\
@@ -26,28 +26,28 @@ Ethernet4      N/A        4  204.80 KB/s        N/A         0     1,000       N/
 """
 
 intf_counters_all = """\
-    IFACE    STATE    RX_OK        RX_BPS     RX_PPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR    TX_OK       TX_BPS     TX_PPS    TX_UTIL    TX_ERR    TX_DRP    TX_OVR
----------  -------  -------  ------------  ---------  ---------  --------  --------  --------  -------  -----------  ---------  ---------  --------  --------  --------
-Ethernet0        D        8      0.00 B/s     0.00/s      0.00%        10       100       N/A       10     0.00 B/s     0.00/s      0.00%       N/A       N/A       N/A
-Ethernet4      N/A        4   204.80 KB/s   200.00/s        N/A         0     1,000       N/A       40  204.85 KB/s   201.00/s        N/A       N/A       N/A       N/A
-Ethernet8      N/A        6  1350.00 KB/s  9000.00/s        N/A       100        10       N/A       60   13.37 MB/s  9000.00/s        N/A       N/A       N/A       N/A
+    IFACE    STATE    RX_OK        RX_BPS       RX_PPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR    TX_OK        TX_BPS       TX_PPS    TX_UTIL    TX_ERR    TX_DRP    TX_OVR
+---------  -------  -------  ------------  -----------  ---------  --------  --------  --------  -------  ------------  -----------  ---------  --------  --------  --------
+Ethernet0        D        8  2000.00 MB/s  247000.00/s     64.00%        10       100       N/A       10  1500.00 MB/s  183000.00/s     48.00%       N/A       N/A       N/A
+Ethernet4      N/A        4   204.80 KB/s     200.00/s        N/A         0     1,000       N/A       40   204.85 KB/s     201.00/s        N/A       N/A       N/A       N/A
+Ethernet8      N/A        6  1350.00 KB/s    9000.00/s        N/A       100        10       N/A       60    13.37 MB/s    9000.00/s        N/A       N/A       N/A       N/A
 """
 
 intf_counters_period = """\
 The rates are calculated within 3 seconds period
-    IFACE    STATE    RX_OK        RX_BPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR    TX_OK       TX_BPS    TX_UTIL    TX_ERR    TX_DRP    TX_OVR
----------  -------  -------  ------------  ---------  --------  --------  --------  -------  -----------  ---------  --------  --------  --------
-Ethernet0        D        0      0.00 B/s      0.00%         0         0       N/A        0     0.00 B/s      0.00%       N/A       N/A       N/A
-Ethernet4      N/A        0   204.80 KB/s        N/A         0         0       N/A        0  204.85 KB/s        N/A       N/A       N/A       N/A
-Ethernet8      N/A        0  1350.00 KB/s        N/A         0         0       N/A        0   13.37 MB/s        N/A       N/A       N/A       N/A
+    IFACE    STATE    RX_OK        RX_BPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR    TX_OK        TX_BPS    TX_UTIL    TX_ERR    TX_DRP    TX_OVR
+---------  -------  -------  ------------  ---------  --------  --------  --------  -------  ------------  ---------  --------  --------  --------
+Ethernet0        D        0  2000.00 MB/s     64.00%         0         0       N/A        0  1500.00 MB/s     48.00%       N/A       N/A       N/A
+Ethernet4      N/A        0   204.80 KB/s        N/A         0         0       N/A        0   204.85 KB/s        N/A       N/A       N/A       N/A
+Ethernet8      N/A        0  1350.00 KB/s        N/A         0         0       N/A        0    13.37 MB/s        N/A       N/A       N/A       N/A
 """
 
 intf_counter_after_clear = """\
-    IFACE    STATE    RX_OK        RX_BPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR    TX_OK       TX_BPS    TX_UTIL    TX_ERR    TX_DRP    TX_OVR
----------  -------  -------  ------------  ---------  --------  --------  --------  -------  -----------  ---------  --------  --------  --------
-Ethernet0        D        0      0.00 B/s      0.00%         0         0       N/A        0     0.00 B/s      0.00%       N/A       N/A       N/A
-Ethernet4      N/A        0   204.80 KB/s        N/A         0         0       N/A        0  204.85 KB/s        N/A       N/A       N/A       N/A
-Ethernet8      N/A        0  1350.00 KB/s        N/A         0         0       N/A        0   13.37 MB/s        N/A       N/A       N/A       N/A"""
+    IFACE    STATE    RX_OK        RX_BPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR    TX_OK        TX_BPS    TX_UTIL    TX_ERR    TX_DRP    TX_OVR
+---------  -------  -------  ------------  ---------  --------  --------  --------  -------  ------------  ---------  --------  --------  --------
+Ethernet0        D        0  2000.00 MB/s     64.00%         0         0       N/A        0  1500.00 MB/s     48.00%       N/A       N/A       N/A
+Ethernet4      N/A        0   204.80 KB/s        N/A         0         0       N/A        0   204.85 KB/s        N/A       N/A       N/A       N/A
+Ethernet8      N/A        0  1350.00 KB/s        N/A         0         0       N/A        0    13.37 MB/s        N/A       N/A       N/A       N/A"""
 
 clear_counter = """\
 Cleared counters"""


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Update test for checking TX/RX utilization

#### How I did it
Add real values for TX/RX to mock table instead of zeroes 

#### How to verify it
run **portstat_test.py** via  `python3 setup.py test`  in  sonic-utilities tests 

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)