### PR TITLE
[show][config] add presence of cable, hwmode consistency in mux status; add support for config muxcable reset, nonhitless firmware upgrade, pcs, fec stats

### DIFF
--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -29,8 +29,10 @@ VENDOR_MODEL_REGEX = re.compile(r"CAC\w{3}321P2P\w{2}MS")
 
 # Helper functions
 
+
 def db_connect(db_name, namespace=EMPTY_NAMESPACE):
     return swsscommon.DBConnector(db_name, REDIS_TIMEOUT_MSECS, True, namespace)
+
 
 def get_value_for_key_in_dict(mdict, port, key, table_name):
     value = mdict.get(key, None)
@@ -38,6 +40,7 @@ def get_value_for_key_in_dict(mdict, port, key, table_name):
         click.echo("could not retrieve key {} value for port {} inside table {}".format(key, port, table_name))
         sys.exit(CONFIG_FAIL)
     return value
+
 
 def delete_all_keys_in_db_table(db_type, table_name):
 
@@ -55,13 +58,13 @@ def delete_all_keys_in_db_table(db_type, table_name):
             table[asic_id]._del(key)
 
 
-def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_name, rsp_table_name, port, cmd_timeout_secs, arg=None):
+def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_name, cmd_arg_table_name, rsp_table_name, port, cmd_timeout_secs, param_dict=None, arg=None):
 
     res_dict = {}
     state_db, appl_db = {}, {}
     firmware_rsp_tbl, firmware_rsp_tbl_keys = {}, {}
     firmware_rsp_sub_tbl = {}
-    firmware_cmd_tbl = {}
+    firmware_cmd_tbl, firmware_cmd_arg_tbl = {}, {}
 
     CMD_TIMEOUT_SECS = cmd_timeout_secs
 
@@ -74,6 +77,8 @@ def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_
         state_db[asic_id] = db_connect("STATE_DB", namespace)
         appl_db[asic_id] = db_connect("APPL_DB", namespace)
         firmware_cmd_tbl[asic_id] = swsscommon.Table(appl_db[asic_id], cmd_table_name)
+        if cmd_arg_table_name is not None:
+            firmware_cmd_arg_tbl[asic_id] = swsscommon.Table(appl_db[asic_id], cmd_arg_table_name)
         firmware_rsp_sub_tbl[asic_id] = swsscommon.SubscriberStateTable(state_db[asic_id], rsp_table_name)
         firmware_rsp_tbl[asic_id] = swsscommon.Table(state_db[asic_id], rsp_table_name)
         firmware_rsp_tbl_keys[asic_id] = firmware_rsp_tbl[asic_id].getKeys()
@@ -108,6 +113,11 @@ def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_
         cmd_arg = "null"
     else:
         cmd_arg = str(arg)
+
+    if param_dict is not None:
+        for key, value in param_dict.items():
+            fvs = swsscommon.FieldValuePairs([(str(key), str(value))])
+            firmware_cmd_arg_tbl[asic_index].set(port, fvs)
 
     fvs = swsscommon.FieldValuePairs([(cmd_name, cmd_arg)])
     firmware_cmd_tbl[asic_index].set(port, fvs)
@@ -161,7 +171,6 @@ def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_
                 # check if xcvrd got a probe command
                 result = fvp_dict[rsp_name]
 
-
                 if result == exp_rsp:
                     res_dict[1] = result
                     res_dict[0] = 0
@@ -186,6 +195,7 @@ def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_
 
     return res_dict
 
+
 def get_value_for_key_in_config_tbl(config_db, port, key, table):
     info_dict = {}
     info_dict = config_db.get_entry(table, port)
@@ -200,6 +210,7 @@ def get_value_for_key_in_config_tbl(config_db, port, key, table):
 #
 # 'muxcable' command ("config muxcable")
 #
+
 
 @click.group(name='muxcable', cls=clicommon.AliasedGroup)
 def muxcable():
@@ -340,35 +351,92 @@ def prbs():
 
 
 @prbs.command()
-@click.argument('port', required=True, default=None, type=click.INT)
-@click.argument('target', required=True, default=None, type=click.INT)
+@click.argument('port', required=True, default=None)
+@click.argument('target', metavar='<target> 0 NIC 1 ToR A 2 ToR B 3 Local', required=True, type=click.Choice(["0", "1", "2", "3"]))
 @click.argument('mode_value', required=True, default=None, type=click.INT)
-@click.argument('lane_map', required=True, default=None, type=click.INT)
-def enable(port, target, mode_value, lane_map):
-    """Enable PRBS mode on a port"""
+@click.argument('lane_mask', required=True, default=None, type=click.INT)
+@click.argument('prbs_direction', metavar='<PRBS_DIRECTION> PRBS_DIRECTION_BOTH = 0 PRBS_DIRECTION_GENERATOR = 1 PRBS_DIRECTION_CHECKER = 2', required=False, default="0", type=click.Choice(["0", "1", "2"]))
+@clicommon.pass_db
+def enable(db, port, target, mode_value, lane_mask, prbs_direction):
+    """Enable PRBS mode on a port args port target mode_value lane_mask prbs_direction
+       example sudo config mux prbs enable Ethernet48 0 3 3 0
+    """
 
-    import sonic_y_cable.y_cable
-    res = sonic_y_cable.y_cable.enable_prbs_mode(port, target, mode_value, lane_map)
-    if res != True:
-        click.echo("PRBS config unsuccesful")
-        sys.exit(CONFIG_FAIL)
-    click.echo("PRBS config sucessful")
-    sys.exit(CONFIG_SUCCESSFUL)
+    port = platform_sfputil_helper.get_interface_alias(port, db)
+
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD")
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD_ARG")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_PRBS_RSP")
+
+    if port is not None:
+        click.confirm(('Muxcable at port {} will be changed to PRBS mode {} state; disable traffic Continue?'.format(
+            port, mode_value)), abort=True)
+
+        res_dict = {}
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+        param_dict = {}
+        param_dict["target"] = target
+        param_dict["mode_value"] = mode_value
+        param_dict["lane_mask"] = lane_mask
+        param_dict["direction"] = prbs_direction
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "config_prbs", "status", "True", "XCVRD_CONFIG_PRBS_CMD", "XCVRD_CONFIG_PRBS_CMD_ARG", "XCVRD_CONFIG_PRBS_RSP", port, 30, param_dict, "enable")
+
+        rc = res_dict[0]
+
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD")
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD_ARG")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_PRBS_RSP")
+
+        if rc == 0:
+            click.echo("Success in PRBS mode port {} to {}".format(port, mode_value))
+        else:
+            click.echo("ERR: Unable to set PRBS mode port {} to {}".format(port, mode_value))
+            sys.exit(CONFIG_FAIL)
 
 
 @prbs.command()
-@click.argument('port', required=True, default=None, type=click.INT)
-@click.argument('target', required=True, default=None, type=click.INT)
-def disable(port, target):
-    """Disable PRBS mode on a port"""
+@click.argument('port', required=True, default=None)
+@click.argument('target', required=True, metavar='<target> 0 NIC 1 ToR A 2 ToR B 3 Local', type=click.Choice(["0", "1", "2", "3"]))
+@click.argument('prbs_direction',  metavar='<PRBS_DIRECTION> PRBS_DIRECTION_BOTH = 0 PRBS_DIRECTION_GENERATOR = 1 PRBS_DIRECTION_CHECKER = 2', required=False, default="0", type=click.Choice(["0", "1", "2"]))
+@clicommon.pass_db
+def disable(db, port, target, prbs_direction):
+    """Disable PRBS mode on a port
+       example sudo config mux prbs disable Ethernet48 0
+    """
+    port = platform_sfputil_helper.get_interface_alias(port, db)
 
-    import sonic_y_cable.y_cable
-    res = sonic_y_cable.y_cable.disable_prbs_mode(port, target)
-    if res != True:
-        click.echo("PRBS disable unsuccesful")
-        sys.exit(CONFIG_FAIL)
-    click.echo("PRBS disable sucessful")
-    sys.exit(CONFIG_SUCCESSFUL)
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD")
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD_ARG")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_PRBS_RSP")
+
+    if port is not None:
+        click.confirm(('Muxcable at port {} will be changed to disable PRBS mode {} target; disable traffic Continue?'.format(
+            port, target)), abort=True)
+
+        res_dict = {}
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+        param_dict = {}
+        param_dict["target"] = target
+        param_dict["direction"] = prbs_direction
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "config_prbs", "status", "True", "XCVRD_CONFIG_PRBS_CMD", "XCVRD_CONFIG_PRBS_CMD_ARG", "XCVRD_CONFIG_PRBS_RSP", port, 30, param_dict, "disable")
+
+        rc = res_dict[0]
+
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD")
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD_ARG")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_PRBS_RSP")
+
+        if rc == 0:
+            click.echo("Success in disable PRBS mode port {} on target {}".format(port, target))
+        else:
+            click.echo("ERR: Unable to disable PRBS mode port {} on target {}".format(port, target))
+            sys.exit(CONFIG_FAIL)
 
 
 @muxcable.group(cls=clicommon.AbbreviationGroup)
@@ -378,34 +446,85 @@ def loopback():
 
 
 @loopback.command()
-@click.argument('port', required=True, default=None, type=click.INT)
-@click.argument('target', required=True, default=None, type=click.INT)
-@click.argument('lane_map', required=True, default=None, type=click.INT)
-def enable(port, target, lane_map):
-    """Enable loopback mode on a port"""
+@click.argument('port', required=True, default=None)
+@click.argument('target', required=True, metavar='<target> 0 NIC 1 ToR A 2 ToR B 3 Local', type=click.Choice(["0", "1", "2", "3"]))
+@click.argument('lane_mask', required=True, default=None, type=click.INT)
+@click.argument('mode_value', required=False, metavar='<Loop mode> 1 LOOPBACK_MODE_NEAR_END 2 LOOPBACK_MODE_FAR_END', default="1", type=click.Choice(["1", "2"]))
+@clicommon.pass_db
+def enable(db, port, target, lane_mask, mode_value):
+    """Enable loopback mode on a port args port target lane_map mode_value"""
 
-    import sonic_y_cable.y_cable
-    res = sonic_y_cable.y_cable.enable_loopback_mode(port, target, lane_map)
-    if res != True:
-        click.echo("loopback config unsuccesful")
-        sys.exit(CONFIG_FAIL)
-    click.echo("loopback config sucessful")
-    sys.exit(CONFIG_SUCCESSFUL)
+    port = platform_sfputil_helper.get_interface_alias(port, db)
+
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_LOOP_CMD")
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_LOOP_CMD_ARG")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_LOOP_RSP")
+
+    if port is not None:
+        click.confirm(('Muxcable at port {} will be changed to LOOP mode {} state; disable traffic Continue?'.format(
+            port, mode_value)), abort=True)
+
+        res_dict = {}
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+        param_dict = {}
+        param_dict["target"] = target
+        param_dict["mode_value"] = mode_value
+        param_dict["lane_mask"] = lane_mask
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "config_loop", "status", "True", "XCVRD_CONFIG_LOOP_CMD", "XCVRD_CONFIG_LOOP_CMD_ARG", "XCVRD_CONFIG_LOOP_RSP", port, 30, param_dict, "enable")
+
+        rc = res_dict[0]
+
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_LOOP_CMD")
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_LOOP_CMD_ARG")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_LOOP_RSP")
+
+        if rc == 0:
+            click.echo("Success in LOOP mode port {} to {}".format(port, mode_value))
+        else:
+            click.echo("ERR: Unable to set LOOP mode port {} to {}".format(port, mode_value))
+            sys.exit(CONFIG_FAIL)
 
 
 @loopback.command()
-@click.argument('port', required=True, default=None, type=click.INT)
-@click.argument('target', required=True, default=None, type=click.INT)
-def disable(port, target):
+@click.argument('port', required=True, default=None)
+@click.argument('target', required=True,  metavar='<target> 0 NIC 1 ToR A 2 ToR B 3 Local', type=click.Choice(["0", "1", "2", "3"]))
+@clicommon.pass_db
+def disable(db, port, target):
     """Disable loopback mode on a port"""
 
-    import sonic_y_cable.y_cable
-    res = sonic_y_cable.y_cable.disable_loopback_mode(port, target)
-    if res != True:
-        click.echo("loopback disable unsuccesful")
-        sys.exit(CONFIG_FAIL)
-    click.echo("loopback disable sucessful")
-    sys.exit(CONFIG_SUCCESSFUL)
+    port = platform_sfputil_helper.get_interface_alias(port, db)
+
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_LOOP_CMD")
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_LOOP_CMD_ARG")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_LOOP_RSP")
+
+    if port is not None:
+        click.confirm(('Muxcable at port {} will be changed to disable LOOP mode {} state; disable traffic Continue?'.format(
+            port, target)), abort=True)
+
+        res_dict = {}
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+        param_dict = {}
+        param_dict["target"] = target
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "config_loop", "status", "True", "XCVRD_CONFIG_LOOP_CMD", "XCVRD_CONFIG_LOOP_CMD_ARG", "XCVRD_CONFIG_LOOP_RSP", port, 30, param_dict, "disable")
+
+        rc = res_dict[0]
+
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_LOOP_CMD")
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_LOOP_CMD_ARG")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_LOOP_RSP")
+
+        if rc == 0:
+            click.echo("Success in disable LOOP mode port {} to {}".format(port, target))
+        else:
+            click.echo("ERR: Unable to set disable LOOP mode port {} to {}".format(port, target))
+            sys.exit(CONFIG_FAIL)
 
 
 @muxcable.group(cls=clicommon.AbbreviationGroup)
@@ -430,9 +549,10 @@ def state(db, state, port):
         click.confirm(('Muxcable at port {} will be changed to {} state. Continue?'.format(port, state)), abort=True)
 
         res_dict = {}
-        res_dict [0] = CONFIG_FAIL
-        res_dict [1] = "unknown"
-        res_dict = update_and_get_response_for_xcvr_cmd("config","result", "True", "XCVRD_CONFIG_HWMODE_DIR_CMD", "XCVRD_CONFIG_HWMODE_DIR_RSP", port, 1, state)
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "config", "result", "True", "XCVRD_CONFIG_HWMODE_DIR_CMD", None, "XCVRD_CONFIG_HWMODE_DIR_RSP", port, 1, None, state)
 
         rc = res_dict[0]
 
