### PR TITLE
show command help text fix.

### DIFF
--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -203,7 +203,7 @@ def get_value_for_key_in_config_tbl(config_db, port, key, table):
 
 @click.group(name='muxcable', cls=clicommon.AliasedGroup)
 def muxcable():
-    """SONiC command line - 'show muxcable' command"""
+    """Show muxcable information"""
 
     if os.geteuid() != 0:
         click.echo("Root privileges are required for this operation")

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -366,7 +366,7 @@ This command displays the full list of show commands available in the software; 
     ipv6                  Show IPv6 commands
     kubernetes            Show kubernetes commands
     line                  Show all /dev/ttyUSB lines and their info
-    lldp                  LLDP (Link Layer Discovery Protocol)...
+    lldp                  Show LLDP information
     logging               Show system log
     mac                   Show MAC (FDB) entries
     mirror_session        Show existing everflow sessions
@@ -378,10 +378,10 @@ This command displays the full list of show commands available in the software; 
     pfc                   Show details of the priority-flow-control...
     platform              Show platform-specific hardware info
     priority-group        Show details of the PGs
-    processes             Display process information
+    processes             Show process information
     queue                 Show details of the queues
     reboot-cause          Show cause of most recent reboot
-    route-map             show route-map
+    route-map             Show route-map
     runningconfiguration  Show current running configuration...
     services              Show all daemon services
     startupconfiguration  Show startup configuration information

--- a/show/main.py
+++ b/show/main.py
@@ -940,7 +940,7 @@ def link_local_mode(verbose):
 
 @cli.group(cls=clicommon.AliasedGroup)
 def lldp():
-    """LLDP (Link Layer Discovery Protocol) information"""
+    """Show LLDP information"""
     pass
 
 # Default 'lldp' command (called if no subcommands or their aliases were passed)

--- a/show/processes.py
+++ b/show/processes.py
@@ -8,7 +8,7 @@ import utilities_common.cli as clicommon
 
 @click.group(cls=clicommon.AliasedGroup)
 def processes():
-    """Display process information"""
+    """Show process information"""
     pass
 
 

--- a/show/system_health.py
+++ b/show/system_health.py
@@ -10,7 +10,7 @@ import utilities_common.cli as clicommon
 #
 @click.group(name='system-health', cls=clicommon.AliasedGroup)
 def system_health():
-    """SONiC command line - 'show system-health' command"""
+    """Show system-health information"""
     return
 
 @system_health.command()

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -269,7 +269,7 @@ def is_port_vlan_member(config_db, port, vlan):
     return False
 
 def interface_is_in_vlan(vlan_member_table, interface_name):
-    """ Check if an interface  is in a vlan """
+    """ Check if an interface is in a vlan """
     for _,intf in vlan_member_table:
         if intf == interface_name:
             return True
@@ -436,12 +436,12 @@ def run_command_in_alias_mode(command):
                 print_output_in_alias_mode(output, index)
 
             elif (command.startswith("sudo sfputil show eeprom")):
-                """show interface transceiver eeprom"""
+                """Show interface transceiver eeprom"""
                 index = 0
                 print_output_in_alias_mode(raw_output, index)
 
             elif (command.startswith("sudo sfputil show")):
-                """show interface transceiver lpmode,
+                """Show interface transceiver lpmode,
                    presence
                 """
                 index = 0
@@ -451,7 +451,7 @@ def run_command_in_alias_mode(command):
                 print_output_in_alias_mode(output, index)
 
             elif command == "sudo lldpshow":
-                """show lldp table"""
+                """Show lldp table"""
                 index = 0
                 if output.startswith("LocalPort"):
                     output = output.replace("LocalPort", "LocalPort".rjust(
@@ -459,7 +459,7 @@ def run_command_in_alias_mode(command):
                 print_output_in_alias_mode(output, index)
 
             elif command.startswith("queuestat"):
-                """show queue counters"""
+                """Show queue counters"""
                 index = 0
                 if output.startswith("Port"):
                     output = output.replace("Port", "Port".rjust(
@@ -467,7 +467,7 @@ def run_command_in_alias_mode(command):
                 print_output_in_alias_mode(output, index)
 
             elif command == "fdbshow":
-                """show mac"""
+                """Show mac"""
                 index = 3
                 if output.startswith("No."):
                     output = "  " + output
@@ -478,13 +478,13 @@ def run_command_in_alias_mode(command):
                 print_output_in_alias_mode(output, index)
 
             elif command.startswith("nbrshow"):
-                """show arp"""
+                """Show arp"""
                 index = 2
                 if "Vlan" in output:
                     output = output.replace('Vlan', '  Vlan')
                 print_output_in_alias_mode(output, index)
             elif command.startswith("sudo ipintutil"):
-                """show ip(v6) int"""
+                """Show ip(v6) int"""
                 index = 0
                 if output.startswith("Interface"):
                    output = output.replace("Interface", "Interface".rjust(


### PR DESCRIPTION
#### What I did
Changed the show command help text to be more consistent with eachother. In particular, I made them all have the same format.
#### How I did it
Edited the relevant comments in the show command scripts and the Command-Reference.md documentation.
#### How to verify it
Run show -h.
#### Previous command output (if the output of a command-line utility has changed)
For example, 
lldp                  LLDP (Link Layer Discovery Protocol) information.
#### New command output (if the output of a command-line utility has changed)
For example, 
lldp                  Show LLDP information.