### PR TITLE
[generic_config_updater] Logging

### DIFF
--- a/generic_config_updater/generic_updater.py
+++ b/generic_config_updater/generic_updater.py
@@ -2,7 +2,7 @@ import json
 import os
 from enum import Enum
 from .gu_common import GenericConfigUpdaterError, ConfigWrapper, \
-                       DryRunConfigWrapper, PatchWrapper, loggingSettings
+                       DryRunConfigWrapper, PatchWrapper, genericUpdaterLogging
 from .patch_sorter import PatchSorter
 
 CHECKPOINTS_DIR = "/etc/sonic/checkpoints"
@@ -32,7 +32,7 @@ class PatchApplier:
                  changeapplier=None,
                  config_wrapper=None,
                  patch_wrapper=None):
-        self.logger=loggingSettings.getLogger(title="Patch Applier")
+        self.logger = genericUpdaterLogging.get_logger(title="Patch Applier")
         self.config_wrapper = config_wrapper if config_wrapper is not None else ConfigWrapper()
         self.patch_wrapper = patch_wrapper if patch_wrapper is not None else PatchWrapper()
         self.patchsorter = patchsorter if patchsorter is not None else PatchSorter(self.config_wrapper, self.patch_wrapper)
@@ -313,7 +313,7 @@ class GenericUpdateFactory:
         return config_rollbacker
 
     def init_verbose_logging(self, verbose):
-        loggingSettings.set_verbose(verbose)
+        genericUpdaterLogging.set_verbose(verbose)
 
     def get_config_wrapper(self, dry_run):
         if dry_run:

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -2,6 +2,7 @@ import json
 import jsonpatch
 from jsonpointer import JsonPointer
 import sonic_yang
+import syslog
 import subprocess
 import yang as ly
 import copy
@@ -9,6 +10,7 @@ import re
 from enum import Enum
 
 YANG_DIR = "/usr/local/yang-models"
+SYSLOG_IDENTIFIER = "GenericConfigUpdater"
 
 class GenericConfigUpdaterError(Exception):
     pass
@@ -691,3 +693,44 @@ class PathAddressing:
                     return submodel
 
         return None
+
+class GenericUpdaterLogger:
+    """
+        Logs are printed to console and added to syslog.
+        Console settings: log levels [error, warning, info] always printed, [debug] only printed if verbose logging
+        Syslog settings: log all levels [error, warning, info, debug]
+    """
+    def init_verbose_logging(self, verbose):
+        # Usually logs have levels such as: error, warning, info, debug.
+        # By default all log levels should show up to the user, except debug.
+        # By allowing verbose logging, debug msgs will also be shown to the user.
+        self.enable_verbose_logging = verbose
+
+    def log_error(self, title,  msg):
+        self.log(title, msg, syslog.LOG_ERR)
+
+    def log_warning(self, title, msg):
+        self.log(title, msg, syslog.LOG_WARNING)
+
+    def log_info(self, title, msg):
+        self.log(title, msg, syslog.LOG_INFO)
+
+    def log_debug(self, title, msg):
+        self.log(title, msg, syslog.LOG_DEBUG)
+
+    def log(self, title, msg, logLevel):
+        combined_msg = f"{title}: {msg}"
+        self._log_to_console(combined_msg, logLevel)
+        self._log_to_syslog(combined_msg, logLevel)
+
+    def _log_to_console(self, msg, logLevel):
+        # Always log [warning, error, info] i.e. not debug, but if verbose logging print debug as well
+        if logLevel < syslog.LOG_DEBUG or self.enable_verbose_logging:
+            print(msg)
+
+    def _log_to_syslog(self, msg, logLevel):
+        syslog.openlog(SYSLOG_IDENTIFIER)
+        syslog.syslog(logLevel, msg)
+        syslog.closelog()
+
+logger = GenericUpdaterLogger()

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -694,9 +694,9 @@ class PathAddressing:
 
         return None
 
-class GenericUpdaterLogger(logger.Logger):
-    def __init__(self, title, verbose):
-        super().__init__(SYSLOG_IDENTIFIER)
+class TitledLogger(logger.Logger):
+    def __init__(self, syslog_identifier, title, verbose):
+        super().__init__(syslog_identifier)
         self._title = title
         if verbose:
             self.set_min_log_priority_debug()
