### PR TITLE
[ci] allowPartiallySucceededBuilds when copying sonic-swss-common artifact

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -28,6 +28,7 @@ jobs:
       artifact: sonic-swss-common.amd64.ubuntu20_04
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/202012'
+      allowPartiallySucceededBuilds: true
     displayName: "Download sonic swss common deb packages"
 
   - task: DownloadPipelineArtifact@2

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -29,6 +29,7 @@ jobs:
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/202012'
       allowPartiallySucceededBuilds: true
+      allowFailedBuilds: true
     displayName: "Download sonic swss common deb packages"
 
   - task: DownloadPipelineArtifact@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,6 +58,8 @@ stages:
         artifact: sonic-swss-common
         runVersion: 'latestFromBranch'
         runBranch: 'refs/heads/202012'
+        allowPartiallySucceededBuilds: true
+        allowFailedBuilds: true
       displayName: "Download sonic swss common deb packages"
 
     - script: |


### PR DESCRIPTION
#### What I did
Otherwise, a partial failure like test failure will block the build job.

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

