### PR TITLE
[log_ssd_health]Fix log_ssd_health hang issue

### DIFF
--- a/scripts/log_ssd_health
+++ b/scripts/log_ssd_health
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-timeout 30 smartctl -a /dev/sda > /tmp/smartctl
+timeout --foreground 30 smartctl -a /dev/sda > /tmp/smartctl
 if [ -f /tmp/smartctl ];then
     logger -f /tmp/smartctl
 fi


### PR DESCRIPTION
#### What I did
Fix https://github.com/Azure/sonic-buildimage/issues/9114
The log_ssd_health command hangs due to timeout being used with docker exec -i which also affect warmboot flow.

#### How I did it
Added foreground option for timeout. This is recommended when not using the command on shell
https://man7.org/linux/man-pages/man1/timeout.1.html


#### How to verify it
Run log_ssd_health and verify it does not hang

Signed-off-by: Sudharsan Dhamal Gopalarathnam <sudharsand@nvidia.com>

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

