### PR TITLE
Fix sfputil output for OSFP xcvrs

### DIFF
--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -260,7 +260,8 @@ def convert_sfp_info_to_output_string(sfp_info_dict):
         elif key == 'cable_length':
             pass
         elif key == 'specification_compliance':
-            if sfp_info_dict['type'] == "QSFP-DD Double Density 8X Pluggable Transceiver":
+            if sfp_info_dict['type'] == "QSFP-DD Double Density 8X Pluggable Transceiver" or \
+            sfp_info_dict['type'] == "OSFP 8X Pluggable Transceiver":
                 output += '{}{}: {}\n'.format(indent, QSFP_DATA_MAP[key], sfp_info_dict[key])
             else:
                 output += '{}{}:\n'.format(indent, QSFP_DATA_MAP['specification_compliance'])


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Enhanced 'sfputil show eeprom' to properly handle OSFP xcvrs

#### How I did it
Fixed condition in convert_sfp_info_to_output_string to include OSFP xcvrs

#### How to verify it
Verified on Arista platform with OSFP xcvrs

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

