### PR TITLE
[201911][port2alias]: Fix to get right number of return values

### DIFF
--- a/scripts/port2alias
+++ b/scripts/port2alias
@@ -50,7 +50,7 @@ def translate_line(line, ports):
 
 def main():
     (platform, hwsku) = get_platform_hwsku()
-    (ports, _) = get_port_config(hwsku, platform)
+    (ports, _, _) = get_port_config(hwsku, platform)
     for line in sys.stdin:
         sys.stdout.write(translate_line(line, ports))
 

--- a/scripts/port2alias
+++ b/scripts/port2alias
@@ -50,7 +50,14 @@ def translate_line(line, ports):
 
 def main():
     (platform, hwsku) = get_platform_hwsku()
-    (ports, _, _) = get_port_config(hwsku, platform)
+    ports = {}
+    for ns in multi_asic.get_namespace_list():
+        if ns:
+            asic_id = multi_asic.get_asic_id_from_name(ns)
+        else:
+            asic_id = None
+        (ports_ns, _, _) = get_port_config(hwsku, platform, asic=asic_id)
+        ports.update(ports_ns)
     for line in sys.stdin:
         sys.stdout.write(translate_line(line, ports))
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
master branch PR: https://github.com/Azure/sonic-utilities/pull/1906
get_port_config was modified to return different set number of arguments in PR: Azure/sonic-buildimage#4222. Changes in this PR is:

To address the different set of return values
To get the ports from all namespaces
How I did it
Modify port2alias to read ports from all namespaces and also add unit-test

How to verify it
Tested on single and multi-asic platforms.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

