### PR TITLE
[VS test] [202106]Increase vs test timeout to 240 seconds

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -1,7 +1,7 @@
 parameters:
 - name: timeout
   type: number
-  default: 180
+  default: 240
 
 - name: log_artifact_name
   type: string


### PR DESCRIPTION
Signed-off-by: Sudharsan Dhamal Gopalarathnam <sudharsand@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Increase vs test timeout to 240 seconds similar to https://github.com/Azure/sonic-utilities/pull/1924

Started observing the following error:

##[error]The job running on agent Azure Pipelines 5 ran longer than the maximum time of 180 minutes. For more information, see https://go.microsoft.com/fwlink/?linkid=2077134


#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

