### PR TITLE
Update swss_ready check to check per namespace swss service

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -767,8 +767,20 @@ def _delay_timers_elapsed():
             return False
     return True
 
+def _per_namespace_swss_ready(service_name):
+    out = clicommon.run_command("systemctl show {} --property ActiveState --value".format(service_name), return_cmd=True)
+    if out.strip() != "active":
+        return False
+    out = clicommon.run_command("systemctl show {} --property ActiveEnterTimestampMonotonic --value".format(service_name), return_cmd=True)
+    swss_up_time = float(out.strip())/1000000
+    now =  time.monotonic()
+    if (now - swss_up_time > 120):
+        return True
+    else:
+        return False
+
 def _swss_ready():
-    list_of_swss = []
+    list_of_swss = [] 
     num_asics = multi_asic.get_num_asics()
     if num_asics == 1:
         list_of_swss.append("swss.service")
@@ -781,19 +793,7 @@ def _swss_ready():
         if _per_namespace_swss_ready(service_name) == False:
             return False
 
-    return True
-
-def _per_namespace_swss_ready(service_name):
-    out = clicommon.run_command("systemctl show {} --property ActiveState --value".format(service_name), return_cmd=True)
-    if out.strip() != "active":
-        return False
-    out = clicommon.run_command("systemctl show {} --property ActiveEnterTimestampMonotonic --value".format(service_name), return_cmd=True)
-    swss_up_time = float(out.strip())/1000000
-    now =  time.monotonic()
-    if (now - swss_up_time > 120):
-        return True
-    else:
-        return False
+    return True 
 
 def _is_system_starting():
     out = clicommon.run_command("sudo systemctl is-system-running", return_cmd=True)

--- a/config/main.py
+++ b/config/main.py
@@ -768,10 +768,26 @@ def _delay_timers_elapsed():
     return True
 
 def _swss_ready():
-    out = clicommon.run_command("systemctl show swss.service --property ActiveState --value", return_cmd=True)
+    list_of_swss = []
+    num_asics = multi_asic.get_num_asics()
+    if num_asics == 1:
+        list_of_swss.append("swss.service")
+    else:
+        for asic in range(num_asics):
+            service = "swss@{}.service".format(asic)
+            list_of_swss.append(service)
+
+    for service_name in list_of_swss:
+        if _per_namespace_swss_ready(service_name) == False:
+            return False
+
+    return True
+
+def _per_namespace_swss_ready(service_name):
+    out = clicommon.run_command("systemctl show {} --property ActiveState --value".format(service_name), return_cmd=True)
     if out.strip() != "active":
         return False
-    out = clicommon.run_command("systemctl show swss.service --property ActiveEnterTimestampMonotonic --value", return_cmd=True)
+    out = clicommon.run_command("systemctl show {} --property ActiveEnterTimestampMonotonic --value".format(service_name), return_cmd=True)
     swss_up_time = float(out.strip())/1000000
     now =  time.monotonic()
     if (now - swss_up_time > 120):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
fixes https://github.com/Azure/sonic-buildimage/issues/9411
on multi-asic platform, config reload CLI was not working without -f option.
This was because swss_ready function was checking status of swss.service and multi-asic platform will not have swss.service, it will have per-namespace swss service.

#### How I did it
Fix swss_ready function to check all swss services status running on the platform.

#### How to verify it
On multi-asic platform, before Fix:
admin@vlab-08:~$ sudo config reload -y
SwSS container is not ready. Retry later or use -f to avoid system checks

