### PR TITLE
[sfputil] Firmware download/upgrade CLI support for QSFP-DD

### DIFF
--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -9,6 +9,7 @@ import os
 import sys
 import natsort
 import ast
+import time
 
 import subprocess
 import click
@@ -26,12 +27,16 @@ SYSLOG_IDENTIFIER = "sfputil"
 PLATFORM_JSON = 'platform.json'
 PORT_CONFIG_INI = 'port_config.ini'
 
+EXIT_FAIL = -1
 ERROR_PERMISSIONS = 1
 ERROR_CHASSIS_LOAD = 2
 ERROR_SFPUTILHELPER_LOAD = 3
 ERROR_PORT_CONFIG_LOAD = 4
 ERROR_NOT_IMPLEMENTED = 5
 ERROR_INVALID_PORT = 6
+SMBUS_BLOCK_WRITE_SIZE = 32
+# Default host password as per CMIS spec
+CDB_DEFAULT_HOST_PASSWORD = 0x00001011
 
 # TODO: We should share these maps and the formatting functions between sfputil and sfpshow
 QSFP_DATA_MAP = {
@@ -407,6 +412,19 @@ def logical_port_name_to_physical_port_list(port_name):
             return None
     else:
         return [int(port_name)]
+
+def logical_port_to_physical_port_index(port_name):
+    if platform_sfputil.is_logical_port(port_name) == 0:
+        click.echo("Error: invalid port '{}'\n".format(port_name))
+        print_all_valid_port_values()
+        sys.exit(ERROR_INVALID_PORT)
+
+    physical_port = logical_port_name_to_physical_port_list(port_name)[0]
+    if physical_port is None:
+        click.echo("Error: No physical port found for logical port '{}'".format(port_name))
+        sys.exit(EXIT_FAIL)
+
+    return physical_port
 
 
 def print_all_valid_port_values():
@@ -805,6 +823,36 @@ def lpmode(port):
 
     click.echo(tabulate(output_table, table_header, tablefmt='simple'))
 
+def show_firmware_version(physical_port):
+    try:
+        sfp = platform_chassis.get_sfp(physical_port)
+        api = sfp.get_xcvr_api()
+        out = api.get_module_fw_info()
+        click.echo(out['info'])
+    except NotImplementedError:
+        click.echo("This functionality is currently not implemented for this platform")
+        sys.exit(ERROR_NOT_IMPLEMENTED)
+
+# 'fwversion' subcommand
+@show.command()
+@click.argument('port_name', metavar='<port_name>', required=True)
+def fwversion(port_name):
+    """Show firmware version of the transceiver"""
+
+    physical_port = logical_port_to_physical_port_index(port_name)
+    sfp = platform_chassis.get_sfp(physical_port)
+
+    try:
+        presence = sfp.get_presence()
+    except NotImplemented:
+        click.echo("sfp get_presence() NOT implemented!")
+        sys.exit(EXIT_FAIL)
+
+    if not presence:
+        click.echo("{}: SFP EEPROM not detected\n".format(port_name))
+        sys.exit(EXIT_FAIL)
+
+    show_firmware_version(physical_port)
 
 # 'lpmode' subgroup
 @cli.group()
@@ -903,6 +951,291 @@ def reset(port_name):
 
         i += 1
 
+# 'firmware' subgroup
+@cli.group()
+def firmware():
+    """Download/Upgrade firmware on the transceiver"""
+    pass
+
+def run_firmware(port_name, mode):
+    status = 0
+    physical_port = logical_port_to_physical_port_index(port_name)
+    sfp = platform_chassis.get_sfp(physical_port)
+
+    try:
+        api = sfp.get_xcvr_api()
+    except NotImplementedError:
+        click.echo("This functionality is currently not implemented for this platform")
+        sys.exit(ERROR_NOT_IMPLEMENTED)
+
+    if mode == 0:
+        click.echo("Running firmare: Non-hitless Reset to Inactive Image")
+    elif mode == 1:
+        click.echo("Running firmware: Hitless Reset to Inactive Image")
+    elif mode == 2:
+        click.echo("Running firmware: Attempt non-hitless Reset to Running Image")
+    elif mode == 3:
+        click.echo("Running firmware: Attempt Hitless Reset to Running Image")
+    else:
+        click.echo("Running firmwaer: Unknown mode {}".format(mode))
+        sys.exit(EXIT_FAIL)
+
+    try:
+        status = api.cdb_run_firmware(mode)
+    except NotImplementedError:
+        click.echo("This functionality is not applicable for this transceiver")
+
+    return status
+
+def commit_firmware(port_name):
+    status = 0
+    physical_port = logical_port_to_physical_port_index(port_name)
+    sfp = platform_chassis.get_sfp(physical_port)
+
+    try:
+        api = sfp.get_xcvr_api()
+    except NotImplementedError:
+        click.echo("This functionality is currently not implemented for this platform")
+        sys.exit(ERROR_NOT_IMPLEMENTED)
+
+    try:
+        status = api.cdb_commit_firmware()
+    except NotImplementedError:
+        click.echo("This functionality is not applicable for this transceiver")
+
+    return status
+
+def download_firmware(port_name, filepath):
+    """Download firmware on the transceiver"""
+    try:
+        fd = open(filepath, 'rb')
+        fd.seek(0, 2)
+        file_size = fd.tell()
+        fd.seek(0, 0)
+    except FileNotFoundError:
+        click.echo("Firmware file {} NOT found".format(filepath))
+        sys.exit(EXIT_FAIL)
+
+    physical_port = logical_port_to_physical_port_index(port_name)
+    sfp = platform_chassis.get_sfp(physical_port)
+    try:
+        api = sfp.get_xcvr_api()
+    except NotImplementedError:
+        click.echo("This functionality is NOT applicable to this platform")
+        sys.exit(ERROR_NOT_IMPLEMENTED)
+
+    try:
+        fwinfo = api.get_module_fw_mgmt_feature()
+        if fwinfo['status'] == True:
+            startLPLsize, maxblocksize, lplonly_flag, autopaging_flag, writelength = fwinfo['feature']
+        else:
+            click.echo("Failed to fetch CDB Firmware management features")
+            sys.exit(EXIT_FAIL)
+    except NotImplementedError:
+        click.echo("This functionality is NOT applicable for this transceiver")
+        sys.exit(ERROR_NOT_IMPLEMENTED)
+
+    click.echo('CDB: Starting firmware download')
+    startdata = fd.read(startLPLsize)
+    status = api.cdb_start_firmware_download(startLPLsize, startdata, file_size)
+    if status != 1:
+        click.echo('CDB: Start firmware download failed - status {}'.format(status))
+        sys.exit(EXIT_FAIL)
+
+    # Increase the optoe driver's write max to speed up firmware download
+    sfp.set_optoe_write_max(SMBUS_BLOCK_WRITE_SIZE)
+
+    with click.progressbar(length=file_size, label="Downloading ...") as bar:
+        address = 0
+        BLOCK_SIZE = 116 if lplonly_flag else maxblocksize
+        remaining = file_size - startLPLsize
+        while remaining > 0:
+            count = BLOCK_SIZE if remaining >= BLOCK_SIZE else remaining
+            data = fd.read(count)
+            if lplonly_flag:
+                status = api.cdb_lpl_block_write(address, data)
+            else:
+                status = api.cdb_epl_block_write(address, data, autopaging_flag, writelength)
+            bar.update(count)
+            time.sleep(0.1)
+            address += count
+            remaining = remaining - count
+
+    # Restore the optoe driver's write max to '1' (default value)
+    sfp.set_optoe_write_max(1)
+
+    time.sleep(2)
+    status = api.cdb_firmware_download_complete()
+    click.echo('CDB: firmware download complete')
+    return status
+
+# 'run' subcommand
+@firmware.command()
+@click.argument('port_name', required=True, default=None)
+@click.option('--mode', type=click.Choice(["0", "1", "2", "3"]), help="0 = Non-hitless Reset to Inactive Image\n \
+                                                               1 = Hitless Reset to Inactive Image\n \
+                                                               2 = Attempt non-hitless Reset to Running Image\n \
+                                                               3 = Attempt Hitless Reset to Running Image\n")
+def run(port_name, mode):
+    """Run the firmware with default mode=1"""
+    physical_port = logical_port_to_physical_port_index(port_name)
+    sfp = platform_chassis.get_sfp(physical_port)
+
+    try:
+        presence = sfp.get_presence()
+    except NotImplemented:
+        click.echo("sfp get_presence() NOT implemented!")
+        sys.exit(EXIT_FAIL)
+
+    if not presence:
+        click.echo("{}: SFP EEPROM not detected\n".format(port_name))
+        sys.exit(EXIT_FAIL)
+
+    if mode is None:
+        mode = 1
+
+    status = run_firmware(port_name, int(mode))
+    if status != 1:
+        click.echo('Failed to run firmware! CDB status: {}'.format(status))
+        sys.exit(EXIT_FAIL)
+
+    click.echo("Firmware run in mode {} success".format(mode))
+
+# 'commit' subcommand
+@firmware.command()
+@click.argument('port_name', required=True, default=None)
+def commit(port_name):
+    """Commit the running firmware"""
+
+    physical_port = logical_port_to_physical_port_index(port_name)
+    sfp = platform_chassis.get_sfp(physical_port)
+
+    try:
+        presence = sfp.get_presence()
+    except NotImplemented:
+        click.echo("sfp get_presence() NOT implemented!")
+        sys.exit(EXIT_FAIL)
+
+    if not presence:
+        click.echo("{}: SFP EEPROM not detected\n".format(port_name))
+        sys.exit(EXIT_FAIL)
+
+    status = commit_firmware(port_name)
+    if status != 1:
+        click.echo('Failed to commit firmware! CDB status: {}'.format(status))
+        sys.exit(EXIT_FAIL)
+
+    click.echo("Firmware commit successful")
+
+# 'upgrade' subcommand
+@firmware.command()
+@click.argument('port_name', required=True, default=None)
+@click.argument('filepath', required=True, default=None)
+def upgrade(port_name, filepath):
+    """Upgrade firmware on the transceiver"""
+
+    physical_port = logical_port_to_physical_port_index(port_name)
+    sfp = platform_chassis.get_sfp(physical_port)
+
+    try:
+        presence = sfp.get_presence()
+    except NotImplemented:
+        click.echo("sfp get_presence() NOT implemented!")
+        sys.exit(EXIT_FAIL)
+
+    if not presence:
+        click.echo("{}: SFP EEPROM not detected\n".format(port_name))
+        sys.exit(EXIT_FAIL)
+
+    show_firmware_version(physical_port)
+
+    status = download_firmware(port_name, filepath)
+    if status == 1:
+        click.echo("Firmware download complete success")
+    else:
+        click.echo("Firmware download complete failed! CDB status = {}".format(status))
+
+    show_firmware_version(physical_port)
+
+    status = run_firmware(port_name, 1)
+    if status != 1:
+        click.echo('Failed to run firmware! CDB status: {}'.format(status))
+        sys.exit(EXIT_FAIL)
+
+    click.echo("Firmware run in mode 1 successful")
+
+    status = commit_firmware(port_name)
+    if status != 1:
+        click.echo('Failed to commit firmware! CDB status: {}'.format(status))
+        sys.exit(EXIT_FAIL)
+
+    click.echo("Firmware commit successful")
+    show_firmware_version(physical_port)
+
+# 'download' subcommand
+@firmware.command()
+@click.argument('port_name', required=True, default=None)
+@click.argument('filepath', required=True, default=None)
+def download(port_name, filepath):
+    """Download firmware on the transceiver"""
+
+    physical_port = logical_port_to_physical_port_index(port_name)
+    sfp = platform_chassis.get_sfp(physical_port)
+
+    try:
+        presence = sfp.get_presence()
+    except NotImplemented:
+        click.echo("sfp get_presence() NOT implemented!")
+        sys.exit(EXIT_FAIL)
+
+    if not presence:
+        click.echo("{}: SFP EEPROM not detected\n".format(port_name))
+        sys.exit(EXIT_FAIL)
+
+    status = download_firmware(port_name, filepath)
+    if status == 1:
+        click.echo("Firmware download complete success")
+    else:
+        click.echo("Firmware download complete failed! status = {}".format(status))
+        sys.exit(EXIT_FAIL)
+
+# 'unlock' subcommand
+@firmware.command()
+@click.argument('port_name', required=True, default=None)
+@click.option('--password', type=click.INT, help="Password in integer\n")
+def unlock(port_name, password):
+    """Unlock the firmware download feature via CDB host password"""
+    physical_port = logical_port_to_physical_port_index(port_name)
+    sfp = platform_chassis.get_sfp(physical_port)
+
+    try:
+        presence = sfp.get_presence()
+    except NotImplemented:
+        click.echo("sfp get_presence() NOT implemented!")
+        sys.exit(EXIT_FAIL)
+
+    if not presence:
+        click.echo("{}: SFP EEPROM not detected\n".format(port_name))
+        sys.exit(EXIT_FAIL)
+
+    try:
+        api = sfp.get_xcvr_api()
+    except NotImplementedError:
+        click.echo("This functionality is currently not implemented for this platform")
+        sys.exit(ERROR_NOT_IMPLEMENTED)
+
+    if password is None:
+        password = CDB_DEFAULT_HOST_PASSWORD
+    try:
+        status = api.cdb_enter_host_password(int(password))
+    except NotImplementedError:
+        click.echo("This functionality is not applicable for this transceiver")
+        sys.exit(EXIT_FAIL)
+
+    if status == 1:
+        click.echo("CDB: Host password accepted")
+    else:
+        click.echo("CDB: Host password NOT accepted! status = {}".format(status))
 
 # 'version' subcommand
 @cli.command()

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -844,7 +844,7 @@ def fwversion(port_name):
 
     try:
         presence = sfp.get_presence()
-    except NotImplemented:
+    except NotImplementedError:
         click.echo("sfp get_presence() NOT implemented!")
         sys.exit(EXIT_FAIL)
 

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -1056,6 +1056,10 @@ def download_firmware(port_name, filepath):
                 status = api.cdb_lpl_block_write(address, data)
             else:
                 status = api.cdb_epl_block_write(address, data, autopaging_flag, writelength)
+            if (status != 1):
+                click.echo("CDB: firmware download failed! - status {}".format(status))
+                sys.exit(EXIT_FAIL)
+
             bar.update(count)
             time.sleep(0.1)
             address += count
@@ -1083,7 +1087,7 @@ def run(port_name, mode):
 
     try:
         presence = sfp.get_presence()
-    except NotImplemented:
+    except NotImplementedError:
         click.echo("sfp get_presence() NOT implemented!")
         sys.exit(EXIT_FAIL)
 
@@ -1112,7 +1116,7 @@ def commit(port_name):
 
     try:
         presence = sfp.get_presence()
-    except NotImplemented:
+    except NotImplementedError:
         click.echo("sfp get_presence() NOT implemented!")
         sys.exit(EXIT_FAIL)
 
@@ -1139,7 +1143,7 @@ def upgrade(port_name, filepath):
 
     try:
         presence = sfp.get_presence()
-    except NotImplemented:
+    except NotImplementedError:
         click.echo("sfp get_presence() NOT implemented!")
         sys.exit(EXIT_FAIL)
 
@@ -1155,8 +1159,6 @@ def upgrade(port_name, filepath):
     else:
         click.echo("Firmware download complete failed! CDB status = {}".format(status))
 
-    show_firmware_version(physical_port)
-
     status = run_firmware(port_name, 1)
     if status != 1:
         click.echo('Failed to run firmware! CDB status: {}'.format(status))
@@ -1170,7 +1172,6 @@ def upgrade(port_name, filepath):
         sys.exit(EXIT_FAIL)
 
     click.echo("Firmware commit successful")
-    show_firmware_version(physical_port)
 
 # 'download' subcommand
 @firmware.command()
@@ -1184,7 +1185,7 @@ def download(port_name, filepath):
 
     try:
         presence = sfp.get_presence()
-    except NotImplemented:
+    except NotImplementedError:
         click.echo("sfp get_presence() NOT implemented!")
         sys.exit(EXIT_FAIL)
 
@@ -1210,7 +1211,7 @@ def unlock(port_name, password):
 
     try:
         presence = sfp.get_presence()
-    except NotImplemented:
+    except NotImplementedError:
         click.echo("sfp get_presence() NOT implemented!")
         sys.exit(EXIT_FAIL)
 

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -36,8 +36,11 @@ ERROR_PORT_CONFIG_LOAD = 4
 ERROR_NOT_IMPLEMENTED = 5
 ERROR_INVALID_PORT = 6
 SMBUS_BLOCK_WRITE_SIZE = 32
-# Default host password as per CMIS spec
+# Default host password as per CMIS spec:
+# http://www.qsfp-dd.com/wp-content/uploads/2021/05/CMIS5p0.pdf
 CDB_DEFAULT_HOST_PASSWORD = 0x00001011
+
+MAX_LPL_FIRMWARE_BLOCK_SIZE = 116 #Bytes
 
 # TODO: We should share these maps and the formatting functions between sfputil and sfpshow
 QSFP_DATA_MAP = {
@@ -988,7 +991,7 @@ def run_firmware(port_name, mode):
         sys.exit(ERROR_NOT_IMPLEMENTED)
 
     if mode == 0:
-        click.echo("Running firmare: Non-hitless Reset to Inactive Image")
+        click.echo("Running firmware: Non-hitless Reset to Inactive Image")
     elif mode == 1:
         click.echo("Running firmware: Hitless Reset to Inactive Image")
     elif mode == 2:
@@ -1067,7 +1070,7 @@ def download_firmware(port_name, filepath):
 
     with click.progressbar(length=file_size, label="Downloading ...") as bar:
         address = 0
-        BLOCK_SIZE = 116 if lplonly_flag else maxblocksize
+        BLOCK_SIZE = MAX_LPL_FIRMWARE_BLOCK_SIZE if lplonly_flag else maxblocksize
         remaining = file_size - startLPLsize
         while remaining > 0:
             count = BLOCK_SIZE if remaining >= BLOCK_SIZE else remaining

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -1,6 +1,7 @@
 import sys
 import os
 from unittest import mock
+from unittest.mock import MagicMock, patch
 
 from .mock_tables import dbconnector
 
@@ -189,3 +190,54 @@ class TestSfputil(object):
         expected_output_ethernet0 = expected_output[:1]
         output = sfputil.fetch_error_status_from_state_db('Ethernet0', db.db)
         assert output == expected_output_ethernet0
+
+    @patch('sfputil.main.platform_chassis')
+    @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
+    def test_show_firmware_version(self, mock_chassis):
+        mock_sfp = MagicMock()
+        mock_api = MagicMock()
+        mock_sfp.get_xcvr_api = MagicMock(return_value=mock_api)
+        mock_sfp.get_presence.return_value = True
+        mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
+        mock_api.get_module_fw_info.return_value = {'info' : ""}
+        runner = CliRunner()
+        result = runner.invoke(sfputil.cli.commands['show'].commands['fwversion'], ["Ethernet0"])
+        assert result.exit_code == 0
+
+    @patch('sfputil.main.platform_chassis')
+    @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
+    def test_unlock_firmware(self, mock_chassis):
+        mock_sfp = MagicMock()
+        mock_api = MagicMock()
+        mock_sfp.get_xcvr_api = MagicMock(return_value=mock_api)
+        mock_sfp.get_presence.return_value = True
+        mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
+        mock_api.cdb_enter_host_password.return_value = 0
+        runner = CliRunner()
+        result = runner.invoke(sfputil.cli.commands['firmware'].commands['unlock'], ["Ethernet0"])
+        assert result.exit_code == 0
+
+
+    @patch('sfputil.main.platform_chassis')
+    @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
+    def test_run_firmwre(self, mock_chassis):
+        mock_sfp = MagicMock()
+        mock_api = MagicMock()
+        mock_sfp.get_xcvr_api = MagicMock(return_value=mock_api)
+        mock_sfp.get_presence.return_value = True
+        mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
+        mock_api.cdb_run_firmware.return_value = 1
+        status = sfputil.run_firmware("Ethernet0", 1)
+        assert status == 1
+
+    @patch('sfputil.main.platform_chassis')
+    @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
+    def test_commit_firmwre(self, mock_chassis):
+        mock_sfp = MagicMock()
+        mock_api = MagicMock()
+        mock_sfp.get_xcvr_api = MagicMock(return_value=mock_api)
+        mock_sfp.get_presence.return_value = True
+        mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
+        mock_api.cdb_commit_firmware.return_value = 1
+        status = sfputil.commit_firmware("Ethernet0")
+        assert status == 1


### PR DESCRIPTION
Signed-off-by: Prince George <prgeor@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added following sfputil CLIs to support firmware upgrade on QSFP-DD transceivers:-
1. sfputil show fwversion [OPTIONS] <port_name>
2. sfputil firmware [OPTIONS] COMMAND [ARGS] ...
    a. commit - Commit the running firmware
    b. download - Download firmware 
    c. run - Run the firmware
    d. unlock - Unlock firmware download feature
    e. upgrade - Upgrade firmware (combines a,b,c and d as one CLI) 

#### How to verify it
Firmware upgrade done successfully on Inphi, Molex and Centera QSFP-DD modules

#### New command output (if the output of a command-line utility has changed)
![Capture](https://user-images.githubusercontent.com/45705344/143282671-219c7478-fd4e-429e-a1b9-da08938d08be.JPG)