@@ -705,14 +705,14 @@ class GenericUpdaterLogger(logger.Logger):
         combined_msg = f"{self._title}: {msg}"
         super().log(priority, combined_msg, also_print_to_console)
 
-class LoggingSettings:
+class GenericUpdaterLogging:
     def __init__(self):
         self.set_verbose(False)
 
     def set_verbose(self, verbose):
         self._verbose = verbose
 
-    def getLogger(self, title):
-        return GenericUpdaterLogger(title, self._verbose)
+    def get_logger(self, title):
+        return TitledLogger(SYSLOG_IDENTIFIER, title, self._verbose)
 
-loggingSettings = LoggingSettings()
+genericUpdaterLogging = GenericUpdaterLogging()


### PR DESCRIPTION
#### What I did
Add some logs to generic_updater

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
Empty patch
```
admin@vlab-01:~$ sudo config apply-patch empty.json-patch 
Patch Applier: Patch application starting.
Patch Applier: Patch: []
Patch Applier: Validating patch is not making changes to tables without YANG models.
Patch Applier: Getting current config db.
Patch Applier: Simulating the target full config after applying the patch.
Patch Applier: Validating target config according to YANG models.
... [logs from sonic-yang-mgmt framework]
Patch Applier: Sorting patch updates.
Patch Applier: The patch was sorted into 0 changes.
Patch Applier: Applying changes in order.
Patch Applier: Verifying patch updates are reflected on ConfigDB.
Patch Applier: Patch application completed.
Patch applied successfully.
admin@vlab-01:~$ 
```

Single change patch
```
admin@vlab-01:~$ sudo config apply-patch dhcp_add.json-patch 
Patch Applier: Patch application starting.
Patch Applier: Patch: [{"op": "add", "path": "/VLAN/Vlan1000/dhcp_servers/4", "value": "192.0.0.5"}]
Patch Applier: Validating patch is not making changes to tables without YANG models.
Patch Applier: Getting current config db.
Patch Applier: Simulating the target full config after applying the patch.
Patch Applier: Validating target config according to YANG models.
... [logs from sonic-yang-mgmt framework]
Patch Applier: The patch was sorted into 1 change:
Patch Applier:   * [{"op": "add", "path": "/VLAN/Vlan1000/dhcp_servers/4", "value": "192.0.0.5"}]
Patch Applier: Applying changes in order.
Failed to apply patch
Usage: config apply-patch [OPTIONS] PATCH_FILE_PATH
Try "config apply-patch -h" for help.

Error: ChangeApplier.apply(change) is not implemented yet
admin@vlab-01:~$ 
```

Multi change patch:
```
admin@vlab-01:~$ sudo config apply-patch update_lanes.json-patch 
Patch Applier: Patch application starting.
Patch Applier: Patch: [{"op": "replace", "path": "/PORT/Ethernet100/lanes", "value": "121,122,123"}]
Patch Applier: Validating patch is not making changes to tables without YANG models.
Patch Applier: Getting current config db.
Patch Applier: Simulating the target full config after applying the patch.
Patch Applier: Validating target config according to YANG models.
... [logs from sonic-yang-mgmt framework]
Patch Applier: Sorting patch updates.
... [logs from sonic-yang-mgmt framework]
Patch Applier: The patch was sorted into 2 changes:
Patch Applier:   * [{"op": "remove", "path": "/PORT/Ethernet100"}]
Patch Applier:   * [{"op": "add", "path": "/PORT/Ethernet100", "value": {"alias": "fortyGigE0/100", "description": "fortyGigE0/100", "index": "25", "lanes": "121,122,123", "mtu": "9100", "pfc_asym": "off", "speed": "40000", "tpid": "0x8100"}}]
Patch Applier: Applying changes in order.
Failed to apply patch
Usage: config apply-patch [OPTIONS] PATCH_FILE_PATH
Try "config apply-patch -h" for help.

Error: ChangeApplier.apply(change) is not implemented yet
admin@vlab-01:~$ 
```