### PR TITLE
[dump] [copp] Fixed the NameError Exception for copp dump module

### DIFF
--- a/dump/main.py
+++ b/dump/main.py
@@ -165,7 +165,7 @@ def populate_fv(info, module, namespace):
             final_info[id][db_name]["tables_not_found"] = info[id][db_name]["tables_not_found"]
             for key in info[id][db_name]["keys"]:
                 if db_name is "CONFIG_FILE":
-                    fv = db_dict[db_name].get(db_name, key)
+                    fv = db_cfg_file.get(db_name, key)
                 else:
                     fv = db_conn.get_all(db_name, key)
                 final_info[id][db_name]["keys"].append({key: fv})

--- a/tests/dump_tests/dump_state_test.py
+++ b/tests/dump_tests/dump_state_test.py
@@ -205,7 +205,6 @@ class TestDumpState(object):
         assert result.output == "Namespace option is not valid for a single-ASIC device\n"
     
     def test_populate_fv_config_file(self):
-        # dump.plugins.copp.Copp.CONFIG_FILE = "/sonic/src/sonic-utilities/tests/dump_input/copp_cfg.json"
         test_data = {
             "COPP_TRAP": {
                 "bgp": {

--- a/tests/dump_tests/dump_state_test.py
+++ b/tests/dump_tests/dump_state_test.py
@@ -79,6 +79,30 @@ table_display_output_no_filtering = '''\
 +-------------+-----------+-----------------------------------------------------------+
 '''
 
+table_config_file_copp='''\
++-----------+-------------+---------------------------------------------------------------+
+| trap_id   | DB_NAME     | DUMP                                                          |
++===========+=============+===============================================================+
+| bgp       | CONFIG_FILE | +--------------------------+--------------------------------+ |
+|           |             | | Keys                     | field-value pairs              | |
+|           |             | +==========================+================================+ |
+|           |             | | COPP_TRAP|bgp            | +------------+---------------+ | |
+|           |             | |                          | | field      | value         | | |
+|           |             | |                          | |------------+---------------| | |
+|           |             | |                          | | trap_ids   | bgp,bgpv6     | | |
+|           |             | |                          | | trap_group | queue4_group1 | | |
+|           |             | |                          | +------------+---------------+ | |
+|           |             | +--------------------------+--------------------------------+ |
+|           |             | | COPP_GROUP|queue4_group1 | +---------------+---------+    | |
+|           |             | |                          | | field         | value   |    | |
+|           |             | |                          | |---------------+---------|    | |
+|           |             | |                          | | trap_action   | trap    |    | |
+|           |             | |                          | | trap_priority | 4       |    | |
+|           |             | |                          | | queue         | 4       |    | |
+|           |             | |                          | +---------------+---------+    | |
+|           |             | +--------------------------+--------------------------------+ |
++-----------+-------------+---------------------------------------------------------------+
+'''
 
 class TestDumpState(object):
 
@@ -178,6 +202,14 @@ class TestDumpState(object):
         result = runner.invoke(dump.state, ["port", "Ethernet0", "--table", "--key-map", "--namespace", "asic0"])
         print(result.output)
         assert result.output == "Namespace option is not valid for a single-ASIC device\n"
+    
+    def test_populate_fv_config_file(self):
+        dump.plugins.copp.Copp.CONFIG_FILE = "/sonic/src/sonic-utilities/tests/dump_input/copp_cfg.json"
+        runner = CliRunner()
+        result = runner.invoke(dump.state, ["copp", "bgp", "--table", "--db", "CONFIG_FILE"])
+        print(result)
+        print(result.output)
+        assert result.output == table_config_file_copp
 
     @classmethod
     def teardown(cls):

--- a/tests/dump_tests/dump_state_test.py
+++ b/tests/dump_tests/dump_state_test.py
@@ -10,6 +10,7 @@ from importlib import reload
 from utilities_common.db import Db
 import traceback
 from utilities_common.constants import DEFAULT_NAMESPACE
+from pyfakefs.fake_filesystem_unittest import Patcher
 
 
 def compare_json_output(exp_json, rec, exclude_paths=None):
@@ -204,12 +205,29 @@ class TestDumpState(object):
         assert result.output == "Namespace option is not valid for a single-ASIC device\n"
     
     def test_populate_fv_config_file(self):
-        dump.plugins.copp.Copp.CONFIG_FILE = "/sonic/src/sonic-utilities/tests/dump_input/copp_cfg.json"
-        runner = CliRunner()
-        result = runner.invoke(dump.state, ["copp", "bgp", "--table", "--db", "CONFIG_FILE"])
-        print(result)
-        print(result.output)
-        assert result.output == table_config_file_copp
+        # dump.plugins.copp.Copp.CONFIG_FILE = "/sonic/src/sonic-utilities/tests/dump_input/copp_cfg.json"
+        test_data = {
+            "COPP_TRAP": {
+                "bgp": {
+                    "trap_ids": "bgp,bgpv6",
+                    "trap_group": "queue4_group1"
+                }
+            },
+            "COPP_GROUP": {
+                "queue4_group1": {
+                    "trap_action":"trap",
+                    "trap_priority":"4",
+                    "queue": "4"
+                }
+            }
+        }
+        with Patcher() as patcher:
+            patcher.fs.create_file("/etc/sonic/copp_cfg.json", contents=json.dumps(test_data))
+            runner = CliRunner()
+            result = runner.invoke(dump.state, ["copp", "bgp", "--table", "--db", "CONFIG_FILE"])
+            print(result)
+            print(result.output)
+            assert result.output == table_config_file_copp
 
     @classmethod
     def teardown(cls):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Copp dump module is raising an exception because of a undefined variable. Recitifed the issue and added to a UT to cover the scenario

```
admin@sonic:~$ dump state copp bgp
Traceback (most recent call last):
  File "/usr/local/bin/dump", line 8, in <module>
    sys.exit(dump())
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/dump/main.py", line 93, in state
    collected_info = populate_fv(collected_info, module, namespace)
  File "/usr/local/lib/python3.7/dist-packages/dump/main.py", line 168, in populate_fv
    fv = db_dict[db_name].get(db_name, key)
NameError: name 'db_dict' is not defined
```

#### How I did it

Fixed the issue and added a test case

#### How to verify it

```
admin@sonic:~$ dump state copp bgp --db CONFIG_FILE
{
    "bgp": {
        "CONFIG_FILE": {
            "keys": [
                {
                    "COPP_TRAP|bgp": {
                        "trap_ids": "bgp,bgpv6",
                        "trap_group": "queue4_group1"
                    }
                },
                {
                    "COPP_GROUP|queue4_group1": {
                        "trap_action": "trap",
                        "trap_priority": "4",
                        "queue": "4"
                    }
                }
            ],
            "tables_not_found": []
        }
    }
}
```


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

