### PR TITLE
[warm/fast-reboot] Fix kexec portion to support platforms based on De…

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -27,6 +27,7 @@ SSD_FW_UPDATE="ssd-fw-upgrade"
 TAG_LATEST=yes
 DETACH=no
 LOG_PATH="/var/log/${REBOOT_TYPE}.txt"
+UIMAGE_HDR_SIZE=64
 
 # Require 100M available on the hard drive for warm reboot temp files,
 # Size is in 1K blocks:
@@ -327,15 +328,33 @@ function setup_reboot_variables()
             KERNEL_IMAGE="$(ls $IMAGE_PATH/boot/vmlinuz-*)"
             BOOT_OPTIONS="$(cat "$IMAGE_PATH/kernel-cmdline" | tr '\n' ' ') SONIC_BOOT_TYPE=${BOOT_TYPE_ARG}"
         fi
+        INITRD=$(echo $KERNEL_IMAGE | sed 's/vmlinuz/initrd.img/g')
     elif grep -q onie_platform= /host/machine.conf; then
-        KERNEL_OPTIONS=$(cat /host/grub/grub.cfg | sed "/$NEXT_SONIC_IMAGE'/,/}/"'!'"g" | grep linux)
-        KERNEL_IMAGE="/host$(echo $KERNEL_OPTIONS | cut -d ' ' -f 2)"
-        BOOT_OPTIONS="$(echo $KERNEL_OPTIONS | sed -e 's/\s*linux\s*/BOOT_IMAGE=/') SONIC_BOOT_TYPE=${BOOT_TYPE_ARG}"
+        if [ -r /host/grub/grub.cfg ]; then
+            KERNEL_OPTIONS=$(cat /host/grub/grub.cfg | sed "/$NEXT_SONIC_IMAGE'/,/}/"'!'"g" | grep linux)
+            KERNEL_IMAGE="/host$(echo $KERNEL_OPTIONS | cut -d ' ' -f 2)"
+            BOOT_OPTIONS="$(echo $KERNEL_OPTIONS | sed -e 's/\s*linux\s*/BOOT_IMAGE=/') SONIC_BOOT_TYPE=${BOOT_TYPE_ARG}"
+            INITRD=$(echo $KERNEL_IMAGE | sed 's/vmlinuz/initrd.img/g')
+        # Handle architectures supporting Device Tree
+        elif [ -f /sys/firmware/devicetree/base/chosen/bootargs ]; then
+            KERNEL_IMAGE="$(ls $IMAGE_PATH/boot/vmlinuz-*)"
+            BOOT_OPTIONS="$(cat /sys/firmware/devicetree/base/chosen/bootargs | sed 's/.$//') SONIC_BOOT_TYPE=${BOOT_TYPE_ARG}"
+            INITRD=$(echo $KERNEL_IMAGE | sed 's/vmlinuz/initrd.img/g')
+
+            # If initrd is a U-Boot uImage, remove the uImage header
+            if file ${INITRD} | grep -q uImage; then
+                INITRD_RAW=$(echo $KERNEL_IMAGE | sed 's/vmlinuz/initrd-raw.img/g')
+                tail -c+$((${UIMAGE_HDR_SIZE}+1)) < ${INITRD} > ${INITRD_RAW}
+                INITRD=${INITRD_RAW}
+            fi
+        else
+            error "Unknown ONIE platform bootloader. ${REBOOT_TYPE} is not supported."
+            exit "${EXIT_NOT_SUPPORTED}"
+        fi
     else
         error "Unknown bootloader. ${REBOOT_TYPE} is not supported."
         exit "${EXIT_NOT_SUPPORTED}"
     fi
-    INITRD=$(echo $KERNEL_IMAGE | sed 's/vmlinuz/initrd.img/g')
 }
 
 function check_docker_exec()
@@ -393,7 +412,7 @@ function reboot_pre_check()
         error "Failed to verify next image. Exit code: $INSTALLER_VERIFY_RC"
         exit ${EXIT_SONIC_INSTALLER_VERIFY_REBOOT}
     fi
-    
+
     # Make sure ASIC configuration has not changed between images
     ASIC_CONFIG_CHECK_SCRIPT="/usr/local/bin/asic_config_check"
     ASIC_CONFIG_CHECK_SUCCESS=0

--- a/scripts/soft-reboot
+++ b/scripts/soft-reboot
@@ -5,6 +5,7 @@ REBOOT_TIME=$(date)
 REBOOT_METHOD="/sbin/kexec -e"
 LOG_SSD_HEALTH="/usr/local/bin/log_ssd_health"
 WATCHDOG_UTIL="/usr/local/bin/watchdogutil"
+UIMAGE_HDR_SIZE=64
 
 EXIT_SUCCESS=0
 EXIT_FAILURE=1
@@ -133,7 +134,7 @@ function setup_reboot_variables()
             # If initrd is a U-Boot uImage, remove the uImage header
             if file ${INITRD} | grep -q uImage; then
                 INITRD_RAW=$(echo $KERNEL_IMAGE | sed 's/vmlinuz/initrd-raw.img/g')
-                tail -c+65 < ${INITRD} > ${INITRD_RAW}
+                tail -c+$((${UIMAGE_HDR_SIZE}+1)) < ${INITRD} > ${INITRD_RAW}
                 INITRD=${INITRD_RAW}
             fi
         else


### PR DESCRIPTION
…vice Tree

The warm-reboot and fast-reboot commands currently expect a platform that uses
GRUB.  Information about the current kernel boot arguments is extracted from
the GRUB config file. This commit adds support for platforms that do not use
GRUB but rather use Device Tree to define the current kernel boot arguments.
Example platform architectures using Device Tree include armhf and arm64.

This commit also includes a minor improvement to a similar change made to the
soft-reboot command in PR# [1963](https://github.com/Azure/sonic-utilities/pull/1963)

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix kexec portion of warm-reboot and fast-reboot commands for the armhf and arm64 platforms

#### How I did it
Add logic to retrieve kernel boot arguments from the Device Tree rather than from the GRUB config for these platforms

#### How to verify it
Execute the warm-reboot and fast-reboot commands on an armhf or arm64 platform and confirm that kexec reboots the switch  as expected

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

