### PR TITLE
[fstrim] limit smartctl execution time to 30 seconds

### DIFF
--- a/scripts/log_ssd_health
+++ b/scripts/log_ssd_health
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-smartctl -a /dev/sda > /tmp/smartctl
+timeout 30 smartctl -a /dev/sda > /tmp/smartctl
 if [ -f /tmp/smartctl ];then
     logger -f /tmp/smartctl
 fi


### PR DESCRIPTION
#### What I did

At early boot up time, smartctl is observed could stuck forever, which causes fstrim service to be stuck in pre-start state forever.
This is a transient issue. The periodic retry will go through when pmon docker is healthy.

#### How to verify it
This issue is not highly repeatable. Tested on the device hit the issue.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
