### PR TITLE
[generic-config-updater] Handling empty tables while sorting a patch

### DIFF
--- a/generic_config_updater/generic_updater.py
+++ b/generic_config_updater/generic_updater.py
@@ -55,8 +55,8 @@ class PatchApplier:
         # Validate target config does not have empty tables since they do not show up in ConfigDb
         self.logger.log_notice("Validating target config does not have empty tables, " \
                                "since they do not show up in ConfigDb.")
-        has_empty_tables, empty_tables = self.config_wrapper.has_empty_tables(target_config)
-        if has_empty_tables:
+        empty_tables = self.config_wrapper.get_empty_tables(target_config)
+        if empty_tables: # if there are empty tables
             empty_tables_txt = ", ".join(empty_tables)
             raise ValueError("Given patch is not valid because it will result in empty tables " \
                              "which is not allowed in ConfigDb. " \

--- a/generic_config_updater/generic_updater.py
+++ b/generic_config_updater/generic_updater.py
@@ -52,7 +52,17 @@ class PatchApplier:
         self.logger.log_notice("Simulating the target full config after applying the patch.")
         target_config = self.patch_wrapper.simulate_patch(patch, old_config)
 
-        # Validate target config
+        # Validate target config does not have empty tables since they do not show up in ConfigDb
+        self.logger.log_notice("Validating target config does not have empty tables, " \
+                               "since they do not show up in ConfigDb.")
+        has_empty_tables, empty_tables = self.config_wrapper.has_empty_tables(target_config)
+        if has_empty_tables:
+            empty_tables_txt = ", ".join(empty_tables)
+            raise ValueError("Given patch is not valid because it will result in empty tables " \
+                             "which is not allowed in ConfigDb. " \
+                            f"Table{'s' if len(empty_tables) != 1 else ''}: {empty_tables_txt}")
+
+        # Validate target config according to YANG models
         self.logger.log_notice("Validating target config according to YANG models.")
         if not(self.config_wrapper.validate_config_db_config(target_config)):
             raise ValueError(f"Given patch is not valid because it will result in an invalid config")

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -133,6 +133,14 @@ class ConfigWrapper:
         sy._cropConfigDB()
 
         return sy.jIn
+    
+    def has_empty_tables(self, config):
+        empty_tables = []
+        for key in config.keys():
+            if not(config[key]):
+                empty_tables.append(key)
+        return len(empty_tables) != 0, empty_tables
+        
 
 class DryRunConfigWrapper(ConfigWrapper):
     # TODO: implement DryRunConfigWrapper

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -134,12 +134,12 @@ class ConfigWrapper:
 
         return sy.jIn
     
-    def has_empty_tables(self, config):
+    def get_empty_tables(self, config):
         empty_tables = []
         for key in config.keys():
             if not(config[key]):
                 empty_tables.append(key)
-        return len(empty_tables) != 0, empty_tables
+        return empty_tables
         
 
 class DryRunConfigWrapper(ConfigWrapper):

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -599,8 +599,8 @@ class NoEmptyTableMoveValidator:
         return True
 
     def _validate_table(self, table, config):
-        is_empty = table in config and not(config[table])
-        return not(is_empty)
+        # the only invalid case is if table exists and is empty
+        return table not in config or config[table]
 
 class LowLevelMoveGenerator:
     """

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -573,6 +573,35 @@ class NoDependencyMoveValidator:
             refs.extend(self.path_addressing.find_ref_paths(path, config))
         return refs
 
+class NoEmptyTableMoveValidator:
+    """
+    A class to validate that a move will not result in an empty table, because empty table do not show up in ConfigDB.
+    """
+    def __init__(self, path_addressing):
+        self.path_addressing = path_addressing
+
+    def validate(self, move, diff):
+        simulated_config = move.apply(diff.current_config)
+        op_path = move.path
+
+        if op_path == "": # If updating whole file
+            tables_to_check = simulated_config.keys()
+        else:
+            tokens = self.path_addressing.get_path_tokens(op_path)
+            tables_to_check = [tokens[0]]
+
+        return self._validate_tables(tables_to_check, simulated_config)
+
+    def _validate_tables(self, tables, config):
+        for table in tables:
+            if not(self._validate_table(table, config)):
+                return False
+        return True
+
+    def _validate_table(self, table, config):
+        is_empty = table in config and not(config[table])
+        return not(is_empty)
+
 class LowLevelMoveGenerator:
     """
     A class to generate the low level moves i.e. moves corresponding to differences between current/target config
@@ -969,7 +998,8 @@ class SortAlgorithmFactory:
                            FullConfigMoveValidator(self.config_wrapper),
                            NoDependencyMoveValidator(self.path_addressing, self.config_wrapper),
                            UniqueLanesMoveValidator(),
-                           CreateOnlyMoveValidator(self.path_addressing) ]
+                           CreateOnlyMoveValidator(self.path_addressing),
+                           NoEmptyTableMoveValidator(self.path_addressing)]
 
         move_wrapper = MoveWrapper(move_generators, move_extenders, move_validators)
 

