### PR TITLE
[Command Reference] Add command reference for trap flow counters

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -51,6 +51,9 @@
 * [Feature](#feature)
   * [Feature show commands](#feature-show-commands)
   * [Feature config commands](#feature-config-commands)
+* [Flow Counters](#flow-counters)
+  * [Flow Counters show commands](#flow-counters-show-commands)
+  * [Flow Counters clear commands](#flow-counters-clear-commands)
 * [Gearbox](#gearbox)
   * [Gearbox show commands](#gearbox-show-commands)
 * [Interfaces](#interfaces)
@@ -3025,6 +3028,58 @@ commands are don't care and will not update state/auto-restart value.
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#feature)
 
+## Flow Counters
+
+This section explains all the Flow Counters show commands and clear commands that are supported in SONiC. Flow counters are usually used for debugging, troubleshooting and performance enhancement processes. Flow counters supports case like:
+
+  - Host interface traps (number of received traps per Trap ID)
+
+### Flow Counters show commands
+
+**show flowcnt-trap stats**
+
+This command is used to show the current statistics for the registered host interface traps. 
+
+Because clear (see below) is handled on a per-user basis different users may see different counts.
+
+- Usage:
+  ```
+  show flowcnt-trap stats
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ show flowcnt-trap stats
+  Trap Name    Packets    Bytes      PPS
+  ---------  ---------  -------  -------
+       dhcp        100    2,000  50.25/s
+
+  For multi-ASIC:
+  admin@sonic:~$ show flowcnt-trap stats
+  ASIC ID    Trap Name    Packets    Bytes      PPS
+  -------  -----------  ---------  -------  -------
+    asic0         dhcp        100    2,000  50.25/s
+    asic1         dhcp        200    3,000  45.25/s
+  ```
+
+### Flow Counters clear commands
+
+**sonic-clear flowcnt-trap**
+
+This command is used to clear the current statistics for the registered host interface traps. This is done on a per-user basis.
+
+- Usage:
+  ```
+  sonic-clear flowcnt-trap
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sonic-clear flowcnt-trap
+  Trap Flow Counters were successfully cleared
+  ```
+
+Go Back To [Beginning of the document](#) or [Beginning of this section](#flow-counters)
 ## Gearbox
 
 This section explains all the Gearbox PHY show commands that are supported in SONiC.


### PR DESCRIPTION
Depend on https://github.com/Azure/sonic-utilities/pull/1868
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Add command reference for trap flow counters

#### How I did it

Add command reference for trap flow counters to describe the show and clear command

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

