### PR TITLE
[202012] [techsupport] Techsupport Error Reporting pending fixes

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -86,8 +86,9 @@ save_bcmcmd() {
             if [ $ret -eq 124 ]; then
                 echo "Command: $cmd timedout after ${TIMEOUT_MIN} minutes."
             else
-                grep "polling socket timeout: Success" ${filepath} &>/dev/null
-                if [ $? -eq 0 ]; then
+                RC=0
+                grep "polling socket timeout: Success" ${filepath} &>/dev/null || RC=$?
+                if [ $RC -eq 0 ]; then
                     echo "bcmcmd command timeout. Setting SKIP_BCMCMD to true ..."
                     SKIP_BCMCMD=1
                 fi
@@ -187,8 +188,9 @@ save_cmd() {
         if $NOOP; then
             echo "${timeout_cmd} bash -c \"${cmds}\""
         else
-            eval "${timeout_cmd} bash -c \"${cmds}\""
-            if [ $? -ne 0 ]; then
+            RC=0
+            eval "${timeout_cmd} bash -c \"${cmds}\"" || RC=$?
+            if [ $RC -ne 0 ]; then
                 echo "Command: $cmds timedout after ${TIMEOUT_MIN} minutes."
             fi
         fi

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -65,7 +65,9 @@ save_bcmcmd() {
     local do_gzip=${3:-false}
     local tarpath="${BASE}/dump/$filename"
     local timeout_cmd="timeout --foreground ${TIMEOUT_MIN}m"
-    [ ! -d $LOGDIR ] && $MKDIR $V -p $LOGDIR
+    if [ ! -d $LOGDIR ]; then
+        $MKDIR $V -p $LOGDIR
+    fi
 
     if [ $SKIP_BCMCMD -eq 1 ]; then
         echo "Skip $cmd"
@@ -78,8 +80,8 @@ save_bcmcmd() {
     if $NOOP; then
         echo "${timeout_cmd} $cmd &> '${filepath}'"
     else
-        eval "${timeout_cmd} $cmd" &> "${filepath}"
-        ret=$?
+        ret=0
+        eval "${timeout_cmd} $cmd" &> "${filepath}" || ret=$?
         if [ $ret -ne 0 ]; then
             if [ $ret -eq 124 ]; then
                 echo "Command: $cmd timedout after ${TIMEOUT_MIN} minutes."
@@ -164,14 +166,15 @@ save_cmd() {
     local timeout_cmd="timeout --foreground ${TIMEOUT_MIN}m"
     local redirect='&>'
     local redirect_eval='2>&1'
+    if [ ! -d $LOGDIR ]; then
+        $MKDIR $V -p $LOGDIR
+    fi
 
     if ! $SAVE_STDERR
     then
         redirect=">"
         redirect_eval=""
     fi
-
-    [ ! -d $LOGDIR ] && $MKDIR $V -p $LOGDIR
 
     # eval required here to re-evaluate the $cmd properly at runtime
     # This is required if $cmd has quoted strings that should be bunched
@@ -264,12 +267,13 @@ copy_from_docker() {
         echo "${timeout_cmd} ${touch_cmd}"
         echo "${timeout_cmd} ${cp_cmd}"
     else
-        eval "${timeout_cmd} ${touch_cmd}"
-        if [ $? -ne 0 ]; then
+        RC=0
+        eval "${timeout_cmd} ${touch_cmd}" || RC=$?
+        if [ $RC -ne 0 ]; then
             echo "Command: $touch_cmd timedout after ${TIMEOUT_MIN} minutes."
         fi
-        eval "${timeout_cmd} ${cp_cmd}"
-        if [ $? -ne 0 ]; then
+        eval "${timeout_cmd} ${cp_cmd}" || RC=$?
+        if [ $RC -ne 0 ]; then
             echo "Command: $cp_cmd timedout after ${TIMEOUT_MIN} minutes."
         fi
     fi
@@ -710,7 +714,9 @@ save_file() {
     local tar_path="${BASE}/$supp_dir/$(basename $orig_path)"
     local do_gzip=${3:-true}
     local do_tar_append=${4:-true}
-    [ ! -d "$TARDIR/$supp_dir" ] && $MKDIR $V -p "$TARDIR/$supp_dir"
+    if [ ! -d "$TARDIR/$supp_dir" ]; then
+        $MKDIR $V -p "$TARDIR/$supp_dir"
+    fi
 
     if $do_gzip; then
         gz_path="${gz_path}.gz"
@@ -1244,8 +1250,9 @@ main() {
     $RM $V -rf $TARDIR
 
     if $DO_COMPRESS; then
-        $GZIP $V $TARFILE
-        if [ $? -eq 0 ]; then
+        RC=0
+        $GZIP $V $TARFILE || RC=$?
+        if [ $RC -eq 0 ]; then
             TARFILE="${TARFILE}.gz"
         else
             echo "WARNING: gzip operation appears to have failed." >&2

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1157,7 +1157,7 @@ main() {
     save_cmd "show interface status -d all" "interface.status"
     save_cmd "show interface transceiver presence" "interface.xcvrs.presence"
     save_cmd "show interface transceiver eeprom --dom" "interface.xcvrs.eeprom"
-    save_cmd "show ip interface -d all" "ip.interface"
+    save_cmd "show ip interface" "ip.interface"
 
     save_cmd "lldpctl" "lldpctl"
     if [[ ( "$NUM_ASICS" > 1 ) ]]; then

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -65,9 +65,7 @@ save_bcmcmd() {
     local do_gzip=${3:-false}
     local tarpath="${BASE}/dump/$filename"
     local timeout_cmd="timeout --foreground ${TIMEOUT_MIN}m"
-    if [ ! -d $LOGDIR ]; then
-        $MKDIR $V -p $LOGDIR
-    fi
+    [ ! -d $LOGDIR ] && $MKDIR $V -p $LOGDIR
 
     if [ $SKIP_BCMCMD -eq 1 ]; then
         echo "Skip $cmd"
@@ -80,8 +78,8 @@ save_bcmcmd() {
     if $NOOP; then
         echo "${timeout_cmd} $cmd &> '${filepath}'"
     else
-        ret=0
-        eval "${timeout_cmd} $cmd" &> "${filepath}" || ret=$?
+        eval "${timeout_cmd} $cmd" &> "${filepath}"
+        ret=$?
         if [ $ret -ne 0 ]; then
             if [ $ret -eq 124 ]; then
                 echo "Command: $cmd timedout after ${TIMEOUT_MIN} minutes."
@@ -167,15 +165,14 @@ save_cmd() {
     local timeout_cmd="timeout --foreground ${TIMEOUT_MIN}m"
     local redirect='&>'
     local redirect_eval='2>&1'
-    if [ ! -d $LOGDIR ]; then
-        $MKDIR $V -p $LOGDIR
-    fi
 
     if ! $SAVE_STDERR
     then
         redirect=">"
         redirect_eval=""
     fi
+
+    [ ! -d $LOGDIR ] && $MKDIR $V -p $LOGDIR
 
     # eval required here to re-evaluate the $cmd properly at runtime
     # This is required if $cmd has quoted strings that should be bunched
@@ -269,13 +266,12 @@ copy_from_docker() {
         echo "${timeout_cmd} ${touch_cmd}"
         echo "${timeout_cmd} ${cp_cmd}"
     else
-        RC=0
-        eval "${timeout_cmd} ${touch_cmd}" || RC=$?
-        if [ $RC -ne 0 ]; then
+        eval "${timeout_cmd} ${touch_cmd}"
+        if [ $? -ne 0 ]; then
             echo "Command: $touch_cmd timedout after ${TIMEOUT_MIN} minutes."
         fi
-        eval "${timeout_cmd} ${cp_cmd}" || RC=$?
-        if [ $RC -ne 0 ]; then
+        eval "${timeout_cmd} ${cp_cmd}"
+        if [ $? -ne 0 ]; then
             echo "Command: $cp_cmd timedout after ${TIMEOUT_MIN} minutes."
         fi
     fi
@@ -716,9 +712,7 @@ save_file() {
     local tar_path="${BASE}/$supp_dir/$(basename $orig_path)"
     local do_gzip=${3:-true}
     local do_tar_append=${4:-true}
-    if [ ! -d "$TARDIR/$supp_dir" ]; then
-        $MKDIR $V -p "$TARDIR/$supp_dir"
-    fi
+    [ ! -d "$TARDIR/$supp_dir" ] && $MKDIR $V -p "$TARDIR/$supp_dir"
 
     if $do_gzip; then
         gz_path="${gz_path}.gz"
@@ -1252,9 +1246,8 @@ main() {
     $RM $V -rf $TARDIR
 
     if $DO_COMPRESS; then
-        RC=0
-        $GZIP $V $TARFILE || RC=$?
-        if [ $RC -eq 0 ]; then
+        $GZIP $V $TARFILE
+        if [ $? -eq 0 ]; then
             TARFILE="${TARFILE}.gz"
         else
             echo "WARNING: gzip operation appears to have failed." >&2

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -660,11 +660,11 @@ save_redis() {
 save_saidump() {
     trap 'handle_error $? $LINENO' ERR
     if [[ ( "$NUM_ASICS" == 1 ) ]] ; then
-        save_cmd "docker exec -it syncd saidump" "saidump"
+        save_cmd "docker exec syncd saidump" "saidump"
     else
         for (( i=0; i<$NUM_ASICS; i++ ))
         do
-            save_cmd "docker exec -it syncd$i saidump" "saidump$i"
+            save_cmd "docker exec syncd$i saidump" "saidump$i"
         done
     fi
 }
@@ -803,7 +803,7 @@ enable_logrotate() {
 collect_mellanox() {
     trap 'handle_error $? $LINENO' ERR
     local sai_dump_filename="/tmp/sai_sdk_dump_$(date +"%m_%d_%Y_%I_%M_%p")"
-    ${CMD_PREFIX}docker exec -it syncd saisdkdump -f $sai_dump_filename
+    ${CMD_PREFIX}docker exec syncd saisdkdump -f $sai_dump_filename
     ${CMD_PREFIX}docker exec syncd tar Ccf $(dirname $sai_dump_filename) - $(basename $sai_dump_filename) | tar Cxf /tmp/ -
     save_file $sai_dump_filename sai_sdk_dump true
 

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -84,9 +84,8 @@ save_bcmcmd() {
             if [ $ret -eq 124 ]; then
                 echo "Command: $cmd timedout after ${TIMEOUT_MIN} minutes."
             else
-                RC=0
-                grep "polling socket timeout: Success" ${filepath} &>/dev/null || RC=$?
-                if [ $RC -eq 0 ]; then
+                grep "polling socket timeout: Success" ${filepath} &>/dev/null
+                if [ $? -eq 0 ]; then
                     echo "bcmcmd command timeout. Setting SKIP_BCMCMD to true ..."
                     SKIP_BCMCMD=1
                 fi
@@ -185,9 +184,8 @@ save_cmd() {
         if $NOOP; then
             echo "${timeout_cmd} bash -c \"${cmds}\""
         else
-            RC=0
-            eval "${timeout_cmd} bash -c \"${cmds}\"" || RC=$?
-            if [ $RC -ne 0 ]; then
+            eval "${timeout_cmd} bash -c \"${cmds}\""
+            if [ $? -ne 0 ]; then
                 echo "Command: $cmds timedout after ${TIMEOUT_MIN} minutes."
             fi
         fi


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

This PR include some fixes which were missed while manually porting the error reporting PR onto 202012 https://github.com/Azure/sonic-utilities/pull/1833. 

i.e. removing -it option from the docker exec commands. to understand why the -it option was removed, refer https://github.com/Azure/sonic-utilities/pull/1723 

This also include another fix which removes -d from the show ip interface command, which fails otherwise

#### How I did it

#### How to verify it

- Run the show tech-support and check the return status. It should be zero. (Atleast, it was on mellanox platform. I couldn't check the functions which were platform specific)
- Run the "show techsupport" test. one case will still fail complaining about this. This is expected as -it option was removed. and the test has to be updated. 

`cmd_not_found = defaultdict(<type 'list'>, {'docker_cmds': ['docker exec -it syncd saidump', 'docker exec -it lldp lldpcli show statistics']})`



#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