--- a/tests/generic_config_updater/files/config_db_with_interface.json
+++ b/tests/generic_config_updater/files/config_db_with_interface.json
@@ -4,7 +4,8 @@
         "Ethernet8|10.0.0.1/30": {
             "family": "IPv4",
             "scope": "global"
-        }
+        },
+        "Ethernet9": {}
     },
     "PORT": {
         "Ethernet8": {
@@ -13,6 +14,15 @@
             "description": "Ethernet8",
             "fec": "rs",
             "lanes": "65",
+            "mtu": "9000",
+            "speed": "25000"
+        },
+        "Ethernet9": {
+            "admin_status": "up",
+            "alias": "eth9",
+            "description": "Ethernet9",
+            "fec": "rs",
+            "lanes": "6",
             "mtu": "9000",
             "speed": "25000"
         }

--- a/tests/generic_config_updater/generic_updater_test.py
+++ b/tests/generic_config_updater/generic_updater_test.py
@@ -72,9 +72,9 @@ class TestPatchApplier(unittest.TestCase):
             [Files.CONFIG_DB_AS_JSON, Files.CONFIG_DB_AFTER_MULTI_PATCH]
         config_wrapper.validate_config_db_config.side_effect = \
             create_side_effect_dict({(str(Files.CONFIG_DB_AFTER_MULTI_PATCH),): valid_config_db})
-        config_wrapper.has_empty_tables.side_effect = \
-            create_side_effect_dict({(str(Files.CONFIG_DB_AFTER_MULTI_PATCH),): \
-                (not(valid_patch_does_not_produce_empty_tables), ["AnyTable"])})
+        empty_tables = [] if valid_patch_does_not_produce_empty_tables else ["AnyTable"]
+        config_wrapper.get_empty_tables.side_effect = \
+            create_side_effect_dict({(str(Files.CONFIG_DB_AFTER_MULTI_PATCH),): empty_tables})
 
         patch_wrapper = Mock()
         patch_wrapper.validate_config_db_patch_has_yang_models.side_effect = \

--- a/tests/generic_config_updater/generic_updater_test.py
+++ b/tests/generic_config_updater/generic_updater_test.py
@@ -19,6 +19,13 @@ class TestPatchApplier(unittest.TestCase):
         # Act and assert
         self.assertRaises(ValueError, patch_applier.apply, Files.MULTI_OPERATION_CONFIG_DB_PATCH)
 
+    def test_apply__invalid_patch_producing_empty_tables__failure(self):
+        # Arrange
+        patch_applier = self.__create_patch_applier(valid_patch_does_not_produce_empty_tables=False)
+
+        # Act and assert
+        self.assertRaises(ValueError, patch_applier.apply, Files.MULTI_OPERATION_CONFIG_DB_PATCH)
+
     def test_apply__invalid_config_db__failure(self):
         # Arrange
         patch_applier = self.__create_patch_applier(valid_config_db=False)
@@ -58,12 +65,16 @@ class TestPatchApplier(unittest.TestCase):
                                changes=None,
                                valid_patch_only_tables_with_yang_models=True,
                                valid_config_db=True,
+                               valid_patch_does_not_produce_empty_tables=True,
                                verified_same_config=True):
         config_wrapper = Mock()
         config_wrapper.get_config_db_as_json.side_effect = \
             [Files.CONFIG_DB_AS_JSON, Files.CONFIG_DB_AFTER_MULTI_PATCH]
         config_wrapper.validate_config_db_config.side_effect = \
             create_side_effect_dict({(str(Files.CONFIG_DB_AFTER_MULTI_PATCH),): valid_config_db})
