### PR TITLE
[soft-reboot] Add support for platforms based on Device Tree

### DIFF
--- a/scripts/soft-reboot
+++ b/scripts/soft-reboot
@@ -127,7 +127,7 @@ function setup_reboot_variables()
         # Handle architectures supporting Device Tree
         elif [ -f /sys/firmware/devicetree/base/chosen/bootargs ]; then
             KERNEL_IMAGE="$(ls $IMAGE_PATH/boot/vmlinuz-*)"
-            BOOT_OPTIONS=$(cat /sys/firmware/devicetree/base/chosen/bootargs | sed 's/.$/\n/')" SONIC_BOOT_TYPE=soft"
+            BOOT_OPTIONS=$(cat /sys/firmware/devicetree/base/chosen/bootargs | sed 's/.$/\n/')" SONIC_BOOT_TYPE=${BOOT_TYPE_ARG}"
             INITRD=$(echo $KERNEL_IMAGE | sed 's/vmlinuz/initrd.img/g')
 
             # If initrd is a U-Boot uImage, remove the uImage header

--- a/scripts/soft-reboot
+++ b/scripts/soft-reboot
@@ -127,7 +127,7 @@ function setup_reboot_variables()
         # Handle architectures supporting Device Tree
         elif [ -f /sys/firmware/devicetree/base/chosen/bootargs ]; then
             KERNEL_IMAGE="$(ls $IMAGE_PATH/boot/vmlinuz-*)"
-            BOOT_OPTIONS=$(cat /sys/firmware/devicetree/base/chosen/bootargs | sed 's/.$/\n/')" SONIC_BOOT_TYPE=${BOOT_TYPE_ARG}"
+            BOOT_OPTIONS="$(cat /sys/firmware/devicetree/base/chosen/bootargs | sed 's/.$//') SONIC_BOOT_TYPE=${BOOT_TYPE_ARG}"
             INITRD=$(echo $KERNEL_IMAGE | sed 's/vmlinuz/initrd.img/g')
 
             # If initrd is a U-Boot uImage, remove the uImage header

--- a/scripts/soft-reboot
+++ b/scripts/soft-reboot
@@ -117,15 +117,33 @@ function setup_reboot_variables()
     if grep -q aboot_platform= /host/machine.conf; then
         KERNEL_IMAGE="$(ls $IMAGE_PATH/boot/vmlinuz-*)"
         BOOT_OPTIONS="$(cat "$IMAGE_PATH/kernel-cmdline" | tr '\n' ' ') SONIC_BOOT_TYPE=${BOOT_TYPE_ARG}"
+        INITRD=$(echo $KERNEL_IMAGE | sed 's/vmlinuz/initrd.img/g')
     elif grep -q onie_platform= /host/machine.conf; then
-        KERNEL_OPTIONS=$(cat /host/grub/grub.cfg | sed "/$NEXT_SONIC_IMAGE'/,/}/"'!'"g" | grep linux)
-        KERNEL_IMAGE="/host$(echo $KERNEL_OPTIONS | cut -d ' ' -f 2)"
-        BOOT_OPTIONS="$(echo $KERNEL_OPTIONS | sed -e 's/\s*linux\s*/BOOT_IMAGE=/') SONIC_BOOT_TYPE=${BOOT_TYPE_ARG}"
+        if [ -r /host/grub/grub.cfg ]; then
+            KERNEL_OPTIONS=$(cat /host/grub/grub.cfg | sed "/$NEXT_SONIC_IMAGE'/,/}/"'!'"g" | grep linux)
+            KERNEL_IMAGE="/host$(echo $KERNEL_OPTIONS | cut -d ' ' -f 2)"
+            BOOT_OPTIONS="$(echo $KERNEL_OPTIONS | sed -e 's/\s*linux\s*/BOOT_IMAGE=/') SONIC_BOOT_TYPE=${BOOT_TYPE_ARG}"
+            INITRD=$(echo $KERNEL_IMAGE | sed 's/vmlinuz/initrd.img/g')
+        # Handle architectures supporting Device Tree
+        elif [ -f /sys/firmware/devicetree/base/chosen/bootargs ]; then
+            KERNEL_IMAGE="$(ls $IMAGE_PATH/boot/vmlinuz-*)"
+            BOOT_OPTIONS=$(cat /sys/firmware/devicetree/base/chosen/bootargs | sed 's/.$/\n/')" SONIC_BOOT_TYPE=soft"
+            INITRD=$(echo $KERNEL_IMAGE | sed 's/vmlinuz/initrd.img/g')
+
+            # If initrd is a U-Boot uImage, remove the uImage header
+            if file ${INITRD} | grep -q uImage; then
+                INITRD_RAW=$(echo $KERNEL_IMAGE | sed 's/vmlinuz/initrd-raw.img/g')
+                tail -c+65 < ${INITRD} > ${INITRD_RAW}
+                INITRD=${INITRD_RAW}
+            fi
+        else
+            error "Unknown ONIE platform bootloader. ${REBOOT_TYPE} is not supported."
+            exit "${EXIT_NOT_SUPPORTED}"
+        fi
     else
         error "Unknown bootloader. ${REBOOT_TYPE} is not supported."
         exit "${EXIT_NOT_SUPPORTED}"
     fi
-    INITRD=$(echo $KERNEL_IMAGE | sed 's/vmlinuz/initrd.img/g')
 }
 
 function load_kernel() {


### PR DESCRIPTION
The soft-reboot command currently expects a platform that uses GRUB.
Information about the current kernel boot arguments is extracted from the
GRUB config file. This commit adds support for platforms that do not use GRUB
but rather uses Device Tree to define the current kernel boot arguments.
Example platform architectures using Device Tree include armhf and arm64.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add soft-reboot command support for the armhf and arm64 platforms

#### How I did it
Add logic to retrieve kernel boot arguments from the Device Tree rather than from the GRUB config for these platforms

#### How to verify it
Execute the soft-reboot command on an armhf or arm64 platform

#### Previous command output (if the output of a command-line utility has changed)
sudo soft-reboot
Error response from daemon: Container 68b38ffde1c8a95922eed7706a2f92c46e5b6582539cecc4aaa7263803db56e3 is not running
cat: /host/grub/grub.cfg: No such file or directory
requested COLD shutdown
syscall kexec_file_load not available.
Read on /host failed: Is a directory
Cannot read /hostFailed to arm Watchdog for 180 seconds
Nothing has been loaded!

#### New command output (if the output of a command-line utility has changed)
Successful reboot via kexec to Sonic login prompt

