### PR TITLE
[202012] [generate_dump] allow to extend dump with plugin scripts

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -32,6 +32,7 @@ DUMPDIR=/var/dump
 TARDIR=$DUMPDIR/$BASE
 TARFILE=$DUMPDIR/$BASE.tar
 LOGDIR=$DUMPDIR/$BASE/dump
+PLUGINS_DIR=/usr/local/bin/debug-dump
 NUM_ASICS=1
 HOME=${HOME:-/root}
 USER=${USER:-root}
@@ -153,6 +154,7 @@ save_bcmcmd_all_ns() {
 #  filename: the filename to save the output as in $BASE/dump
 #  do_gzip: (OPTIONAL) true or false. Should the output be gzipped
 #  cleanup_method: (OPTIONAL) the cleanup method to procress dump file after it generated.
+#  save_stderr: (OPTIONAL) true or false. Should the stderr output be saved
 # Returns:
 #  None
 ###############################################################################
@@ -164,6 +166,7 @@ save_cmd() {
     local filename=$2
     local filepath="${LOGDIR}/$filename"
     local do_gzip=${3:-false}
+    local save_stderr=${4:-true}
     local tarpath="${BASE}/dump/$filename"
     local timeout_cmd="timeout --foreground ${TIMEOUT_MIN}m"
     local cleanup_method=${4:-dummy_cleanup_method}
@@ -181,6 +184,11 @@ save_cmd() {
 
     if [ ! -d $LOGDIR ]; then
         $MKDIR $V -p $LOGDIR
+    fi
+
+    if ! $save_stderr
+    then
+        redirect=">"
     fi
 
     # eval required here to re-evaluate the $cmd properly at runtime
@@ -839,7 +847,7 @@ collect_mellanox() {
         ${CMD_PREFIX}/usr/bin/mstdump /dev/mst/mt*conf0 > "${mst_dump_filename}${i}"
         save_file "${mst_dump_filename}${i}" mstdump true
     done
-    
+
     # Save SDK error dumps
     local sdk_dump_path=`${CMD_PREFIX}docker exec syncd cat /tmp/sai.profile|grep "SAI_DUMP_STORE_PATH"|cut -d = -f2`
     if [[ -d $sdk_dump_path ]]; then
@@ -1056,7 +1064,7 @@ save_crash_files() {
 get_asic_count() {
     trap 'handle_error $? $LINENO' ERR
     local redirect_eval="2>&1"
-    if ! $SAVE_STDERR 
+    if ! $SAVE_STDERR
     then
          redirect_eval=""
     fi
@@ -1216,6 +1224,12 @@ main() {
     save_cmd "docker ps -a" "docker.ps"
     save_cmd "docker top pmon" "docker.pmon"
 
+    local -r dump_plugins="$(find ${PLUGINS_DIR} -type f -executable)"
+    for plugin in $dump_plugins; do
+        # save stdout output of plugin and gzip it
+        save_cmd "$plugin" "$(basename $plugin)" true false
+    done
+
     save_saidump
 
     if [[ "$asic" = "mellanox" ]]; then
@@ -1298,7 +1312,7 @@ main() {
     fi
 
     echo ${TARFILE}
-    
+
     if ! $SAVE_STDERR
     then
     	exit $RETURN_CODE
@@ -1350,7 +1364,7 @@ remove_secret_from_etc_files() {
 
     # Remove snmp community string from snmp.yml
     sed -i -E 's/(\s*snmp_\S*community\s*:\s*)(\S*)/\1****/g' $dumppath/etc/sonic/snmp.yml
-    
+
     # Remove secret from /etc/sonic/config_db.json
     cat $dumppath/etc/sonic/config_db.json | remove_secret_from_config_db_dump > $dumppath/etc/sonic/config_db.json.temp
     mv $dumppath/etc/sonic/config_db.json.temp $dumppath/etc/sonic/config_db.json
@@ -1409,7 +1423,7 @@ OPTIONS
         "24 March", "yesterday", etc.
     -t TIMEOUT_MINS
         Command level timeout in minutes
-    -r 
+    -r
         Redirect any intermediate errors to STDERR
 
 EOF


### PR DESCRIPTION
Signed-off-by: Noa Or <noaor@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added support for tech support extension scripts,
by cherry-picking of https://github.com/Azure/sonic-utilities/pull/1335 to branch 202012

The purpose is to have dumps of extensions in SONiC techsupport, even without App Extension infrastructure.
The new application will write a file that contains the dump command into /usr/bin/debug-dump folder, and it will appear in the output of `show techsupport` command.
#### How I did it
It looks at /usr/bin/debug-dump for scripts, if it finds one it will execute them and save the output to dump/ folder.

#### How to verify it
Write a simple scripts that outputs something and place it under /usr/bin/debug-dump/

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

