### PR TITLE
[TH3] Skipp Control Plane Assist on WARM Reboot for TH3 HWSKUs

### DIFF
--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -561,6 +561,20 @@ def reset_vxlan_tunnel():
 
 
 #
+# Helper function to determine of HWSKU is capable of handling CPA
+#
+CPA_skip_hwsku = ['DellEMC-Z9332f-M-O16C64', 'DellEMC-Z9332f-M-O16C64-lab']
+
+def check_hwsku_not_capable_handle_CPA():
+    hwsku = get_switch_hwsku()
+    if hwsku in CPA_skip_hwsku:
+        log.log_warning('HWSKU {} not able to handle CPA programming. Skipping it gracefully.'.format(hwsku))
+        return True
+    else:
+        return False
+
+
+#
 # Main function
 #
 
@@ -579,6 +593,11 @@ def main():
 
     connect_config_db()
     connect_app_db()
+
+    # Some HWSKU not able to support CPA and should be skipped gracefully
+    if check_hwsku_not_capable_handle_CPA():
+        sys.exit(0)
+
     if operation_mode == 'set':
         set_success = False
 

--- a/tests/neighbor_advertiser_test.py
+++ b/tests/neighbor_advertiser_test.py
@@ -66,3 +66,15 @@ class TestNeighborAdvertiser(object):
         for key in expected_mapping.keys():
             assert(key in tunnel_mapping.keys())
             assert(expected_mapping[key] == tunnel_mapping[key])
+
+
+    def test_CPA_Capability_skip(self, set_up):
+        neighbor_advertiser.get_switch_hwsku = mock.MagicMock(return_value='DellEMC-Z9332f-M-O16C64')
+        output = neighbor_advertiser.check_hwsku_not_capable_handle_CPA()
+        assert output == True
+
+
+    def test_CPA_Capability_not_skip(self, set_up):
+        neighbor_advertiser.get_switch_hwsku = mock.MagicMock(return_value='Mellanox-SN3800-D112C8')
+        output = neighbor_advertiser.check_hwsku_not_capable_handle_CPA()
+        assert output == False


### PR DESCRIPTION
#### What I did
Added Code to Skip over Control Plane Assist (CPA) executed during Warm reboot operation for those HW that is not capable of handling CPA such as TH3 based HW SKUs.

#### How to verify it
Execute testcase "arp/test_wr_arp.py" to ensure the operation to program VxLAN Tunnel and Mirror ACLs are all skipped.
This is skipped during setup as well as finalizer time.  
Syslog captured that shows the skipping is made when HW SKU of TH3 is detected:

```
```

Also added new test cases to specifically test out the new helper function I added.