### PR TITLE
[show][platform summary] Add chassis type in the platform summary

### DIFF
--- a/show/platform.py
+++ b/show/platform.py
@@ -64,6 +64,9 @@ def summary(json):
         click.echo("Serial Number: {}".format(chassis_info['serial']))
         click.echo("Model Number: {}".format(chassis_info['model']))
         click.echo("Hardware Revision: {}".format(chassis_info['revision']))
+        chassis_type = platform_info.get('chassis_type')
+        if chassis_type:
+            click.echo("Chassis Type: {}".format(chassis_type))
 
 
 # 'syseeprom' subcommand ("show platform syseeprom")

--- a/show/platform.py
+++ b/show/platform.py
@@ -64,9 +64,9 @@ def summary(json):
         click.echo("Serial Number: {}".format(chassis_info['serial']))
         click.echo("Model Number: {}".format(chassis_info['model']))
         click.echo("Hardware Revision: {}".format(chassis_info['revision']))
-        chassis_type = platform_info.get('chassis_type')
-        if chassis_type:
-            click.echo("Chassis Type: {}".format(chassis_type))
+        switch_type = platform_info.get('switch_type')
+        if switch_type:
+            click.echo("Switch Type: {}".format(switch_type))
 
 
 # 'syseeprom' subcommand ("show platform syseeprom")


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add chassis type in the platform summary on chassis platforms.

#### How I did it
Get the switch type from platform_info() API.

#### How to verify it
```
admin@str2-chasssis-lc3-1:~$ show platform summary
Platform: chassis_lc
HwSKU: chassis
ASIC: broadcom
ASIC Count: 1
Serial Number: xyz
Model Number: chassis-LC
Hardware Revision: N/A
Switch Type: voq

```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

