### PR TITLE
preserve old order for config reload

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1421,14 +1421,16 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, disable_arp_cach
         # or by default DEFAULT_CONFIG_DB_FILE. In the case of database service running in namespace,
         # the default config_db<namespaceID>.json format is used.
 
+
         config_gen_opts = ""
+        
+        if os.path.isfile(INIT_CFG_FILE):
+            config_gen_opts += " -j {} ".format(INIT_CFG_FILE)
+        
         if file_format == 'config_db':
             config_gen_opts += ' -j {} '.format(file)
         else:
             config_gen_opts += ' -Y {} '.format(file)
-
-        if os.path.isfile(INIT_CFG_FILE):
-            config_gen_opts += " -j {} ".format(INIT_CFG_FILE)
 
         if namespace is not None:
             config_gen_opts += " -n {} ".format(namespace)


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixes https://github.com/Azure/sonic-buildimage/issues/9473
#### How I did it
Preserve the old order of the config reload

#### How to verify it
Manual tests
- change `SFLOW` feature state
```
admin@vlab-01:~$ show feature status
Feature         State            AutoRestart     SetOwner
--------------  ---------------  --------------  ----------
bgp             enabled          enabled
database        always_enabled   always_enabled
dhcp_relay      enabled          enabled         local
gbsyncd         enabled          enabled
lldp            enabled          enabled
macsec          disabled         enabled
mgmt-framework  enabled          enabled
mux             always_disabled  enabled
nat             disabled         enabled
pmon            enabled          enabled
radv            enabled          enabled
sflow           disabled         enabled
snmp            enabled          enabled
swss            enabled          enabled
syncd           enabled          enabled
teamd           enabled          enabled
telemetry       enabled          enabled
```
```
admin@vlab-01:~$ sudo config feature state sflow enabled
admin@vlab-01:~$ show feature status
Feature         State            AutoRestart     SetOwner
--------------  ---------------  --------------  ----------
bgp             enabled          enabled
database        always_enabled   always_enabled
dhcp_relay      enabled          enabled         local
gbsyncd         enabled          enabled
lldp            enabled          enabled
macsec          disabled         enabled
mgmt-framework  enabled          enabled
mux             always_disabled  enabled
nat             disabled         enabled
pmon            enabled          enabled
radv            enabled          enabled
sflow           enabled          enabled
snmp            enabled          enabled
swss            enabled          enabled
syncd           enabled          enabled
teamd           enabled          enabled
telemetry       enabled          enabled
```
- save config and do config reload
```
admin@vlab-01:~$ sudo config save
Existing files will be overwritten, continue? [y/N]: y
Running command: /usr/local/bin/sonic-cfggen -d --print-data > /etc/sonic/config_db.json
admin@vlab-01:~$ sudo config reload -y
Running command: rm -rf /tmp/dropstat-*
Disabling container monitoring ...
Stopping SONiC target ...
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db.json  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate
Running command: /usr/local/bin/sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t /usr/share/sonic/templates/sonic-environment.j2,/etc/sonic/sonic-environment
Restarting SONiC target ...
Enabling container monitoring ...
Reloading Monit configuration ...
Reinitializing monit daemon
```

- verify the feature state is same as before config reload
```
admin@vlab-01:~$ show feature status
Feature         State            AutoRestart     SetOwner
--------------  ---------------  --------------  ----------
bgp             enabled          enabled
database        always_enabled   always_enabled
dhcp_relay      enabled          enabled         local
gbsyncd         enabled          enabled
lldp            enabled          enabled
macsec          disabled         enabled
mgmt-framework  enabled          enabled
mux             always_disabled  enabled
nat             disabled         enabled
pmon            enabled          enabled
radv            enabled          enabled
sflow           enabled          enabled
snmp            enabled          enabled
swss            enabled          enabled
syncd           enabled          enabled
teamd           enabled          enabled
telemetry       enabled          enabled
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