After fix, on multi-asic platform, execute config load_minigraph to reload all services, immediately after that execute config reload. This should print swss not ready message.
Once swss services are up, execute config reload again and this time it should run without -f option.
```
admin@vlab-08:~$ sudo config load_minigraph -y
Disabling container monitoring ...
Stopping SONiC target ...
..
admin@vlab-08:~$ sudo config reload -y
SwSS container is not ready. Retry later or use -f to avoid system checks
admin@vlab-08:~$ sudo config reload -y
SwSS container is not ready. Retry later or use -f to avoid system checks
admin@vlab-08:~$ sudo config reload -y
Running command: rm -rf /tmp/dropstat-*
Disabling container monitoring ...
Stopping SONiC target ...
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/config_db.json  -j /etc/sonic/init_cfg.json  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/config_db0.json  -j /etc/sonic/init_cfg.json  -n asic0  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic0
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/config_db1.json  -j /etc/sonic/init_cfg.json  -n asic1  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic1
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/config_db2.json  -j /etc/sonic/init_cfg.json  -n asic2  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic2
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/config_db3.json  -j /etc/sonic/init_cfg.json  -n asic3  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic3
Running command: /usr/local/bin/sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t /usr/share/sonic/templates/sonic-environment.j2,/etc/sonic/sonic-environment
Restarting SONiC target ...
Enabling container monitoring ...
Reloading Monit configuration ...
Reinitializing monit daemon

admin@vlab-08:~$ docker ps
CONTAINER ID   IMAGE                                COMMAND                  CREATED       STATUS              PORTS     NAMES
81bb5eda49c7   docker-router-advertiser:latest      "/usr/bin/docker-iniâ€¦"   5 hours ago   Up 58 seconds                 radv
c15141bab5c8   docker-lldp:latest                   "/usr/bin/docker-lldâ€¦"   5 hours ago   Up 59 seconds                 lldp0
6e04586084ac   docker-lldp:latest                   "/usr/bin/docker-lldâ€¦"   5 hours ago   Up 59 seconds                 lldp2
f0a1003ad30e   docker-sonic-mgmt-framework:latest   "/usr/local/bin/supeâ€¦"   5 hours ago   Up 59 seconds                 mgmt-framework
d26c2cd31995   docker-sonic-telemetry:latest        "/usr/local/bin/supeâ€¦"   5 hours ago   Up 59 seconds                 telemetry
88f09b440b2e   docker-snmp:latest                   "/usr/local/bin/supeâ€¦"   5 hours ago   Up 58 seconds                 snmp
39149a821ced   docker-lldp:latest                   "/usr/bin/docker-lldâ€¦"   5 hours ago   Up About a minute             lldp3
70b18b3dc0ad   docker-lldp:latest                   "/usr/bin/docker-lldâ€¦"   5 hours ago   Up 59 seconds                 lldp1
32c8ab784421   docker-syncd-vs:latest               "/usr/local/bin/supeâ€¦"   5 hours ago   Up About a minute             syncd0
34301c9ec75c   docker-syncd-vs:latest               "/usr/local/bin/supeâ€¦"   5 hours ago   Up About a minute             syncd3
6e50ff68bceb   docker-teamd:latest                  "/usr/local/bin/supeâ€¦"   5 hours ago   Up About a minute             teamd1
1a280a802f56   docker-syncd-vs:latest               "/usr/local/bin/supeâ€¦"   5 hours ago   Up About a minute             syncd1
ad2e0746e4db   docker-teamd:latest                  "/usr/local/bin/supeâ€¦"   5 hours ago   Up About a minute             teamd0
5ec3f7d12756   docker-syncd-vs:latest               "/usr/local/bin/supeâ€¦"   5 hours ago   Up About a minute             syncd2
9934bbad6dbb   docker-teamd:latest                  "/usr/local/bin/supeâ€¦"   5 hours ago   Up About a minute             teamd3
dd968a9047cd   docker-teamd:latest                  "/usr/local/bin/supeâ€¦"   5 hours ago   Up About a minute             teamd2
f786f22755f4   docker-orchagent:latest              "/usr/bin/docker-iniâ€¦"   5 hours ago   Up About a minute             swss0
d289e9cfe24e   docker-orchagent:latest              "/usr/bin/docker-iniâ€¦"   5 hours ago   Up About a minute             swss3
1af61d7a515e   docker-orchagent:latest              "/usr/bin/docker-iniâ€¦"   5 hours ago   Up About a minute             swss1
2e41c739ab92   docker-orchagent:latest              "/usr/bin/docker-iniâ€¦"   5 hours ago   Up About a minute             swss2
854709d17784   docker-gbsyncd-vs:latest             "/usr/local/bin/supeâ€¦"   5 hours ago   Up About a minute             gbsyncd
13b6a70936a4   docker-fpm-frr:latest                "/usr/bin/docker_iniâ€¦"   5 hours ago   Up About a minute             bgp2
0b79dd040480   docker-fpm-frr:latest                "/usr/bin/docker_iniâ€¦"   5 hours ago   Up About a minute             bgp1
d399e4663437   docker-fpm-frr:latest                "/usr/bin/docker_iniâ€¦"   5 hours ago   Up About a minute             bgp3
0a828098d038   docker-fpm-frr:latest                "/usr/bin/docker_iniâ€¦"   5 hours ago   Up About a minute             bgp0
e872fe014506   docker-lldp:latest                   "/usr/bin/docker-lldâ€¦"   5 hours ago   Up About a minute             lldp
8e76c59481e0   docker-platform-monitor:latest       "/usr/bin/docker_iniâ€¦"   5 hours ago   Up About a minute             pmon
edf8db5ce850   docker-database:latest               "/usr/local/bin/dockâ€¦"   5 hours ago   Up 5 hours                    database0
f0d325b5abfb   docker-database:latest               "/usr/local/bin/dockâ€¦"   5 hours ago   Up 5 hours                    database1
67515aad1976   docker-database:latest               "/usr/local/bin/dockâ€¦"   5 hours ago   Up 5 hours                    database2
060396d764c9   docker-database:latest               "/usr/local/bin/dockâ€¦"   5 hours ago   Up 5 hours                    database3
d4c131e48bdc   docker-database:latest               "/usr/local/bin/dockâ€¦"   5 hours ago   Up 5 hours                    database
```
Verified that there is no change on single asic VS:
```
admin@vlab-01:~$ sudo config load_minigraph -y
Disabling container monitoring ...
Stopping SONiC target ...
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json   --write-to-db
Running command: pfcwd start_default
Running command: /usr/local/bin/sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t /usr/share/sonic/templates/sonic-environment.j2,/etc/sonic/sonic-environment
Running command: config qos reload --no-dynamic-buffer
Running command: /usr/local/bin/sonic-cfggen  -d --write-to-db -t /usr/share/sonic/device/x86_64-kvm_x86_64-r0/Force10-S6000/buffers.json.j2,config-db -t /usr/share/sonic/device/x86_64-kvm_x86_64-r0/Force10-S6000/qos.json.j2,config-db -y /etc/sonic/sonic_version.yml
Restarting SONiC target ...
Enabling container monitoring ...
Reloading Monit configuration ...
Reinitializing monit daemon
Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`.
admin@vlab-01:~$ sudo config reload -y
SwSS container is not ready. Retry later or use -f to avoid system checks
admin@vlab-01:~$ sudo config reload -y
SwSS container is not ready. Retry later or use -f to avoid system checks
admin@vlab-01:~$ sudo config reload -y
SwSS container is not ready. Retry later or use -f to avoid system checks
admin@vlab-01:~$ sudo config reload -y
SwSS container is not ready. Retry later or use -f to avoid system checks
admin@vlab-01:~$ sudo config reload -y
SwSS container is not ready. Retry later or use -f to avoid system checks
admin@vlab-01:~$ sudo config reload -y
Running command: rm -rf /tmp/dropstat-*
Disabling container monitoring ...
Stopping SONiC target ...
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/config_db.json  -j /etc/sonic/init_cfg.json  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate
Running command: /usr/local/bin/sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t /usr/share/sonic/templates/sonic-environment.j2,/etc/sonic/sonic-environment
Restarting SONiC target ...
Enabling container monitoring ...
Reloading Monit configuration ...
Reinitializing monit daemon
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

