### PR TITLE
Fix invalid output of syslog IPv6 servers

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1357,16 +1357,19 @@ def show_run_snmp(db, ctx):
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def syslog(verbose):
     """Show Syslog running configuration
-    To match below cases:
+    To match below cases(port is optional):
     *.* @IPv4:port
+    *.* @@IPv4:port
     *.* @[IPv4]:port
+    *.* @@[IPv4]:port
     *.* @[IPv6]:port
+    *.* @@[IPv6]:port
     """
     syslog_servers = []
     syslog_dict = {}
-    re_ipv4_1 = re.compile(r'^\*\.\* @(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):\d+')
-    re_ipv4_2 = re.compile(r'^\*\.\* @\[(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\]:\d+')
-    re_ipv6 = re.compile(r'^\*\.\* @\[([0-9a-fA-F:]+)\]:\d+')
+    re_ipv4_1 = re.compile(r'^\*\.\* @{1,2}(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})(:\d+)?')
+    re_ipv4_2 = re.compile(r'^\*\.\* @{1,2}\[(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\](:\d+)?')
+    re_ipv6 = re.compile(r'^\*\.\* @{1,2}\[([0-9a-fA-F:]+)\](:\d+)?')
     with open("/etc/rsyslog.conf") as syslog_file:
         data = syslog_file.readlines()
     for line in data:

--- a/show/main.py
+++ b/show/main.py
@@ -1369,7 +1369,7 @@ def syslog(verbose):
     syslog_dict = {}
     re_ipv4_1 = re.compile(r'^\*\.\* @{1,2}(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})(:\d+)?')
     re_ipv4_2 = re.compile(r'^\*\.\* @{1,2}\[(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\](:\d+)?')
-    re_ipv6 = re.compile(r'^\*\.\* @{1,2}\[([0-9a-fA-F:]+)\](:\d+)?')
+    re_ipv6 = re.compile(r'^\*\.\* @{1,2}\[([0-9a-fA-F:.]+)\](:\d+)?')
     with open("/etc/rsyslog.conf") as syslog_file:
         data = syslog_file.readlines()
     for line in data:

--- a/show/main.py
+++ b/show/main.py
@@ -1356,18 +1356,29 @@ def show_run_snmp(db, ctx):
 @runningconfiguration.command()
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def syslog(verbose):
-    """Show Syslog running configuration"""
+    """Show Syslog running configuration
+    To match below cases:
+    *.* @IPv4:port
+    *.* @[IPv4]:port
+    *.* @[IPv6]:port
+    """
     syslog_servers = []
     syslog_dict = {}
+    re_ipv4_1 = re.compile(r'^\*\.\* @(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):\d+')
+    re_ipv4_2 = re.compile(r'^\*\.\* @\[(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\]:\d+')
+    re_ipv6 = re.compile(r'^\*\.\* @\[([0-9a-fA-F:]+)\]:\d+')
     with open("/etc/rsyslog.conf") as syslog_file:
         data = syslog_file.readlines()
     for line in data:
-        if line.startswith("*.* @"):
-            end = line.find("]")
-            if end == -1:
-                continue
-            server = line[5:end+1]
-            syslog_servers.append(server)
+        if re_ipv4_1.match(line):
+            server =  re_ipv4_1.match(line).group(1)
+        if re_ipv4_2.match(line):
+            server =  re_ipv4_2.match(line).group(1)
+        elif re_ipv6.match(line):
+            server =  re_ipv6.match(line).group(1)
+        else:
+            continue
+        syslog_servers.append("[{}]".format(server))
     syslog_dict['Syslog Servers'] = syslog_servers
     print(tabulate(syslog_dict, headers=list(syslog_dict.keys()), tablefmt="simple", stralign='left', missingval=""))
 

--- a/show/main.py
+++ b/show/main.py
@@ -1363,8 +1363,10 @@ def syslog(verbose):
         data = syslog_file.readlines()
     for line in data:
         if line.startswith("*.* @"):
-            line = line.split(":")
-            server = line[0][5:]
+            end = line.find("]")
+            if end == -1:
+                continue
+            server = line[5:end+1]
             syslog_servers.append(server)
     syslog_dict['Syslog Servers'] = syslog_servers
     print(tabulate(syslog_dict, headers=list(syslog_dict.keys()), tablefmt="simple", stralign='left', missingval=""))

--- a/show/main.py
+++ b/show/main.py
@@ -1372,7 +1372,7 @@ def syslog(verbose):
     for line in data:
         if re_ipv4_1.match(line):
             server =  re_ipv4_1.match(line).group(1)
-        if re_ipv4_2.match(line):
+        elif re_ipv4_2.match(line):
             server =  re_ipv4_2.match(line).group(1)
         elif re_ipv6.match(line):
             server =  re_ipv6.match(line).group(1)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Modify the filter function of `show runningconfiguration syslog`
#### How I did it
Filter by ending "]" rather than split by ":"
#### How to verify it
add a syslog v6 server `sudo config syslog add f587::1:1`
run command `show runningconfiguration syslog`
#### Previous command output (if the output of a command-line utility has changed)
```
admin@vlab-01:~$ show runningconfiguration syslog
Syslog Servers
----------------
[10.0.0.5]
[10.0.0.6]
[f587
```
#### New command output (if the output of a command-line utility has changed)
```
admin@vlab-01:~$ show runningconfiguration syslog
Syslog Servers
----------------
[10.0.0.5]
[10.0.0.6]
[f587::1:1]
```
