### PR TITLE
[debug dump] Refactoring Modules and Unit Tests

### DIFF
--- a/dump/helper.py
+++ b/dump/helper.py
@@ -1,4 +1,4 @@
-import os, sys
+import os, sys, json
 
 def create_template_dict(dbs):
     """ Generate a Template which will be returned by Executor Classes """
@@ -33,3 +33,15 @@ def sort_lists(ret_template):
             if isinstance(ret_template[db][key], list):
                 ret_template[db][key].sort()
     return ret_template
+
+
+def populate_mock(db, db_names, dedicated_dbs):
+    for db_name in db_names:
+        db.connect(db_name)
+        # Delete any default data
+        db.delete_all_by_pattern(db_name, "*")
+        with open(dedicated_dbs[db_name]) as f:
+            mock_json = json.load(f)
+        for key in mock_json:
+            for field, value in mock_json[key].items():
+                db.set(db_name, key, field, value)

--- a/dump/plugins/evpn.py
+++ b/dump/plugins/evpn.py
@@ -11,7 +11,6 @@ class Evpn(Executor):
 
     def __init__(self, match_engine=None):
         super().__init__(match_engine)
-        self.ret_temp = {}
         self.ns = ''
         self.remote_ip = ''
         self.vlan = ''
@@ -40,14 +39,6 @@ class Evpn(Executor):
         self.init_asic_evpn_term_info()
         self.init_state_evpn_info(evpn_name)
         return self.ret_temp
-
-    def add_to_ret_template(self, table, db, keys, err):
-        if not err and keys:
-            self.ret_temp[db]["keys"].extend(keys)
-            return True
-        else:
-            self.ret_temp[db]["tables_not_found"].extend([table])
-            return False
 
     def init_evpn_appl_info(self, evpn_name):
         req = MatchRequest(db="APPL_DB", table="VXLAN_REMOTE_VNI_TABLE", key_pattern=evpn_name, ns=self.ns)

--- a/dump/plugins/executor.py
+++ b/dump/plugins/executor.py
@@ -16,6 +16,7 @@ class Executor(ABC):
             self.match_engine = MatchEngine(None)
         else:
             self.match_engine = match_engine
+        self.ret_temp = {}
 
     @abstractmethod
     def execute(self, params):
@@ -24,3 +25,14 @@ class Executor(ABC):
     @abstractmethod
     def get_all_args(self, ns):
         pass
+    
+    def add_to_ret_template(self, table, db, keys, err, add_to_tables_not_found=True):
+        if db not in self.ret_temp:
+            return []
+
+        if not err and keys:
+            self.ret_temp[db]["keys"].extend(keys)
+            return keys
+        elif add_to_tables_not_found:
+            self.ret_temp[db]["tables_not_found"].extend([table])
+        return []

--- a/dump/plugins/port.py
+++ b/dump/plugins/port.py
@@ -29,14 +29,6 @@ class Port(Executor):
         self.init_state_port_info(port_name)
         return self.ret_temp
 
-    def add_to_ret_template(self, table, db, keys, err):
-        if not err and keys:
-            self.ret_temp[db]["keys"].extend(keys)
-            return True
-        else:
-            self.ret_temp[db]["tables_not_found"].extend([table])
-            return False
-
     def init_port_config_info(self, port_name):
         req = MatchRequest(db="CONFIG_DB", table="PORT", key_pattern=port_name, ns=self.ns)
         ret = self.match_engine.fetch(req)

--- a/dump/plugins/portchannel.py
+++ b/dump/plugins/portchannel.py
@@ -11,7 +11,6 @@ class Portchannel(Executor):
 
     def __init__(self, match_engine=None):
         super().__init__(match_engine)
-        self.ret_temp = {}
         self.ns = ''
         self.lag_members = set()
 
@@ -37,14 +36,6 @@ class Portchannel(Executor):
         lag_type_objs_asic = self.init_lag_member_type_obj_asic_info()
         self.init_lag_asic_info(lag_type_objs_asic)
         return self.ret_temp
-
-    def add_to_ret_template(self, table, db, keys, err):
-        if not err and keys:
-            self.ret_temp[db]["keys"].extend(keys)
-            return True
-        else:
-            self.ret_temp[db]["tables_not_found"].extend([table])
-            return False
 
     def init_lag_config_info(self):
         req = MatchRequest(db="CONFIG_DB", table="PORTCHANNEL", key_pattern=self.lag_name, ns=self.ns)