+        config_wrapper.has_empty_tables.side_effect = \
+            create_side_effect_dict({(str(Files.CONFIG_DB_AFTER_MULTI_PATCH),): \
+                (not(valid_patch_does_not_produce_empty_tables), ["AnyTable"])})
 
         patch_wrapper = Mock()
         patch_wrapper.validate_config_db_patch_has_yang_models.side_effect = \

--- a/tests/generic_config_updater/gu_common_test.py
+++ b/tests/generic_config_updater/gu_common_test.py
@@ -148,6 +148,42 @@ class TestConfigWrapper(unittest.TestCase):
         # Assert
         self.assertDictEqual(expected, actual)
 
+    def test_has_empty_tables__no_empty_tables__returns_false(self):
+        # Arrange
+        config_wrapper = gu_common.ConfigWrapper()
+        config = {"any_table": {"key": "value"}}
+
+        # Act
+        flag, empty_tables = config_wrapper.has_empty_tables(config)
+
+        # Assert
+        self.assertFalse(flag)
+        self.assertCountEqual([], empty_tables)
+
+    def test_has_empty_tables__single_empty_table__returns_true(self):
+        # Arrange
+        config_wrapper = gu_common.ConfigWrapper()
+        config = {"any_table": {"key": "value"}, "another_table":{}}
+
+        # Act
+        flag, empty_tables = config_wrapper.has_empty_tables(config)
+
+        # Assert
+        self.assertTrue(flag)
+        self.assertCountEqual(["another_table"], empty_tables)
+
+    def test_has_empty_tables__multiple_empty_tables__returns_true(self):
+        # Arrange
+        config_wrapper = gu_common.ConfigWrapper()
+        config = {"any_table": {"key": "value"}, "another_table":{}, "yet_another_table":{}}
+
+        # Act
+        flag, empty_tables = config_wrapper.has_empty_tables(config)
+
+        # Assert
+        self.assertTrue(flag)
+        self.assertCountEqual(["another_table", "yet_another_table"], empty_tables)
+
 class TestPatchWrapper(unittest.TestCase):
     def setUp(self):
         self.config_wrapper_mock = gu_common.ConfigWrapper()

--- a/tests/generic_config_updater/gu_common_test.py
+++ b/tests/generic_config_updater/gu_common_test.py
@@ -148,40 +148,37 @@ class TestConfigWrapper(unittest.TestCase):
         # Assert
         self.assertDictEqual(expected, actual)
 
-    def test_has_empty_tables__no_empty_tables__returns_false(self):
+    def test_get_empty_tables__no_empty_tables__returns_no_tables(self):
         # Arrange
         config_wrapper = gu_common.ConfigWrapper()
         config = {"any_table": {"key": "value"}}
 
         # Act
-        flag, empty_tables = config_wrapper.has_empty_tables(config)
+        empty_tables = config_wrapper.get_empty_tables(config)
 
         # Assert
-        self.assertFalse(flag)
         self.assertCountEqual([], empty_tables)
 
-    def test_has_empty_tables__single_empty_table__returns_true(self):
+    def test_get_empty_tables__single_empty_table__returns_one_table(self):
         # Arrange
         config_wrapper = gu_common.ConfigWrapper()
         config = {"any_table": {"key": "value"}, "another_table":{}}
 
         # Act
-        flag, empty_tables = config_wrapper.has_empty_tables(config)
+        empty_tables = config_wrapper.get_empty_tables(config)
 
         # Assert
-        self.assertTrue(flag)
         self.assertCountEqual(["another_table"], empty_tables)
 
-    def test_has_empty_tables__multiple_empty_tables__returns_true(self):
+    def test_get_empty_tables__multiple_empty_tables__returns_multiple_tables(self):
         # Arrange
         config_wrapper = gu_common.ConfigWrapper()
         config = {"any_table": {"key": "value"}, "another_table":{}, "yet_another_table":{}}
 
         # Act
-        flag, empty_tables = config_wrapper.has_empty_tables(config)
+        empty_tables = config_wrapper.get_empty_tables(config)
 
         # Assert
-        self.assertTrue(flag)
         self.assertCountEqual(["another_table", "yet_another_table"], empty_tables)
 
 class TestPatchWrapper(unittest.TestCase):


