### PR TITLE
[generic-config-updater] Improving CreateOnly validator and marking /LOOPBACK_INTERFACE/LOOPBACK#/vrf_name as create-only

### DIFF
--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -380,6 +380,14 @@ class CreateOnlyMoveValidator:
     def __init__(self, path_addressing):
         self.path_addressing = path_addressing
 
+        # TODO: create-only fields are hard-coded for now, it should be moved to YANG models
+        # Each pattern consist of a list of tokens. Token matching starts from the root level of the config.
+        # Each token is either a specific key or '*' to match all keys.
+        self.create_only_patterns = [
+            ["PORT", "*", "lanes"],
+            ["LOOPBACK_INTERFACE", "*", "vrf_name"],
+        ]
+
     def validate(self, move, diff):
         simulated_config = move.apply(diff.current_config)
         paths = set(list(self._get_create_only_paths(diff.current_config)) + list(self._get_create_only_paths(simulated_config)))
@@ -395,15 +403,8 @@ class CreateOnlyMoveValidator:
 
         return True
 
-    # TODO: create-only fields are hard-coded for now, it should be moved to YANG models
     def _get_create_only_paths(self, config):
-        # Each pattern consist of a list of tokens. Token matching starts from the root level of the config.
-        # Each token is either a specific key or '*' to match all keys.
-        create_only_patterns = [
-            ["PORT", "*", "lanes"],
-            ["LOOPBACK_INTERFACE", "*", "vrf_name"]
-        ]
-        for pattern in create_only_patterns:
+        for pattern in self.create_only_patterns:
             for create_only_path in self._get_create_only_path_recursive(config, pattern, [], 0):
                 yield create_only_path
 

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -372,40 +372,46 @@ class UniqueLanesMoveValidator:
 
 class CreateOnlyMoveValidator:
     """
-    A class to validate create-only fields are only added/removed but never replaced.
-    Parents of create-only fields are also only added/removed but never replaced when they contain
-    a modified create-only field.
+    A class to validate create-only fields are only created, but never modified/updated. In other words:
+    - Field cannot be replaced.
+    - Field cannot be added, only if the parent is added.
+    - Field cannot be deleted, only if the parent is deleted.
     """
     def __init__(self, path_addressing):
         self.path_addressing = path_addressing
 
     def validate(self, move, diff):
-        if move.op_type != OperationType.REPLACE:
-            return True
-
-        # The 'create-only' field needs to be common between current and simulated anyway but different.
-        # This means it is enough to just get the paths from current_config, paths that are not common can be ignored.
-        paths = self._get_create_only_paths(diff.current_config)
         simulated_config = move.apply(diff.current_config)
+        paths = set(list(self._get_create_only_paths(diff.current_config)) + list(self._get_create_only_paths(simulated_config)))
 
         for path in paths:
             tokens = self.path_addressing.get_path_tokens(path)
             if self._value_exist_but_different(tokens, diff.current_config, simulated_config):
+                return False
+            if self._value_added_but_parent_exist(tokens, diff.current_config, simulated_config):
+                return False
+            if self._value_removed_but_parent_remain(tokens, diff.current_config, simulated_config):
                 return False
 
         return True
 
     # TODO: create-only fields are hard-coded for now, it should be moved to YANG models
     def _get_create_only_paths(self, config):
-        if "PORT" not in config:
-            return
+        if "PORT" in config:
+            ports = config["PORT"]
 
-        ports = config["PORT"]
+            for port in ports:
+                attrs = ports[port]
+                if "lanes" in attrs:
+                    yield f"/PORT/{port}/lanes"
 
-        for port in ports:
-            attrs = ports[port]
-            if "lanes" in attrs:
-                yield f"/PORT/{port}/lanes"
+        if "LOOPBACK_INTERFACE" in config:
+            interfaces = config["LOOPBACK_INTERFACE"]
+
+            for interface in interfaces:
+                attrs = interfaces[interface]
+                if "vrf_name" in attrs:
+                    yield f"/LOOPBACK_INTERFACE/{interface}/vrf_name"
 
     def _value_exist_but_different(self, tokens, current_config_ptr, simulated_config_ptr):
         for token in tokens:
