### PR TITLE
[db_migrator] Fix the target db version of the port-channel key test

### DIFF
--- a/tests/db_migrator_input/config_db/portchannel-expected.json
+++ b/tests/db_migrator_input/config_db/portchannel-expected.json
@@ -33,7 +33,7 @@
         "lacp_key": "auto"
     },
     "VERSIONS|DATABASE": {
-        "VERSION": "version_2_0_3"
+        "VERSION": "version_2_0_2"
     }
 } 
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
The port-channel key migrator was introduced in version `2_0_2` so the expected database version of the test case should be `2_0_2`. 
It was modified to `2_0_3` when the new version was introduced by mistake. This won't fail the test but disable the require its database version to be updated every time a new version is introduced. (Refer #1566 and #1614 for details)
This is to correct it by changing it back to `2_0_2`.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