### PR DESCRIPTION
#### What I did
Fixing issue #1908 

#### How I did it
- When the given patch produces empty-table, reject it since ConfigDb cannot show empty tables. Achieved that by:
  - Adding a validation step before patch-sorting
- The patch-sorter should not produce steps which result in empty-tables because it is not possible in ConfigDb, we should instead delete the whole table. Achieved that by:
  - Adding a new validator to reject moves producing empty tables
  - No need to add a generator for deleting the whole table, current generators take care of that. They do by the following:
    - The move to empty a table is rejected by `NoEmptyTableMoveValidator`
    - The previous rejected move is used to generate moves using `UpperLevelMoveExtender` which produces either
      - Remove move for parent -- This is good, we are removing the table
      - Replace move for parent -- This later on will be extended to a Delete move using `DeleteInsteadOfReplaceMoveExtender`

The generators/validators are documented in the `PatchSorter.py`, check the documentation out.

#### How to verify it
unit-test

#### Previous command output (if the output of a command-line utility has changed)
```sh
admin@vlab-01:~$ sudo config apply-patch empty-a-table.json-patch -v
Patch Applier: Patch application starting.
Patch Applier: Patch: [{"op": "replace", "path": "/DEVICE_METADATA", "value": {}}]
Patch Applier: Validating patch is not making changes to tables without YANG models.
Patch Applier: Getting current config db.
Patch Applier: Simulating the target full config after applying the patch.
Patch Applier: Validating target config according to YANG models.
... sonig-yang-mgmt logs
Patch Applier: Sorting patch updates.
... sonig-yang-mgmt logs
Patch Applier: The patch was sorted into 11 changes:
Patch Applier:   * [{"op": "remove", "path": "/DEVICE_METADATA/localhost/bgp_asn"}]
Patch Applier:   * [{"op": "remove", "path": "/DEVICE_METADATA/localhost/buffer_model"}]
Patch Applier:   * [{"op": "remove", "path": "/DEVICE_METADATA/localhost/default_bgp_status"}]
Patch Applier:   * [{"op": "remove", "path": "/DEVICE_METADATA/localhost/default_pfcwd_status"}]
Patch Applier:   * [{"op": "remove", "path": "/DEVICE_METADATA/localhost/deployment_id"}]
Patch Applier:   * [{"op": "remove", "path": "/DEVICE_METADATA/localhost/docker_routing_config_mode"}]
Patch Applier:   * [{"op": "remove", "path": "/DEVICE_METADATA/localhost/hostname"}]
Patch Applier:   * [{"op": "remove", "path": "/DEVICE_METADATA/localhost/hwsku"}]
Patch Applier:   * [{"op": "remove", "path": "/DEVICE_METADATA/localhost/mac"}]
Patch Applier:   * [{"op": "remove", "path": "/DEVICE_METADATA/localhost/platform"}]
Patch Applier:   * [{"op": "remove", "path": "/DEVICE_METADATA/localhost"}]
Patch Applier: Applying changes in order.
Patch Applier: Verifying patch updates are reflected on ConfigDB.
Failed to apply patch
Usage: config apply-patch [OPTIONS] PATCH_FILE_PATH
Try "config apply-patch -h" for help.

Error: After applying patch to config, there are still some parts not updated
admin@vlab-01:~$ 
```

The above error occurs because post the update, the whole `DEVICE_METADATA` table is deleted, not just showing as empty i.e. `"DEVICE_METADATA": {}`

#### New command output (if the output of a command-line utility has changed)
```
admin@vlab-01:~$ sudo config apply-patch empty-a-table.json-patch -v
Patch Applier: Patch application starting.
Patch Applier: Patch: [{"op": "replace", "path": "/DEVICE_METADATA", "value": {}}]
Patch Applier: Validating patch is not making changes to tables without YANG models.
Patch Applier: Getting current config db.
Patch Applier: Simulating the target full config after applying the patch.
Patch Applier: Validating target config does not have empty tables, since they do not show up in ConfigDb.
Failed to apply patch
Usage: config apply-patch [OPTIONS] PATCH_FILE_PATH
Try "config apply-patch -h" for help.

Error: Given patch is not valid because it will result in empty tables which is not allowed in ConfigDb. Table: DEVICE_METADATA
admin@vlab-01:~$ 
```
