### PR TITLE
[portconfig] Fixed CLI speed validation

### DIFF
--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -111,7 +111,9 @@ class portconfig(object):
             print("Setting speed %s on port %s" % (speed, port))
         supported_speeds_str = self.get_supported_speeds(port)
         if supported_speeds_str:
-            if supported_speeds_str.find(str(speed)) == -1:
+            try:
+                supported_speeds_str.split(',').index(str(speed))
+            except ValueError:
                 print('Invalid speed specified: {}'.format(speed))
                 print('Valid speeds:{}'.format(supported_speeds_str))
                 exit(1)

--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -111,9 +111,7 @@ class portconfig(object):
             print("Setting speed %s on port %s" % (speed, port))
         supported_speeds_str = self.get_supported_speeds(port)
         if supported_speeds_str:
-            try:
-                supported_speeds_str.split(',').index(str(speed))
-            except ValueError:
+            if str(speed) not in supported_speeds_str.split(','):
                 print('Invalid speed specified: {}'.format(speed))
                 print('Valid speeds:{}'.format(supported_speeds_str))
                 exit(1)

--- a/tests/config_an_test.py
+++ b/tests/config_an_test.py
@@ -42,6 +42,26 @@ class TestConfigInterface(object):
         assert 'Invalid speed' in result.output
         assert 'Valid speeds:' in result.output
         self.basic_check("speed", ["Ethernet0", "invalid"], ctx, operator.ne)
+        # 499 is not a supported speed
+        result = self.basic_check("speed", ["Ethernet0", "499"], ctx, operator.ne)
+        assert 'Invalid speed' in result.output
+        assert 'Valid speeds:' in result.output
+        self.basic_check("speed", ["Ethernet0", "invalid"], ctx, operator.ne)
+        # 10 is not a supported speed
+        result = self.basic_check("speed", ["Ethernet0", "10"], ctx, operator.ne)
+        assert 'Invalid speed' in result.output
+        assert 'Valid speeds:' in result.output
+        self.basic_check("speed", ["Ethernet0", "invalid"], ctx, operator.ne)
+        # 250 is not a supported speed
+        result = self.basic_check("speed", ["Ethernet0", "250"], ctx, operator.ne)
+        assert 'Invalid speed' in result.output
+        assert 'Valid speeds:' in result.output
+        self.basic_check("speed", ["Ethernet0", "invalid"], ctx, operator.ne)
+        # 400 is not a supported speed
+        result = self.basic_check("speed", ["Ethernet0", "400"], ctx, operator.ne)
+        assert 'Invalid speed' in result.output
+        assert 'Valid speeds:' in result.output
+        self.basic_check("speed", ["Ethernet0", "invalid"], ctx, operator.ne)
 
     def test_config_adv_speeds(self, ctx):
         self.basic_check("advertised-speeds", ["Ethernet0", "40000,100000"], ctx)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixed algorithm for CLI speed validation.

#### How I did it
Changed the `portconfig` script.

#### How to verify it
Extended existing UT with new values.

#### Previous command output (if the output of a command-line utility has changed)
`Valid speeds:200000,100000,50000,40000,25000,10000,1000`
The user was able to set invalid speed modes - any substring from valid speeds (above), such as:
`config interface speed Ethernet0 500`
`config interface speed Ethernet0 5`
`config interface speed Ethernet0 00`
`config interface speed Ethernet0 10`
`config interface speed Ethernet0 ,`

#### New command output (if the output of a command-line utility has changed)
CLI output didn't change, but now the user cannot set modes described in the previous section.

