### PR TITLE
[config reload] Update command reference

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -4855,9 +4855,11 @@ When user specifies the optional argument "-n" or "--no-service-restart", this c
 running on the device. One use case for this option is during boot time when config-setup service loads existing old configuration and there is no services
 running on the device.
 
+When user specifies the optional argument "-f" or "--force", this command ignores the system sanity checks. By default a list of sanity checks are performed and if one of the checks fail, the command will not execute. The sanity checks include ensuring the system status is not starting, all the essential services are up and swss is in ready state.
+
 - Usage:
   ```
-  config reload [-y|--yes] [-l|--load-sysinfo] [<filename>] [-n|--no-service-restart]
+  config reload [-y|--yes] [-l|--load-sysinfo] [<filename>] [-n|--no-service-restart] [-f|--force]
   ```
 
 - Example:
@@ -4878,6 +4880,19 @@ running on the device.
   Running command: systemctl restart hostname-config
   Running command: systemctl restart interfaces-config
   Timeout, server 10.11.162.42 not responding.
+  ```
+  When some sanity checks fail below error messages can be seen
+  ```
+  admin@sonic:~$ sudo config reload -y
+  System is not up. Retry later or use -f to avoid system checks
+  ```
+  ```
+  admin@sonic:~$ sudo config reload -y
+  Relevant services are not up. Retry later or use -f to avoid system checks
+  ```
+  ```
+  admin@sonic:~$ sudo config reload -y
+  SwSS container is not ready. Retry later or use -f to avoid system checks
   ```
 
 


### PR DESCRIPTION
Updating command reference reflecting the latest config reload behavior

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Update command reference for the config reload behavior. These changes were introduced by https://github.com/Azure/sonic-utilities/pull/1664

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

