### PR TITLE
[config] Add portchannel support  for static route 

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -896,7 +896,7 @@ def cli_sroute_to_config(ctx, command_str, strict_nh = True):
                 if nh.startswith('PortChannel'):
                     config_db = ctx.obj['config_db']
                     if not nh in config_db.get_keys('PORTCHANNEL'):
-                        ctx.fail("portchannel doest not exist.")
+                        ctx.fail("portchannel does not exist.")
                 else:
                     ipaddress.ip_address(nh)
     except ValueError:

--- a/config/main.py
+++ b/config/main.py
@@ -893,7 +893,11 @@ def cli_sroute_to_config(ctx, command_str, strict_nh = True):
             nh_list = config_entry['nexthop'].split(',')
             for nh in nh_list:
                 # Nexthop to portchannel
-                if not nh.startswith('PortChannel'):
+                if nh.startswith('PortChannel'):
+                    config_db = ctx.obj['config_db']
+                    if not nh in config_db.get_keys('PORTCHANNEL'):
+                        ctx.fail("portchannel doest not exist.")
+                else:
                     ipaddress.ip_address(nh)
     except ValueError:
             ctx.fail("ip address is not valid.")

--- a/config/main.py
+++ b/config/main.py
@@ -890,11 +890,13 @@ def cli_sroute_to_config(ctx, command_str, strict_nh = True):
     try:
         ipaddress.ip_network(ip_prefix)
         if 'nexthop' in config_entry:
-            nh = config_entry['nexthop'].split(',')
-            for ip in nh:
-                ipaddress.ip_address(ip)
+            nh_list = config_entry['nexthop'].split(',')
+            for nh in nh_list:
+                # Nexthop to portchannel
+                if not nh.startswith('PortChannel'):
+                    ipaddress.ip_address(nh)
     except ValueError:
-        ctx.fail("ip address is not valid.")
+            ctx.fail("ip address is not valid.")
 
     if not vrf_name == "":
         key = vrf_name + "|" + ip_prefix

--- a/config/main.py
+++ b/config/main.py
@@ -900,7 +900,7 @@ def cli_sroute_to_config(ctx, command_str, strict_nh = True):
                 else:
                     ipaddress.ip_address(nh)
     except ValueError:
-            ctx.fail("ip address is not valid.")
+        ctx.fail("ip address is not valid.")
 
     if not vrf_name == "":
         key = vrf_name + "|" + ip_prefix

--- a/tests/static_routes_test.py
+++ b/tests/static_routes_test.py
@@ -25,6 +25,9 @@ Error: Not found {} in {}
 ERROR_INVALID_IP = '''
 Error: ip address is not valid.
 '''
+ERROR_INVALID_PORTCHANNEL = '''
+Error: portchannel doest not exist.
+'''
 
 
 class TestStaticRoutes(object):
@@ -51,31 +54,16 @@ class TestStaticRoutes(object):
         print(result.exit_code, result.output)
         assert not '1.2.3.4/32' in db.cfgdb.get_table('STATIC_ROUTE')
 
-    def test_portchannel_static_route(self):
+    def test_invalid_portchannel_static_route(self):
         db = Db()
         runner = CliRunner()
         obj = {'config_db':db.cfgdb}
-
-        # config portchannel add PortChannel0101
-        result = runner.invoke(config.config.commands["portchannel"].commands["add"], ["PortChannel0101"], obj=obj)
-        print(result.exit_code, result.output)
 
         # config route add prefix 1.2.3.4/32 nexthop PortChannel0101
         result = runner.invoke(config.config.commands["route"].commands["add"], \
         ["prefix", "1.2.3.4/32", "nexthop", "PortChannel0101"], obj=obj)
         print(result.exit_code, result.output)
-        assert ('1.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
-        assert db.cfgdb.get_entry('STATIC_ROUTE', '1.2.3.4/32') == {'nexthop': 'PortChannel0101', 'blackhole': 'false', 'distance': '0', 'ifname': '', 'nexthop-vrf': ''}
-
-        # config route del prefix 1.2.3.4/32 nexthop PortChannel0101
-        result = runner.invoke(config.config.commands["route"].commands["del"], \
-        ["prefix", "1.2.3.4/32", "nexthop", "PortChannel0101"], obj=obj)
-        print(result.exit_code, result.output)
-        assert not '1.2.3.4/32' in db.cfgdb.get_table('STATIC_ROUTE')
-
-        # config portchannel del PortChannel0101
-        result = runner.invoke(config.config.commands["portchannel"].commands["del"], ["PortChannel0101"], obj=obj)
-        print(result.exit_code, result.output)
+        assert ERROR_INVALID_PORTCHANNEL in result.output
 
     def test_static_route_invalid_prefix_ip(self):
         db = Db()

--- a/tests/static_routes_test.py
+++ b/tests/static_routes_test.py
@@ -26,7 +26,7 @@ ERROR_INVALID_IP = '''
 Error: ip address is not valid.
 '''
 ERROR_INVALID_PORTCHANNEL = '''
-Error: portchannel doest not exist.
+Error: portchannel does not exist.
 '''
 
 

--- a/tests/static_routes_test.py
+++ b/tests/static_routes_test.py
@@ -51,6 +51,32 @@ class TestStaticRoutes(object):
         print(result.exit_code, result.output)
         assert not '1.2.3.4/32' in db.cfgdb.get_table('STATIC_ROUTE')
 
+    def test_portchannel_static_route(self):
+        db = Db()
+        runner = CliRunner()
+        obj = {'config_db':db.cfgdb}
+
+        # config portchannel add PortChannel0101
+        result = runner.invoke(config.config.commands["portchannel"].commands["add"], ["PortChannel0101"], obj=obj)
+        print(result.exit_code, result.output)
+
+        # config route add prefix 1.2.3.4/32 nexthop PortChannel0101
+        result = runner.invoke(config.config.commands["route"].commands["add"], \
+        ["prefix", "1.2.3.4/32", "nexthop", "PortChannel0101"], obj=obj)
+        print(result.exit_code, result.output)
+        assert ('1.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
+        assert db.cfgdb.get_entry('STATIC_ROUTE', '1.2.3.4/32') == {'nexthop': 'PortChannel0101', 'blackhole': 'false', 'distance': '0', 'ifname': '', 'nexthop-vrf': ''}
+
+        # config route del prefix 1.2.3.4/32 nexthop PortChannel0101
+        result = runner.invoke(config.config.commands["route"].commands["del"], \
+        ["prefix", "1.2.3.4/32", "nexthop", "PortChannel0101"], obj=obj)
+        print(result.exit_code, result.output)
+        assert not '1.2.3.4/32' in db.cfgdb.get_table('STATIC_ROUTE')
+
+        # config portchannel del PortChannel0101
+        result = runner.invoke(config.config.commands["portchannel"].commands["del"], ["PortChannel0101"], obj=obj)
+        print(result.exit_code, result.output)
+
     def test_static_route_invalid_prefix_ip(self):
         db = Db()
         runner = CliRunner()


### PR DESCRIPTION
#### What I did
Added portchannels support for static routes.
fix https://github.com/Azure/sonic-buildimage/issues/8907

#### How I did it
Added check if nexthop is a portchannel and added check if this portchannel exists in config db.

#### How to verify it
```
config portchannel add PortChannel0001
sudo config route add prefix 20.0.0.1/32 nexthop PortChannel0001
```
Also
```
sudo config route add prefix 20.0.0.1/32 nexthop PortChannel0003
Error: portchannel does not exist.
```
