### PR TITLE
[kdump] Remove automatic saving of kdump config in startup config

### DIFF
--- a/config/kdump.py
+++ b/config/kdump.py
@@ -16,6 +16,8 @@ def disable():
     if config_db is not None:
         config_db.connect()
         config_db.mod_entry("KDUMP", "config", {"enabled": "false"})
+        click.echo("KDUMP configuration changes may require a reboot to take effect.")
+        click.echo("Save SONiC configuration using 'config save' before issuing the reboot command.")
 
 @kdump.command()
 def enable():
@@ -24,6 +26,8 @@ def enable():
     if config_db is not None:
         config_db.connect()
         config_db.mod_entry("KDUMP", "config", {"enabled": "true"})
+        click.echo("KDUMP configuration changes may require a reboot to take effect.")
+        click.echo("Save SONiC configuration using 'config save' before issuing the reboot command.")
 
 @kdump.command()
 @click.argument('kdump_memory', metavar='<kdump_memory>', required=True)
@@ -33,6 +37,8 @@ def memory(kdump_memory):
     if config_db is not None:
         config_db.connect()
         config_db.mod_entry("KDUMP", "config", {"memory": kdump_memory})
+        click.echo("KDUMP configuration changes may require a reboot to take effect.")
+        click.echo("Save SONiC configuration using 'config save' before issuing the reboot command.")
 
 @kdump.command('num-dumps')
 @click.argument('kdump_num_dumps', metavar='<kdump_num_dumps>', required=True, type=int)

--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -356,39 +356,6 @@ def write_num_dumps(num_dumps):
         print_err("Error while writing KDUMP_NUM_DUMPS into %s" % kdump_cfg)
         sys.exit(1)
 
-## Save kdump configuration into the startup configuration
-# @kdump_enabled Administrative mode (False/True)
-# @memory        Amount of memory allocated for the capture kernel
-# @num_dumps     Max number of core files saved locally
-def save_config(kdump_enabled, memory, num_dumps):
-
-    configdb_fname = '/etc/sonic/config_db.json'
-
-    # Read current configuration
-    if not os.path.exists(configdb_fname):
-        print_err("Startup configuration not found, Kdump configuration is not saved")
-        return
-    else:
-        try:
-            with open(configdb_fname) as json_file:
-                data = json.load(json_file)
-        except Exception as e:
-            print_err("Error [%s] while reading startup configuration" % e)
-            return
-
-    # Rewrite configuration
-    try:
-        kdump_data = {'config': {'enabled': '', 'num_dumps': '', 'memory': ''}}
-        (kdump_data['config'])['enabled']   = str(kdump_enabled).lower()
-        (kdump_data['config'])['num_dumps'] = str(num_dumps)
-        (kdump_data['config'])['memory']    = memory
-        data['KDUMP'] = kdump_data
-        with open(configdb_fname, 'w') as fp:
-            json.dump(data, fp, indent=4, sort_keys=False)
-        print("Kdump configuration has been updated in the startup configuration")
-    except Exception as e:
-        print_err("Error [%s] while saving Kdump configuration to startup configuration" % e)
-
 ## Enable kdump
 #
 #  @param verbose If True, the function will display a few additinal information
@@ -432,9 +399,6 @@ def kdump_enable(verbose, kdump_enabled, memory, num_dumps, image, cmdline_file)
 
     if changed:
         rewrite_cfg(lines, cmdline_file)
-        save_config(kdump_enabled, memory, num_dumps)
-    else:
-        save_config(kdump_enabled, memory, num_dumps)
 
     write_use_kdump(1)
     if crash_kernel_in_cmdline is not None:
@@ -545,7 +509,6 @@ def kdump_disable(verbose, kdump_enabled, memory, num_dumps, image, cmdline_file
 
     if changed:
         rewrite_grub_cfg(lines, grub_cfg)
-        save_config(kdump_enabled, memory, num_dumps)
 
     return changed
 
@@ -590,7 +553,6 @@ def cmd_kdump_memory(verbose, memory):
                 print("Kdump updated memory will be only operational after the system reboots")
         else:
             num_dumps = get_kdump_num_dumps()
-            save_config(False, memory, num_dumps)
 
 ## Command: Set / Get num_dumps
 #
@@ -605,7 +567,6 @@ def cmd_kdump_num_dumps(verbose, num_dumps):
         write_num_dumps(num_dumps)
         kdump_enabled = get_kdump_administrative_mode()
         kdump_memory = get_kdump_memory()
-        save_config(kdump_enabled, kdump_memory, num_dumps)
 
 ## Command: Display kdump status
 def cmd_kdump_status():

--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -551,8 +551,6 @@ def cmd_kdump_memory(verbose, memory):
             if memory != crash_kernel_in_cmdline or memory != memory_in_db or memory != memory_in_json:
                 cmd_kdump_enable(verbose)
                 print("Kdump updated memory will be only operational after the system reboots")
-        else:
-            num_dumps = get_kdump_num_dumps()
 
 ## Command: Set / Get num_dumps
 #
@@ -565,8 +563,6 @@ def cmd_kdump_num_dumps(verbose, num_dumps):
         print('\n'.join(lines))
     else:
         write_num_dumps(num_dumps)
-        kdump_enabled = get_kdump_administrative_mode()
-        kdump_memory = get_kdump_memory()
 
 ## Command: Display kdump status
 def cmd_kdump_status():


### PR DESCRIPTION
Fix Azure/sonic-buildimage#8888

Warn user to save the config instead of saving the kdump config
in config_db.json under the covers. Having more than one actors
operate on config_db.json can result in an exception.


<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Remove automatic saving of kdump config in startup config. Warn user to save the config instead of saving the kdump config in config_db.json under the covers.

#### How I did it
Remove automatic saving of kdump config in startup config. Warn user to save the config instead of saving the kdump config in config_db.json under the covers.

#### How to verify it
config kdump enable
config kdump disable
config kdump memory

#### Previous command output (if the output of a command-line utility has changed)
root@sonic:/home/admin# config kdump disable
root@sonic:/home/admin# config kdump enable
root@sonic:/home/admin# config kdump memory 512M

#### New command output (if the output of a command-line utility has changed)
root@sonic:/home/admin# config kdump disable
KDUMP configuration changes may require a reboot to take effect.
Save SONiC configuration using 'config save' before issuing the reboot command.

root@sonic:/home/admin# config kdump enable
KDUMP configuration changes may require a reboot to take effect.
Save SONiC configuration using 'config save' before issuing the reboot command.

root@sonic:/home/admin# config kdump memory 0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M
KDUMP configuration changes may require a reboot to take effect.
Save SONiC configuration using 'config save' before issuing the reboot command.
