### PR TITLE
Revert "[sonic-package-manager] support sonic-cli-gen and packages wi…

### DIFF
--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -2,13 +2,8 @@
 config_mgmt.py provides classes for configuration validation and for Dynamic
 Port Breakout.
 '''
-
-import os
 import re
-import shutil
 import syslog
-import tempfile
-import yang as ly
 from json import load
 from sys import flags
 from time import sleep as tsleep
@@ -51,37 +46,33 @@ class ConfigMgmt():
         try:
             self.configdbJsonIn = None
             self.configdbJsonOut = None
-            self.source = source
             self.allowTablesWithoutYang = allowTablesWithoutYang
 
             # logging vars
             self.SYSLOG_IDENTIFIER = "ConfigMgmt"
             self.DEBUG = debug
 
-            self.__init_sonic_yang()
+            self.sy = sonic_yang.SonicYang(YANG_DIR, debug=debug)
+            # load yang models
+            self.sy.loadYangModel()
+            # load jIn from config DB or from config DB json file.
+            if source.lower() == 'configdb':
+                self.readConfigDB()
+            # treat any other source as file input
+            else:
+                self.readConfigDBJson(source)
+            # this will crop config, xlate and load.
+            self.sy.loadData(self.configdbJsonIn)
+
+            # Raise if tables without YANG models are not allowed but exist.
+            if not allowTablesWithoutYang and len(self.sy.tablesWithOutYang):
+                raise Exception('Config has tables without YANG models')
 
         except Exception as e:
             self.sysLog(doPrint=True, logLevel=syslog.LOG_ERR, msg=str(e))
             raise Exception('ConfigMgmt Class creation failed')
 
         return
-
-    def __init_sonic_yang(self):
-        self.sy = sonic_yang.SonicYang(YANG_DIR, debug=self.DEBUG)
-        # load yang models
-        self.sy.loadYangModel()
-        # load jIn from config DB or from config DB json file.
-        if self.source.lower() == 'configdb':
-            self.readConfigDB()
-        # treat any other source as file input
-        else:
-            self.readConfigDBJson(self.source)
-        # this will crop config, xlate and load.
-        self.sy.loadData(self.configdbJsonIn)
-
-        # Raise if tables without YANG models are not allowed but exist.
-        if not self.allowTablesWithoutYang and len(self.sy.tablesWithOutYang):
-            raise Exception('Config has tables without YANG models')
 
     def __del__(self):
         pass
@@ -221,69 +212,6 @@ class ConfigMgmt():
         configdb.mod_config(sonic_cfggen.FormatConverter.output_to_db(data))
 
         return
-
-    def add_module(self, yang_module_str):
-        """
-        Validate and add new YANG module to the system.
-
-        Parameters:
-            yang_module_str (str): YANG module in string representation.
-
-        Returns:
-            None
-        """
-
-        module_name = self.get_module_name(yang_module_str)
-        module_path = os.path.join(YANG_DIR, '{}.yang'.format(module_name))
-        if os.path.exists(module_path):
-            raise Exception('{} already exists'.format(module_name))
-        with open(module_path, 'w') as module_file:
-            module_file.write(yang_module_str)
-        try:
-            self.__init_sonic_yang()
-        except Exception:
-            os.remove(module_path)
-            raise
-
-    def remove_module(self, module_name):
-        """
-        Remove YANG module from the system and validate.
-
-        Parameters:
-            module_name (str): YANG module name.
-
-        Returns:
-            None
-        """
-
-        module_path = os.path.join(YANG_DIR, '{}.yang'.format(module_name))
-        if not os.path.exists(module_path):
-            return
-        temp = tempfile.NamedTemporaryFile(delete=False)
-        try:
-            shutil.move(module_path, temp.name)
-            self.__init_sonic_yang()
-        except Exception:
-            shutil.move(temp.name, module_path)
-            raise
-
-    @staticmethod
-    def get_module_name(yang_module_str):
-        """
-        Read yangs module name from yang_module_str
-
-        Parameters:
-            yang_module_str(str): YANG module string.
-
-        Returns:
-            str: Module name
-        """
-
-        # Instantiate new context since parse_module_mem() loads the module into context.
-        sy = sonic_yang.SonicYang(YANG_DIR)
-        module = sy.ctx.parse_module_mem(yang_module_str, ly.LYS_IN_YANG)
-        return module.name()
-
 
 # End of Class ConfigMgmt
 
@@ -489,8 +417,8 @@ class ConfigMgmtDPB(ConfigMgmt):
                     deps.extend(dep)
 
             # No further action with no force and deps exist
-            if not force and deps:
-                return configToLoad, deps, False
+            if force == False and deps:
+                return configToLoad, deps, False;
 
             # delets all deps, No topological sort is needed as of now, if deletion
             # of deps fails, return immediately
@@ -508,8 +436,8 @@ class ConfigMgmtDPB(ConfigMgmt):
                 self.sy.deleteNode(str(xPathPort))
 
             # Let`s Validate the tree now
-            if not self.validateConfigData():
-                return configToLoad, deps, False
+            if self.validateConfigData()==False:
+                return configToLoad, deps, False;
 
             # All great if we are here, Lets get the diff
             self.configdbJsonOut = self.sy.getData()

--- a/sonic_package_manager/main.py
+++ b/sonic_package_manager/main.py
@@ -414,11 +414,10 @@ def reset(ctx, name, force, yes, skip_host_plugins):
 
 @cli.command()
 @add_options(PACKAGE_COMMON_OPERATION_OPTIONS)
-@click.option('--keep-config', is_flag=True, help='Keep features configuration in CONFIG DB.')
 @click.argument('name')
 @click.pass_context
 @root_privileges_required
-def uninstall(ctx, name, force, yes, keep_config):
+def uninstall(ctx, name, force, yes):
     """ Uninstall package. """
 
     manager: PackageManager = ctx.obj
@@ -429,7 +428,6 @@ def uninstall(ctx, name, force, yes, keep_config):
 
     uninstall_opts = {
         'force': force,
-        'keep_config': keep_config,
     }
 
     try:

--- a/sonic_package_manager/manifest.py
+++ b/sonic_package_manager/manifest.py
@@ -205,9 +205,7 @@ class ManifestSchema:
             ManifestField('mandatory', DefaultMarshaller(bool), False),
             ManifestField('show', DefaultMarshaller(str), ''),
             ManifestField('config', DefaultMarshaller(str), ''),
-            ManifestField('clear', DefaultMarshaller(str), ''),
-            ManifestField('auto-generate-show', DefaultMarshaller(bool), False),
-            ManifestField('auto-generate-config', DefaultMarshaller(bool), False),
+            ManifestField('clear', DefaultMarshaller(str), '')
         ])
     ])
 

--- a/sonic_package_manager/metadata.py
+++ b/sonic_package_manager/metadata.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 
 import json
 import tarfile
-from typing import Dict, Optional
+from typing import Dict
 
 from sonic_package_manager import utils
 from sonic_package_manager.errors import MetadataError
@@ -54,7 +54,6 @@ class Metadata:
 
     manifest: Manifest
     components: Dict[str, Version] = field(default_factory=dict)
-    yang_module_str: Optional[str] = None
 
 
 class MetadataResolver:
@@ -164,6 +163,5 @@ class MetadataResolver:
                 except ValueError as err:
                     raise MetadataError(f'Failed to parse component version: {err}')
 
-        yang_module_str = sonic_metadata.get('yang-module')
+        return Metadata(Manifest.marshal(manifest_dict), components)
 
-        return Metadata(Manifest.marshal(manifest_dict), components, yang_module_str)

--- a/sonic_package_manager/service_creator/feature.py
+++ b/sonic_package_manager/service_creator/feature.py
@@ -144,3 +144,15 @@ class FeatureRegistry:
             'has_global_scope': str(manifest['service']['host-service']),
             'has_timer': str(manifest['service']['delayed']),
         }
+
+    def _get_tables(self):
+        tables = []
+        running = self._sonic_db.running_table(FEATURE)
+        if running is not None:  # it's Ok if there is no database container running
+            tables.append(running)
+        persistent = self._sonic_db.persistent_table(FEATURE)
+        if persistent is not None:  # it's Ok if there is no config_db.json
+            tables.append(persistent)
+        tables.append(self._sonic_db.initial_table(FEATURE))  # init_cfg.json is must
+
+        return tables


### PR DESCRIPTION
Revert #1650 

This reverts commit f5e5a567f7e6f87eb3de81d29d988e042940e49a.


Getting following build failure while updating sonic-utilities submodule [PR9467](https://github.com/Azure/sonic-buildimage/pull/9467)
```
2021-12-13T11:10:48.6811881Z "gbsyncd": {
2021-12-13T11:10:48.6812291Z         "repository": "docker-gbsyncd-vs",
2021-12-13T11:10:48.6812715Z         "description": "SONiC gbsyncd package",
2021-12-13T11:10:48.6813182Z         "default-reference": "1.0.0",
2021-12-13T11:10:48.6813725Z         "installed-version": "1.0.0",
2021-12-13T11:10:48.6814236Z         "built-in": true,
2021-12-13T11:10:48.6814867Z         "installed": true
2021-12-13T11:10:48.6815196Z     }
2021-12-13T11:10:48.6815357Z 
2021-12-13T11:10:48.6815555Z }
2021-12-13T11:10:48.6815934Z + '[' 0 '!=' 0 ']'
2021-12-13T11:10:48.6816655Z + sudo cp files/build_templates/docker_image_ctl.j2 ./fsroot-vs/usr/share/sonic/templates/docker_image_ctl.j2
2021-12-13T11:10:48.6817592Z + sudo LANG=C DOCKER_HOST= chroot ./fsroot-vs /usr/local/bin/generate_shutdown_order.py
2021-12-13T11:10:48.6819243Z libyang[0]: Value "{% if not (DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and DEVICE_METADATA['localhost']['type'] != 'ToRRouter') %}enabled{% else %}disabled{% endif %}" does not satisfy the constraint "enabled|disabled|always_enabled|always_disabled" (range, length, or pattern). (path: /sonic-feature:sonic-feature/FEATURE/FEATURE_LIST[name='dhcp_relay']/state)
2021-12-13T11:10:48.6821253Z sonic_yang(3):Data Loading Failed:Value "{% if not (DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and DEVICE_METADATA['localhost']['type'] != 'ToRRouter') %}enabled{% else %}disabled{% endif %}" does not satisfy the constraint "enabled|disabled|always_enabled|always_disabled" (range, length, or pattern).
2021-12-13T11:10:48.6822091Z Data Loading Failed
2021-12-13T11:10:48.6823172Z Value "{% if not (DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and DEVICE_METADATA['localhost']['type'] != 'ToRRouter') %}enabled{% else %}disabled{% endif %}" does not satisfy the constraint "enabled|disabled|always_enabled|always_disabled" (range, length, or pattern).
2021-12-13T11:10:48.6823980Z Traceback (most recent call last):
2021-12-13T11:10:48.6824541Z   File "/usr/local/lib/python3.9/dist-packages/sonic_yang_ext.py", line 1065, in loadData
2021-12-13T11:10:48.6825037Z     self.root = self.ctx.parse_data_mem(dumps(self.xlateJson), \
2021-12-13T11:10:48.6825605Z   File "/usr/lib/python3/dist-packages/yang.py", line 2604, in parse_data_mem
2021-12-13T11:10:48.6826068Z     return _yang.Context_parse_data_mem(self, data, format, options)
2021-12-13T11:10:48.6827257Z RuntimeError: Value "{% if not (DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and DEVICE_METADATA['localhost']['type'] != 'ToRRouter') %}enabled{% else %}disabled{% endif %}" does not satisfy the constraint "enabled|disabled|always_enabled|always_disabled" (range, length, or pattern).
2021-12-13T11:10:48.6827923Z 
2021-12-13T11:10:48.6831352Z During handling of the above exception, another exception occurred:
2021-12-13T11:10:48.6831689Z 
2021-12-13T11:10:48.6831968Z Traceback (most recent call last):
2021-12-13T11:10:48.6832674Z   File "/usr/local/lib/python3.9/dist-packages/config/config_mgmt.py", line 61, in __init__
2021-12-13T11:10:48.6833344Z     self.__init_sonic_yang()
2021-12-13T11:10:48.6833926Z   File "/usr/local/lib/python3.9/dist-packages/config/config_mgmt.py", line 80, in __init_sonic_yang
2021-12-13T11:10:48.6834407Z     self.sy.loadData(self.configdbJsonIn)
2021-12-13T11:10:48.6834958Z   File "/usr/local/lib/python3.9/dist-packages/sonic_yang_ext.py", line 1072, in loadData
2021-12-13T11:10:48.6835465Z     raise SonicYangException("Data Loading Failed\n{}".format(str(e)))
2021-12-13T11:10:48.6835827Z sonic_yang_ext.SonicYangException: Data Loading Failed
2021-12-13T11:10:48.6836962Z Value "{% if not (DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and DEVICE_METADATA['localhost']['type'] != 'ToRRouter') %}enabled{% else %}disabled{% endif %}" does not satisfy the constraint "enabled|disabled|always_enabled|always_disabled" (range, length, or pattern).
2021-12-13T11:10:48.6837604Z 
2021-12-13T11:10:48.6837951Z During handling of the above exception, another exception occurred:
2021-12-13T11:10:48.6838154Z 
2021-12-13T11:10:48.6838377Z Traceback (most recent call last):
2021-12-13T11:10:48.6838835Z   File "/usr/local/bin/generate_shutdown_order.py", line 15, in <module>
2021-12-13T11:10:48.6839142Z     main()
2021-12-13T11:10:48.6839425Z   File "/usr/local/bin/generate_shutdown_order.py", line 8, in main
2021-12-13T11:10:48.6839959Z     manager = PackageManager.get_manager()
2021-12-13T11:10:48.6840567Z   File "/usr/local/lib/python3.9/dist-packages/sonic_package_manager/manager.py", line 1012, in get_manager
2021-12-13T11:10:48.6841085Z     cfg_mgmt = config_mgmt.ConfigMgmt(source=INIT_CFG_JSON)
2021-12-13T11:10:48.6841660Z   File "/usr/local/lib/python3.9/dist-packages/config/config_mgmt.py", line 65, in __init__
2021-12-13T11:10:48.6842296Z     raise Exception('ConfigMgmt Class creation failed')
2021-12-13T11:10:48.6842704Z Exception: ConfigMgmt Class creation failed
2021-12-13T11:10:48.6842987Z + clean_proc
2021-12-13T11:10:48.6843210Z + sudo umount /proc
2021-12-13T11:10:48.6843443Z + clean_sys
2021-12-13T11:10:48.6844659Z + sudo chroot ./fsroot-vs umount /sys/fs/cgroup/blkio /sys/fs/cgroup/cpu /sys/fs/cgroup/cpu,cpuacct /sys/fs/cgroup/cpuacct /sys/fs/cgroup/cpuset /sys/fs/cgroup/devices /sys/fs/cgroup/freezer /sys/fs/cgroup/hugetlb /sys/fs/cgroup/memory /sys/fs/cgroup/net_cls /sys/fs/cgroup/net_cls,net_prio /sys/fs/cgroup/net_prio /sys/fs/cgroup/perf_event /sys/fs/cgroup/pids /sys/fs/cgroup/rdma /sys/fs/cgroup/systemd /sys/fs/cgroup /sys
2021-12-13T11:10:48.6845590Z umount: /sys/fs/cgroup/cpu: no mount point specified.
2021-12-13T11:10:48.6845957Z umount: /sys/fs/cgroup/cpu,cpuacct: no mount point specified.
2021-12-13T11:10:48.6846371Z umount: /sys/fs/cgroup/cpuacct: no mount point specified.
2021-12-13T11:10:48.6846735Z umount: /sys/fs/cgroup/net_cls: no mount point specified.
2021-12-13T11:10:48.6847096Z umount: /sys/fs/cgroup/net_cls,net_prio: no mount point specified.
2021-12-13T11:10:48.6847557Z umount: /sys/fs/cgroup/net_prio: no mount point specified.
2021-12-13T11:10:48.6847907Z umount: /sys/fs/cgroup/systemd: no mount point specified.
2021-12-13T11:10:48.6848187Z + true
2021-12-13T11:10:48.6848380Z + true
2021-12-13T11:10:48.6848793Z + sudo LANG=C chroot ./fsroot-vs umount /proc
2021-12-13T11:10:48.6849132Z + true
2021-12-13T11:10:48.6849547Z [  FAIL LOG END  ] [ target/sonic-vs.img.gz ]
2021-12-13T11:10:48.6850110Z make: *** [slave.mk:990: target/sonic-vs.img.gz] Error 1
2021-12-13T11:10:50.3928072Z make[1]: *** [Makefile.work:309: target/sonic-vs.img.gz] Error 2
2021-12-13T11:10:50.3928876Z make[1]: Leaving directory '/agent/_work/1/s'
2021-12-13T11:10:50.3929425Z make: *** [Makefile:33: target/sonic-vs.img.gz] Error 2
2021-12-13T11:10:50.4767031Z ##[error]Bash exited with code '2'.
2021-12-13T11:10:50.5440899Z ##[section]Finishing: Build sonic image
```
