### PR TITLE
[202012] Fix bug introduced by cherry-picking of fastboot changes

### DIFF
--- a/scripts/fast-reboot-dump.py
+++ b/scripts/fast-reboot-dump.py
@@ -320,7 +320,7 @@ def generate_default_route_entries(filename):
         json.dump(default_routes_output, fp, indent=2, separators=(',', ': '))
 
 def generate_media_config(filename):
-    db = SonicV2Connector(host='127.0.0.1')
+    db = swsssdk.SonicV2Connector(host='127.0.0.1')
     db.connect(db.APPL_DB, False)   # Make one attempt only
     media_config= []
     port_serdes_keys = ["preemphasis", "idriver", "ipredriver", "pre1", "pre2", "pre3", "main", "post1", "post2", "post3","attn"]


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixed bug introduced by cherry-picking of https://github.com/Azure/sonic-utilities/pull/1910 (slight difference in code between master and 202012)

#### How I did it

#### How to verify it
Run fast-reboot command on 202012

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