@@ -421,6 +427,46 @@ class CreateOnlyMoveValidator:
             simulated_config_ptr = simulated_config_ptr[mod_token]
 
         return current_config_ptr != simulated_config_ptr
+
+    def _value_added_but_parent_exist(self, tokens, current_config_ptr, simulated_config_ptr):
+        # if value is not added, return false
+        if not self._exist_only_in_first(tokens, simulated_config_ptr, current_config_ptr):
+            return False
+
+        # if parent is added, return false
+        if self._exist_only_in_first(tokens[:-1], simulated_config_ptr, current_config_ptr):
+            return False
+
+        # otherwise parent exist and value is added
+        return True
+
+    def _value_removed_but_parent_remain(self, tokens, current_config_ptr, simulated_config_ptr):
+        # if value is not removed, return false
+        if not self._exist_only_in_first(tokens, current_config_ptr, simulated_config_ptr):
+            return False
+
+        # if parent is removed, return false
+        if self._exist_only_in_first(tokens[:-1], current_config_ptr, simulated_config_ptr):
+            return False
+
+        # otherwise parent remained and value is removed
+        return True
+
+    def _exist_only_in_first(self, tokens, first_config_ptr, second_config_ptr):
+        for token in tokens:
+            mod_token = int(token) if isinstance(first_config_ptr, list) else token
+
+            if mod_token not in second_config_ptr:
+                return True
+
+            if mod_token not in first_config_ptr:
+                return False
+
+            first_config_ptr = first_config_ptr[mod_token]
+            second_config_ptr = second_config_ptr[mod_token]
+
+        # tokens exist in both
+        return False
 
 class NoDependencyMoveValidator:
     """

--- a/tests/generic_config_updater/files/config_db_with_loopback_interfaces.json
+++ b/tests/generic_config_updater/files/config_db_with_loopback_interfaces.json
@@ -1,0 +1,16 @@
+{
+    "LOOPBACK_INTERFACE": {
+        "Loopback0": {},
+        "Loopback0|10.1.0.32/32": {},
+        "Loopback0|1100:1::32/128": {},
+        "Loopback1": {
+            "vrf_name": "Vrf_02"
+        },
+        "Loopback1|20.2.0.32/32": {},
+        "Loopback1|2200:2::32/128": {}
+    },
+    "VRF": {
+        "Vrf_01": {},
+        "Vrf_02": {}
+    }
+}


### PR DESCRIPTION
#### What I did
Fix #1962

Updated `create-only` flag meaning.

From, Field is not replaceable but can be added or deleted. In other words:
- Field can be added
- Field can be deleted
- Field cannot be replaced

To, Field is only created, but never modified/updated. In other words:
- Field cannot be added, only if the parent is added
- Field cannot be deleted, only if the parent is deleted
- Field cannot be replaced

Also marked `/LOOPBACK_INTERFACE/LOOPBACK#/vrf_name` as `create-only`

#### How I did it
- Field was already not replaceable -- so no changes
- If field is added, but parent already exist -- fail create-only validation
- If field is deleted, but parent remain -- fail create-only validation

#### How to verify it
unit-test

#### Examples
Check issue to see how `apply-patch` behaved before this fix.

Each example below we show configdb, vrf_01, vrf_02, and ip interfaces before and after the update.

**Adding vrf_name**
```sh
admin@vlab-01:~/lo$ show run all | grep -i 'loopback0\|vrf_01' -a3
        }
    },
    "LOOPBACK_INTERFACE": {
        "Loopback0": {},
        "Loopback0|10.1.0.32/32": {},
        "Loopback0|FC00:1::32/128": {}
    },
    "MAP_PFC_PRIORITY_TO_QUEUE": {
        "AZURE": {
--
        }
    },
    "VRF": {
        "Vrf_01": {},
        "Vrf_02": {}
    },
    "WRED_PROFILE": {
admin@vlab-01:~/lo$ show ip route vrf Vrf_01
admin@vlab-01:~/lo$ show ip route vrf Vrf_02
admin@vlab-01:~/lo$ show ip interfaces | grep -i loopback0
Loopback0                  10.1.0.32/32         up/up         N/A             N/A
admin@vlab-01:~/lo$ sudo config apply-patch add-lo0-vrf01.json-patch -i /BGP_NEIGHBOR -i /DEVICE_METADATA -i /FEATURE -i /FLEX_COUNTER_TABLE -i /VLAN/Vlan1000/members -i /SCHEDULER -i /QUEUE
Patch Applier: Patch application starting.
Patch Applier: Patch: [{"op": "add", "path": "/LOOPBACK_INTERFACE/Loopback0/vrf_name", "value": "Vrf_01"}]
Patch Applier: Getting current config db.
Patch Applier: Simulating the target full config after applying the patch.
Patch Applier: Validating target config does not have empty tables, since they do not show up in ConfigDb.
Patch Applier: Sorting patch updates.
Note: Below table(s) have no YANG models:
BGP_PEER_RANGE, CABLE_LENGTH, CONSOLE_SWITCH, DEVICE_NEIGHBOR_METADATA, DHCP_SERVER, KDUMP, RESTAPI, SNMP, SNMP_COMMUNITY, SYSLOG_SERVER, TELEMETRY, 
Note: Below table(s) have no YANG models:
BGP_PEER_RANGE, CABLE_LENGTH, CONSOLE_SWITCH, DEVICE_NEIGHBOR_METADATA, DHCP_SERVER, KDUMP, RESTAPI, SNMP, SNMP_COMMUNITY, SYSLOG_SERVER, TELEMETRY, 
Note: Below table(s) have no YANG models:
BGP_PEER_RANGE, CABLE_LENGTH, CONSOLE_SWITCH, DEVICE_NEIGHBOR_METADATA, DHCP_SERVER, KDUMP, RESTAPI, SNMP, SNMP_COMMUNITY, SYSLOG_SERVER, TELEMETRY, 
libyang[0]: Must condition "(current() = ../../LOOPBACK_INTERFACE_LIST[name=current()]/name)" not satisfied. (path: /sonic-loopback-interface:sonic-loopback-interface/LOOPBACK_INTERFACE/LOOPBACK_INTERFACE_IPPREFIX_LIST[name='Loopback0'][ip-prefix='10.1.0.32/32']/name)
libyang[0]: Must condition not satisfied, Try adding lo<>: {}, Example: 'lo1': {} (path: /sonic-loopback-interface:sonic-loopback-interface/LOOPBACK_INTERFACE/LOOPBACK_INTERFACE_IPPREFIX_LIST[name='Loopback0'][ip-prefix='10.1.0.32/32']/name)
sonic_yang(3):Data Loading Failed:Must condition not satisfied, Try adding lo<>: {}, Example: 'lo1': {}
Patch Applier: The patch was sorted into 4 changes:
Patch Applier:   * [{"op": "remove", "path": "/LOOPBACK_INTERFACE"}]
Patch Applier:   * [{"op": "add", "path": "/LOOPBACK_INTERFACE", "value": {"Loopback0": {"vrf_name": "Vrf_01"}}}]
Patch Applier:   * [{"op": "add", "path": "/LOOPBACK_INTERFACE/Loopback0|10.1.0.32~132", "value": {}}]
Patch Applier:   * [{"op": "add", "path": "/LOOPBACK_INTERFACE/Loopback0|FC00:1::32~1128", "value": {}}]
Patch Applier: Applying 4 changes in order:
Patch Applier:   * [{"op": "remove", "path": "/LOOPBACK_INTERFACE"}]
Patch Applier:   * [{"op": "add", "path": "/LOOPBACK_INTERFACE", "value": {"Loopback0": {"vrf_name": "Vrf_01"}}}]
Patch Applier:   * [{"op": "add", "path": "/LOOPBACK_INTERFACE/Loopback0|10.1.0.32~132", "value": {}}]
Patch Applier:   * [{"op": "add", "path": "/LOOPBACK_INTERFACE/Loopback0|FC00:1::32~1128", "value": {}}]
Patch Applier: Verifying patch updates are reflected on ConfigDB.
Patch Applier: Patch application completed.
Patch applied successfully.
admin@vlab-01:~/lo$ show run all | grep -i 'loopback0\|vrf_01' -a3
        }
    },
    "LOOPBACK_INTERFACE": {
        "Loopback0": {
            "vrf_name": "Vrf_01"
        },
        "Loopback0|10.1.0.32/32": {},
        "Loopback0|FC00:1::32/128": {}
    },
    "MAP_PFC_PRIORITY_TO_QUEUE": {
        "AZURE": {
--
        }
    },
    "VRF": {
        "Vrf_01": {},
        "Vrf_02": {}
    },
    "WRED_PROFILE": {
admin@vlab-01:~/lo$ show ip route vrf Vrf_01
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup

VRF Vrf_01:
C>* 10.1.0.32/32 is directly connected, Loopback0, 00:00:19

admin@vlab-01:~/lo$ show ip route vrf Vrf_02
admin@vlab-01:~/lo$ show ip interfaces | grep -i loopback0
Loopback0        Vrf_01    10.1.0.32/32         up/up         N/A             N/A
admin@vlab-01:~/lo$ 
```

**Replacing vrf_name**
```sh
admin@vlab-01:~/lo$ show run all | grep -i 'loopback0\|vrf_01' -a3
        }
    },
    "LOOPBACK_INTERFACE": {
        "Loopback0": {
            "vrf_name": "Vrf_01"
        },
        "Loopback0|10.1.0.32/32": {},
        "Loopback0|FC00:1::32/128": {}
    },
    "MAP_PFC_PRIORITY_TO_QUEUE": {
        "AZURE": {
--
        }
    },
    "VRF": {
        "Vrf_01": {},
        "Vrf_02": {}
    },
    "WRED_PROFILE": {
admin@vlab-01:~/lo$ show ip route vrf Vrf_01
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup

VRF Vrf_01:
C>* 10.1.0.32/32 is directly connected, Loopback0, 00:00:19

admin@vlab-01:~/lo$ show ip route vrf Vrf_02
admin@vlab-01:~/lo$ show ip interfaces | grep -i loopback0
Loopback0        Vrf_01    10.1.0.32/32         up/up         N/A             N/A
admin@vlab-01:~/lo$ sudo config apply-patch replace-lo0-vrf02.json-patch -i /BGP_NEIGHBOR -i /DEVICE_METADATA -i /FEATURE -i /FLEX_COUNTER_TABLE -i /VLAN/Vlan1000/members -i /SCHEDULER -i /QUEUE
Patch Applier: Patch application starting.
Patch Applier: Patch: [{"op": "replace", "path": "/LOOPBACK_INTERFACE/Loopback0/vrf_name", "value": "Vrf_02"}]
Patch Applier: Getting current config db.
Patch Applier: Simulating the target full config after applying the patch.
Patch Applier: Validating target config does not have empty tables, since they do not show up in ConfigDb.
Patch Applier: Sorting patch updates.
Note: Below table(s) have no YANG models:
BGP_PEER_RANGE, CABLE_LENGTH, CONSOLE_SWITCH, DEVICE_NEIGHBOR_METADATA, DHCP_SERVER, KDUMP, RESTAPI, SNMP, SNMP_COMMUNITY, SYSLOG_SERVER, TELEMETRY, 
Note: Below table(s) have no YANG models:
BGP_PEER_RANGE, CABLE_LENGTH, CONSOLE_SWITCH, DEVICE_NEIGHBOR_METADATA, DHCP_SERVER, KDUMP, RESTAPI, SNMP, SNMP_COMMUNITY, SYSLOG_SERVER, TELEMETRY, 
Note: Below table(s) have no YANG models:
BGP_PEER_RANGE, CABLE_LENGTH, CONSOLE_SWITCH, DEVICE_NEIGHBOR_METADATA, DHCP_SERVER, KDUMP, RESTAPI, SNMP, SNMP_COMMUNITY, SYSLOG_SERVER, TELEMETRY, 
libyang[0]: Must condition "(current() = ../../LOOPBACK_INTERFACE_LIST[name=current()]/name)" not satisfied. (path: /sonic-loopback-interface:sonic-loopback-interface/LOOPBACK_INTERFACE/LOOPBACK_INTERFACE_IPPREFIX_LIST[name='Loopback0'][ip-prefix='10.1.0.32/32']/name)
libyang[0]: Must condition not satisfied, Try adding lo<>: {}, Example: 'lo1': {} (path: /sonic-loopback-interface:sonic-loopback-interface/LOOPBACK_INTERFACE/LOOPBACK_INTERFACE_IPPREFIX_LIST[name='Loopback0'][ip-prefix='10.1.0.32/32']/name)
sonic_yang(3):Data Loading Failed:Must condition not satisfied, Try adding lo<>: {}, Example: 'lo1': {}
Patch Applier: The patch was sorted into 4 changes:
Patch Applier:   * [{"op": "remove", "path": "/LOOPBACK_INTERFACE"}]
Patch Applier:   * [{"op": "add", "path": "/LOOPBACK_INTERFACE", "value": {"Loopback0": {"vrf_name": "Vrf_02"}}}]
Patch Applier:   * [{"op": "add", "path": "/LOOPBACK_INTERFACE/Loopback0|10.1.0.32~132", "value": {}}]
Patch Applier:   * [{"op": "add", "path": "/LOOPBACK_INTERFACE/Loopback0|FC00:1::32~1128", "value": {}}]
Patch Applier: Applying 4 changes in order:
Patch Applier:   * [{"op": "remove", "path": "/LOOPBACK_INTERFACE"}]
Patch Applier:   * [{"op": "add", "path": "/LOOPBACK_INTERFACE", "value": {"Loopback0": {"vrf_name": "Vrf_02"}}}]
Patch Applier:   * [{"op": "add", "path": "/LOOPBACK_INTERFACE/Loopback0|10.1.0.32~132", "value": {}}]
Patch Applier:   * [{"op": "add", "path": "/LOOPBACK_INTERFACE/Loopback0|FC00:1::32~1128", "value": {}}]
Patch Applier: Verifying patch updates are reflected on ConfigDB.
Patch Applier: Patch application completed.
Patch applied successfully.
admin@vlab-01:~/lo$ show run all | grep -i 'loopback0\|vrf_01' -a3        }
    },
    "LOOPBACK_INTERFACE": {
        "Loopback0": {
            "vrf_name": "Vrf_02"
        },
        "Loopback0|10.1.0.32/32": {},
        "Loopback0|FC00:1::32/128": {}
    },
    "MAP_PFC_PRIORITY_TO_QUEUE": {
        "AZURE": {
--
        }
    },
    "VRF": {
        "Vrf_01": {},
        "Vrf_02": {}
    },
    "WRED_PROFILE": {
admin@vlab-01:~/lo$ show ip route vrf Vrf_01
admin@vlab-01:~/lo$ show ip route vrf Vrf_02
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup

VRF Vrf_02:
C>* 10.1.0.32/32 is directly connected, Loopback0, 00:00:29

admin@vlab-01:~/lo$ show ip interfaces | grep -i loopback0
Loopback0        Vrf_02    10.1.0.32/32         up/up         N/A             N/A
admin@vlab-01:~/lo$ 
```

**Removing vrf_name**
```sh
admin@vlab-01:~/lo$ show run all | grep -i 'loopback0\|vrf_01' -a3        }
    },
    "LOOPBACK_INTERFACE": {
        "Loopback0": {
            "vrf_name": "Vrf_02"
        },
        "Loopback0|10.1.0.32/32": {},
        "Loopback0|FC00:1::32/128": {}
    },
    "MAP_PFC_PRIORITY_TO_QUEUE": {
        "AZURE": {
--
        }
    },
    "VRF": {
        "Vrf_01": {},
        "Vrf_02": {}
    },
    "WRED_PROFILE": {
admin@vlab-01:~/lo$ show ip route vrf Vrf_01
admin@vlab-01:~/lo$ show ip route vrf Vrf_02
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup

VRF Vrf_02:
C>* 10.1.0.32/32 is directly connected, Loopback0, 00:00:29

admin@vlab-01:~/lo$ show ip interfaces | grep -i loopback0
Loopback0        Vrf_02    10.1.0.32/32         up/up         N/A             N/A
admin@vlab-01:~/lo$ sudo config apply-patch remove-lo0-vrf02.json-patch -i /BGP_NEIGHBOR -i /DEVICE_METADATA -i /FEATURE -i /FLEX_COUNTER_TABLE -i /VLAN/Vlan1000/members -i /SCHEDULER -i /QUEUE
Patch Applier: Patch application starting.
Patch Applier: Patch: [{"op": "remove", "path": "/LOOPBACK_INTERFACE/Loopback0/vrf_name"}]
Patch Applier: Getting current config db.
Patch Applier: Simulating the target full config after applying the patch.
Patch Applier: Validating target config does not have empty tables, since they do not show up in ConfigDb.
Patch Applier: Sorting patch updates.
Note: Below table(s) have no YANG models:
BGP_PEER_RANGE, CABLE_LENGTH, CONSOLE_SWITCH, DEVICE_NEIGHBOR_METADATA, DHCP_SERVER, KDUMP, RESTAPI, SNMP, SNMP_COMMUNITY, SYSLOG_SERVER, TELEMETRY, 
Note: Below table(s) have no YANG models:
BGP_PEER_RANGE, CABLE_LENGTH, CONSOLE_SWITCH, DEVICE_NEIGHBOR_METADATA, DHCP_SERVER, KDUMP, RESTAPI, SNMP, SNMP_COMMUNITY, SYSLOG_SERVER, TELEMETRY, 
Note: Below table(s) have no YANG models:
BGP_PEER_RANGE, CABLE_LENGTH, CONSOLE_SWITCH, DEVICE_NEIGHBOR_METADATA, DHCP_SERVER, KDUMP, RESTAPI, SNMP, SNMP_COMMUNITY, SYSLOG_SERVER, TELEMETRY, 
libyang[0]: Must condition "(current() = ../../LOOPBACK_INTERFACE_LIST[name=current()]/name)" not satisfied. (path: /sonic-loopback-interface:sonic-loopback-interface/LOOPBACK_INTERFACE/LOOPBACK_INTERFACE_IPPREFIX_LIST[name='Loopback0'][ip-prefix='10.1.0.32/32']/name)
libyang[0]: Must condition not satisfied, Try adding lo<>: {}, Example: 'lo1': {} (path: /sonic-loopback-interface:sonic-loopback-interface/LOOPBACK_INTERFACE/LOOPBACK_INTERFACE_IPPREFIX_LIST[name='Loopback0'][ip-prefix='10.1.0.32/32']/name)
sonic_yang(3):Data Loading Failed:Must condition not satisfied, Try adding lo<>: {}, Example: 'lo1': {}
Patch Applier: The patch was sorted into 4 changes:
Patch Applier:   * [{"op": "remove", "path": "/LOOPBACK_INTERFACE"}]
Patch Applier:   * [{"op": "add", "path": "/LOOPBACK_INTERFACE", "value": {"Loopback0": {}}}]
Patch Applier:   * [{"op": "add", "path": "/LOOPBACK_INTERFACE/Loopback0|10.1.0.32~132", "value": {}}]
Patch Applier:   * [{"op": "add", "path": "/LOOPBACK_INTERFACE/Loopback0|FC00:1::32~1128", "value": {}}]
Patch Applier: Applying 4 changes in order:
Patch Applier:   * [{"op": "remove", "path": "/LOOPBACK_INTERFACE"}]
Patch Applier:   * [{"op": "add", "path": "/LOOPBACK_INTERFACE", "value": {"Loopback0": {}}}]
Patch Applier:   * [{"op": "add", "path": "/LOOPBACK_INTERFACE/Loopback0|10.1.0.32~132", "value": {}}]
Patch Applier:   * [{"op": "add", "path": "/LOOPBACK_INTERFACE/Loopback0|FC00:1::32~1128", "value": {}}]
Patch Applier: Verifying patch updates are reflected on ConfigDB.
Patch Applier: Patch application completed.
Patch applied successfully.
admin@vlab-01:~/lo$ show run all | grep -i 'loopback0\|vrf_01' -a3
        }
    },
    "LOOPBACK_INTERFACE": {
        "Loopback0": {},
        "Loopback0|10.1.0.32/32": {},
        "Loopback0|FC00:1::32/128": {}
    },
    "MAP_PFC_PRIORITY_TO_QUEUE": {
        "AZURE": {
--
        }
    },
    "VRF": {
        "Vrf_01": {},
        "Vrf_02": {}
    },
    "WRED_PROFILE": {
admin@vlab-01:~/lo$ show ip route vrf Vrf_01
admin@vlab-01:~/lo$ show ip route vrf Vrf_02
admin@vlab-01:~/lo$ show ip interfaces | grep -i loopback0
Loopback0                  10.1.0.32/32         up/up         N/A             N/A
admin@vlab-01:~/lo$ 
```
