### PR TITLE
[fdbshow]: Handle FDB cleanup gracefully

### DIFF
--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -83,7 +83,7 @@ class FdbShow(object):
         if not self.if_br_oid_map:
             return
         
-        fdb_str = self.db.keys('ASIC_DB', "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY:*")
+        fdb_str = self.db.keys(self.db.ASIC_DB, "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY:*")
         if not fdb_str:
             return
 
@@ -95,7 +95,10 @@ class FdbShow(object):
             if not fdb:
                 continue
 
-            ent = self.db.get_all('ASIC_DB', s, blocking=True)
+            ent = self.db.get_all(self.db.ASIC_DB, s)
+            if not ent:
+                continue
+
             br_port_id = ent["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID"][oid_pfx:]
             ent_type = ent["SAI_FDB_ENTRY_ATTR_TYPE"]
             fdb_type = ['Dynamic','Static'][ent_type == "SAI_FDB_ENTRY_TYPE_STATIC"]


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

The race condition is caused by a blocking Redis call which gets the contents of the FDB entry from ASIC DB.
Since it has been implemented as a simple loop, there is no guarantee that entry will be present in DB when the contents are being read.

```bash
root@sonic:/home/admin# ./reproduce.sh
...
Tue Nov  9 15:58:49 UTC 2021: Query...
Tue Nov  9 15:58:52 UTC 2021: Query...
...
=> Read ASIC DB: start
=> Read ASIC DB: done
=> Read ASIC DB: start
Key 'ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY:{"bvid":"oid:0x260000000009cc","mac":"02:11:22:33:20:00","switch_id":"oid:0x21000000000000"}' unavailable in database '1'
```

The `fdbshow` script:
```bash
root@sonic:/home/admin# vim /usr/bin/fdbshow

...

class FdbShow(object):

    HEADER = ['No.', 'Vlan', 'MacAddress', 'Port', 'Type']
    FDB_COUNT = 0

    def __init__(self):
        super(FdbShow,self).__init__()
        self.db = SonicV2Connector(host="127.0.0.1")
        self.if_name_map, \
        self.if_oid_map = port_util.get_interface_oid_map(self.db)
        self.if_br_oid_map = port_util.get_bridge_port_map(self.db)
        self.fetch_fdb_data()
        return

    def fetch_fdb_data(self):
        """
            Fetch FDB entries from ASIC DB.
            FDB entries are sorted on "VlanID" and stored as a list of tuples
        """
        self.db.connect(self.db.ASIC_DB)
        self.bridge_mac_list = []

        fdb_str = self.db.keys('ASIC_DB', "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY:*")
        if not fdb_str:
            return

        if self.if_br_oid_map is None:
            return

        oid_pfx = len("oid:0x")
        for s in fdb_str:
            fdb_entry = s.decode()
            fdb = json.loads(fdb_entry .split(":", 2)[-1])
            if not fdb:
                continue

            print("=> Read ASIC DB: start")
            ent = self.db.get_all('ASIC_DB', s, blocking=True)
            print("=> Read ASIC DB: done")
            br_port_id = ent[b"SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID"][oid_pfx:]
            ent_type = ent[b"SAI_FDB_ENTRY_ATTR_TYPE"]
            fdb_type = ['Dynamic','Static'][ent_type == "SAI_FDB_ENTRY_TYPE_STATIC"]

...
```

The `reproduce.sh` script:

```bash
root@sonic:/home/admin# cat reproduce.sh
#!/bin/bash

out=""
rc="0"

while [[ "${rc}" -eq "0" ]]; do
    echo "$(date): Query..."
    out="$(show mac)"
    rc="$?"
done

echo "${out}"
```

Closes #1866

#### What I did
* Fixed: https://github.com/Azure/sonic-utilities/issues/1866

#### How I did it
* Removed blocking calls from `fdbshow`

#### How to verify it
1. Run FDB test

#### Which release branch to backport (provide reason below if selected)
<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201911
- [x] 202012
- [x] 202106

#### Previous command output (if the output of a command-line utility has changed)
```bash
root@sonic:/home/admin# show mac
Key 'ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY:{"bvid":"oid:0x260000000009cc","mac":"02:11:22:33:20:00","switch_id":"oid:0x21000000000000"}' unavailable in database '1'
```

#### New command output (if the output of a command-line utility has changed)
```bash
root@sonic:/home/admin# show mac
No.    Vlan    MacAddress    Port    Type
-----  ------  ------------  ------  ------
Total number of entries 0
```