### PR TITLE
[port] Fix port speed set

### DIFF
--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -109,12 +109,12 @@ class portconfig(object):
     def set_speed(self, port, speed):
         if self.verbose:
             print("Setting speed %s on port %s" % (speed, port))
-        supported_speeds_str = self.get_supported_speeds(port)
-        if supported_speeds_str:
-            if supported_speeds_str.find(str(speed)) == -1:
-                print('Invalid speed specified: {}'.format(speed))
-                print('Valid speeds:{}'.format(supported_speeds_str))
-                exit(1)
+        supported_speeds_str = self.get_supported_speeds(port) or ''
+        supported_speeds = [int(s) for s in supported_speeds_str.split(',')]
+        if int(speed) not in supported_speeds:
+            print('Invalid speed specified: {​​​​​​​}​​​​​​​'.format(speed))
+            print('Valid speeds:{​​​​​​​}​​​​​​​'.format(supported_speeds_str))
+            exit(1)
         self.db.mod_entry(PORT_TABLE_NAME, port, {PORT_SPEED_CONFIG_FIELD_NAME: speed})
 
     def set_fec(self, port, fec):

--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -110,8 +110,8 @@ class portconfig(object):
         if self.verbose:
             print("Setting speed %s on port %s" % (speed, port))
         supported_speeds_str = self.get_supported_speeds(port) or ''
-        supported_speeds = [int(s) for s in supported_speeds_str.split(',')]
-        if int(speed) not in supported_speeds:
+        supported_speeds = [int(s) for s in supported_speeds_str.split(',') if s]
+        if supported_speeds and int(speed) not in supported_speeds:
             print('Invalid speed specified: {}'.format(speed))
             print('Valid speeds:{}'.format(supported_speeds_str))
             exit(1)

--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -112,8 +112,8 @@ class portconfig(object):
         supported_speeds_str = self.get_supported_speeds(port) or ''
         supported_speeds = [int(s) for s in supported_speeds_str.split(',')]
         if int(speed) not in supported_speeds:
-            print('Invalid speed specified: {​​​​​​​}​​​​​​​'.format(speed))
-            print('Valid speeds:{​​​​​​​}​​​​​​​'.format(supported_speeds_str))
+            print('Invalid speed specified: {}'.format(speed))
+            print('Valid speeds:{}'.format(supported_speeds_str))
             exit(1)
         self.db.mod_entry(PORT_TABLE_NAME, port, {PORT_SPEED_CONFIG_FIELD_NAME: speed})
 


### PR DESCRIPTION
Signed-off-by: Mykola Gerasymenko <mykolax.gerasymenko@intel.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Wrong port speed is set if included as a substring in a speed literal.
For example if we have a valid supported speeds for a port with 4 lanes: 40000 and 100000. Then if we try to set 4000.
`sudo config interface speed Ethernet0 4000`
As a result, we will get a wrong set speed 4G:
```
dut:~$ show interfaces status
Interface  Lanes  Speed  MTU  FEC   Alias     Vlan   Oper  Admin   Type      Asym PFC
--------- ------ ------ ----  ---- --------   -----  ----- ------ -----------   -----
Ethernet0  0,1,2,3  4G  9100  rs  Ethernet1/1 routed  up    up   QSFP28 or later     off
```
#### How I did it
Fixed finding the target (set) speed in the supported speeds list.

#### How to verify it
Set the wrong speed, which included as a substring in a speed literal.
For example, for a speed 40000 it is 4000.
If the wrong speed is set, an error message should appear:
```
admin@sonic:~$ sudo config interface speed Ethernet0 4000
Invalid speed specified: 4000
Valid speeds:40000,100000
```
Only speeds from the list of "Valid speeds" have been successfully set.
`sudo config interface speed Ethernet0 40000`
