### PR TITLE
[load_minigraph] Delay pfcwd start until the buffer templates are rendered

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1515,11 +1515,6 @@ def load_minigraph(db, no_service_restart):
         clicommon.run_command(command, display_cmd=True)
         client.set(config_db.INIT_INDICATOR, 1)
 
-    # get the device type
-    device_type = _get_device_type()
-    if device_type != 'MgmtToRRouter' and device_type != 'MgmtTsToR' and device_type != 'EPMS':
-        clicommon.run_command("pfcwd start_default", display_cmd=True)
-
     # Update SONiC environmnet file
     update_sonic_environment()
 
@@ -1534,6 +1529,11 @@ def load_minigraph(db, no_service_restart):
 
     # generate QoS and Buffer configs
     clicommon.run_command("config qos reload --no-dynamic-buffer", display_cmd=True)
+
+    # get the device type
+    device_type = _get_device_type()
+    if device_type != 'MgmtToRRouter' and device_type != 'MgmtTsToR' and device_type != 'EPMS':
+        clicommon.run_command("pfcwd start_default", display_cmd=True)
 
     # Write latest db version string into db
     db_migrator='/usr/local/bin/db_migrator.py'

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -21,8 +21,8 @@ import config.main as config
 load_minigraph_command_output="""\
 Stopping SONiC target ...
 Running command: /usr/local/bin/sonic-cfggen -H -m --write-to-db
-Running command: pfcwd start_default
 Running command: config qos reload --no-dynamic-buffer
+Running command: pfcwd start_default
 Restarting SONiC target ...
 Reloading Monit configuration ...
 Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`.


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
Fixes Azure/sonic-buildimage#9292

#### What I did
Pfcwd was not getting started after executing load_minigraph after the changes done in #1508. This was because the PORT_QOS_MAP table is not yet present in config db (this gets populated only after the buffer templates are rendered) at the time we try to start pfcwd and hence the 'pfc_enable' field will always be empty and we skip writing PFC_WD table entries to config db. 

#### How I did it
Delay pfcwd start until the buffer templates are rendered

#### How to verify it
Issue "config load_minigraph" with the changes and ensure that pfcwd is started on all active ports


