### PR TITLE
[202012][show techsupport] address show techsupport return none zero code issue

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -65,7 +65,9 @@ save_bcmcmd() {
     local do_gzip=${3:-false}
     local tarpath="${BASE}/dump/$filename"
     local timeout_cmd="timeout --foreground ${TIMEOUT_MIN}m"
-    [ ! -d $LOGDIR ] && $MKDIR $V -p $LOGDIR
+    if [ ! -d $LOGDIR ]; then
+        $MKDIR $V -p $LOGDIR
+    fi
 
     if [ $SKIP_BCMCMD -eq 1 ]; then
         echo "Skip $cmd"
@@ -78,14 +80,15 @@ save_bcmcmd() {
     if $NOOP; then
         echo "${timeout_cmd} $cmd &> '${filepath}'"
     else
-        eval "${timeout_cmd} $cmd" &> "${filepath}"
-        ret=$?
+        ret=0
+        eval "${timeout_cmd} $cmd" &> "${filepath}" || ret=$?
         if [ $ret -ne 0 ]; then
             if [ $ret -eq 124 ]; then
                 echo "Command: $cmd timedout after ${TIMEOUT_MIN} minutes."
             else
-                grep "polling socket timeout: Success" ${filepath} &>/dev/null
-                if [ $? -eq 0 ]; then
+                RC=0
+                grep "polling socket timeout: Success" ${filepath} &>/dev/null || RC=$?
+                if [ $RC -eq 0 ]; then
                     echo "bcmcmd command timeout. Setting SKIP_BCMCMD to true ..."
                     SKIP_BCMCMD=1
                 fi
@@ -164,6 +167,9 @@ save_cmd() {
     local timeout_cmd="timeout --foreground ${TIMEOUT_MIN}m"
     local redirect='&>'
     local redirect_eval='2>&1'
+    if [ ! -d $LOGDIR ]; then
+        $MKDIR $V -p $LOGDIR
+    fi
 
     if ! $SAVE_STDERR
     then
@@ -171,7 +177,9 @@ save_cmd() {
         redirect_eval=""
     fi
 
-    [ ! -d $LOGDIR ] && $MKDIR $V -p $LOGDIR
+    if [ ! -d $LOGDIR ]; then
+        $MKDIR $V -p $LOGDIR
+    fi
 
     # eval required here to re-evaluate the $cmd properly at runtime
     # This is required if $cmd has quoted strings that should be bunched
@@ -184,8 +192,9 @@ save_cmd() {
         if $NOOP; then
             echo "${timeout_cmd} bash -c \"${cmds}\""
         else
-            eval "${timeout_cmd} bash -c \"${cmds}\""
-            if [ $? -ne 0 ]; then
+            RC=0
+            eval "${timeout_cmd} bash -c \"${cmds}\"" || RC=$?
+            if [ $RC -ne 0 ]; then
                 echo "Command: $cmds timedout after ${TIMEOUT_MIN} minutes."
             fi
         fi
@@ -193,8 +202,9 @@ save_cmd() {
         if $NOOP; then
             echo "${timeout_cmd} $cmd $redirect '$filepath'"
         else
-            eval "${timeout_cmd} $cmd" "$redirect" "$filepath"
-            if [ $? -ne 0 ]; then
+            RC=0
+            eval "${timeout_cmd} $cmd" "$redirect" "$filepath" || RC=$?
+            if [ $RC -ne 0 ]; then
                 echo "Command: $cmd timedout after ${TIMEOUT_MIN} minutes."
             fi
         fi
@@ -263,12 +273,13 @@ copy_from_docker() {
         echo "${timeout_cmd} ${touch_cmd}"
         echo "${timeout_cmd} ${cp_cmd}"
     else
-        eval "${timeout_cmd} ${touch_cmd}"
-        if [ $? -ne 0 ]; then
+        RC=0
+        eval "${timeout_cmd} ${touch_cmd}" || RC=$?
+        if [ $RC -ne 0 ]; then
             echo "Command: $touch_cmd timedout after ${TIMEOUT_MIN} minutes."
         fi
-        eval "${timeout_cmd} ${cp_cmd}"
-        if [ $? -ne 0 ]; then
+        eval "${timeout_cmd} ${cp_cmd}" || RC=$?
+        if [ $RC -ne 0 ]; then
             echo "Command: $cp_cmd timedout after ${TIMEOUT_MIN} minutes."
         fi
     fi
@@ -709,7 +720,9 @@ save_file() {
     local tar_path="${BASE}/$supp_dir/$(basename $orig_path)"
     local do_gzip=${3:-true}
     local do_tar_append=${4:-true}
-    [ ! -d "$TARDIR/$supp_dir" ] && $MKDIR $V -p "$TARDIR/$supp_dir"
+    if [ ! -d "$TARDIR/$supp_dir" ]; then
+        $MKDIR $V -p "$TARDIR/$supp_dir"
+    fi
 
     if $do_gzip; then
         gz_path="${gz_path}.gz"
@@ -953,8 +966,8 @@ save_log_files() {
 #  None
 ###############################################################################
 save_warmboot_files() {
-    trap 'handle_error $? $LINENO' ERR
     # Copy the warmboot files
+    trap 'handle_error $? $LINENO' ERR
     start_t=$(date +%s%3N)
     if $NOOP; then
         echo "$CP $V -rf /host/warmboot $TARDIR"
@@ -983,26 +996,30 @@ save_warmboot_files() {
 save_crash_files() {
     # archive core dump files
     trap 'handle_error $? $LINENO' ERR
-    for file in $(find_files "/var/core/"); do
-        # don't gzip already-gzipped log files :)
-        if [ -z "${file##*.gz}" ]; then
-            save_file $file core false
-        else
-            save_file $file core true
-        fi
-    done
+    if [ -d /var/core/ ]; then
+        for file in $(find_files "/var/core/"); do
+            # don't gzip already-gzipped log files :)
+            if [ -z "${file##*.gz}" ]; then
+                save_file $file core false
+            else
+                save_file $file core true
+            fi
+        done
+    fi
 
     # archive kernel dump files
-    [ -d /var/crash/ ] && for file in $(find_files "/var/crash/"); do
-        # don't gzip already-gzipped dmesg files :)
-        if [ ! ${file} = "/var/crash/kexec_cmd" -a ! ${file} = "/var/crash/export" ]; then
-            if [[ ${file} == *"kdump."* ]]; then
-                save_file $file kdump false
-            else
-                save_file $file kdump true
+    if [ -d /var/crash/ ]; then
+        for file in $(find_files "/var/crash/"); do
+            # don't gzip already-gzipped dmesg files :)
+            if [ ! ${file} = "/var/crash/kexec_cmd" -a ! ${file} = "/var/crash/export" ]; then
+                if [[ ${file} == *"kdump."* ]]; then
+                    save_file $file kdump false
+                else
+                    save_file $file kdump true
+                fi
             fi
-        fi
-    done
+        done
+    fi
 }
 
 ###############################################################################
@@ -1239,8 +1256,9 @@ main() {
     $RM $V -rf $TARDIR
 
     if $DO_COMPRESS; then
-        $GZIP $V $TARFILE
-        if [ $? -eq 0 ]; then
+        RC=0
+        $GZIP $V $TARFILE || RC=$?
+        if [ $RC -eq 0 ]; then
             TARFILE="${TARFILE}.gz"
         else
             echo "WARNING: gzip operation appears to have failed." >&2


### PR DESCRIPTION
#### What I did
Some bash syntax is correct without error handler on $?. With the error handler, they need to use different syntax to avoid false positives.

#### How I did it
Update bash syntax.

#### How to verify it
tested with show techsuppor test.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>