@@ -478,10 +598,11 @@ def state(db, state, port):
                 continue
 
             res_dict = {}
-            res_dict [0] = CONFIG_FAIL
-            res_dict [1] = 'unknown'
+            res_dict[0] = CONFIG_FAIL
+            res_dict[1] = 'unknown'
 
-            res_dict = update_and_get_response_for_xcvr_cmd("config","result", "True", "XCVRD_CONFIG_HWMODE_DIR_CMD", "XCVRD_CONFIG_HWMODE_DIR_RSP", port, 1, state)
+            res_dict = update_and_get_response_for_xcvr_cmd(
+                "config", "result", "True", "XCVRD_CONFIG_HWMODE_DIR_CMD", None, "XCVRD_CONFIG_HWMODE_DIR_RSP", port, 1, None, state)
 
             rc = res_dict[0]
 
@@ -508,7 +629,6 @@ def setswitchmode(db, state, port):
 
     port = platform_sfputil_helper.get_interface_name(port, db)
 
-
     delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_HWMODE_SWMODE_CMD")
     delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_HWMODE_SWMODE_RSP")
 
@@ -516,10 +636,10 @@ def setswitchmode(db, state, port):
         click.confirm(('Muxcable at port {} will be changed to {} switching mode. Continue?'.format(port, state)), abort=True)
 
         res_dict = {}
-        res_dict [0] = CONFIG_FAIL
-        res_dict [1] = "unknown"
-        res_dict = update_and_get_response_for_xcvr_cmd("config", "result", "True", "XCVRD_CONFIG_HWMODE_SWMODE_CMD", "XCVRD_CONFIG_HWMODE_SWMODE_RSP", port, 1, state)
-
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "config", "result", "True", "XCVRD_CONFIG_HWMODE_SWMODE_CMD", None, "XCVRD_CONFIG_HWMODE_SWMODE_RSP", port, 1, None, state)
 
         rc = res_dict[0]
 
@@ -565,9 +685,10 @@ def setswitchmode(db, state, port):
                 continue
 
             res_dict = {}
-            res_dict [0] = CONFIG_FAIL
-            res_dict [1] = "unknown"
-            res_dict = update_and_get_response_for_xcvr_cmd("config", "result", "True", "XCVRD_CONFIG_HWMODE_SWMODE_CMD", "XCVRD_CONFIG_HWMODE_SWMODE_RSP", port, 1, state)
+            res_dict[0] = CONFIG_FAIL
+            res_dict[1] = "unknown"
+            res_dict = update_and_get_response_for_xcvr_cmd(
+                "config", "result", "True", "XCVRD_CONFIG_HWMODE_SWMODE_CMD", None, "XCVRD_CONFIG_HWMODE_SWMODE_RSP", port, 1, None, state)
 
             rc = res_dict[0]
 
@@ -606,9 +727,10 @@ def download(db, fwfile, port):
     if port is not None and port != "all":
 
         res_dict = {}
-        res_dict [0] = CONFIG_FAIL
-        res_dict [1] = "unknown"
-        res_dict = update_and_get_response_for_xcvr_cmd("download_firmware", "status", "0", "XCVRD_DOWN_FW_CMD", "XCVRD_DOWN_FW_RSP", port, 1000, fwfile)
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "download_firmware", "status", "0", "XCVRD_DOWN_FW_CMD", None, "XCVRD_DOWN_FW_RSP", port, 1000, None, fwfile)
 
         rc = res_dict[0]
 
@@ -655,9 +777,10 @@ def download(db, fwfile, port):
 
             res_dict = {}
 
-            res_dict [0] = CONFIG_FAIL
-            res_dict [1] = "unknown"
-            res_dict = update_and_get_response_for_xcvr_cmd("download_firmware", "status", "0", "XCVRD_DOWN_FW_CMD", "XCVRD_DOWN_FW_RSP", port, 1000, fwfile)
+            res_dict[0] = CONFIG_FAIL
+            res_dict[1] = "unknown"
+            res_dict = update_and_get_response_for_xcvr_cmd(
+                "download_firmware", "status", "0", "XCVRD_DOWN_FW_CMD", "XCVRD_DOWN_FW_RSP", port, 1000, fwfile)
 
             rc = res_dict[0]
 
@@ -678,21 +801,28 @@ def download(db, fwfile, port):
 @firmware.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
 @click.argument('fwfile', metavar='<firmware_file>', required=False, default=None)
+@click.option('--nonhitless', 'nonhitless', required=False, is_flag=True, type=click.BOOL)
 @clicommon.pass_db
-def activate(db, port, fwfile):
+def activate(db, port, fwfile, nonhitless):
     """Config muxcable firmware activate"""
 
     port = platform_sfputil_helper.get_interface_name(port, db)
 
     delete_all_keys_in_db_table("STATE_DB", "XCVRD_ACTI_FW_RSP")
     delete_all_keys_in_db_table("APPL_DB", "XCVRD_ACTI_FW_CMD")
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_ACTI_FW_CMD_ARG")
 
     if port is not None and port != "all":
 
         res_dict = {}
-        res_dict [0] = CONFIG_FAIL
-        res_dict [1] = "unknown"
-        res_dict = update_and_get_response_for_xcvr_cmd("activate_firmware", "status", "0", "XCVRD_ACTI_FW_CMD", "XCVRD_ACTI_FW_RSP", port, 60, fwfile)
+        param_dict = {}
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+        if nonhitless:
+            param_dict["hitless"] = "1"
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "activate_firmware", "status", "0", "XCVRD_ACTI_FW_CMD", "XCVRD_ACTI_FW_CMD_ARG", "XCVRD_ACTI_FW_RSP", port, 60, param_dict, fwfile)
 
         rc = res_dict[0]
 
@@ -738,12 +868,14 @@ def activate(db, port, fwfile):
 
             res_dict = {}
 
-            res_dict [0] = CONFIG_FAIL
-            res_dict [1] = "unknown"
-            res_dict = update_and_get_response_for_xcvr_cmd("activate_firmware", "status", "0", "XCVRD_ACTI_FW_CMD", "XCVRD_ACTI_FW_RSP", port, 60, fwfile)
+            res_dict[0] = CONFIG_FAIL
+            res_dict[1] = "unknown"
+            res_dict = update_and_get_response_for_xcvr_cmd(
+                "activate_firmware", "status", "0", "XCVRD_ACTI_FW_CMD", None, "XCVRD_ACTI_FW_RSP", port, 60, None, fwfile)
 
             delete_all_keys_in_db_table("STATE_DB", "XCVRD_ACTI_FW_RSP")
             delete_all_keys_in_db_table("APPL_DB", "XCVRD_ACTI_FW_CMD")
+            delete_all_keys_in_db_table("APPL_DB", "XCVRD_ACTI_FW_CMD_ARG")
 
             rc = res_dict[0]
 
@@ -773,9 +905,10 @@ def rollback(db, port, fwfile):
     if port is not None and port != "all":
 
         res_dict = {}
-        res_dict [0] = CONFIG_FAIL
-        res_dict [1] = "unknown"
-        res_dict = update_and_get_response_for_xcvr_cmd("rollback_firmware", "status", "0", "XCVRD_ROLL_FW_CMD", "XCVRD_ROLL_FW_RSP", port, 60, fwfile)
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "rollback_firmware", "status", "0", "XCVRD_ROLL_FW_CMD", None, "XCVRD_ROLL_FW_RSP", port, 60, None, fwfile)
 
         delete_all_keys_in_db_table("STATE_DB", "XCVRD_ROLL_FW_RSP")
         delete_all_keys_in_db_table("APPL_DB", "XCVRD_ROLL_FW_CMD")
@@ -821,9 +954,10 @@ def rollback(db, port, fwfile):
 
             res_dict = {}
 
-            res_dict [0] = CONFIG_FAIL
-            res_dict [1] = "unknown"
-            res_dict = update_and_get_response_for_xcvr_cmd("rollback_firmware", "status", "0", "XCVRD_ROLL_FW_CMD", "XCVRD_ROLL_FW_RSP", port, 60, fwfile)
+            res_dict[0] = CONFIG_FAIL
+            res_dict[1] = "unknown"
+            res_dict = update_and_get_response_for_xcvr_cmd(
+                "rollback_firmware", "status", "0", "XCVRD_ROLL_FW_CMD", None, "XCVRD_ROLL_FW_RSP", port, 60, None, fwfile)
 
             delete_all_keys_in_db_table("STATE_DB", "XCVRD_ROLL_FW_RSP")
             delete_all_keys_in_db_table("APPL_DB", "XCVRD_ROLL_FW_CMD")
@@ -839,3 +973,82 @@ def rollback(db, port, fwfile):
                 rc_exit = CONFIG_FAIL
 
         sys.exit(rc_exit)