--- a/dump/plugins/portchannel_member.py
+++ b/dump/plugins/portchannel_member.py
@@ -10,7 +10,6 @@ class Portchannel_Member(Executor):
 
     def __init__(self, match_engine=None):
         super().__init__(match_engine)
-        self.ret_temp = {}
         self.ns = ''
         self.lag_member_key = ''
         self.lag = ''
@@ -38,14 +37,6 @@ class Portchannel_Member(Executor):
         # ASIC_DB
         self.init_lag_member_type_obj_asic_info()
         return self.ret_temp
-
-    def add_to_ret_template(self, table, db, keys, err):
-        if not err and keys:
-            self.ret_temp[db]["keys"].extend(keys)
-            return True
-        else:
-            self.ret_temp[db]["tables_not_found"].extend([table])
-            return False
 
     def init_lag_member_config_info(self):
         req = MatchRequest(db="CONFIG_DB", table="PORTCHANNEL_MEMBER", key_pattern=self.lag_member_key, ns=self.ns)

--- a/dump/plugins/route.py
+++ b/dump/plugins/route.py
@@ -53,7 +53,6 @@ class Route(Executor):
         4) CLASS_BASED_NEXT_HOP_GROUP_TABLE
         5) NEXTHOP_GROUP_TABLE
         """
-        self.ret_temp = {}
         self.ns = ''
         self.dest_net = ''
         self.nh_id = ''
@@ -82,14 +81,6 @@ class Route(Executor):
         # ASIC DB - KEYS dependent on NEXT HOP ID
         self.init_asic_nh()
         return self.ret_temp
-
-    def add_to_ret_template(self, table, db, keys, err, add_to_tables_not_found=True):
-        if not err and keys:
-            self.ret_temp[db]["keys"].extend(keys)
-            return keys
-        elif add_to_tables_not_found:
-            self.ret_temp[db]["tables_not_found"].extend([table])
-        return []
 
     def init_route_config_info(self):
         req = MatchRequest(db="CONFIG_DB", table="STATIC_ROUTE", key_pattern=self.dest_net, ns=self.ns)

--- a/dump/plugins/vlan.py
+++ b/dump/plugins/vlan.py
@@ -30,27 +30,18 @@ class Vlan(Executor):
     def init_vlan_config_info(self, vlan_name):
         req = MatchRequest(db="CONFIG_DB", table="VLAN", key_pattern=vlan_name, ns=self.ns)
         ret = self.match_engine.fetch(req)
-        if not ret["error"] and len(ret["keys"]) != 0:
-            self.ret_temp[req.db]["keys"] = ret["keys"]
-        else:
-            self.ret_temp[req.db]["tables_not_found"] = [req.table]
+        self.add_to_ret_template(req.table, req.db, ret["keys"], ret["error"])
     
     def init_vlan_appl_info(self, vlan_name):
         req = MatchRequest(db="APPL_DB", table="VLAN_TABLE", key_pattern=vlan_name, ns=self.ns)
         ret = self.match_engine.fetch(req)
-        if not ret["error"] and len(ret["keys"]) != 0:
-            self.ret_temp[req.db]["keys"] = ret["keys"]
-        else:
-            self.ret_temp[req.db]["tables_not_found"] = [req.table]
+        self.add_to_ret_template(req.table, req.db, ret["keys"], ret["error"])
         
     def init_state_vlan_info(self, vlan_name):
         req = MatchRequest(db="STATE_DB", table="VLAN_TABLE", key_pattern=vlan_name, ns=self.ns)
         ret = self.match_engine.fetch(req)
-        if not ret["error"] and len(ret["keys"]) != 0:
-            self.ret_temp[req.db]["keys"] = ret["keys"]
-        else:
-            self.ret_temp[req.db]["tables_not_found"] = [req.table]
-    
+        self.add_to_ret_template(req.table, req.db, ret["keys"], ret["error"])
+
     def init_asic_vlan_info(self, vlan_name):
         # Convert 'Vlanxxx' to 'xxx'
         if vlan_name[0:4] != "Vlan" or not vlan_name[4:].isnumeric():
@@ -62,8 +53,4 @@ class Vlan(Executor):
         req = MatchRequest(db="ASIC_DB", table="ASIC_STATE:SAI_OBJECT_TYPE_VLAN", key_pattern="*", field="SAI_VLAN_ATTR_VLAN_ID", 
                            value=str(vlan_num), ns=self.ns)
         ret = self.match_engine.fetch(req)
-        if not ret["error"] and len(ret["keys"]) != 0:
-            self.ret_temp[req.db]["keys"] = ret["keys"]
-        else:
-            self.ret_temp[req.db]["tables_not_found"] = [req.table]
-    
+        self.add_to_ret_template(req.table, req.db, ret["keys"], ret["error"])

--- a/dump/plugins/vlan_member.py
+++ b/dump/plugins/vlan_member.py
@@ -49,20 +49,12 @@ class Vlan_Member(Executor):
     def init_vlan_member_appl_info(self, vlan_name, member_name):
         req = MatchRequest(db="APPL_DB", table="VLAN_MEMBER_TABLE", key_pattern=vlan_name+':'+member_name+"*", ns=self.ns)
         ret = self.match_engine.fetch(req)
-        if not ret["error"] and len(ret["keys"]) != 0:
-            for mem in ret["keys"]:
-                self.ret_temp[req.db]["keys"].append(mem)
-        else:
-            self.ret_temp[req.db]["tables_not_found"].append(req.table)
+        self.add_to_ret_template(req.table, req.db, ret["keys"], ret["error"])
         
     def init_state_vlan_member_info(self, vlan_name, member_name):
         req = MatchRequest(db="STATE_DB", table="VLAN_MEMBER_TABLE", key_pattern=vlan_name+'|'+member_name+"*", ns=self.ns)
         ret = self.match_engine.fetch(req)
-        if not ret["error"] and len(ret["keys"]) != 0:
-            for mem in ret["keys"]:
-                self.ret_temp[req.db]["keys"].append(mem)
-        else:
-            self.ret_temp[req.db]["tables_not_found"].append(req.table)
+        self.add_to_ret_template(req.table, req.db, ret["keys"], ret["error"])
 
     def init_asic_vlan_member_info(self, vlan_name, member_name):
         
@@ -140,5 +132,3 @@ class Vlan_Member(Executor):
         else:
             self.ret_temp["ASIC_DB"]["tables_not_found"].append("ASIC_STATE:SAI_OBJECT_TYPE_VLAN_MEMBER")
             self.ret_temp["ASIC_DB"]["tables_not_found"].append("ASIC_STATE:SAI_OBJECT_TYPE_BRIDGE_PORT")
-        
-

--- a/dump/plugins/vxlan_tunnel.py
+++ b/dump/plugins/vxlan_tunnel.py
@@ -11,7 +11,6 @@ class Vxlan_tunnel(Executor):
 
     def __init__(self, match_engine=None):
         super().__init__(match_engine)
-        self.ret_temp = {}
         self.ns = ''
         self.src_ip = ''
         self.dst_ip = ''
@@ -36,14 +35,6 @@ class Vxlan_tunnel(Executor):
         self.init_asic_vxlan_tunnel_term_info()
         self.init_state_vxlan_tunnel_info(vxlan_tunnel_name)
         return self.ret_temp
-
-    def add_to_ret_template(self, table, db, keys, err):
-        if not err and keys:
-            self.ret_temp[db]["keys"].extend(keys)
-            return True
-        else:
-            self.ret_temp[db]["tables_not_found"].extend([table])
-            return False
 
     def init_vxlan_tunnel_config_info(self, vxlan_tunnel_name):
         req = MatchRequest(db="CONFIG_DB", table="VXLAN_TUNNEL", key_pattern=vxlan_tunnel_name, ns=self.ns)

--- a/dump/plugins/vxlan_tunnel_map.py
+++ b/dump/plugins/vxlan_tunnel_map.py
@@ -11,7 +11,6 @@ class Vxlan_tunnel_map(Executor):
 
     def __init__(self, match_engine=None):
         super().__init__(match_engine)
-        self.ret_temp = {}
         self.ns = ''
         self.vlan = ''
         self.vni = ''
@@ -34,14 +33,6 @@ class Vxlan_tunnel_map(Executor):
         self.init_asic_vxlan_tunnel_map_entry_info()
         self.init_asic_vxlan_tunnel_map_info()
         return self.ret_temp
-
-    def add_to_ret_template(self, table, db, keys, err):
-        if not err and keys:
-            self.ret_temp[db]["keys"].extend(keys)
-            return True
-        else:
-            self.ret_temp[db]["tables_not_found"].extend([table])
-            return False
 
     def init_vxlan_tunnel_map_config_info(self, vxlan_tunnel_map_name):
         req = MatchRequest(db="CONFIG_DB", table="VXLAN_TUNNEL_MAP", key_pattern=vxlan_tunnel_map_name, ns=self.ns,

--- a/tests/dump_tests/module_tests/copp_test.py
+++ b/tests/dump_tests/module_tests/copp_test.py
@@ -6,7 +6,7 @@ import unittest
 import pytest
 from deepdiff import DeepDiff
 from mock import patch
-from dump.helper import create_template_dict, sort_lists
+from dump.helper import create_template_dict, sort_lists, populate_mock
 from dump.plugins.copp import Copp
 from dump.match_infra import MatchEngine, ConnectionPool
 from swsscommon.swsscommon import SonicV2Connector
@@ -26,18 +26,6 @@ dedicated_dbs['ASIC_DB'] = os.path.join(copp_files_path, "asic_db.json")
 dedicated_dbs['STATE_DB'] = os.path.join(copp_files_path, "state_db.json")
 
 
-def populate_mock(db, db_names):
-    for db_name in db_names:
-        db.connect(db_name)
-        # Delete any default data
-        db.delete_all_by_pattern(db_name, "*")
-        with open(dedicated_dbs[db_name]) as f:
-            mock_json = json.load(f)
-        for key in mock_json:
-            for field, value in mock_json[key].items():
-                db.set(db_name, key, field, value)
-
-
 @pytest.fixture(scope="class", autouse=True)
 def match_engine():
 
@@ -51,7 +39,7 @@ def match_engine():
     # popualate the db with mock data
     db_names = list(dedicated_dbs.keys())
     try:
-        populate_mock(db, db_names)
+        populate_mock(db, db_names, dedicated_dbs)
     except Exception as e:
         assert False, "Mock initialization failed: " + str(e)
 

--- a/tests/dump_tests/module_tests/evpn_test.py
+++ b/tests/dump_tests/module_tests/evpn_test.py
@@ -2,7 +2,7 @@ import json
 import os
 import pytest
 from deepdiff import DeepDiff
-from dump.helper import create_template_dict
+from dump.helper import create_template_dict, populate_mock
 from dump.plugins.evpn import Evpn
 from dump.match_infra import MatchEngine, ConnectionPool
 from swsscommon.swsscommon import SonicV2Connector
@@ -21,18 +21,6 @@ dedicated_dbs['ASIC_DB'] = os.path.join(evpn_files_path, "asic_db.json")
 dedicated_dbs['STATE_DB'] = os.path.join(evpn_files_path, "state_db.json")
 
 
-def populate_mock(db, db_names):
-    for db_name in db_names:
-        db.connect(db_name)
-        # Delete any default data
-        db.delete_all_by_pattern(db_name, "*")
-        with open(dedicated_dbs[db_name]) as f:
-            mock_json = json.load(f)
-        for key in mock_json:
-            for field, value in mock_json[key].items():
-                db.set(db_name, key, field, value)
-
-
 @pytest.fixture(scope="class", autouse=True)
 def match_engine():
 
@@ -46,7 +34,7 @@ def match_engine():
     # popualate the db with mock data
     db_names = list(dedicated_dbs.keys())
     try:
-        populate_mock(db, db_names)
+        populate_mock(db, db_names, dedicated_dbs)
     except Exception as e:
         assert False, "Mock initialization failed: " + str(e)
 

--- a/tests/dump_tests/module_tests/port_test.py
+++ b/tests/dump_tests/module_tests/port_test.py
@@ -6,7 +6,7 @@ import unittest
 import pytest
 from deepdiff import DeepDiff
 from mock import patch
-from dump.helper import create_template_dict, sort_lists
+from dump.helper import create_template_dict, sort_lists, populate_mock
 from dump.plugins.port import Port
 from dump.match_infra import MatchEngine, ConnectionPool
 from swsscommon.swsscommon import SonicV2Connector
@@ -26,18 +26,6 @@ dedicated_dbs['ASIC_DB'] = os.path.join(port_files_path, "asic_db.json")
 dedicated_dbs['STATE_DB'] = os.path.join(port_files_path, "state_db.json")
 
 
-def populate_mock(db, db_names):
-    for db_name in db_names:
-        db.connect(db_name)
-        # Delete any default data
-        db.delete_all_by_pattern(db_name, "*")
-        with open(dedicated_dbs[db_name]) as f:
-            mock_json = json.load(f)
-        for key in mock_json:
-            for field, value in mock_json[key].items():
-                db.set(db_name, key, field, value)
-
-
 @pytest.fixture(scope="class", autouse=True)
 def match_engine():
 
@@ -51,7 +39,7 @@ def match_engine():
     # popualate the db with mock data
     db_names = list(dedicated_dbs.keys())
     try:
-        populate_mock(db, db_names)
+        populate_mock(db, db_names, dedicated_dbs)
     except Exception as e:
         assert False, "Mock initialization failed: " + str(e)
 

--- a/tests/dump_tests/module_tests/portchannel_member_test.py
+++ b/tests/dump_tests/module_tests/portchannel_member_test.py
@@ -4,7 +4,7 @@ import unittest
 import pytest
 from deepdiff import DeepDiff
 from mock import patch
-from dump.helper import create_template_dict, sort_lists
+from dump.helper import create_template_dict, sort_lists, populate_mock
 from dump.plugins.portchannel_member import Portchannel_Member
 from dump.match_infra import MatchEngine, ConnectionPool
 from swsscommon.swsscommon import SonicV2Connector
@@ -25,18 +25,6 @@ dedicated_dbs['ASIC_DB'] = os.path.join(port_files_path, "asic_db.json")
 dedicated_dbs['STATE_DB'] = os.path.join(port_files_path, "state_db.json")
 
 
-def populate_mock(db, db_names):
-    for db_name in db_names:
-        db.connect(db_name)
-        # Delete any default data
-        db.delete_all_by_pattern(db_name, "*")
-        with open(dedicated_dbs[db_name]) as f:
-            mock_json = json.load(f)
-        for key in mock_json:
-            for field, value in mock_json[key].items():
-                db.set(db_name, key, field, value)
-
-
 @pytest.fixture(scope="class", autouse=True)
 def match_engine():
 
@@ -50,7 +38,7 @@ def match_engine():
     # popualate the db with mock data
     db_names = list(dedicated_dbs.keys())
     try:
-        populate_mock(db, db_names)
+        populate_mock(db, db_names, dedicated_dbs)
     except Exception as e:
         assert False, "Mock initialization failed: " + str(e)
 

--- a/tests/dump_tests/module_tests/portchannel_test.py
+++ b/tests/dump_tests/module_tests/portchannel_test.py
@@ -4,7 +4,7 @@ import unittest
 import pytest
 from deepdiff import DeepDiff
 from mock import patch
-from dump.helper import create_template_dict, sort_lists
+from dump.helper import create_template_dict, sort_lists, populate_mock
 from dump.plugins.portchannel import Portchannel
 from dump.match_infra import MatchEngine, ConnectionPool
 from swsscommon.swsscommon import SonicV2Connector
@@ -25,18 +25,6 @@ dedicated_dbs['ASIC_DB'] = os.path.join(port_files_path, "asic_db.json")
 dedicated_dbs['STATE_DB'] = os.path.join(port_files_path, "state_db.json")
 
 
-def populate_mock(db, db_names):
-    for db_name in db_names:
-        db.connect(db_name)
-        # Delete any default data
-        db.delete_all_by_pattern(db_name, "*")
-        with open(dedicated_dbs[db_name]) as f:
-            mock_json = json.load(f)
-        for key in mock_json:
-            for field, value in mock_json[key].items():
-                db.set(db_name, key, field, value)
-
-
 @pytest.fixture(scope="class", autouse=True)
 def match_engine():
 
@@ -50,7 +38,7 @@ def match_engine():
     # popualate the db with mock data
     db_names = list(dedicated_dbs.keys())
     try:
-        populate_mock(db, db_names)
+        populate_mock(db, db_names, dedicated_dbs)
     except Exception as e:
         assert False, "Mock initialization failed: " + str(e)
 

--- a/tests/dump_tests/module_tests/route_test.py
+++ b/tests/dump_tests/module_tests/route_test.py
@@ -4,7 +4,7 @@ import pytest
 import json
 from deepdiff import DeepDiff
 from mock import patch
-from dump.helper import create_template_dict
+from dump.helper import create_template_dict, populate_mock
 from dump.plugins.route import Route
 from dump.match_infra import MatchEngine, ConnectionPool
 from swsscommon.swsscommon import SonicV2Connector
@@ -24,18 +24,6 @@ dedicated_dbs['APPL_DB'] = os.path.join(Route_files_path, "appl_db.json")
 dedicated_dbs['ASIC_DB'] = os.path.join(Route_files_path, "asic_db.json")
 
 
-def populate_mock(db, db_names):
-    for db_name in db_names:
-        db.connect(db_name)
-        # Delete any default data
-        db.delete_all_by_pattern(db_name, "*")
-        with open(dedicated_dbs[db_name]) as f:
-            mock_json = json.load(f)
-        for key in mock_json:
-            for field, value in mock_json[key].items():
-                db.set(db_name, key, field, value)
-
-
 @pytest.fixture(scope="class", autouse=True)
 def match_engine():
 
@@ -49,7 +37,7 @@ def match_engine():
     # popualate the db with mock data
     db_names = list(dedicated_dbs.keys())
     try:
-        populate_mock(db, db_names)
+        populate_mock(db, db_names, dedicated_dbs)
     except Exception as e:
         assert False, "Mock initialization failed: " + str(e)
 

--- a/tests/dump_tests/module_tests/vlan_test.py
+++ b/tests/dump_tests/module_tests/vlan_test.py
@@ -4,7 +4,7 @@ import unittest
 import pytest
 from deepdiff import DeepDiff
 from mock import patch
-from dump.helper import create_template_dict, sort_lists
+from dump.helper import create_template_dict, sort_lists, populate_mock
 from dump.plugins.vlan import Vlan
 from dump.plugins.vlan_member import Vlan_Member
 from dump.match_infra import MatchEngine, ConnectionPool
@@ -25,6 +25,7 @@ dedicated_dbs['APPL_DB'] = os.path.join(vlan_files_path, "appl_db.json")
 dedicated_dbs['ASIC_DB'] = os.path.join(vlan_files_path, "asic_db.json")
 dedicated_dbs['STATE_DB'] = os.path.join(vlan_files_path, "state_db.json")
 
+
 def verbosity_setup():
     print("SETUP")
     os.environ["VERBOSE"] = "1"
@@ -32,16 +33,6 @@ def verbosity_setup():
     print("TEARDOWN")
     os.environ["VERBOSE"] = "0"
 
-def populate_mock(db, db_names):
-    for db_name in db_names:
-        db.connect(db_name)
-        # Delete any default data
-        db.delete_all_by_pattern(db_name, "*")
-        with open(dedicated_dbs[db_name]) as f:
-            mock_json = json.load(f)
-        for key in mock_json:
-            for field, value in mock_json[key].items():
-                db.set(db_name, key, field, value)
 
 @pytest.fixture(scope="class", autouse=True)
 def match_engine():
@@ -53,7 +44,7 @@ def match_engine():
     # popualate the db with mock data
     db_names = list(dedicated_dbs.keys())
     try:
-        populate_mock(db, db_names)
+        populate_mock(db, db_names, dedicated_dbs)
     except Exception as e:
         assert False, "Mock initialization failed: " + str(e)
 

--- a/tests/dump_tests/module_tests/vxlan_tunnel_map_test.py
+++ b/tests/dump_tests/module_tests/vxlan_tunnel_map_test.py
@@ -2,7 +2,7 @@ import json
 import os
 import pytest
 from deepdiff import DeepDiff
-from dump.helper import create_template_dict
+from dump.helper import create_template_dict, populate_mock
 from dump.plugins.vxlan_tunnel_map import Vxlan_tunnel_map
 from dump.match_infra import MatchEngine, ConnectionPool
 from swsscommon.swsscommon import SonicV2Connector
@@ -21,18 +21,6 @@ dedicated_dbs['APPL_DB'] = os.path.join(vxlan_tunnel_map_files_path, "appl_db.js
 dedicated_dbs['ASIC_DB'] = os.path.join(vxlan_tunnel_map_files_path, "asic_db.json")
 
 
-def populate_mock(db, db_names):
-    for db_name in db_names:
-        db.connect(db_name)
-        # Delete any default data
-        db.delete_all_by_pattern(db_name, "*")
-        with open(dedicated_dbs[db_name]) as f:
-            mock_json = json.load(f)
-        for key in mock_json:
-            for field, value in mock_json[key].items():
-                db.set(db_name, key, field, value)
-
-
 @pytest.fixture(scope="class", autouse=True)
 def match_engine():
 
@@ -46,7 +34,7 @@ def match_engine():
     # popualate the db with mock data
     db_names = list(dedicated_dbs.keys())
     try:
-        populate_mock(db, db_names)
+        populate_mock(db, db_names, dedicated_dbs)
     except Exception as e:
         assert False, "Mock initialization failed: " + str(e)
 

--- a/tests/dump_tests/module_tests/vxlan_tunnel_test.py
+++ b/tests/dump_tests/module_tests/vxlan_tunnel_test.py
@@ -2,7 +2,7 @@ import json
 import os
 import pytest
 from deepdiff import DeepDiff
-from dump.helper import create_template_dict
+from dump.helper import create_template_dict, populate_mock
 from dump.plugins.vxlan_tunnel import Vxlan_tunnel
 from dump.match_infra import MatchEngine, ConnectionPool
 from swsscommon.swsscommon import SonicV2Connector
@@ -21,18 +21,6 @@ dedicated_dbs['APPL_DB'] = os.path.join(vxlan_tunnel_files_path, "appl_db.json")
 dedicated_dbs['ASIC_DB'] = os.path.join(vxlan_tunnel_files_path, "asic_db.json")
 
 
-def populate_mock(db, db_names):
-    for db_name in db_names:
-        db.connect(db_name)
-        # Delete any default data
-        db.delete_all_by_pattern(db_name, "*")
-        with open(dedicated_dbs[db_name]) as f:
-            mock_json = json.load(f)
-        for key in mock_json:
-            for field, value in mock_json[key].items():
-                db.set(db_name, key, field, value)
-
-
 @pytest.fixture(scope="class", autouse=True)
 def match_engine():
 
@@ -46,7 +34,7 @@ def match_engine():
     # popualate the db with mock data
     db_names = list(dedicated_dbs.keys())
     try:
-        populate_mock(db, db_names)
+        populate_mock(db, db_names, dedicated_dbs)
     except Exception as e:
         assert False, "Mock initialization failed: " + str(e)
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

1) Moved the "populate_mock" method to dump/helper.py i.e. common to all the tests
2) Moved the "add_to_ret_template" to Executor class i.e. common across all the modules.

#### How I did it

#### How to verify it

```
Unit Tests's:

vkarri@96050efd4f16:/sonic/src/sonic-utilities$ pytest-3 tests/dump_tests/ 
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.9.2, pytest-6.0.2, py-1.10.0, pluggy-0.13.0
rootdir: /sonic/src/sonic-utilities/tests, configfile: pytest.ini
plugins: pyfakefs-4.5.3, cov-2.10.1
collected 116 items                                                                                                                                                        

tests/dump_tests/dump_state_test.py .............                                                                                                                    [ 11%]
tests/dump_tests/match_engine_test.py ...............................                                                                                                [ 37%]
tests/dump_tests/module_tests/copp_test.py ..........                                                                                                                [ 46%]
tests/dump_tests/module_tests/evpn_test.py ......                                                                                                                    [ 51%]
tests/dump_tests/module_tests/port_test.py ......                                                                                                                    [ 56%]
tests/dump_tests/module_tests/portchannel_member_test.py ...                                                                                                         [ 59%]
tests/dump_tests/module_tests/portchannel_test.py ....                                                                                                               [ 62%]
tests/dump_tests/module_tests/route_test.py ..........                                                                                                               [ 71%]
tests/dump_tests/module_tests/vlan_test.py .....................                                                                                                     [ 89%]
tests/dump_tests/module_tests/vxlan_tunnel_map_test.py .....                                                                                                         [ 93%]
tests/dump_tests/module_tests/vxlan_tunnel_test.py .......                                                                                                           [100%]

=========================================================================== 116 passed in 1.21s ============================================================================
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