+
+
+@muxcable.command()
+@click.argument('port', required=True, default=None)
+@click.argument('target', required=True,  metavar='<target> 0 NIC 1 ToR A 2 ToR B 3 Local', type=click.Choice(["0", "1", "2", "3"]))
+@clicommon.pass_db
+def reset(db, port, target):
+    """Enable PRBS mode on a port args port target mode_value lane_mask prbs_direction"""
+
+    port = platform_sfputil_helper.get_interface_alias(port, db)
+
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD")
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD_ARG")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_PRBS_RSP")
+
+    if port is not None:
+        click.confirm(('Muxcable at port {} will be reset; CAUTION: disable traffic Continue?'.format(port)), abort=True)
+
+        res_dict = {}
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+        param_dict = {}
+        param_dict["target"] = target
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "config_prbs", "status", "True", "XCVRD_CONFIG_PRBS_CMD", "XCVRD_CONFIG_PRBS_CMD_ARG", "XCVRD_CONFIG_PRBS_RSP", port, 30, param_dict, "reset")
+
+        rc = res_dict[0]
+
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD")
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD_ARG")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_PRBS_RSP")
+
+        if rc == 0:
+            click.echo("Success in reset port {}".format(port))
+        else:
+            click.echo("ERR: Unable to reset port {}".format(port))
+            sys.exit(CONFIG_FAIL)
+
+
+@muxcable.command()
+@click.argument('port', required=True, default=None)
+@click.argument('target', required=True,  metavar='<target> 0 NIC 1 ToR A 2 ToR B 3 Local', type=click.Choice(["0", "1", "2", "3"]))
+@click.argument('mode', required=True, metavar='<target> 0 disable 1 enable',  default=True, type=click.Choice(["0", "1"]))
+@clicommon.pass_db
+def set_anlt(db, port, target, mode):
+    """Enable PRBS mode on a port args port target mode_value lane_mask prbs_direction"""
+
+    port = platform_sfputil_helper.get_interface_alias(port, db)
+
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD")
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD_ARG")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_PRBS_RSP")
+
+    if port is not None:
+        click.confirm(
+            ('Muxcable at port {} will be changed to enable/disable anlt mode {} state; disable traffic Continue?'.format(port, mode)), abort=True)
+
+        res_dict = {}
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+        param_dict = {}
+        param_dict["target"] = target
+        param_dict["mode"] = mode
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "config_prbs", "status", "True", "XCVRD_CONFIG_PRBS_CMD", "XCVRD_CONFIG_PRBS_CMD_ARG", "XCVRD_CONFIG_PRBS_RSP", port, 30, param_dict, "anlt")
+
+        rc = res_dict[0]
+
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD")
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD_ARG")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_PRBS_RSP")
+
+        if rc == 0:
+            click.echo("Success in anlt enable/disable port {} to {}".format(port, mode))
+        else:
+            click.echo("ERR: Unable to set anlt enable/disable port {} to {}".format(port, mode))
+            sys.exit(CONFIG_FAIL)

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -362,7 +362,7 @@ def enable(db, port, target, mode_value, lane_mask, prbs_direction):
        example sudo config mux prbs enable Ethernet48 0 3 3 0
     """
 
-    port = platform_sfputil_helper.get_interface_alias(port, db)
+    port = platform_sfputil_helper.get_interface_name(port, db)
 
     delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD")
     delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD_ARG")
@@ -386,6 +386,7 @@ def enable(db, port, target, mode_value, lane_mask, prbs_direction):
 
         rc = res_dict[0]
 
+        port = platform_sfputil_helper.get_interface_alias(port, db)
         delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD")
         delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD_ARG")
         delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_PRBS_RSP")
@@ -406,7 +407,7 @@ def disable(db, port, target, prbs_direction):
     """Disable PRBS mode on a port
        example sudo config mux prbs disable Ethernet48 0
     """
-    port = platform_sfputil_helper.get_interface_alias(port, db)
+    port = platform_sfputil_helper.get_interface_name(port, db)
 
     delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD")
     delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD_ARG")
@@ -432,6 +433,7 @@ def disable(db, port, target, prbs_direction):
         delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD_ARG")
         delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_PRBS_RSP")
 
+        port = platform_sfputil_helper.get_interface_alias(port, db)
         if rc == 0:
             click.echo("Success in disable PRBS mode port {} on target {}".format(port, target))
         else:
@@ -454,7 +456,7 @@ def loopback():
 def enable(db, port, target, lane_mask, mode_value):
     """Enable loopback mode on a port args port target lane_map mode_value"""
 
-    port = platform_sfputil_helper.get_interface_alias(port, db)
+    port = platform_sfputil_helper.get_interface_name(port, db)
 
     delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_LOOP_CMD")
     delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_LOOP_CMD_ARG")
@@ -481,6 +483,7 @@ def enable(db, port, target, lane_mask, mode_value):
         delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_LOOP_CMD_ARG")
         delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_LOOP_RSP")
 
+        port = platform_sfputil_helper.get_interface_alias(port, db)
         if rc == 0:
             click.echo("Success in LOOP mode port {} to {}".format(port, mode_value))
         else:
@@ -495,7 +498,7 @@ def enable(db, port, target, lane_mask, mode_value):
 def disable(db, port, target):
     """Disable loopback mode on a port"""
 
-    port = platform_sfputil_helper.get_interface_alias(port, db)
+    port = platform_sfputil_helper.get_interface_name(port, db)
 
     delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_LOOP_CMD")
     delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_LOOP_CMD_ARG")
@@ -520,6 +523,7 @@ def disable(db, port, target):
         delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_LOOP_CMD_ARG")
         delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_LOOP_RSP")
 
+        port = platform_sfputil_helper.get_interface_alias(port, db)
         if rc == 0:
             click.echo("Success in disable LOOP mode port {} to {}".format(port, target))
         else:

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -34,6 +34,14 @@ def db_connect(db_name, namespace=EMPTY_NAMESPACE):
     return swsscommon.DBConnector(db_name, REDIS_TIMEOUT_MSECS, True, namespace)
 
 
+target_dict = { "NIC":"0",
+                "TORA":"1",
+                "TORB":"2",
+                "LOCAL":"3"}
+
+def parse_target(target):
+    return target_dict.get(target, None)
+
 def get_value_for_key_in_dict(mdict, port, key, table_name):
     value = mdict.get(key, None)
     if value is None:
@@ -352,7 +360,7 @@ def prbs():
 
 @prbs.command()
 @click.argument('port', required=True, default=None)
-@click.argument('target', metavar='<target> 0 NIC 1 ToR A 2 ToR B 3 Local', required=True, type=click.Choice(["0", "1", "2", "3"]))
+@click.argument('target', metavar='<target> NIC TORA TORB LOCAL', required=True, default=None, type=click.Choice(["NIC", "TORA", "TORB", "LOCAL"]))
 @click.argument('mode_value', required=True, default=None, type=click.INT)
 @click.argument('lane_mask', required=True, default=None, type=click.INT)
 @click.argument('prbs_direction', metavar='<PRBS_DIRECTION> PRBS_DIRECTION_BOTH = 0 PRBS_DIRECTION_GENERATOR = 1 PRBS_DIRECTION_CHECKER = 2', required=False, default="0", type=click.Choice(["0", "1", "2"]))
@@ -376,6 +384,7 @@ def enable(db, port, target, mode_value, lane_mask, prbs_direction):
         res_dict[0] = CONFIG_FAIL
         res_dict[1] = "unknown"
         param_dict = {}
+        target = parse_target(target)
         param_dict["target"] = target
         param_dict["mode_value"] = mode_value
         param_dict["lane_mask"] = lane_mask
@@ -400,7 +409,7 @@ def enable(db, port, target, mode_value, lane_mask, prbs_direction):
 
 @prbs.command()
 @click.argument('port', required=True, default=None)
-@click.argument('target', required=True, metavar='<target> 0 NIC 1 ToR A 2 ToR B 3 Local', type=click.Choice(["0", "1", "2", "3"]))
+@click.argument('target', metavar='<target> NIC TORA TORB LOCAL', required=True, default=None, type=click.Choice(["NIC", "TORA", "TORB", "LOCAL"]))
 @click.argument('prbs_direction',  metavar='<PRBS_DIRECTION> PRBS_DIRECTION_BOTH = 0 PRBS_DIRECTION_GENERATOR = 1 PRBS_DIRECTION_CHECKER = 2', required=False, default="0", type=click.Choice(["0", "1", "2"]))
 @clicommon.pass_db
 def disable(db, port, target, prbs_direction):
@@ -421,6 +430,7 @@ def disable(db, port, target, prbs_direction):
         res_dict[0] = CONFIG_FAIL
         res_dict[1] = "unknown"
         param_dict = {}
+        target = parse_target(target)
         param_dict["target"] = target
         param_dict["direction"] = prbs_direction
 
@@ -449,7 +459,7 @@ def loopback():
 
 @loopback.command()
 @click.argument('port', required=True, default=None)
-@click.argument('target', required=True, metavar='<target> 0 NIC 1 ToR A 2 ToR B 3 Local', type=click.Choice(["0", "1", "2", "3"]))
+@click.argument('target', metavar='<target> NIC TORA TORB LOCAL', required=True, default=None, type=click.Choice(["NIC", "TORA", "TORB", "LOCAL"]))
 @click.argument('lane_mask', required=True, default=None, type=click.INT)
 @click.argument('mode_value', required=False, metavar='<Loop mode> 1 LOOPBACK_MODE_NEAR_END 2 LOOPBACK_MODE_FAR_END', default="1", type=click.Choice(["1", "2"]))
 @clicommon.pass_db
@@ -470,6 +480,7 @@ def enable(db, port, target, lane_mask, mode_value):
         res_dict[0] = CONFIG_FAIL
         res_dict[1] = "unknown"
         param_dict = {}
+        target = parse_target(target)
         param_dict["target"] = target
         param_dict["mode_value"] = mode_value
         param_dict["lane_mask"] = lane_mask
@@ -493,7 +504,7 @@ def enable(db, port, target, lane_mask, mode_value):
 
 @loopback.command()
 @click.argument('port', required=True, default=None)
-@click.argument('target', required=True,  metavar='<target> 0 NIC 1 ToR A 2 ToR B 3 Local', type=click.Choice(["0", "1", "2", "3"]))
+@click.argument('target', metavar='<target> NIC TORA TORB LOCAL', required=True, default=None, type=click.Choice(["NIC", "TORA", "TORB", "LOCAL"]))
 @clicommon.pass_db
 def disable(db, port, target):
     """Disable loopback mode on a port"""
@@ -512,6 +523,7 @@ def disable(db, port, target):
         res_dict[0] = CONFIG_FAIL
         res_dict[1] = "unknown"
         param_dict = {}
+        target = parse_target(target)
         param_dict["target"] = target
 
         res_dict = update_and_get_response_for_xcvr_cmd(
@@ -981,10 +993,10 @@ def rollback(db, port, fwfile):
 
 @muxcable.command()
 @click.argument('port', required=True, default=None)
-@click.argument('target', required=True,  metavar='<target> 0 NIC 1 ToR A 2 ToR B 3 Local', type=click.Choice(["0", "1", "2", "3"]))
+@click.argument('target', metavar='<target> NIC TORA TORB LOCAL', required=True, default=None, type=click.Choice(["NIC", "TORA", "TORB", "LOCAL"]))
 @clicommon.pass_db
 def reset(db, port, target):
-    """reset a target on the cable 0 NIC 1 ToR A 2 ToR B 3 Local """
+    """reset a target on the cable NIC TORA TORB Local """
 
     port = platform_sfputil_helper.get_interface_name(port, db)
 
@@ -999,6 +1011,7 @@ def reset(db, port, target):
         res_dict[0] = CONFIG_FAIL
         res_dict[1] = "unknown"
         param_dict = {}
+        target = parse_target(target)
         param_dict["target"] = target
 
         res_dict = update_and_get_response_for_xcvr_cmd(
@@ -1020,11 +1033,11 @@ def reset(db, port, target):
 
 @muxcable.command()
 @click.argument('port', required=True, default=None)
-@click.argument('target', required=True,  metavar='<target> 0 NIC 1 ToR A 2 ToR B 3 Local', type=click.Choice(["0", "1", "2", "3"]))
+@click.argument('target', metavar='<target> NIC TORA TORB LOCAL', required=True, default=None, type=click.Choice(["NIC", "TORA", "TORB", "LOCAL"]))
 @click.argument('mode', required=True, metavar='<mode> 0 disable 1 enable',  default=True, type=click.Choice(["0", "1"]))
 @clicommon.pass_db
 def set_anlt(db, port, target, mode):
-    """Enable anlt mode on a port args port <target> 0 NIC 1 ToR A 2 ToR B 3 Local enable/disable 1/0"""
+    """Enable anlt mode on a port args port <target> NIC TORA TORB LOCAL enable/disable 1/0"""
 
     port = platform_sfputil_helper.get_interface_name(port, db)
 
@@ -1040,6 +1053,7 @@ def set_anlt(db, port, target, mode):
         res_dict[0] = CONFIG_FAIL
         res_dict[1] = "unknown"
         param_dict = {}
+        target = parse_target(target)
         param_dict["target"] = target
         param_dict["mode"] = mode
 
@@ -1061,11 +1075,11 @@ def set_anlt(db, port, target, mode):
 
 @muxcable.command()
 @click.argument('port', required=True, default=None)
-@click.argument('target', required=True,  metavar='<target> 0 NIC 1 ToR A 2 ToR B 3 Local', type=click.Choice(["0", "1", "2", "3"]))
+@click.argument('target', metavar='<target> NIC TORA TORB LOCAL', required=True, default=None, type=click.Choice(["NIC", "TORA", "TORB", "LOCAL"]))
 @click.argument('mode', required=True, metavar='<mode> FEC_MODE_NONE 0 FEC_MODE_RS 1 FEC_MODE_FC 2',  default=True, type=click.Choice(["0", "1", "2"]))
 @clicommon.pass_db
 def set_fec(db, port, target, mode):
-    """Enable fec mode on a port args port <target> 0 NIC 1 ToR A 2 ToR B 3 Local <mode_value> FEC_MODE_NONE 0 FEC_MODE_RS 1 FEC_MODE_FC 2 """
+    """Enable fec mode on a port args port <target>  NIC TORA TORB LOCAL <mode_value> FEC_MODE_NONE 0 FEC_MODE_RS 1 FEC_MODE_FC 2 """
 
     port = platform_sfputil_helper.get_interface_name(port, db)
 
@@ -1081,6 +1095,7 @@ def set_fec(db, port, target, mode):
         res_dict[0] = CONFIG_FAIL
         res_dict[1] = "unknown"
         param_dict = {}
+        target = parse_target(target)
         param_dict["target"] = target
         param_dict["mode"] = mode
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -5344,10 +5344,10 @@ While displaying the muxcable configuration, users can configure the following f
 **show muxcable ber-info**
 
 This command displays the ber(Bit error rate) of the port user provides on the target user provides. The target provided as an integer corresponds to actual target as.
-0 -> local
-1 -> tor 1
-2 -> tor 2
-3 -> nic
+NIC
+TORA
+TORB
+LOCAL
 
 - Usage:
   ```
@@ -5360,19 +5360,20 @@ This command displays the ber(Bit error rate) of the port user provides on the t
 
 - Example:
     ```
-        admin@sonic:~$ show muxcable ber-info 1 1
+        admin@sonic:~$ show muxcable ber-info Ethernet48 NIC
         Lane1    Lane2
         -------  -------
         0       0
     ```
 
-**show muxcable ber-info**
+**show muxcable eye-info**
 
 This command displays the eye info in mv(milli volts) of the port user provides on the target user provides. The target provided as an integer corresponds to actual target as.
-0 -> local
-1 -> tor 1
-2 -> tor 2
-3 -> nic
+NIC
+TORA
+TORB
+LOCAL
+
 
 - Usage:
   ```
@@ -5384,10 +5385,117 @@ This command displays the eye info in mv(milli volts) of the port user provides 
 
 - Example:
     ```
-        admin@sonic:~$ show muxcable ber-info 1 1
+        admin@sonic:~$ show muxcable eye-info Ethernet48 NIC
         Lane1    Lane2
         -------  -------
         632      622
+    ```
+
+**show muxcable alivecablestatus**
+
+This command displays whether the cable is alive if connected to a muxcable port, which basically means if the NIC side is configured and powered on
+
+
+- Usage:
+  ```
+  Usage: Usage: show mux alivecablestatus [OPTIONS] <port_name>
+  ```
+
+- PORT   required - Port number should be a valid port
+
+- Example:
+    ```
+      admin@sonic:~$ show mux alivecablestatus Ethernet48
+          PORT        ATTR    VALUE
+          ----------  ------  -------
+          Ethernet48  cable   False
+
+    ```
+
+    **show muxcable pcsstatistics**
+
+This command displays pcs layer statistics on the target which the user enters. The attributes will be predefined by the vendor. Target can be any of
+NIC
+TORA
+TORB
+LOCAL
+
+- Usage:
+  ```
+  : show mux pcsstatistics [OPTIONS] <port_name> <target> NIC TORA TORB LOCAL
+
+  ```
+
+- PORT   required - Port number should be a valid port
+- TARGET required - the actual target to get the ber info of.
+
+- Example:
+    ```
+    admin@sonic:~$ show mux pcsstatistics Ethernet48 NIC
+                  PORT        ATTR                    VALUE
+                  ----------  --------------------  -------
+                  Ethernet48  Rx Frames OK                0
+                  Ethernet48  Rx Chk SEQ Errs             0
+                  Ethernet48  Rx Alignment Errs           0
+                  Ethernet48  Rx In Errs                  0
+                  Ethernet48  Rx FrameTooLong Errs        0
+                  Ethernet48  Rx Octets OK                0
+                  Ethernet48  Tx Frames OK                0
+                  Ethernet48  Tx Out Errs                 0
+                  Ethernet48  Tx Octets OK                0
+    ```
+**show muxcable fecstatistics**
+
+This command displays fec layer statistics on the target which the user enters. The attributes will be predefined by the vendor. Target can be any of
+NIC
+TORA
+TORB
+LOCAL
+
+
+- Usage:
+  ```
+  Usage: show mux fecstatistics [OPTIONS] <port_name> <target> NIC TORA TORB LOCAL
+  ```
+
+- PORT   required - Port number should be a valid port
+- TARGET required - the actual target to get the eye info of.
+- Example:
+    ```
+      show mux fec Ethernet48 NIC
+      PORT        ATTR                         VALUE
+      ----------  -------------------------  -------
+      Ethernet48  Total recevied CW                0
+      Ethernet48  Total correct CW                 0
+      Ethernet48  Total corrected CW               0
+      Ethernet48  Total uncorrectable CW           0
+      Ethernet48  Corrected CW ( 1 sym err)        0
+    ```
+
+**show muxcable get-fec-anlt-speed**
+
+This command displays the fec, anlt and speed related configurations for the cable
+
+
+- Usage:
+  ```
+  Usage: Usage: show mux get-fec-anlt-speed [OPTIONS] <port_name>
+  ```
+
+- PORT   required - Port number should be a valid port
+
+- Example:
+    ```
+      admin@sonic:~$ show mux get-fec-anlt-speed Ethernet48
+      PORT        ATTR          VALUE
+      ----------  ----------  -------
+      Ethernet48  fec_nic           0
+      Ethernet48  fec_tor_a         0
+      Ethernet48  fec_tor_b         0
+      Ethernet48  speed         50000
+      Ethernet48  anlt_nic      False
+      Ethernet48  anlt_tor_a    False
+      Ethernet48  anlt_tor_b    False
     ```
 
 ### Muxcable Config commands
@@ -5454,10 +5562,10 @@ While configuring the muxcable, users needs to configure the following fields fo
 
 - PORT   required - Port number should be a valid port
 - TARGET  required - the actual target to run the prbs on
-                         0 -> local side,
-                         1 -> TOR 1
-                         2 -> TOR 2
-                         3 -> NIC
+                        NIC
+                        TORA
+                        TORB
+                        LOCAL
 - MODE_VALUE  required - the mode/type for configuring the PRBS mode.
              0x00 = PRBS 9, 0x01 = PRBS 15, 0x02 = PRBS 23, 0x03 = PRBS 31
 - LANE_MAP  required - an integer representing the lane_map to be run PRBS on
@@ -5465,9 +5573,9 @@ While configuring the muxcable, users needs to configure the following fields fo
              for example 3 -> 0b'0011 , means running on lane0 and lane1
 - Example:
     ```
-        admin@sonic:~$ sudo config muxcable prbs enable 1 1 3 3
+        admin@sonic:~$ sudo config muxcable prbs enable Ethernet48 NIC 3 3
         PRBS config sucessful
-        admin@sonic:~$  sudo config muxcable prbs disable 1 0
+        admin@sonic:~$  sudo config muxcable prbs disable Ethernet48 NIC
         PRBS disable sucessful
     ```
 
@@ -5481,25 +5589,102 @@ This command is used for setting the configuration and enable/disable of loopbac
   config muxcable loopback disable [OPTIONS] PORT TARGET
   ```
 
-While configuring the muxcable, users needs to configure the following fields for the operation
+While configuring the muxcable, users needs to provide the following fields for the operation
 
 - PORT   required - Port number should be a valid port
 - TARGET  required - the actual target to run the loopback on
-                         0 -> local side,
-                         1 -> TOR 1
-                         2 -> TOR 2
-                         3 -> NIC
+                        NIC
+                        TORA
+                        TORB
+                        LOCAL
 - LANE_MAP  required - an integer representing the lane_map to be run loopback on
              0bit for lane 0, 1bit for lane1 and so on.
              for example 3 -> 0b'0011 , means running on lane0 and lane1
 
 - Example:
     ```
-        admin@sonic:~$ sudo config muxcable loopback enable 1 1 3
+        admin@sonic:~$ sudo config muxcable loopback enable Ethernet48 NIC 3
         loopback config sucessful
-        admin@sonic:~$  sudo config muxcable loopback disable 1 0
+        admin@sonic:~$  sudo config muxcable loopback disable Ethernet48 NIC
         loopback disable sucessfull
     ```
+
+
+**config muxcable set-anlt enable/disable**
+
+This command is used for setting the configuration and enable/disable of anlt on the port and target on the cable.
+
+- Usage:
+  ```
+  config mux set-anlt [OPTIONS] PORT <target> NIC TORA TORB LOCAL <mode>0 disable 1 enable
+  ```
+
+While configuring the muxcable for fec, users needs to provide the following fields for the operation
+
+- PORT   required - Port number should be a valid port
+- TARGET  required - the actual target to run the loopback on
+                        NIC
+                        TORA
+                        TORB
+                        LOCAL
+
+- Example:
+    ```
+       admin@sonic:~$ sudo config mux set-fec Ethernet48 NIC 0
+
+       Success in fec mode port Ethernet48 to 0
+    ```
+
+**config muxcable set-fec mode**
+
+This command is used for setting the configuration and enable/disable of fec mode on the port and target on the cable. The fec could be one of FEC_MODE_NONE FEC_MODE_RS  FEC_MODE_FC
+
+- Usage:
+  ```
+  config mux set-fec [OPTIONS] PORT <target> NIC TORA TORB LOCAL <mode>FEC_MODE_NONE 0 FEC_MODE_RS 1 FEC_MODE_FC 2
+  ```
+
+While configuring the muxcable for anlt, users needs to configure the following fields for the operation
+
+- PORT   required - Port number should be a valid port
+- TARGET  required - the actual target to run the loopback on
+                        NIC
+                        TORA
+                        TORB
+                        LOCAL
+
+- Example:
+    ```
+       admin@sonic:~$ sudo config mux set-anlt Ethernet48 NIC 0
+       Success in anlt enable/disable port Ethernet48 to 0
+    ```
+
+
+**config muxcable reset**
+
+This command is used for hard reset for the configuration
+of the MCU on the side which the user wants to.
+
+- Usage:
+  ```
+     config mux reset [OPTIONS] PORT <target> NIC TORA TORB LOCAL
+  ```
+
+While configuring the muxcable for reset, users needs to provide the following fields for the operation
+
+- PORT   required - Port number should be a valid port
+- TARGET  required - the actual target to run the loopback on
+                        NIC
+                        TORA
+                        TORB
+                        LOCAL
+
+- Example:
+    ```
+       admin@sonic:~$ sudo config mux reset Ethernet48 NIC Muxcable at port Ethernet48 will be reset;  CAUTION: disable traffic Continue? [y/N]: y
+       Success in reset port Ethernet48
+    ```
+
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#muxcable)
 

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -1,5 +1,4 @@
 import json
-import os
 import sys
 import time
 

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -99,14 +99,89 @@ def get_response_for_version(port, mux_info_dict):
 
     return mux_info_dict
 
+def get_event_logs(port, res_dict, mux_info_dict):
+    state_db = {}
+    xcvrd_show_fw_res_tbl = {}
 
-def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_name, rsp_table_name, port, cmd_timeout_secs, arg=None):
+    namespaces = multi_asic.get_front_end_namespaces()
+    for namespace in namespaces:
+        asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+        state_db[asic_id] = db_connect("STATE_DB", namespace)
+        xcvrd_show_fw_res_tbl[asic_id] = swsscommon.Table(state_db[asic_id], "XCVRD_EVENT_LOG_RES")
+
+    logical_port_list = platform_sfputil_helper.get_logical_list()
+    if port not in logical_port_list:
+        click.echo("ERR: This is not a valid port, valid ports ({})".format(", ".join(logical_port_list)))
+        rc = EXIT_FAIL
+        res_dict[1] = rc
+        return mux_info_dict
+
+    asic_index = None
+    if platform_sfputil is not None:
+        asic_index = platform_sfputil_helper.get_asic_id_for_logical_port(port)
+    if asic_index is None:
+        # TODO this import is only for unit test purposes, and should be removed once sonic_platform_base
+        # is fully mocked
+        import sonic_platform_base.sonic_sfp.sfputilhelper
+        asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
+        if asic_index is None:
+            click.echo("Got invalid asic index for port {}, cant retreive mux status".format(port))
+            rc = CONFIG_FAIL
+            res_dict[1] = rc
+            return mux_info_dict
+
+    (status, fvp) = xcvrd_show_fw_res_tbl[asic_index].get(port)
+    res_dir = dict(fvp)
+
+    for key, value in res_dir.items():
+        mux_info_dict[key] = value;
+
+    return mux_info_dict
+
+def get_result(port, res_dict, cmd ,result, table_name):
+    state_db = {}
+    xcvrd_show_fw_res_tbl = {}
+
+    namespaces = multi_asic.get_front_end_namespaces()
+    for namespace in namespaces:
+        asic_id = multi_asic.get_asic_index_from_namespace(namespace)
+        state_db[asic_id] = db_connect("STATE_DB", namespace)
+        xcvrd_show_fw_res_tbl[asic_id] = swsscommon.Table(state_db[asic_id], table_name)
+
+    logical_port_list = platform_sfputil_helper.get_logical_list()
+    if port not in logical_port_list:
+        click.echo("ERR: This is not a valid port, valid ports ({})".format(", ".join(logical_port_list)))
+        rc = EXIT_FAIL
+        res_dict[1] = rc
+        return result
+
+    asic_index = None
+    if platform_sfputil is not None:
+        asic_index = platform_sfputil_helper.get_asic_id_for_logical_port(port)
+    if asic_index is None:
+        # TODO this import is only for unit test purposes, and should be removed once sonic_platform_base
+        # is fully mocked
+        import sonic_platform_base.sonic_sfp.sfputilhelper
+        asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
+        if asic_index is None:
+            click.echo("Got invalid asic index for port {}, cant retreive mux status".format(port))
+            rc = CONFIG_FAIL
+            res_dict[1] = rc
+            return result
+
+    (status, fvp) = xcvrd_show_fw_res_tbl[asic_index].get(port)
+    res_dir = dict(fvp)
+
+    return res_dir
+
+def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_name, cmd_arg_table_name, rsp_table_name ,port, cmd_timeout_secs, param_dict= None, arg=None):
 
     res_dict = {}
     state_db, appl_db = {}, {}
     firmware_rsp_tbl, firmware_rsp_tbl_keys = {}, {}
     firmware_rsp_sub_tbl = {}
     firmware_cmd_tbl = {}
+    firmware_cmd_arg_tbl = {}
 
     CMD_TIMEOUT_SECS = cmd_timeout_secs
 
@@ -121,6 +196,8 @@ def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_
         firmware_cmd_tbl[asic_id] = swsscommon.Table(appl_db[asic_id], cmd_table_name)
         firmware_rsp_sub_tbl[asic_id] = swsscommon.SubscriberStateTable(state_db[asic_id], rsp_table_name)
         firmware_rsp_tbl[asic_id] = swsscommon.Table(state_db[asic_id], rsp_table_name)
+        if cmd_arg_table_name is not None:
+            firmware_cmd_arg_tbl[asic_id] = swsscommon.Table(appl_db[asic_id], cmd_arg_table_name)
         firmware_rsp_tbl_keys[asic_id] = firmware_rsp_tbl[asic_id].getKeys()
         for key in firmware_rsp_tbl_keys[asic_id]:
             firmware_rsp_tbl[asic_id]._del(key)
@@ -153,6 +230,11 @@ def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_
         cmd_arg = "null"
     else:
         cmd_arg = str(arg)
+
+    if param_dict is not None:
+        for key, value in param_dict.items():
+            fvs = swsscommon.FieldValuePairs([(str(key), str(value))])
+            firmware_cmd_arg_tbl[asic_index].set(port, fvs)
 
     fvs = swsscommon.FieldValuePairs([(cmd_name, cmd_arg)])
     firmware_cmd_tbl[asic_index].set(port, fvs)
@@ -573,46 +655,248 @@ def config(db, port, json_output):
 
 
 @muxcable.command()
-@click.argument('port', required=True, default=None, type=click.INT)
+@click.argument('port', metavar='<port_name>', required=True, default=None)
 @click.argument('target', required=True, default=None, type=click.INT)
-def berinfo(port, target):
+@clicommon.pass_db
+def berinfo(db, port, target):
     """Show muxcable BER (bit error rate) information"""
 
-    if os.geteuid() != 0:
-        click.echo("Root privileges are required for this operation")
-        sys.exit(EXIT_FAIL)
-    import sonic_y_cable.y_cable
-    res = sonic_y_cable.y_cable.get_ber_info(port, target)
-    if res == False or res == -1:
-        click.echo("Unable to fetch ber info")
-        sys.exit(EXIT_FAIL)
-    headers = ['Lane1', 'Lane2', 'Lane3', 'Lane4']
-    lane_data = []
-    lane_data.append(res)
-    click.echo(tabulate(lane_data, headers=headers))
-    sys.exit(EXIT_SUCCESS)
+    port = platform_sfputil_helper.get_interface_alias(port, db)
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD")
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD_ARG")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RES")
+
+    if port is not None:
+
+        res_dict = {}
+        result = {}
+        param_dict = {}
+        param_dict["target"] = target
+
+
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", "XCVRD_GET_BER_CMD_ARG", "XCVRD_GET_BER_RSP", port, 10, param_dict, "ber")
+
+        if res_dict[1] == "True":
+            result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
+
+
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD")
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD_ARG")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RES")
+
+        click.echo("{}".format(json.dumps(result, indent=4)))
+    else:
+        click.echo("Did not get a valid Port for ber value".format(port))
+        sys.exit(CONFIG_FAIL)
 
 
 @muxcable.command()
-@click.argument('port', required=True, default=None, type=click.INT)
+@click.argument('port', metavar='<port_name>', required=True, default=None)
 @click.argument('target', required=True, default=None, type=click.INT)
-def eyeinfo(port, target):
+@clicommon.pass_db
+def eyeinfo(db, port, target):
     """Show muxcable eye information in mv"""
 
-    if os.geteuid() != 0:
-        click.echo("Root privileges are required for this operation")
-        sys.exit(EXIT_FAIL)
-    import sonic_y_cable.y_cable
-    res = sonic_y_cable.y_cable.get_eye_info(port, target)
-    if res == False or res == -1:
-        click.echo("Unable to fetch eye info")
-        sys.exit(EXIT_FAIL)
-    headers = ['Lane1', 'Lane2', 'Lane3', 'Lane4']
-    lane_data = []
-    lane_data.append(res)
-    click.echo(tabulate(lane_data, headers=headers))
-    sys.exit(EXIT_SUCCESS)
+    port = platform_sfputil_helper.get_interface_alias(port, db)
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD")
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD_ARG")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RES")
 
+    if port is not None:
+
+        res_dict = {}
+        result = {}
+        param_dict = {}
+        param_dict["target"] = target
+
+
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", "XCVRD_GET_BER_CMD_ARG", "XCVRD_GET_BER_RSP", port, 10, param_dict, "eye")
+
+        if res_dict[1] == "True":
+            result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
+
+
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD")
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD_ARG")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RES")
+
+        click.echo("{}".format(json.dumps(result, indent=4)))
+    else:
+        click.echo("Did not get a valid Port for ber value".format(port))
+        sys.exit(CONFIG_FAIL)
+
+
+@muxcable.command()
+@click.argument('port', metavar='<port_name>', required=True, default=None)
+@click.argument('target', required=True, default=None, type=click.INT)
+@clicommon.pass_db
+def fecstatistics(db, port, target):
+    """Show muxcable fec layer statistics information, target 0 NIC 1 ToR A 2 ToR B"""
+
+    port = platform_sfputil_helper.get_interface_alias(port, db)
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD")
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD_ARG")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RES")
+
+    if port is not None:
+
+        res_dict = {}
+        result = {}
+        param_dict = {}
+        param_dict["target"] = target
+
+
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", "XCVRD_GET_BER_CMD_ARG", "XCVRD_GET_BER_RSP", port, 10, param_dict, "fec_stats")
+
+        if res_dict[1] == "True":
+            result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
+
+
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD")
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD_ARG")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RES")
+
+        click.echo("{}".format(json.dumps(result, indent=4)))
+    else:
+        click.echo("Did not get a valid Port for ber value".format(port))
+        sys.exit(CONFIG_FAIL)
+
+
+@muxcable.command()
+@click.argument('port', metavar='<port_name>', required=True, default=None)
+@click.argument('target', metavar='<target> 0 NIC 1 ToR A 2 ToR B 3 Local', required=True, default=None, type=click.INT)
+@clicommon.pass_db
+def pcsstatistics(db, port, target):
+    """Show muxcable pcs layer statistics information"""
+
+    port = platform_sfputil_helper.get_interface_alias(port, db)
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD")
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD_ARG")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RES")
+
+    if port is not None:
+
+        res_dict = {}
+        result = {}
+        param_dict = {}
+        param_dict["target"] = target
+
+
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", "XCVRD_GET_BER_CMD_ARG", "XCVRD_GET_BER_RSP", port, 10, param_dict, "pcs_stats")
+
+        if res_dict[1] == "True":
+            result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
+
+
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD")
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD_ARG")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RES")
+
+        click.echo("{}".format(json.dumps(result, indent=4)))
+    else:
+        click.echo("Did not get a valid Port for pcs statistics".format(port))
+        sys.exit(CONFIG_FAIL)
+
+@muxcable.command()
+@click.argument('port', metavar='<port_name>', required=True, default=None)
+@click.argument('option', required=False, default=None)
+@clicommon.pass_db
+def debugdumpregisters(db, port, option):
+    """Show muxcable debug deump registers information, preagreed by vendors"""
+
+    port = platform_sfputil_helper.get_interface_alias(port, db)
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD")
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD_ARG")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RES")
+
+    if port is not None:
+
+        res_dict = {}
+        result = {}
+        param_dict = {}
+        param_dict["option"] = option
+
+
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", "XCVRD_GET_BER_CMD_ARG", "XCVRD_GET_BER_RSP", port, 10, param_dict, "debug_dump")
+
+        if res_dict[1] == "True":
+            result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
+
+
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD")
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD_ARG")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RES")
+
+        click.echo("{}".format(json.dumps(result, indent=4)))
+    else:
+        click.echo("Did not get a valid Port for debug dump registers".format(port))
+        sys.exit(CONFIG_FAIL)
+
+@muxcable.command()
+@click.argument('port', metavar='<port_name>', required=True, default=None)
+@clicommon.pass_db
+def alivecablestatus(db, port):
+    """Show muxcable alive information """
+
+    port = platform_sfputil_helper.get_interface_alias(port, db)
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RES")
+
+    if port is not None:
+
+        res_dict = {}
+        result = {}
+
+
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", None, "XCVRD_GET_BER_RSP", port, 10, None, "cable_alive")
+
+        if res_dict[1] == "True":
+            result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
+
+
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RES")
+
+        click.echo("{}".format(json.dumps(result, indent=4)))
+    else:
+        click.echo("Did not get a valid Port for cable alive status".format(port))
+        sys.exit(CONFIG_FAIL)
 
 @muxcable.command()
 @click.argument('port', required=True, default=None)
@@ -671,7 +955,7 @@ def muxdirection(db, port):
         res_dict[0] = CONFIG_FAIL
         res_dict[1] = "unknown"
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "state", "state", "True", "XCVRD_SHOW_HWMODE_DIR_CMD", "XCVRD_SHOW_HWMODE_DIR_RSP", port, 1, "probe")
+            "state", "state", "True", "XCVRD_SHOW_HWMODE_DIR_CMD", None, "XCVRD_SHOW_HWMODE_DIR_RSP", port, 1, None, "probe")
 
         body = []
         temp_list = []
@@ -724,7 +1008,7 @@ def muxdirection(db, port):
             res_dict[0] = CONFIG_FAIL
             res_dict[1] = "unknown"
             res_dict = update_and_get_response_for_xcvr_cmd(
-                "state", "state", "True", "XCVRD_SHOW_HWMODE_DIR_CMD", "XCVRD_SHOW_HWMODE_DIR_RSP", port, 1, "probe")
+                "state", "state", "True", "XCVRD_SHOW_HWMODE_DIR_CMD", None, "XCVRD_SHOW_HWMODE_DIR_RSP", port, 1, None, "probe")
             port = platform_sfputil_helper.get_interface_alias(port, db)
             temp_list.append(port)
             temp_list.append(res_dict[1])
@@ -759,7 +1043,7 @@ def switchmode(db, port):
         res_dict[0] = CONFIG_FAIL
         res_dict[1] = "unknown"
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "state", "state", "True", "XCVRD_SHOW_HWMODE_SWMODE_CMD", "XCVRD_SHOW_HWMODE_SWMODE_RSP", port, 1, "probe")
+            "state", "state", "True", "XCVRD_SHOW_HWMODE_SWMODE_CMD", None, "XCVRD_SHOW_HWMODE_SWMODE_RSP", port, 1, None, "probe")
 
         body = []
         temp_list = []
@@ -812,8 +1096,7 @@ def switchmode(db, port):
             res_dict[0] = CONFIG_FAIL
             res_dict[1] = "unknown"
             res_dict = update_and_get_response_for_xcvr_cmd(
-                "state", "state", "True", "XCVRD_SHOW_HWMODE_SWMODE_CMD", "XCVRD_SHOW_HWMODE_SWMODE_RSP", port, 1, "probe")
-            port = platform_sfputil_helper.get_interface_alias(port, db)
+                "state", "state", "True", "XCVRD_SHOW_HWMODE_SWMODE_CMD", None, "XCVRD_SHOW_HWMODE_SWMODE_RSP", port, 1, None, "probe")
             temp_list.append(port)
             temp_list.append(res_dict[1])
             rc = res_dict[1]
@@ -997,7 +1280,7 @@ def version(db, port, active):
         mux_info_dict["version_self_next"] = "N/A"
 
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "firmware_version", "status", "True", "XCVRD_SHOW_FW_CMD", "XCVRD_SHOW_FW_RSP", port, 20, "probe")
+            "firmware_version", "status", "True", "XCVRD_SHOW_FW_CMD", None, "XCVRD_SHOW_FW_RSP", port, 20, None, "probe")
 
         if res_dict[1] == "True":
             mux_info_dict = get_response_for_version(port, mux_info_dict)
@@ -1083,3 +1366,76 @@ def metrics(db, port, json_output):
             headers = ['PORT', 'EVENT', 'TIME']
 
             click.echo(tabulate(print_data, headers=headers))
+
+@muxcable.command()
+@click.argument('port', metavar='<port_name>', required=True, default=None)
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
+@clicommon.pass_db
+def event_log(db, port, json_output):
+    """Show muxcable event log <port>"""
+
+    port = platform_sfputil_helper.get_interface_alias(port, db)
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_EVENT_LOG_CMD")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_EVENT_LOG_RSP")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_EVENT_LOG_RES")
+
+    if port is not None:
+
+        res_dict = {}
+        mux_info_dict, mux_info_active_dict = {}, {}
+
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "show_event", "status", "True", "XCVRD_EVENT_LOG_CMD", None, "XCVRD_EVENT_LOG_RSP", port, 1000, None, "probe")
+
+        if res_dict[1] == "True":
+            get_event_logs(port, res_dict, mux_info_dict)
+
+
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_EVENT_LOG_RSP")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_EVENT_LOG_RES")
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_EVENT_LOG_CMD")
+
+        click.echo("{}".format(json.dumps(mux_info_dict, indent=4)))
+    else:
+        click.echo("Did not get a valid Port for event log".format(port))
+        sys.exit(CONFIG_FAIL)
+
+@muxcable.command()
+@click.argument('port', metavar='<port_name>', required=True, default=None)
+@clicommon.pass_db
+def get_fec_anlt_speed(db, port):
+    """Show muxcable configurations for fec anlt speed <port>"""
+
+    port = platform_sfputil_helper.get_interface_alias(port, db)
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_FEC_CMD")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_FEC_RSP")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_FEC_RES")
+
+    if port is not None:
+
+        res_dict = {}
+        result = {}
+        mux_info_dict, mux_info_active_dict = {}, {}
+
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "get_fec", "status", "True", "XCVRD_GET_FEC_CMD", None, "XCVRD_GET_FEC_RSP", port, 10, None, "probe")
+
+        if res_dict[1] == "True":
+            result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_FEC_RES")
+
+
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_FEC_CMD")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_FEC_RSP")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_FEC_RES")
+
+        click.echo("{}".format(json.dumps(result, indent=4)))
+    else:
+        click.echo("Did not get a valid Port for fec value speed anlt".format(port))
+        sys.exit(CONFIG_FAIL)
+

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -1474,7 +1474,6 @@ def get_fec_anlt_speed(db, port, json_output):
 
         res_dict = {}
         result = {}
-        mux_info_dict, mux_info_active_dict = {}, {}
 
         res_dict[0] = CONFIG_FAIL
         res_dict[1] = "unknown"

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -696,8 +696,8 @@ def berinfo(db, port, target, json_output):
         if json_output:
             click.echo("{}".format(json.dumps(result, indent=4)))
         else:
-            headers = ['PORT', 'VALUE']
-            res = [[key] + [val] for key, val in result.items()]
+            headers = ['PORT', 'ATTR', 'VALUE']
+            res = [[port]+[key] + [val] for key, val in result.items()]
             click.echo(tabulate(res, headers=headers))
 
     else:
@@ -746,8 +746,8 @@ def eyeinfo(db, port, target, json_output):
         if json_output:
             click.echo("{}".format(json.dumps(result, indent=4)))
         else:
-            headers = ['PORT', 'VALUE']
-            res = [[key] + [val] for key, val in result.items()]
+            headers = ['PORT', 'ATTR', 'VALUE']
+            res = [[port]+[key] + [val] for key, val in result.items()]
             click.echo(tabulate(res, headers=headers))
 
     else:
@@ -796,8 +796,8 @@ def fecstatistics(db, port, target, json_output):
         if json_output:
             click.echo("{}".format(json.dumps(result, indent=4)))
         else:
-            headers = ['PORT', 'VALUE']
-            res = [[key] + [val] for key, val in result.items()]
+            headers = ['PORT', 'ATTR', 'VALUE']
+            res = [[port]+[key] + [val] for key, val in result.items()]
             click.echo(tabulate(res, headers=headers))
 
     else:
@@ -846,8 +846,8 @@ def pcsstatistics(db, port, target, json_output):
         if json_output:
             click.echo("{}".format(json.dumps(result, indent=4)))
         else:
-            headers = ['PORT', 'VALUE']
-            res = [[key] + [val] for key, val in result.items()]
+            headers = ['PORT', 'ATTR', 'VALUE']
+            res = [[port]+[key] + [val] for key, val in result.items()]
             click.echo(tabulate(res, headers=headers))
 
         click.echo("{}".format(json.dumps(result, indent=4)))
@@ -896,8 +896,8 @@ def debugdumpregisters(db, port, option, json_output):
         if json_output:
             click.echo("{}".format(json.dumps(result, indent=4)))
         else:
-            headers = ['PORT', 'VALUE']
-            res = [[key] + [val] for key, val in result.items()]
+            headers = ['PORT', 'ATTR', 'VALUE']
+            res = [[port]+[key] + [val] for key, val in result.items()]
             click.echo(tabulate(res, headers=headers))
     else:
         click.echo("Did not get a valid Port for debug dump registers".format(port))
@@ -940,8 +940,8 @@ def alivecablestatus(db, port, json_output):
         if json_output:
             click.echo("{}".format(json.dumps(result, indent=4)))
         else:
-            headers = ['PORT', 'VALUE']
-            res = [[key] + [val] for key, val in result.items()]
+            headers = ['PORT', 'ATTR', 'VALUE']
+            res = [[port]+[key] + [val] for key, val in result.items()]
             click.echo(tabulate(res, headers=headers))
     else:
         click.echo("Did not get a valid Port for cable alive status".format(port))
@@ -1452,8 +1452,8 @@ def event_log(db, port, json_output):
         if json_output:
             click.echo("{}".format(json.dumps(result, indent=4)))
         else:
-            headers = ['PORT', 'VALUE']
-            res = [[key] + [val] for key, val in result.items()]
+            headers = ['PORT', 'ATTR', 'VALUE']
+            res = [[port]+[key] + [val] for key, val in result.items()]
             click.echo(tabulate(res, headers=headers))
     else:
         click.echo("Did not get a valid Port for event log".format(port))
@@ -1495,8 +1495,8 @@ def get_fec_anlt_speed(db, port, json_output):
         if json_output:
             click.echo("{}".format(json.dumps(result, indent=4)))
         else:
-            headers = ['PORT', 'VALUE']
-            res = [[key] + [val] for key, val in result.items()]
+            headers = ['PORT', 'ATTR', 'VALUE']
+            res = [[port]+[key] + [val] for key, val in result.items()]
             click.echo(tabulate(res, headers=headers))
     else:
         click.echo("Did not get a valid Port for fec value speed anlt".format(port))

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -1431,7 +1431,8 @@ def event_log(db, port, json_output):
     if port is not None:
 
         res_dict = {}
-        mux_info_dict, mux_info_active_dict = {}, {}
+        result = {}
+        mux_info_dict = {}
 
         res_dict[0] = CONFIG_FAIL
         res_dict[1] = "unknown"
@@ -1440,7 +1441,7 @@ def event_log(db, port, json_output):
             "show_event", "status", "True", "XCVRD_EVENT_LOG_CMD", None, "XCVRD_EVENT_LOG_RSP", port, 1000, None, "probe")
 
         if res_dict[1] == "True":
-            get_event_logs(port, res_dict, mux_info_dict)
+            result = get_event_logs(port, res_dict, mux_info_dict)
 
 
         delete_all_keys_in_db_table("STATE_DB", "XCVRD_EVENT_LOG_RSP")

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -1146,6 +1146,7 @@ def switchmode(db, port):
             res_dict[1] = "unknown"
             res_dict = update_and_get_response_for_xcvr_cmd(
                 "state", "state", "True", "XCVRD_SHOW_HWMODE_SWMODE_CMD", None, "XCVRD_SHOW_HWMODE_SWMODE_RSP", port, 1, None, "probe")
+            port = platform_sfputil_helper.get_interface_alias(port, db)
             temp_list.append(port)
             temp_list.append(res_dict[1])
             rc = res_dict[1]

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -64,7 +64,6 @@ def check_port_in_mux_cable_table(port):
 
     per_npu_configdb = {}
     mux_tbl_cfg_db = {}
-    peer_switch_tbl_cfg_db = {}
     port_mux_tbl_keys = {}
 
     # Getting all front asic namespace and correspding config and state DB connector

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -656,12 +656,13 @@ def config(db, port, json_output):
 
 @muxcable.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
-@click.argument('target', required=True, default=None, type=click.INT)
+@click.argument('target', metavar='<target> 0 NIC 1 ToR A 2 ToR B 3 Local', required=True, default=None, type=click.Choice(["0", "1", "2", "3"]))
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
 @clicommon.pass_db
-def berinfo(db, port, target):
+def berinfo(db, port, target, json_output):
     """Show muxcable BER (bit error rate) information"""
 
-    port = platform_sfputil_helper.get_interface_alias(port, db)
+    port = platform_sfputil_helper.get_interface_name(port, db)
     delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD")
     delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD_ARG")
     delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
@@ -690,7 +691,15 @@ def berinfo(db, port, target):
         delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
         delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RES")
 
-        click.echo("{}".format(json.dumps(result, indent=4)))
+        port = platform_sfputil_helper.get_interface_alias(port, db)
+
+        if json_output:
+            click.echo("{}".format(json.dumps(result, indent=4)))
+        else:
+            headers = ['PORT', 'VALUE']
+            res = [[key] + [val] for key, val in result.items()]
+            click.echo(tabulate(res, headers=headers))
+
     else:
         click.echo("Did not get a valid Port for ber value".format(port))
         sys.exit(CONFIG_FAIL)
@@ -698,9 +707,10 @@ def berinfo(db, port, target):
 
 @muxcable.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
-@click.argument('target', required=True, default=None, type=click.INT)
+@click.argument('target', metavar='<target> 0 NIC 1 ToR A 2 ToR B 3 Local', required=True, default=None, type=click.Choice(["0", "1", "2", "3"]))
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
 @clicommon.pass_db
-def eyeinfo(db, port, target):
+def eyeinfo(db, port, target, json_output):
     """Show muxcable eye information in mv"""
 
     port = platform_sfputil_helper.get_interface_alias(port, db)
@@ -731,8 +741,15 @@ def eyeinfo(db, port, target):
         delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD_ARG")
         delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
         delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RES")
+        port = platform_sfputil_helper.get_interface_alias(port, db)
 
-        click.echo("{}".format(json.dumps(result, indent=4)))
+        if json_output:
+            click.echo("{}".format(json.dumps(result, indent=4)))
+        else:
+            headers = ['PORT', 'VALUE']
+            res = [[key] + [val] for key, val in result.items()]
+            click.echo(tabulate(res, headers=headers))
+
     else:
         click.echo("Did not get a valid Port for ber value".format(port))
         sys.exit(CONFIG_FAIL)
@@ -740,9 +757,10 @@ def eyeinfo(db, port, target):
 
 @muxcable.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
-@click.argument('target', required=True, default=None, type=click.INT)
+@click.argument('target', metavar='<target> 0 NIC 1 ToR A 2 ToR B 3 Local', required=True, default=None, type=click.Choice(["0", "1", "2", "3"]))
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
 @clicommon.pass_db
-def fecstatistics(db, port, target):
+def fecstatistics(db, port, target, json_output):
     """Show muxcable fec layer statistics information, target 0 NIC 1 ToR A 2 ToR B"""
 
     port = platform_sfputil_helper.get_interface_alias(port, db)
@@ -773,8 +791,15 @@ def fecstatistics(db, port, target):
         delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD_ARG")
         delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
         delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RES")
+        port = platform_sfputil_helper.get_interface_alias(port, db)
 
-        click.echo("{}".format(json.dumps(result, indent=4)))
+        if json_output:
+            click.echo("{}".format(json.dumps(result, indent=4)))
+        else:
+            headers = ['PORT', 'VALUE']
+            res = [[key] + [val] for key, val in result.items()]
+            click.echo(tabulate(res, headers=headers))
+
     else:
         click.echo("Did not get a valid Port for ber value".format(port))
         sys.exit(CONFIG_FAIL)
@@ -782,9 +807,10 @@ def fecstatistics(db, port, target):
 
 @muxcable.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
-@click.argument('target', metavar='<target> 0 NIC 1 ToR A 2 ToR B 3 Local', required=True, default=None, type=click.INT)
+@click.argument('target', metavar='<target> 0 NIC 1 ToR A 2 ToR B 3 Local', required=True, default=None, type=click.Choice(["0", "1", "2", "3"]))
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
 @clicommon.pass_db
-def pcsstatistics(db, port, target):
+def pcsstatistics(db, port, target, json_output):
     """Show muxcable pcs layer statistics information"""
 
     port = platform_sfputil_helper.get_interface_alias(port, db)
@@ -815,6 +841,14 @@ def pcsstatistics(db, port, target):
         delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD_ARG")
         delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
         delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RES")
+        port = platform_sfputil_helper.get_interface_alias(port, db)
+
+        if json_output:
+            click.echo("{}".format(json.dumps(result, indent=4)))
+        else:
+            headers = ['PORT', 'VALUE']
+            res = [[key] + [val] for key, val in result.items()]
+            click.echo(tabulate(res, headers=headers))
 
         click.echo("{}".format(json.dumps(result, indent=4)))
     else:
@@ -824,11 +858,12 @@ def pcsstatistics(db, port, target):
 @muxcable.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
 @click.argument('option', required=False, default=None)
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
 @clicommon.pass_db
-def debugdumpregisters(db, port, option):
+def debugdumpregisters(db, port, option, json_output):
     """Show muxcable debug deump registers information, preagreed by vendors"""
 
-    port = platform_sfputil_helper.get_interface_alias(port, db)
+    port = platform_sfputil_helper.get_interface_name(port, db)
     delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD")
     delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD_ARG")
     delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
@@ -856,19 +891,26 @@ def debugdumpregisters(db, port, option):
         delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD_ARG")
         delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
         delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RES")
+        port = platform_sfputil_helper.get_interface_alias(port, db)
 
-        click.echo("{}".format(json.dumps(result, indent=4)))
+        if json_output:
+            click.echo("{}".format(json.dumps(result, indent=4)))
+        else:
+            headers = ['PORT', 'VALUE']
+            res = [[key] + [val] for key, val in result.items()]
+            click.echo(tabulate(res, headers=headers))
     else:
         click.echo("Did not get a valid Port for debug dump registers".format(port))
         sys.exit(CONFIG_FAIL)
 
 @muxcable.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
 @clicommon.pass_db
-def alivecablestatus(db, port):
+def alivecablestatus(db, port, json_output):
     """Show muxcable alive information """
 
-    port = platform_sfputil_helper.get_interface_alias(port, db)
+    port = platform_sfputil_helper.get_interface_name(port, db)
     delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD")
     delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
     delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RES")
@@ -893,7 +935,14 @@ def alivecablestatus(db, port):
         delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
         delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RES")
 
-        click.echo("{}".format(json.dumps(result, indent=4)))
+        port = platform_sfputil_helper.get_interface_alias(port, db)
+
+        if json_output:
+            click.echo("{}".format(json.dumps(result, indent=4)))
+        else:
+            headers = ['PORT', 'VALUE']
+            res = [[key] + [val] for key, val in result.items()]
+            click.echo(tabulate(res, headers=headers))
     else:
         click.echo("Did not get a valid Port for cable alive status".format(port))
         sys.exit(CONFIG_FAIL)
@@ -1374,7 +1423,7 @@ def metrics(db, port, json_output):
 def event_log(db, port, json_output):
     """Show muxcable event log <port>"""
 
-    port = platform_sfputil_helper.get_interface_alias(port, db)
+    port = platform_sfputil_helper.get_interface_name(port, db)
     delete_all_keys_in_db_table("APPL_DB", "XCVRD_EVENT_LOG_CMD")
     delete_all_keys_in_db_table("STATE_DB", "XCVRD_EVENT_LOG_RSP")
     delete_all_keys_in_db_table("STATE_DB", "XCVRD_EVENT_LOG_RES")
@@ -1397,19 +1446,26 @@ def event_log(db, port, json_output):
         delete_all_keys_in_db_table("STATE_DB", "XCVRD_EVENT_LOG_RSP")
         delete_all_keys_in_db_table("STATE_DB", "XCVRD_EVENT_LOG_RES")
         delete_all_keys_in_db_table("APPL_DB", "XCVRD_EVENT_LOG_CMD")
+        port = platform_sfputil_helper.get_interface_alias(port, db)
 
-        click.echo("{}".format(json.dumps(mux_info_dict, indent=4)))
+        if json_output:
+            click.echo("{}".format(json.dumps(result, indent=4)))
+        else:
+            headers = ['PORT', 'VALUE']
+            res = [[key] + [val] for key, val in result.items()]
+            click.echo(tabulate(res, headers=headers))
     else:
         click.echo("Did not get a valid Port for event log".format(port))
         sys.exit(CONFIG_FAIL)
 
 @muxcable.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
 @clicommon.pass_db
-def get_fec_anlt_speed(db, port):
+def get_fec_anlt_speed(db, port, json_output):
     """Show muxcable configurations for fec anlt speed <port>"""
 
-    port = platform_sfputil_helper.get_interface_alias(port, db)
+    port = platform_sfputil_helper.get_interface_name(port, db)
     delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_FEC_CMD")
     delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_FEC_RSP")
     delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_FEC_RES")
@@ -1433,8 +1489,14 @@ def get_fec_anlt_speed(db, port):
         delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_FEC_CMD")
         delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_FEC_RSP")
         delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_FEC_RES")
+        port = platform_sfputil_helper.get_interface_name(port, db)
 
-        click.echo("{}".format(json.dumps(result, indent=4)))
+        if json_output:
+            click.echo("{}".format(json.dumps(result, indent=4)))
+        else:
+            headers = ['PORT', 'VALUE']
+            res = [[key] + [val] for key, val in result.items()]
+            click.echo(tabulate(res, headers=headers))
     else:
         click.echo("Did not get a valid Port for fec value speed anlt".format(port))
         sys.exit(CONFIG_FAIL)

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -762,7 +762,7 @@ def eyeinfo(db, port, target, json_output):
 def fecstatistics(db, port, target, json_output):
     """Show muxcable fec layer statistics information, target 0 NIC 1 ToR A 2 ToR B"""
 
-    port = platform_sfputil_helper.get_interface_alias(port, db)
+    port = platform_sfputil_helper.get_interface_name(port, db)
     delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD")
     delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD_ARG")
     delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
@@ -812,7 +812,7 @@ def fecstatistics(db, port, target, json_output):
 def pcsstatistics(db, port, target, json_output):
     """Show muxcable pcs layer statistics information"""
 
-    port = platform_sfputil_helper.get_interface_alias(port, db)
+    port = platform_sfputil_helper.get_interface_name(port, db)
     delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD")
     delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD_ARG")
     delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -824,6 +824,8 @@ class TestMuxcable(object):
     @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
                                                                                                       1: "True"}))
+    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={0: 0,
+                                                                          1: "active"}))
     def test_show_mux_fecstatistics(self):
         runner = CliRunner()
         db = Db()
@@ -837,7 +839,9 @@ class TestMuxcable(object):
     @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
                                                                                                       1: "True"}))
-    def test_show_mux_debugdeumpregisters(self):
+    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={0: 0,
+                                                                          1: "active"}))
+    def test_show_mux_event_log(self):
         runner = CliRunner()
         db = Db()
 
@@ -850,11 +854,13 @@ class TestMuxcable(object):
     @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
                                                                                                       1: "True"}))
-    def test_show_mux_debugdeumpregisters(self):
+    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={0: 0,
+                                                                          1: "active"}))
+    def test_show_mux_get_fec_anlt_speed(self):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(show.cli.commands["muxcable"].commands["get_fec_anlt_speed"],
+        result = runner.invoke(show.cli.commands["muxcable"].commands["get-fec-anlt-speed"],
                                ["Ethernet0"], obj=db)
 
         assert result.exit_code == 0

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -839,8 +839,6 @@ class TestMuxcable(object):
     @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
                                                                                                       1: "True"}))
-    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={0: 0,
-                                                                          1: "active"}))
     @mock.patch('show.muxcable.get_event_logs', mock.MagicMock(return_value={0: 0,
                                                                           2: "log"}))
     def test_show_mux_event_log(self):

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -802,7 +802,7 @@ class TestMuxcable(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(show.cli.commands["muxcable"].commands["debugdeumpregisters"],
+        result = runner.invoke(show.cli.commands["muxcable"].commands["debugdumpregisters"],
                                ["Ethernet0"], obj=db)
 
         assert result.exit_code == 0
@@ -845,7 +845,7 @@ class TestMuxcable(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(show.cli.commands["muxcable"].commands["event_log"],
+        result = runner.invoke(show.cli.commands["muxcable"].commands["event-log"],
                                ["Ethernet0"], obj=db)
 
         assert result.exit_code == 0

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -789,7 +789,7 @@ class TestMuxcable(object):
         db = Db()
 
         result = runner.invoke(show.cli.commands["muxcable"].commands["eyeinfo"],
-                               ["Ethernet48", "0"], obj=db)
+                               ["Ethernet0", "NIC"], obj=db)
 
         assert result.exit_code == 0
 
@@ -817,7 +817,7 @@ class TestMuxcable(object):
         db = Db()
 
         result = runner.invoke(show.cli.commands["muxcable"].commands["pcsstatistics"],
-                               ["Ethernet0", "0"], obj=db)
+                               ["Ethernet0", "NIC"], obj=db)
 
         assert result.exit_code == 0
 
@@ -831,7 +831,7 @@ class TestMuxcable(object):
         db = Db()
 
         result = runner.invoke(show.cli.commands["muxcable"].commands["fecstatistics"],
-                               ["Ethernet0", "0"], obj=db)
+                               ["Ethernet0", "NIC"], obj=db)
 
         assert result.exit_code == 0
 
@@ -874,7 +874,7 @@ class TestMuxcable(object):
         db = Db()
 
         result = runner.invoke(show.cli.commands["muxcable"].commands["berinfo"],
-                               ["Ethernet0", "0"], obj=db)
+                               ["Ethernet0", "NIC"], obj=db)
 
         assert result.exit_code == 0
 
@@ -891,7 +891,7 @@ class TestMuxcable(object):
         db = Db()
 
         result = runner.invoke(config.config.commands["muxcable"].commands["prbs"].commands["enable"],
-                               ["0", "0", "0", "0"], obj=db)
+                               ["Ethernet0", "NIC", "0", "0"], obj=db)
 
         assert result.exit_code == 0
 
@@ -908,7 +908,7 @@ class TestMuxcable(object):
         db = Db()
 
         result = runner.invoke(config.config.commands["muxcable"].commands["loopback"].commands["enable"],
-                               ["0", "0", "0"], obj=db)
+                               ["Ethernet0", "NIC", "0"], obj=db)
 
         assert result.exit_code == 0
 
@@ -925,7 +925,7 @@ class TestMuxcable(object):
         db = Db()
 
         result = runner.invoke(config.config.commands["muxcable"].commands["prbs"].commands["disable"],
-                               ["0", "0"], obj=db)
+                               ["Ethernet0", "NIC"], obj=db)
 
         assert result.exit_code == 0
 
@@ -942,7 +942,7 @@ class TestMuxcable(object):
         db = Db()
 
         result = runner.invoke(config.config.commands["muxcable"].commands["loopback"].commands["disable"],
-                               ["Ethernet0", "0"], obj=db)
+                               ["Ethernet0", "NIC"], obj=db)
 
         assert result.exit_code == 0
 
@@ -1406,7 +1406,7 @@ class TestMuxcable(object):
         db = Db()
 
         result = runner.invoke(show.cli.commands["muxcable"].commands["berinfo"],
-                               ["Ethernet0", "0"], obj=db)
+                               ["Ethernet0", "NIC"], obj=db)
 
         assert result.exit_code == 0
 
@@ -1423,7 +1423,7 @@ class TestMuxcable(object):
         db = Db()
 
         result = runner.invoke(config.config.commands["muxcable"].commands["prbs"].commands["enable"],
-                               ["0", "0", "0", "0"], obj=db)
+                               ["Ethernet0", "NIC", "0", "0"], obj=db)
 
         assert result.exit_code == 0
 
@@ -1440,7 +1440,7 @@ class TestMuxcable(object):
         db = Db()
 
         result = runner.invoke(config.config.commands["muxcable"].commands["loopback"].commands["enable"],
-                               ["0", "0", "0"], obj=db)
+                               ["Ethernet0", "NIC", "0"], obj=db)
 
         assert result.exit_code == 0
 
@@ -1457,7 +1457,7 @@ class TestMuxcable(object):
         db = Db()
 
         result = runner.invoke(config.config.commands["muxcable"].commands["prbs"].commands["disable"],
-                               ["0", "0"], obj=db)
+                               ["Ethernet0", "NIC"], obj=db)
 
         assert result.exit_code == 0
 
@@ -1474,7 +1474,7 @@ class TestMuxcable(object):
         db = Db()
 
         result = runner.invoke(config.config.commands["muxcable"].commands["loopback"].commands["disable"],
-                               ["Ethernet0", "0"], obj=db)
+                               ["Ethernet0", "NIC"], obj=db)
 
         assert result.exit_code == 0
 

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -841,6 +841,8 @@ class TestMuxcable(object):
                                                                                                       1: "True"}))
     @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={0: 0,
                                                                           1: "active"}))
+    @mock.patch('show.muxcable.get_event_logs', mock.MagicMock(return_value={0: 0,
+                                                                          2: "log"}))
     def test_show_mux_event_log(self):
         runner = CliRunner()
         db = Db()

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -781,6 +781,8 @@ class TestMuxcable(object):
     @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
                                                                                                       1: "active"}))
+    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={0: 0,
+                                                                          1: "active"}))
     @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
     def test_show_muxcable_eye_info(self):
         runner = CliRunner()
@@ -794,6 +796,8 @@ class TestMuxcable(object):
     @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
                                                                                                       1: "True"}))
+    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={0: 0,
+                                                                          1: "active"}))
     def test_show_mux_debugdeumpregisters(self):
         runner = CliRunner()
         db = Db()
@@ -806,6 +810,8 @@ class TestMuxcable(object):
     @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
                                                                                                       1: "True"}))
+    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={0: 0,
+                                                                          1: "active"}))
     def test_show_mux_pcsstatistics(self):
         runner = CliRunner()
         db = Db()

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -778,8 +778,10 @@ class TestMuxcable(object):
 
         assert result.exit_code == 1
 
-    @mock.patch('os.geteuid', mock.MagicMock(return_value=0))
-    @mock.patch('sonic_y_cable.y_cable.get_eye_info', mock.MagicMock(return_value=[0, 0]))
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "active"}))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
     def test_show_muxcable_eye_info(self):
         runner = CliRunner()
         db = Db()
@@ -789,8 +791,10 @@ class TestMuxcable(object):
 
         assert result.exit_code == 0
 
-    @mock.patch('os.geteuid', mock.MagicMock(return_value=0))
-    @mock.patch('sonic_y_cable.y_cable.get_ber_info', mock.MagicMock(return_value=[0, 0]))
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "active"}))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
     def test_show_muxcable_ber_info(self):
         runner = CliRunner()
         db = Db()
@@ -800,8 +804,14 @@ class TestMuxcable(object):
 
         assert result.exit_code == 0
 
-    @mock.patch('os.geteuid', mock.MagicMock(return_value=0))
-    @mock.patch('sonic_y_cable.y_cable.enable_prbs_mode', mock.MagicMock(return_value=1))
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "active"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
     def test_config_muxcable_enable_prbs(self):
         runner = CliRunner()
         db = Db()
@@ -811,8 +821,14 @@ class TestMuxcable(object):
 
         assert result.exit_code == 0
 
-    @mock.patch('os.geteuid', mock.MagicMock(return_value=0))
-    @mock.patch('sonic_y_cable.y_cable.enable_loopback_mode', mock.MagicMock(return_value=1))
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "active"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
     def test_config_muxcable_enable_loopback(self):
         runner = CliRunner()
         db = Db()
@@ -822,8 +838,14 @@ class TestMuxcable(object):
 
         assert result.exit_code == 0
 
-    @mock.patch('os.geteuid', mock.MagicMock(return_value=0))
-    @mock.patch('sonic_y_cable.y_cable.disable_prbs_mode', mock.MagicMock(return_value=1))
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "active"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
     def test_config_muxcable_disble_prbs(self):
         runner = CliRunner()
         db = Db()
@@ -833,14 +855,20 @@ class TestMuxcable(object):
 
         assert result.exit_code == 0
 
-    @mock.patch('os.geteuid', mock.MagicMock(return_value=0))
-    @mock.patch('sonic_y_cable.y_cable.disable_loopback_mode', mock.MagicMock(return_value=1))
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "active"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
     def test_config_muxcable_disable_loopback(self):
         runner = CliRunner()
         db = Db()
 
         result = runner.invoke(config.config.commands["muxcable"].commands["loopback"].commands["disable"],
-                               ["0", "0"], obj=db)
+                               ["Ethernet0", "0"], obj=db)
 
         assert result.exit_code == 0
 

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -787,7 +787,69 @@ class TestMuxcable(object):
         db = Db()
 
         result = runner.invoke(show.cli.commands["muxcable"].commands["eyeinfo"],
-                               ["0", "0"], obj=db)
+                               ["Ethernet48", "0"], obj=db)
+
+        assert result.exit_code == 0
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    def test_show_mux_debugdeumpregisters(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["debugdeumpregisters"],
+                               ["Ethernet0"], obj=db)
+
+        assert result.exit_code == 0
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    def test_show_mux_pcsstatistics(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["pcsstatistics"],
+                               ["Ethernet0", "0"], obj=db)
+
+        assert result.exit_code == 0
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    def test_show_mux_fecstatistics(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["fecstatistics"],
+                               ["Ethernet0", "0"], obj=db)
+
+        assert result.exit_code == 0
+
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    def test_show_mux_debugdeumpregisters(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["event_log"],
+                               ["Ethernet0"], obj=db)
+
+        assert result.exit_code == 0
+
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    def test_show_mux_debugdeumpregisters(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["get_fec_anlt_speed"],
+                               ["Ethernet0"], obj=db)
 
         assert result.exit_code == 0
 
@@ -800,7 +862,539 @@ class TestMuxcable(object):
         db = Db()
 
         result = runner.invoke(show.cli.commands["muxcable"].commands["berinfo"],
+                               ["Ethernet0", "0"], obj=db)
+
+        assert result.exit_code == 0
+
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "active"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    def test_config_muxcable_enable_prbs(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["muxcable"].commands["prbs"].commands["enable"],
+                               ["0", "0", "0", "0"], obj=db)
+
+        assert result.exit_code == 0
+
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "active"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    def test_config_muxcable_enable_loopback(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["muxcable"].commands["loopback"].commands["enable"],
+                               ["0", "0", "0"], obj=db)
+
+        assert result.exit_code == 0
+
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "active"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    def test_config_muxcable_disble_prbs(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["muxcable"].commands["prbs"].commands["disable"],
                                ["0", "0"], obj=db)
+
+        assert result.exit_code == 0
+
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "active"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    def test_config_muxcable_disable_loopback(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["muxcable"].commands["loopback"].commands["disable"],
+                               ["Ethernet0", "0"], obj=db)
+
+        assert result.exit_code == 0
+
+    @mock.patch('sonic_y_cable.y_cable.get_part_number', mock.MagicMock(return_value=("CACL1X321P2PA1M")))
+    @mock.patch('sonic_y_cable.y_cable.get_vendor', mock.MagicMock(return_value=("Credo          ")))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value=1))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    def test_show_muxcable_cableinfo(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["cableinfo"],
+                               ["Ethernet0"], obj=db)
+
+        assert result.exit_code == 0
+        assert result.output == expected_muxcable_cableinfo_output
+
+    @mock.patch('sonic_y_cable.y_cable.get_part_number', mock.MagicMock(return_value=(False)))
+    @mock.patch('sonic_y_cable.y_cable.get_vendor', mock.MagicMock(return_value=(False)))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value=1))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    def test_show_muxcable_cableinfo_incorrect_port(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["cableinfo"],
+                               ["Ethernet0"], obj=db)
+        assert result.exit_code == 1
+
+    @mock.patch('sonic_y_cable.y_cable.get_part_number', mock.MagicMock(return_value=(False)))
+    @mock.patch('sonic_y_cable.y_cable.get_vendor', mock.MagicMock(return_value=(False)))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value=1))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=0))
+    def test_show_muxcable_cableinfo_incorrect_port_return_value(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["cableinfo"],
+                               ["Ethernet0"], obj=db)
+        assert result.exit_code == 1
+
+    @mock.patch('sonic_y_cable.y_cable.get_part_number', mock.MagicMock(return_value=(False)))
+    @mock.patch('sonic_y_cable.y_cable.get_vendor', mock.MagicMock(return_value=(False)))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value=1))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0, 1]))
+    def test_show_muxcable_cableinfo_incorrect_logical_port_return_value(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["cableinfo"],
+                               ["Ethernet0"], obj=db)
+        assert result.exit_code == 1
+
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "active"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.check_mux_direction', mock.MagicMock(return_value=(1)))
+    @mock.patch('re.match', mock.MagicMock(return_value=(True)))
+    def test_show_muxcable_hwmode_muxdirection_port_active(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["hwmode"].commands["muxdirection"],
+                               ["Ethernet12"], obj=db)
+        assert result.exit_code == 0
+        assert result.output == show_muxcable_hwmode_muxdirection_active_expected_output
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "active"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.check_mux_direction', mock.MagicMock(return_value=(1)))
+    @mock.patch('re.match', mock.MagicMock(return_value=(True)))
+    def test_show_muxcable_hwmode_muxdirection_active_expected_output_alias(self):
+        runner = CliRunner()
+        db = Db()
+        os.environ['SONIC_CLI_IFACE_MODE'] = "alias"
+        result = runner.invoke(show.cli.commands["muxcable"].commands["hwmode"].commands["muxdirection"],
+                               ["etp4"], obj=db)
+        os.environ['SONIC_CLI_IFACE_MODE'] = "default"
+        assert result.exit_code == 0
+        assert result.output == show_muxcable_hwmode_muxdirection_active_expected_output_alias
+
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "standby"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.check_mux_direction', mock.MagicMock(return_value=(1)))
+    @mock.patch('re.match', mock.MagicMock(return_value=(True)))
+    def test_show_muxcable_hwmode_muxdirection_active(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["hwmode"].commands["muxdirection"], obj=db)
+        assert result.exit_code == 0
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "standby"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.check_mux_direction', mock.MagicMock(return_value=(2)))
+    @mock.patch('re.match', mock.MagicMock(return_value=(True)))
+    def test_show_muxcable_hwmode_muxdirection_port_standby(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["hwmode"].commands["muxdirection"],
+                               ["Ethernet12"], obj=db)
+        assert result.exit_code == 0
+        assert result.output == show_muxcable_hwmode_muxdirection_standby_expected_output
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "standby"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.check_mux_direction', mock.MagicMock(return_value=(2)))
+    @mock.patch('re.match', mock.MagicMock(return_value=(True)))
+    def test_show_muxcable_hwmode_muxdirection_port_standby_alias(self):
+        runner = CliRunner()
+        db = Db()
+
+        os.environ['SONIC_CLI_IFACE_MODE'] = "alias"
+        result = runner.invoke(show.cli.commands["muxcable"].commands["hwmode"].commands["muxdirection"],
+                               ["etp4"], obj=db)
+        os.environ['SONIC_CLI_IFACE_MODE'] = "default"
+        assert result.exit_code == 0
+        assert result.output == show_muxcable_hwmode_muxdirection_standby_expected_output_alias
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "sucess"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.check_mux_direction', mock.MagicMock(return_value=(2)))
+    @mock.patch('re.match', mock.MagicMock(return_value=(True)))
+    def test_show_muxcable_hwmode_muxdirection_standby(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["hwmode"].commands["muxdirection"], obj=db)
+        assert result.exit_code == 0
+
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "sucess"}))
+    @mock.patch('config.muxcable.swsscommon.DBConnector', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.Table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.Select', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.SubscriberStateTable', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.check_mux_direction', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.toggle_mux_to_torA', mock.MagicMock(return_value=(True)))
+    @mock.patch('sonic_y_cable.y_cable.toggle_mux_to_torB', mock.MagicMock(return_value=(True)))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    def test_config_muxcable_hwmode_state_port_active(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["muxcable"].commands["hwmode"].commands["state"],
+                               ["active", "Ethernet12"], obj=db)
+        assert result.exit_code == 0
+
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "sucess"}))
+    @mock.patch('config.muxcable.swsscommon.DBConnector', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.Table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.Select', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.SubscriberStateTable', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.check_mux_direction', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.toggle_mux_to_torA', mock.MagicMock(return_value=(True)))
+    @mock.patch('sonic_y_cable.y_cable.toggle_mux_to_torB', mock.MagicMock(return_value=(True)))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    def test_config_muxcable_hwmode_state_active(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["muxcable"].commands["hwmode"].commands["state"],
+                               ["active", "all"], obj=db)
+        assert result.exit_code == 0
+
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "standby"}))
+    @mock.patch('config.muxcable.swsscommon.DBConnector', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.Table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.Select', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.SubscriberStateTable', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.check_mux_direction', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.toggle_mux_to_torA', mock.MagicMock(return_value=(True)))
+    @mock.patch('sonic_y_cable.y_cable.toggle_mux_to_torB', mock.MagicMock(return_value=(True)))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    def test_config_muxcable_hwmode_state_port_standby(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["muxcable"].commands["hwmode"].commands["state"],
+                               ["standby", "Ethernet12"], obj=db)
+        assert result.exit_code == 0
+
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "standby"}))
+    @mock.patch('config.muxcable.swsscommon.DBConnector', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.Table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.Select', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.SubscriberStateTable', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.check_mux_direction', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.toggle_mux_to_torA', mock.MagicMock(return_value=(True)))
+    @mock.patch('sonic_y_cable.y_cable.toggle_mux_to_torB', mock.MagicMock(return_value=(True)))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    def test_config_muxcable_hwmode_state_standby(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["muxcable"].commands["hwmode"].commands["state"],
+                               ["standby", "all"], obj=db)
+        assert result.exit_code == 0
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    @mock.patch('show.muxcable.get_response_for_version', mock.MagicMock(return_value={"version_self_active": "0.6MS",
+                                                                                           "version_self_inactive": "0.6MS",
+                                                                                           "version_self_next": "0.6MS",
+                                                                                           "version_peer_active": "0.6MS",
+                                                                                           "version_peer_inactive": "0.6MS",
+                                                                                           "version_peer_next": "0.6MS",
+                                                                                           "version_nic_active": "0.6MS",
+                                                                                           "version_nic_inactive": "0.6MS",
+                                                                                           "version_nic_next": "0.6MS"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    @mock.patch('sonic_y_cable.y_cable.get_firmware_version', mock.MagicMock(return_value={"version_active": "0.6MS",
+                                                                                           "version_inactive": "0.6MS",
+                                                                                           "version_next": "0.6MS"}))
+    def test_show_muxcable_firmware_version(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["firmware"].commands["version"], [
+                               "Ethernet0"], obj=db)
+        assert result.exit_code == 0
+        assert result.output == show_muxcable_firmware_version_expected_output
+
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "sucess"}))
+    @mock.patch('config.muxcable.swsscommon.DBConnector', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.Table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.Select', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.SubscriberStateTable', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    @mock.patch('sonic_y_cable.y_cable.download_fimware', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.FIRMWARE_DOWNLOAD_SUCCESS', mock.MagicMock(return_value=(1)))
+    def test_config_muxcable_download_firmware(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["muxcable"].commands["firmware"].commands["download"], [
+                               "fwfile", "Ethernet0"], obj=db)
+        assert result.exit_code == 0
+
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "sucess"}))
+    @mock.patch('config.muxcable.swsscommon.DBConnector', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.Table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.Select', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.SubscriberStateTable', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    @mock.patch('sonic_y_cable.y_cable.activate_firmware', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.FIRMWARE_ACTIVATE_SUCCESS', mock.MagicMock(return_value=(1)))
+    def test_config_muxcable_activate_firmware(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["muxcable"].commands["firmware"].commands["activate"], [
+                               "Ethernet0"], obj=db)
+        assert result.exit_code == 0
+
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "sucess"}))
+    @mock.patch("config.muxcable.swsscommon.DBConnector", mock.MagicMock(return_value=0))
+    @mock.patch("config.muxcable.swsscommon.Table", mock.MagicMock(return_value=0))
+    @mock.patch("config.muxcable.swsscommon.Select", mock.MagicMock(return_value=0))
+    @mock.patch("config.muxcable.swsscommon.SubscriberStateTable", mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    @mock.patch('sonic_y_cable.y_cable.rollback_firmware', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.FIRMWARE_ROLLBACK_SUCCESS', mock.MagicMock(return_value=(1)))
+    def test_config_muxcable_rollback_firmware(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["muxcable"].commands["firmware"].commands["rollback"], [
+                               "Ethernet0"], obj=db)
+        assert result.exit_code == 0
+
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    def test_show_muxcable_metrics_port(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["metrics"],
+                               ["Ethernet0"], obj=db)
+        assert result.exit_code == 0
+        assert result.output == show_muxcable_metrics_expected_output
+
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    def test_show_muxcable_metrics_port_alias(self):
+        runner = CliRunner()
+        db = Db()
+
+        os.environ['SONIC_CLI_IFACE_MODE'] = "alias"
+        result = runner.invoke(show.cli.commands["muxcable"].commands["metrics"],
+                               ["etp1"], obj=db)
+
+        os.environ['SONIC_CLI_IFACE_MODE'] = "default"
+        assert result.exit_code == 0
+        assert result.output == show_muxcable_metrics_expected_output_alias
+
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    def test_show_muxcable_metrics_port_json(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["metrics"],
+                               ["Ethernet0", "--json"], obj=db)
+        assert result.exit_code == 0
+        assert result.output == show_muxcable_metrics_expected_output_json
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    @mock.patch('show.muxcable.get_response_for_version', mock.MagicMock(return_value={"version_self_active": "0.6MS",
+                                                                                           "version_self_inactive": "0.6MS",
+                                                                                           "version_self_next": "0.6MS",
+                                                                                           "version_peer_active": "0.6MS",
+                                                                                           "version_peer_inactive": "0.6MS",
+                                                                                           "version_peer_next": "0.6MS",
+                                                                                           "version_nic_active": "0.6MS",
+                                                                                           "version_nic_inactive": "0.6MS",
+                                                                                           "version_nic_next": "0.6MS"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    @mock.patch('sonic_y_cable.y_cable.get_firmware_version', mock.MagicMock(return_value={"version_active": "0.6MS",
+                                                                                           "version_inactive": "0.6MS",
+                                                                                           "version_next": "0.6MS"}))
+    def test_show_muxcable_firmware_active_version(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["firmware"].commands["version"], [
+                               "Ethernet0", "--active"], obj=db)
+        assert result.exit_code == 0
+        assert result.output == show_muxcable_firmware_version_active_expected_output
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        print("TEARDOWN")
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "active"}))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    def test_show_muxcable_ber_info(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["berinfo"],
+                               ["Ethernet0", "0"], obj=db)
 
         assert result.exit_code == 0
 


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
This PR helps us support some more muxcable cli commands. These help us debug the cable issues faster from CLI as well as configure some properties on cable if required. It also adds non-hitless optional support for muxcable firmware CLI

- show muxcable  get-fec-anlt-speed
- show muxcable fecstatistics
- show muxcable pcsstatistics
- show muxcable alivecablestatus
- show muxcable event-log
- show muxcable debugdumpregisters
- config muxcable set-fec
- config muxcable reset
- config muxcable anlt


#### What I did
added new cli for muxcable

#### How I did it
added the changes
#### How to verify it
unit-tests are added for new commands

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
```
admin@sonic:~$ show mux fecstatistics Ethernet48 1
PORT                                      VALUE
-------------------------  --------------------
Total recevied CW          11503052155808982781
Total correct CW            2116945631070750141
Total corrected CW          1488798828427060849
Total uncorrectable CW               1493763484
Corrected CW ( 1 sym err)   2063216930070464037
Corrected CW ( 2 sym err)   6639010623159212327
Corrected CW ( 3 sym err)              19394822
Corrected CW ( 4 sym err)            4245010845
Corrected CW ( 5 sym err)            2645407235
Corrected CW ( 6 sym err)                 51793
Corrected CW ( 7 sym err)                 58883
Corrected CW ( 8 sym err)                  1492
Corrected CW ( 9 sym err)                  8898
Corrected CW (10 sym err)                 39368
Corrected CW (11 sym err)                  4545
Corrected CW (12 sym err)                 10146
Corrected CW (13 sym err)                 36248
Corrected CW (14 sym err)                 33252
Corrected CW (15 sym err)                  2480```

admin@sonic:~$ show mux debugdumpregisters Ethernet48 0 --json
{
    "serde_lane_14": "{'ch_est': 0.0, 'of': 0, 'hf': 0, 'ctle1': 0, 'ctle2': 0, 'delta': -2, 'eye': 0, 'ppm': -9, 'adp_cnt': 0, 'adp_done': 0, 'agc_g1': 85, 'agc_g2': 21, 'exit_code': 0, 'pll_tx': 27, 'pll_rx': 27, 'f1': -7, 'f2': -1, 'f3': 45, 'temp': 54}",
    "serde_lane_2": "{'ch_est': 0.0, 'of': 0, 'hf': 0, 'ctle1': 0, 'ctle2': 0, 'delta': -1, 'eye': 0, 'ppm': 0, 'adp_cnt': 0, 'adp_done': 0, 'agc_g1': 85, 'agc_g2': 21, 'exit_code': 0, 'pll_tx': 27, 'pll_rx': 27, 'f1': -3, 'f2': -1, 'f3': -1, 'temp': 54}",
    "serde_lane_0": "{'ch_est': 1.33203125, 'of': 56, 'hf': 42, 'ctle1': 7, 'ctle2': 7, 'delta': 0, 'eye': 816, 'ppm': -11, 'adp_cnt': 2, 'adp_done': 1, 'agc_g1': 5, 'agc_g2': 5, 'exit_code': 0, 'pll_tx': 35, 'pll_rx': 33, 'f1': 7, 'f2': -3, 'f3': 1, 'temp': 54}",
    "serde_lane_12": "{'ch_est': 0.0, 'of': 0, 'hf': 0, 'ctle1': 7, 'ctle2': 15, 'delta': 0, 'eye': 0, 'ppm': -1, 'adp_cnt': 1, 'adp_done': 0, 'agc_g1': 64, 'agc_g2': 16, 'exit_code': 0, 'pll_tx': 33, 'pll_rx': 33, 'f1': 18, 'f2': 0, 'f3': 0, 'temp': 54}",
    "nic_voltage": "3.2640000000000002",
}

admin@sonic:~$ show mux pcsstatistics Ethernet48 0
PORT                    VALUE
--------------------  -------
Rx Frames OK             6178
Rx Chk SEQ Errs          6178
Rx Alignment Errs        6178
Rx In Errs               6178
Rx FrameTooLong Errs     6178
Rx Octets OK             6178
Tx Frames OK             6178
Tx Out Errs              6178
Tx Octets OK             6178
{
    "Rx Frames OK": "6178",
    "Rx Chk SEQ Errs": "6178",
    "Rx Alignment Errs": "6178",
    "Rx In Errs": "6178",
    "Rx FrameTooLong Errs": "6178",
    "Rx Octets OK": "6178",
    "Tx Frames OK": "6178",
    "Tx Out Errs": "6178",
    "Tx Octets OK": "6178"
}
admin@sonic:~$ show mux alivecablestatus Ethernet24
PORT    VALUE
------  -------
cable   True

admin@sonic:~$ show mux get-fec-anlt-speed Ethernet48
PORT          VALUE
----------  -------
fec_nic           0
fec_tor_a         0
fec_tor_b         0
speed         50000
anlt_nic      False
anlt_tor_a    False
anlt_tor_b    False
admin@sonic:~$ show mux berinfo Ethernet48
Usage: show mux berinfo [OPTIONS] <port_name> TARGET
Try "show mux berinfo -h" for help.

Error: Missing argument "TARGET".
admin@sonic:~$ show mux berinfo Ethernet48 0
  PORT    VALUE
------  -------
     0        0
     1        0
     2        0
     3        0

admin@sonic:~$ sudo config mux set-fec Ethernet48 0 0
Muxcable at port Ethernet48 will be changed to enable/disable fec mode 0 state; disable traffic Continue? [y/N]: y
Success in fec enable/disable port Ethernet48 to 0


admin@sonic~$sudo config mux set-anlt Ethernet48 0 0
Muxcable at port Ethernet48 will be changed to enable/disable anlt mode 0 state; disable traffic Continue? [y/N]: y
Success in anlt enable/disable port Ethernet48 to 0
```