### PR TITLE
[GCU] Using test yang models instead of real yang models for unit-tests

### DIFF
--- a/tests/generic_config_updater/files/test-yang-models/sonic-acl.yang
+++ b/tests/generic_config_updater/files/test-yang-models/sonic-acl.yang
@@ -1,0 +1,284 @@
+/* this is sonic py yang model */
+module sonic-acl {
+
+	yang-version 1.1;
+
+	namespace "http://github.com/Azure/sonic-acl";
+	prefix acl;
+
+	import ietf-inet-types {
+		prefix inet;
+	}
+
+	import sonic-types {
+		prefix stypes;
+		revision-date 2019-07-01;
+	}
+
+	import sonic-extension {
+		prefix ext;
+		revision-date 2019-07-01;
+	}
+
+	import sonic-port {
+		prefix port;
+		revision-date 2019-07-01;
+	}
+
+	import sonic-portchannel {
+		prefix lag;
+	}
+
+	description "ACL YANG Module for SONiC OS";
+
+	revision 2019-07-01 {
+		description "First Revision";
+	}
+
+	container sonic-acl {
+
+		container ACL_RULE {
+
+			description "ACL_RULE part of config_db.json";
+
+			list ACL_RULE_LIST {
+
+				key "ACL_TABLE_NAME RULE_NAME";
+
+				leaf ACL_TABLE_NAME {
+					type leafref {
+						path "/acl:sonic-acl/acl:ACL_TABLE/acl:ACL_TABLE_LIST/acl:ACL_TABLE_NAME";
+					}
+				}
+
+				leaf RULE_NAME {
+					type string {
+						length 1..255;
+					}
+				}
+
+				leaf PACKET_ACTION {
+					type stypes:packet_action;
+				}
+
+				leaf IP_TYPE {
+					type stypes:ip_type;
+				}
+
+				leaf PRIORITY {
+					type uint32 {
+						range 0..999999;
+					}
+				}
+
+				choice ip_prefix {
+
+					case ip4_prefix {
+						when "boolean(IP_TYPE[.='ANY' or .='IP' or .='IPV4' or .='IPv4ANY' or .='ARP'])";
+						leaf SRC_IP {
+							type inet:ipv4-prefix;
+						}
+
+						leaf DST_IP {
+							type inet:ipv4-prefix;
+						}
+					}
+
+					case ip6_prefix {
+						when "boolean(IP_TYPE[.='ANY' or .='IP' or .='IPV6' or .='IPv6ANY'])";
+						leaf SRC_IPV6 {
+							type inet:ipv6-prefix;
+						}
+
+						leaf DST_IPV6 {
+							type inet:ipv6-prefix;
+						}
+					}
+				}
+
+				leaf-list IN_PORTS {
+					/* Values in leaf list are UNIQUE */
+					type uint16;
+				}
+
+				leaf-list OUT_PORTS {
+					/* Values in leaf list are UNIQUE */
+					type uint16;
+				}
+
+				choice src_port {
+					case l4_src_port {
+						leaf L4_SRC_PORT {
+							type uint16;
+						}
+					}
+
+					case l4_src_port_range {
+						leaf L4_SRC_PORT_RANGE {
+							type string {
+								pattern '([0-9]{1,4}|[0-5][0-9]{4}|[6][0-4][0-9]{3}|[6][5][0-2][0-9]{2}|[6][5][3][0-5]{2}|[6][5][3][6][0-5])-([0-9]{1,4}|[0-5][0-9]{4}|[6][0-4][0-9]{3}|[6][5][0-2][0-9]{2}|[6][5][3][0-5]{2}|[6][5][3][6][0-5])';
+							}
+						}
+					}
+				}
+
+				choice dst_port {
+					case l4_dst_port {
+						leaf L4_DST_PORT {
+							type uint16;
+						}
+					}
+
+					case l4_dst_port_range {
+						leaf L4_DST_PORT_RANGE {
+							type string {
+								pattern '([0-9]{1,4}|[0-5][0-9]{4}|[6][0-4][0-9]{3}|[6][5][0-2][0-9]{2}|[6][5][3][0-5]{2}|[6][5][3][6][0-5])-([0-9]{1,4}|[0-5][0-9]{4}|[6][0-4][0-9]{3}|[6][5][0-2][0-9]{2}|[6][5][3][0-5]{2}|[6][5][3][6][0-5])';
+							}
+						}
+					}
+				}
+
+				leaf ETHER_TYPE {
+					type string {
+						pattern "(0x88CC|0x8100|0x8915|0x0806|0x0800|0x86DD|0x8847)";
+					}
+				}
+
+				leaf IP_PROTOCOL {
+					type uint8 {
+						range 1..143;
+					}
+				}
+
+				leaf TCP_FLAGS {
+					type string {
+						pattern '0[x][0-9a-fA-F]{1,2}|0[X][0-9a-fA-F]{1,2}';
+					}
+				}
+
+				leaf DSCP {
+					type uint8;
+				}
+
+				leaf TC {
+					type uint8;
+				}
+
+				choice icmp {
+
+					case icmp4 {
+						when "boolean(IP_TYPE[.='ANY' or .='IP' or .='IPV4' or .='IPv4ANY' or .='ARP'])";
+						leaf ICMP_TYPE {
+							type uint8 {
+								range 1..44;
+							}
+						}
+
+						leaf ICMP_CODE {
+							type uint8 {
+								range 1..16;
+							}
+						}
+					}
+
+					case icmp6 {
+						when "boolean(IP_TYPE[.='ANY' or .='IP' or .='IPV6' or .='IPv6ANY'])";
+						leaf ICMPV6_TYPE {
+							type uint8 {
+								range 1..44;
+							}
+						}
+
+						leaf ICMPV6_CODE {
+							type uint8 {
+								range 1..16;
+							}
+						}
+					}
+				}
+
+				leaf INNER_ETHER_TYPE {
+					type string {
+						pattern "(0x88CC|0x8100|0x8915|0x0806|0x0800|0x86DD|0x8847)";
+					}
+				}
+
+				leaf INNER_IP_PROTOCOL {
+					type uint8 {
+						range 1..143;
+					}
+				}
+
+				leaf INNER_L4_SRC_PORT {
+					type uint16;
+				}
+
+				leaf INNER_L4_DST_PORT {
+					type uint16;
+				}
+			}
+			/* end of ACL_RULE_LIST */
+		}
+		/* end of container ACL_RULE */
+
+		container ACL_TABLE {
+
+			description "ACL_TABLE part of config_db.json";
+
+			list ACL_TABLE_LIST {
+
+				key "ACL_TABLE_NAME";
+
+				leaf ACL_TABLE_NAME {
+					type string;
+				}
+
+				leaf policy_desc {
+					type string {
+						length 1..255;
+					}
+				}
+
+				leaf type {
+					mandatory true;
+					type stypes:acl_table_type;
+				}
+
+				leaf stage {
+					type string {
+						pattern "ingress|egress|INGRESS|EGRESS";
+					}
+					default "INGRESS";
+				}
+
+				leaf-list services {
+					type string;
+				}
+
+				leaf-list ports {
+					/* union of leafref is allowed in YANG 1.1 */
+					type union {
+						type leafref {
+							path /port:sonic-port/port:PORT/port:PORT_LIST/port:name;
+						}
+						type leafref {
+							path /lag:sonic-portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST/lag:name;
+						}
+						type string {
+							pattern "";
+						}
+					}
+					/* Today in SONiC, we do not delete the list once
+					 * created, instead we set to empty list. Due to that
+					 * below default values are needed.
+					 */
+					default "";
+				}
+			}
+			/* end of ACL_TABLE_LIST */
+		}
+        /* end of container ACL_TABLE */
+	}
+    /* end of container sonic-acl */
+}
+/* end of module sonic-acl */

--- a/tests/generic_config_updater/files/test-yang-models/sonic-crm.yang
+++ b/tests/generic_config_updater/files/test-yang-models/sonic-crm.yang
@@ -1,0 +1,415 @@
+module sonic-crm {
+
+    yang-version 1.1;
+
+    namespace "http://github.com/Azure/sonic-crm";
+    prefix crm;
+
+    import sonic-types {
+        prefix stypes;
+        revision-date 2019-07-01;
+    }
+
+    description "CRM YANG Module for SONiC OS";
+
+    revision 2020-04-10 {
+        description "First Revision";
+    }
+
+    container sonic-crm {
+
+        container CRM {
+
+            description "CRM part of config_db.json";
+
+            container Config {
+
+                /* typedef specific to CRM */
+                typedef threshold {
+                    type uint16;
+                }
+
+                leaf acl_counter_threshold_type {
+                    must "(((current()='PERCENTAGE' or current()='percentage') and
+                        ../acl_counter_high_threshold<100 and
+                        ../acl_counter_low_threshold<100) or
+                        (current()!='PERCENTAGE' and current()!='percentage'))";
+                    type stypes:crm_threshold_type;
+                }
+
+                leaf acl_counter_high_threshold {
+                    must "(current() > ../acl_counter_low_threshold)"
+                    {
+                        error-message "high_threshold should be more than low_threshold";
+                    }
+                    type threshold;
+                }
+
+                leaf acl_counter_low_threshold {
+                    type threshold;
+                }
+
+                leaf acl_group_threshold_type {
+                    must "(((current()='PERCENTAGE' or current()='percentage') and
+                        ../acl_group_high_threshold<100 and
+                        ../acl_group_low_threshold<100) or
+                        (current()!='PERCENTAGE' and current()!='percentage'))";
+                    type stypes:crm_threshold_type;
+                }
+
+                leaf acl_group_high_threshold {
+                    must "(current() > ../acl_group_low_threshold)"
+                    {
+                        error-message "high_threshold should be more than low_threshold";
+                    }
+                    type threshold;
+                }
+
+                leaf acl_group_low_threshold {
+                    type threshold;
+                }
+
+                leaf acl_entry_threshold_type {
+                    must "(((current()='PERCENTAGE' or current()='percentage') and
+                        ../acl_entry_high_threshold<100 and
+                        ../acl_entry_low_threshold<100) or
+                        (current()!='PERCENTAGE' and current()!='percentage'))";
+                    type stypes:crm_threshold_type;
+                }
+
+                leaf acl_entry_high_threshold {
+                    must "(current() > ../acl_entry_low_threshold)"
+                    {
+                        error-message "high_threshold should be more than low_threshold";
+                    }
+                    type threshold;
+                }
+
+                leaf acl_entry_low_threshold {
+                    type threshold;
+                }
+
+                leaf acl_table_threshold_type {
+                    must "(((current()='PERCENTAGE' or current()='percentage') and
+                        ../acl_table_high_threshold<100 and
+                        ../acl_table_low_threshold<100) or
+                        (current()!='PERCENTAGE' and current()!='percentage'))";
+                    type stypes:crm_threshold_type;
+                }
+
+                leaf acl_table_high_threshold {
+                    must "(current() > ../acl_table_low_threshold)"
+                    {
+                        error-message "high_threshold should be more than low_threshold";
+                    }
+                    type threshold;
+                }
+
+                leaf acl_table_low_threshold {
+                    type threshold;
+                }
+
+                leaf fdb_entry_threshold_type {
+                    must "(((current()='PERCENTAGE' or current()='percentage') and
+                        ../fdb_entry_high_threshold<100 and
+                        ../fdb_entry_low_threshold<100) or
+                        (current()!='PERCENTAGE' and current()!='percentage'))";
+                    type stypes:crm_threshold_type;
+                }
+
+                leaf fdb_entry_high_threshold {
+                    must "(current() > ../fdb_entry_low_threshold)"
+                    {
+                        error-message "high_threshold should be more than low_threshold";
+                    }
+                    type threshold;
+                }
+
+                leaf fdb_entry_low_threshold {
+                    type threshold;
+                }
+
+                leaf ipv4_neighbor_threshold_type {
+                    must "(((current()='PERCENTAGE' or current()='percentage') and
+                        ../ipv4_neighbor_high_threshold<100 and
+                        ../ipv4_neighbor_low_threshold<100) or
+                        (current()!='PERCENTAGE' and current()!='percentage'))";
+                    type stypes:crm_threshold_type;
+                }
+
+                leaf ipv4_neighbor_high_threshold {
+                    must "(current() > ../ipv4_neighbor_low_threshold)"
+                    {
+                        error-message "high_threshold should be more than low_threshold";
+                    }
+                    type threshold;
+                }
+
+                leaf ipv4_neighbor_low_threshold {
+                    type threshold;
+                }
+
+                leaf ipv4_nexthop_threshold_type {
+                    must "(((current()='PERCENTAGE' or current()='percentage') and
+                        ../ipv4_nexthop_high_threshold<100 and
+                        ../ipv4_nexthop_low_threshold<100) or
+                        (current()!='PERCENTAGE' and current()!='percentage'))";
+                    type stypes:crm_threshold_type;
+                }
+
+                leaf ipv4_nexthop_high_threshold {
+                    must "(current() > ../ipv4_nexthop_low_threshold)"
+                    {
+                        error-message "high_threshold should be more than low_threshold";
+                    }
+                    type threshold;
+                }
+
+                leaf ipv4_nexthop_low_threshold {
+                    type threshold;
+                }
+
+                leaf ipv4_route_threshold_type {
+                    must "(((current()='PERCENTAGE' or current()='percentage') and
+                        ../ipv4_route_high_threshold<100 and
+                        ../ipv4_route_low_threshold<100) or
+                        (current()!='PERCENTAGE' and current()!='percentage'))";
+                    type stypes:crm_threshold_type;
+                }
+
+                leaf ipv4_route_high_threshold {
+                    must "(current() > ../ipv4_route_low_threshold)"
+                    {
+                        error-message "high_threshold should be more than low_threshold";
+                    }
+                    type threshold;
+                }
+
+                leaf ipv4_route_low_threshold {
+                    type threshold;
+                }
+
+                leaf ipv6_neighbor_threshold_type {
+                    must "(((current()='PERCENTAGE' or current()='percentage') and
+                        ../ipv6_neighbor_high_threshold<100 and
+                        ../ipv6_neighbor_low_threshold<100) or
+                        (current()!='PERCENTAGE' and current()!='percentage'))";
+                    type stypes:crm_threshold_type;
+                }
+
+                leaf ipv6_neighbor_high_threshold {
+                    must "(current() > ../ipv6_neighbor_low_threshold)"
+                    {
+                        error-message "high_threshold should be more than low_threshold";
+                    }
+                    type threshold;
+                }
+
+                leaf ipv6_neighbor_low_threshold {
+                    type threshold;
+                }
+
+                leaf ipv6_nexthop_threshold_type {
+                    must "(((current()='PERCENTAGE' or current()='percentage') and
+                        ../ipv6_nexthop_high_threshold<100 and
+                        ../ipv6_nexthop_low_threshold<100) or
+                        (current()!='PERCENTAGE' and current()!='percentage'))";
+                    type stypes:crm_threshold_type;
+                }
+
+                leaf ipv6_nexthop_high_threshold {
+                    must "(current() > ../ipv6_nexthop_low_threshold)"
+                    {
+                        error-message "high_threshold should be more than low_threshold";
+                    }
+                    type threshold;
+                }
+
+                leaf ipv6_nexthop_low_threshold {
+                    type threshold;
+                }
+
+                leaf ipv6_route_threshold_type {
+                    must "(((current()='PERCENTAGE' or current()='percentage') and
+                        ../ipv6_route_high_threshold<100 and
+                        ../ipv6_route_low_threshold<100) or
+                        (current()!='PERCENTAGE' and current()!='percentage'))";
+                    type stypes:crm_threshold_type;
+                }
+
+                leaf ipv6_route_high_threshold {
+                    must "(current() > ../ipv6_route_low_threshold)"
+                    {
+                        error-message "high_threshold should be more than low_threshold";
+                    }
+                    type threshold;
+                }
+
+                leaf ipv6_route_low_threshold {
+                    type threshold;
+                }
+
+                leaf nexthop_group_threshold_type {
+                    must "(((current()='PERCENTAGE' or current()='percentage') and
+                        ../nexthop_group_high_threshold<100 and
+                        ../nexthop_group_low_threshold<100) or
+                        (current()!='PERCENTAGE' and current()!='percentage'))";
+                    type stypes:crm_threshold_type;
+                }
+
+                leaf nexthop_group_high_threshold {
+                    must "(current() > ../nexthop_group_low_threshold)"
+                    {
+                        error-message "high_threshold should be more than low_threshold";
+                    }
+                    type threshold;
+                }
+
+                leaf nexthop_group_low_threshold {
+                    type threshold;
+                }
+
+                leaf nexthop_group_member_threshold_type {
+                    must "(((current()='PERCENTAGE' or current()='percentage') and
+                        ../nexthop_group_member_high_threshold<100 and
+                        ../nexthop_group_member_low_threshold<100) or
+                        (current()!='PERCENTAGE' and current()!='percentage'))";
+                    type stypes:crm_threshold_type;
+                }
+
+                leaf nexthop_group_member_high_threshold {
+                    must "(current() > ../nexthop_group_member_low_threshold)"
+                    {
+                        error-message "high_threshold should be more than low_threshold";
+                    }
+                    type threshold;
+                }
+
+                leaf nexthop_group_member_low_threshold {
+                    type threshold;
+                }
+
+                leaf polling_interval {
+                    type threshold;
+                }
+
+                leaf dnat_entry_threshold_type {
+                    must "(((current()='PERCENTAGE' or current()='percentage') and
+                        ../dnat_entry_high_threshold<100 and
+                        ../dnat_entry_low_threshold<100) or
+                        (current()!='PERCENTAGE' and current()!='percentage'))";
+                    type stypes:crm_threshold_type;
+                }
+
+                leaf dnat_entry_high_threshold {
+                    must "(current() > ../dnat_entry_low_threshold)"
+                    {
+                        error-message "high_threshold should be more than low_threshold";
+                    }
+                    type threshold;
+                }
+
+                leaf dnat_entry_low_threshold {
+                    type threshold;
+                }
+
+                leaf snat_entry_threshold_type {
+                    must "(((current()='PERCENTAGE' or current()='percentage') and
+                        ../snat_entry_high_threshold<100 and
+                        ../snat_entry_low_threshold<100) or
+                        (current()!='PERCENTAGE' and current()!='percentage'))";
+                    type stypes:crm_threshold_type;
+                }
+
+                leaf snat_entry_high_threshold {
+                    must "(current() > ../snat_entry_low_threshold)"
+                    {
+                        error-message "high_threshold should be more than low_threshold";
+                    }
+                    type threshold;
+                }
+
+                leaf snat_entry_low_threshold {
+                    type threshold;
+                }
+
+                leaf ipmc_entry_threshold_type {
+                    must "(((current()='PERCENTAGE' or current()='percentage') and
+                        ../ipmc_entry_high_threshold<100 and
+                        ../ipmc_entry_low_threshold<100) or
+                        (current()!='PERCENTAGE' and current()!='percentage'))";
+                    type stypes:crm_threshold_type;
+                }
+
+                leaf ipmc_entry_high_threshold {
+                    must "(current() > ../ipmc_entry_low_threshold)"
+                    {
+                        error-message "high_threshold should be more than low_threshold";
+                    }
+                    type threshold;
+                }
+
+                leaf ipmc_entry_low_threshold {
+                    type threshold;
+                }
+
+                leaf mpls_inseg_threshold_type {
+                    description "CRM threshold support for MPLS in-segment entries";
+
+                    must "(((current()='PERCENTAGE' or current()='percentage') and
+                        ../mpls_inseg_high_threshold<100 and
+                        ../mpls_inseg_low_threshold<100) or
+                        (current()!='PERCENTAGE' and current()!='percentage'))";
+                    type stypes:crm_threshold_type;
+                }
+
+                leaf mpls_inseg_high_threshold {
+                    description "CRM threshold support for MPLS in-segment entries";
+
+                    must "(current() > ../mpls_inseg_low_threshold)"
+                    {
+                        error-message "high_threshold should be more than low_threshold";
+                    }
+                    type threshold;
+                }
+
+                leaf mpls_inseg_low_threshold {
+                    description "CRM threshold support for MPLS in-segment entries";
+
+                    type threshold;
+                }
+
+                leaf mpls_nexthop_threshold_type {
+                    description "CRM threshold support for MPLS next-hops";
+
+                    must "(((current()='PERCENTAGE' or current()='percentage') and
+                        ../mpls_nexthop_high_threshold<100 and
+                        ../mpls_nexthop_low_threshold<100) or
+                        (current()!='PERCENTAGE' and current()!='percentage'))";
+                    type stypes:crm_threshold_type;
+                }
+
+                leaf mpls_nexthop_high_threshold {
+                    description "CRM threshold support for MPLS next-hops";
+
+                    must "(current() > ../mpls_nexthop_low_threshold)"
+                    {
+                        error-message "high_threshold should be more than low_threshold";
+                    }
+                    type threshold;
+                }
+
+                leaf mpls_nexthop_low_threshold {
+                    description "CRM threshold support for MPLS next-hops";
+
+                    type threshold;
+                }
+
+            }
+            /* end of Config */
+        }
+        /* end of container CRM */
+    }
+    /* end of top level container */
+}
+/* end of module sonic-crm */

--- a/tests/generic_config_updater/files/test-yang-models/sonic-device_metadata.yang
+++ b/tests/generic_config_updater/files/test-yang-models/sonic-device_metadata.yang
@@ -1,0 +1,131 @@
+module sonic-device_metadata {
+
+    yang-version 1.1;
+
+    namespace "http://github.com/Azure/sonic-device_metadata";
+    prefix device_metadata;
+
+    import ietf-yang-types {
+        prefix yang;
+    }
+
+    import ietf-inet-types {
+        prefix inet;
+    }
+
+    import sonic-types {
+        prefix stypes;
+        revision-date 2019-07-01;
+    }
+
+    description "DEVICE_METADATA YANG Module for SONiC OS";
+    
+    revision 2021-02-27 {
+        description "Added frr_mgmt_framework_config field to handle BGP 
+            config DB schema events to configure FRR protocols.";
+    }
+
+    revision 2020-04-10 {
+        description "First Revision";
+    }
+
+    container sonic-device_metadata {
+
+        container DEVICE_METADATA {
+
+            description "DEVICE_METADATA part of config_db.json";
+
+            container localhost{
+
+                leaf hwsku {
+                    type stypes:hwsku;
+                }
+
+                leaf default_bgp_status {
+                    type enumeration {
+                        enum up;
+                        enum down;
+                    }
+                    default up;
+                }
+
+                leaf docker_routing_config_mode {
+                    type string {
+                        pattern "unified|split|separated";
+                    }
+                    default "unified";
+                }
+
+                leaf hostname {
+                    type string {
+                        length 1..255;
+                    }
+                }
+
+                leaf platform {
+                    type string {
+                        length 1..255;
+                    }
+                }
+
+                leaf mac {
+                    type yang:mac-address;
+                }
+
+                leaf default_pfcwd_status {
+                    type enumeration {
+                        enum disable;
+                        enum enable;
+                    }
+                    default disable;
+                }
+
+                leaf bgp_asn {
+                    type inet:as-number;
+                }
+
+                leaf deployment_id {
+                    type uint32;
+                }
+
+                leaf type {
+                    type string {
+                        length 1..255;
+                        pattern "ToRRouter|LeafRouter|SpineChassisFrontendRouter|ChassisBackendRouter|ASIC";
+                    }
+                }
+
+                leaf buffer_model {
+                    description "This leaf is added for dynamic buffer calculation.
+                                The dynamic model represents the model in which the buffer configurations,
+                                like the headroom sizes and buffer pool sizes, are dynamically calculated based
+                                on the ports' speed, cable length, and MTU. This model is used by Mellanox so far.
+                                The traditional model represents the model in which all the buffer configurations
+                                are statically configured in CONFIG_DB tables. This is the default model used by all other vendors";
+                    type string {
+                        pattern "dynamic|traditional";
+                    }
+                }
+
+                leaf frr_mgmt_framework_config {
+                    type boolean;
+                    description "FRR configurations are handled by sonic-frr-mgmt-framework module when set to true, 
+                        otherwise, sonic-bgpcfgd handles the FRR configurations based on the predefined templates.";
+                    default "false";
+                }
+
+                leaf synchronous_mode {
+                    type enumeration {
+                        enum enable;
+                        enum disable;
+                    }
+                    default enable;
+                }
+            }
+            /* end of container localhost */
+        }
+        /* end of container DEVICE_METADATA */
+    }
+    /* end of top level container */
+}
+/* end of module sonic-device_metadata */

--- a/tests/generic_config_updater/files/test-yang-models/sonic-extension.yang
+++ b/tests/generic_config_updater/files/test-yang-models/sonic-extension.yang
@@ -1,0 +1,13 @@
+module sonic-extension {
+
+    yang-version 1.1;
+
+    namespace "http://github.com/Azure/sonic-extension";
+    prefix sonic-extension;
+
+    description "Extension yang Module for SONiC OS";
+
+    revision 2019-07-01 {
+        description "First Revision";
+    }
+}

--- a/tests/generic_config_updater/files/test-yang-models/sonic-flex_counter.yang
+++ b/tests/generic_config_updater/files/test-yang-models/sonic-flex_counter.yang
@@ -1,0 +1,169 @@
+module sonic-flex_counter {
+
+    yang-version 1.1;
+
+    namespace "http://github.com/Azure/sonic-flex_counter";
+    prefix flex_counter;
+
+    description "FLEX COUNTER YANG Module for SONiC OS";
+
+    revision 2020-04-10 {
+        description "First Revision";
+    }
+
+    container sonic-flex_counter {
+
+        container FLEX_COUNTER_TABLE {
+
+            /* typedef specific to FLEX_COUNTER_TABLE */
+            typedef flex_status {
+                type enumeration {
+                    enum enable;
+                    enum disable;
+                }
+            }
+
+            typedef flex_delay_status {
+                type boolean;
+            }
+
+            description "FLEX_COUNTER_TABLE part of config_db.json";
+
+            /* below are in alphabetical order */
+
+            container BUFFER_POOL_WATERMARK {
+                /* BUFFER_POOL_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP */
+                leaf FLEX_COUNTER_STATUS {
+                    type flex_status;
+                }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
+                }
+            }
+
+            container DEBUG_COUNTER {
+                /* DEBUG_COUNTER_FLEX_COUNTER_GROUP */
+                leaf FLEX_COUNTER_STATUS {
+                    type flex_status;
+                }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
+                }
+            }
+
+            container PFCWD {
+                /* PFC_WD_FLEX_COUNTER_GROUP */
+                leaf FLEX_COUNTER_STATUS {
+                    type flex_status;
+                }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
+                }
+            }
+
+            container PG_DROP {
+                /* PG_DROP_STAT_COUNTER_FLEX_COUNTER_GROUP */
+                leaf FLEX_COUNTER_STATUS {
+                    type flex_status;
+                }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
+                }
+            }
+
+            container PG_WATERMARK {
+                /* PG_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP */
+                leaf FLEX_COUNTER_STATUS {
+                    type flex_status;
+                }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
+                }
+            }
+
+            container PORT {
+                /* PORT_STAT_COUNTER_FLEX_COUNTER_GROUP */
+                leaf FLEX_COUNTER_STATUS {
+                    type flex_status;
+                }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
+                }
+            }
+
+            container PORT_RATES {
+                /* PORT_BUFFER_DROP_COUNTER_FLEX_COUNTER_GROUP */
+                leaf FLEX_COUNTER_STATUS {
+                    type flex_status;
+                }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
+                }
+            }
+
+            container PORT_BUFFER_DROP {
+                /* PORT_BUFFER_DROP_COUNTER_FLEX_COUNTER_GROUP */
+                leaf FLEX_COUNTER_STATUS {
+                    type flex_status;
+                }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
+                }
+            }
+
+            container QUEUE {
+                /* QUEUE_STAT_COUNTER_FLEX_COUNTER_GROUP */
+                leaf FLEX_COUNTER_STATUS {
+                    type flex_status;
+                }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
+                }
+            }
+
+            container QUEUE_WATERMARK {
+                /* QUEUE_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP */
+                leaf FLEX_COUNTER_STATUS {
+                    type flex_status;
+                }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
+                }
+            }
+
+            container RIF {
+                /* RIF_STAT_COUNTER_FLEX_COUNTER_GROUP */
+                leaf FLEX_COUNTER_STATUS {
+                    type flex_status;
+                }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
+                }
+            }
+
+            container RIF_RATES {
+                /* RIF_RATE_COUNTER_FLEX_COUNTER_GROUP */
+                leaf FLEX_COUNTER_STATUS {
+                    type flex_status;
+                }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
+                }
+            }
+
+            container ACL {
+                /* ACL_STAT_COUNTER_FLEX_COUNTER_GROUP */
+                leaf FLEX_COUNTER_STATUS {
+                    type flex_status;
+                }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
+                }
+            }
+
+        }
+        /* end of container FLEX_COUNTER_TABLE */
+    }
+    /* end of top level container */
+}
+/* end of module sonic-flex_counter */

--- a/tests/generic_config_updater/files/test-yang-models/sonic-interface.yang
+++ b/tests/generic_config_updater/files/test-yang-models/sonic-interface.yang
@@ -1,0 +1,131 @@
+module sonic-interface {
+
+	yang-version 1.1;
+
+	namespace "http://github.com/Azure/sonic-interface";
+	prefix intf;
+
+	import sonic-types {
+		prefix stypes;
+		revision-date 2019-07-01;
+	}
+
+	import sonic-extension {
+		prefix ext;
+		revision-date 2019-07-01;
+	}
+
+	import sonic-port {
+		prefix port;
+		revision-date 2019-07-01;
+	}
+
+	import sonic-vrf {
+		prefix vrf;
+	}
+
+	description "INTERFACE yang Module for SONiC OS";
+
+	revision 2021-03-30 {
+		description "Modify the type of vrf name";
+	}
+
+	revision 2019-07-01 {
+		description "First Revision";
+	}
+
+	container sonic-interface {
+
+		container INTERFACE {
+
+			description "INTERFACE part of config_db.json";
+
+			list INTERFACE_LIST {
+
+				description "INTERFACE part of config_db.json with vrf";
+
+				key "name";
+
+				leaf name {
+					type leafref {
+						path /port:sonic-port/port:PORT/port:PORT_LIST/port:name;
+					}
+				}
+
+				leaf vrf_name {
+					type leafref {
+						path "/vrf:sonic-vrf/vrf:VRF/vrf:VRF_LIST/vrf:name";
+					}
+				}
+
+				leaf nat_zone {
+					description "NAT Zone for the interface";
+					type uint8 {
+						range "0..3" {
+							error-message "Invalid nat zone for the interface.";
+							error-app-tag nat-zone-invalid;
+						}
+					}
+                                        default "0";
+				}
+				leaf mpls {
+					description "Enable/disable MPLS routing for the interface";
+					type enumeration {
+						enum enable;
+						enum disable;
+					}
+				}
+			}
+			/* end of INTERFACE_LIST */
+
+			list INTERFACE_IPPREFIX_LIST {
+
+				description "INTERFACE part of config_db.json with ip-prefix";
+
+				key "name ip-prefix";
+
+				leaf name {
+					/* This node must be present in INTERFACE_LIST */
+					must "(current() = ../../INTERFACE_LIST[name=current()]/name)"
+					{
+						error-message "Must condition not satisfied, Try adding PORT: {}, Example: 'Ethernet0': {}";
+					}
+
+					type leafref {
+						path /port:sonic-port/port:PORT/port:PORT_LIST/port:name;
+					}
+				}
+
+				leaf ip-prefix {
+					type union {
+						type stypes:sonic-ip4-prefix;
+						type stypes:sonic-ip6-prefix;
+					}
+				}
+
+				leaf scope {
+					type enumeration {
+						enum global;
+						enum local;
+					}
+				}
+
+				leaf family {
+
+					/* family leaf needed for backward compatibility
+					   Both ip4 and ip6 address are string in IETF RFC 6021,
+					   so must statement can check based on : or ., family
+					   should be IPv4 or IPv6 according.
+					 */
+
+					must "(contains(../ip-prefix, ':') and current()='IPv6') or
+						(contains(../ip-prefix, '.') and current()='IPv4')";
+					type stypes:ip-family;
+				}
+			}
+			/* end of INTERFACE_IPPREFIX_LIST */
+
+		}
+		/* end of INTERFACE container */
+	}
+}

--- a/tests/generic_config_updater/files/test-yang-models/sonic-loopback-interface.yang
+++ b/tests/generic_config_updater/files/test-yang-models/sonic-loopback-interface.yang
@@ -1,0 +1,103 @@
+module sonic-loopback-interface {
+
+    yang-version 1.1;
+
+    namespace "http://github.com/Azure/sonic-loopback-interface";
+    prefix lointf;
+
+    import sonic-types {
+        prefix stypes;
+        revision-date 2019-07-01;
+    }
+
+    import sonic-extension {
+        prefix ext;
+        revision-date 2019-07-01;
+    }
+
+    import sonic-vrf {
+        prefix vrf;
+    }
+
+    description
+        "SONIC LOOPBACK INTERFACE";
+
+    revision 2021-04-05 {
+        description "Modify the type of vrf name";
+    }
+
+    revision 2020-02-05 {
+        description "First Revision";
+    }
+
+    container sonic-loopback-interface {
+
+        container LOOPBACK_INTERFACE {
+
+            list LOOPBACK_INTERFACE_LIST {
+                key "name";
+
+                leaf name{
+                    type string;
+                }
+
+                leaf vrf_name {
+                    type leafref {
+                        path "/vrf:sonic-vrf/vrf:VRF/vrf:VRF_LIST/vrf:name";
+                    }
+                }
+
+                leaf nat_zone {
+                    description "NAT Zone for the loopback interface";
+                    type uint8 {
+                        range "0..3" {
+                            error-message "Invalid nat zone for the loopback interface.";
+                            error-app-tag nat-zone-invalid;
+                        }
+                    }
+                    default "0";
+                }
+            }
+            /* end of LOOPBACK_INTERFACE_LIST */
+
+            list LOOPBACK_INTERFACE_IPPREFIX_LIST {
+
+                key "name ip-prefix";
+
+                leaf name{
+                     type leafref {
+                        path "../../LOOPBACK_INTERFACE_LIST/name";
+                    }                    
+                }
+
+                leaf ip-prefix {
+                    type union {
+                        type stypes:sonic-ip4-prefix;
+                        type stypes:sonic-ip6-prefix;
+                    }
+                }
+
+                leaf scope {
+                    type enumeration {
+                        enum global;
+                        enum local;
+                    }
+                }
+
+                leaf family {
+
+                    /* family leaf needed for backward compatibility
+                       Both ip4 and ip6 address are string in IETF RFC 6021,
+                       so must statement can check based on : or ., family
+                       should be IPv4 or IPv6 according.
+                     */
+
+                    must "(contains(../ip-prefix, ':') and current()='IPv6') or
+                        (contains(../ip-prefix, '.') and current()='IPv4')";
+                    type stypes:ip-family;
+                }
+            }
+        }
+        /* end of LOOPBACK_INTERFACE_IPPREFIX_LIST */
+    }
+}

--- a/tests/generic_config_updater/files/test-yang-models/sonic-port.yang
+++ b/tests/generic_config_updater/files/test-yang-models/sonic-port.yang
@@ -1,0 +1,149 @@
+module sonic-port{
+
+	yang-version 1.1;
+
+	namespace "http://github.com/Azure/sonic-port";
+	prefix port;
+
+	import sonic-types {
+		prefix stypes;
+		revision-date 2019-07-01;
+	}
+
+	import sonic-extension {
+		prefix ext;
+		revision-date 2019-07-01;
+	}
+
+	description "PORT yang Module for SONiC OS";
+
+	revision 2019-07-01 {
+		description "First Revision";
+	}
+
+	container sonic-port{
+
+		container PORT {
+
+			description "PORT part of config_db.json";
+
+			list PORT_LIST {
+
+				key "name";
+
+				leaf name {
+					type string {
+						length 1..128;
+					}
+				}
+
+				leaf alias {
+					type string {
+						length 1..128;
+					}
+				}
+
+				leaf lanes {
+					mandatory true;
+					type string {
+						length 1..128;
+					}
+				}
+
+				leaf description {
+					type string {
+						length 0..255;
+					}
+				}
+
+				leaf speed {
+					mandatory true;
+					type uint32 {
+						range 1..400000;
+					}
+				}
+
+				leaf autoneg {
+					description "Port auto negotiation mode";
+
+					type string {
+						pattern "on|off";
+					}
+				}
+
+				leaf-list adv_speeds {
+					description "Port advertised speeds, valid value could be a list of interger or all";
+					
+					type union {
+						type uint32 {
+							range 1..400000;
+						}
+						type string {
+							pattern "all";
+						}
+					}
+				}
+
+				must "(count(adv_speeds[text()='all']) = 0) or (count(adv_speeds) = 1)";
+
+				leaf interface_type {
+					description "Port interface type";
+
+					type stypes:interface_type;
+				}
+
+				leaf-list adv_interface_types {
+					description "Port advertised interface type, valid value could be a list of stypes:interface_type or all";
+
+					type union {
+						type stypes:interface_type;
+						type string {
+							pattern "all";
+						}
+					}
+				}
+
+				must "(count(adv_interface_types[text()='all']) = 0) or (count(adv_interface_types) = 1)";
+					
+				leaf mtu {
+					type uint16 {
+						range 1..9216;
+					}
+				}
+
+				leaf index {
+					type uint16 {
+						range 0..256;
+					}
+				}
+
+				leaf admin_status {
+					type stypes:admin_status;
+				}
+
+				leaf fec {
+					type string {
+						pattern "rs|fc|none";
+					}
+				}
+
+				leaf pfc_asym {
+					type string {
+						pattern "on|off";
+					}
+				}
+
+				leaf tpid {
+					description "This leaf describes the possible TPID value that can be configured
+					            to the specified port if the HW supports TPID configuration. The possible
+					            values are 0x8100, 0x9100, 0x9200, 0x88a8, and 0x88A8";
+					type stypes:tpid_type;
+				}
+
+			} /* end of list PORT_LIST */
+
+		} /* end of container PORT */
+
+	} /* end of container sonic-port */
+
+} /* end of module sonic-port */

--- a/tests/generic_config_updater/files/test-yang-models/sonic-portchannel.yang
+++ b/tests/generic_config_updater/files/test-yang-models/sonic-portchannel.yang
@@ -1,0 +1,212 @@
+module sonic-portchannel {
+
+    yang-version 1.1;
+
+    namespace "http://github.com/Azure/sonic-portchannel";
+    prefix lag;
+
+    import sonic-types {
+        prefix stypes;
+        revision-date 2019-07-01;
+    }
+
+    import sonic-extension {
+        prefix ext;
+        revision-date 2019-07-01;
+    }
+
+    import sonic-port {
+        prefix port;
+        revision-date 2019-07-01;
+    }
+
+    import sonic-vrf {
+        prefix vrf;
+    }
+
+    description "PORTCHANNEL yang Module for SONiC OS";
+
+    revision 2021-06-13 {
+        description "Change min-links valid range from 1-128 to 1-1024";
+    }
+
+    revision 2021-03-31 {
+        description "Add PortChannel Interface List with VRF attribute";
+    }
+
+    revision 2021-03-15 {
+        description "Add SONiC PortChannel Interface model";
+    }
+
+    revision 2019-07-01 {
+        description "First Revision";
+    }
+
+
+    container sonic-portchannel {
+
+        container PORTCHANNEL {
+
+            description "PORTCHANNEL part of config_db.json";
+
+            list PORTCHANNEL_LIST {
+
+                key "name";
+
+                leaf name {
+                    type string {
+                        length 1..128;
+                        pattern 'PortChannel[0-9]{1,4}';
+                    }
+                }
+
+                leaf-list members {
+                    /* leaf-list members are unique by default */
+                    type union {
+                        type leafref {
+                            path /port:sonic-port/port:PORT/port:PORT_LIST/port:name;
+                        }
+                        type string {
+                            pattern "";
+                        }
+                    }
+                    /* Today in SONiC, we do not delete the list once
+                     * created, instead we set to empty list. Due to that
+                     * below default values are needed.
+                     */
+                    default "";
+                }
+
+                leaf min_links {
+                    type uint16 {
+                        range 1..1024;
+                    }
+                }
+
+                leaf description {
+                    type string {
+                        length 1..255;
+                    }
+                }
+
+                leaf mtu {
+                    type uint16 {
+                        range 1..9216;
+                    }
+                }
+
+                leaf admin_status {
+                    mandatory true;
+                    type stypes:admin_status;
+                }
+
+                leaf lacp_key {
+                    /* lacp key should be either auto or a integer in the range of 1 to 65535 */
+                    /* When lacp_key is set to 'auto' the lacp key would be set to be the number */
+                    /* on the end of the PortChannel name with a prefix of 1 */
+                    type union {
+                        type string {
+                            pattern "auto";
+                        }
+                        type uint16 {
+                            range 1..65535;
+                        }
+                    }
+                }
+
+                leaf tpid {
+                    description "This leaf describes the possible TPID value that can be configured
+                                to the specified portchannel if the HW supports TPID configuration. The possible
+                                values are 0x8100, 0x9100, 0x9200, 0x88a8, and 0x88A8";
+                    type stypes:tpid_type;
+                }
+
+            } /* end of list PORTCHANNEL_LIST */
+
+        } /* end of container PORTCHANNEL */
+
+        container PORTCHANNEL_MEMBER {
+
+            description "PORTCHANNEL_MEMBER part of config_db.json";
+
+            list PORTCHANNEL_MEMBER_LIST {
+
+                key "name port";
+
+                leaf name {
+                    type leafref {
+                        path "/lag:sonic-portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST/lag:name";
+                    }
+                }
+        
+                leaf port {
+                    /* key elements are mandatory by default */
+                    type leafref {
+                        path /port:sonic-port/port:PORT/port:PORT_LIST/port:name;
+                    }
+                }
+            } /* end of list PORTCHANNEL_MEMBER_LIST */
+
+        } /* end of container PORTCHANNEL_MEMBER */
+
+        container PORTCHANNEL_INTERFACE {
+
+            description "PORTCHANNEL_INTERFACE part of config_db.json";
+
+            list PORTCHANNEL_INTERFACE_LIST {
+                key "name";
+
+                leaf name {
+                    /* key elements are mandatory by default */
+                    type leafref {
+                        path "/lag:sonic-portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST/lag:name";
+                    }
+                }
+
+                leaf vrf_name {
+                    type leafref {
+                        path "/vrf:sonic-vrf/vrf:VRF/vrf:VRF_LIST/vrf:name";
+                    }
+                }
+
+		leaf nat_zone {
+		    description "NAT Zone for the portchannel interface";
+		    type uint8 {
+		        range "0..3" {
+			    error-message "Invalid nat zone for the portchannel interface.";
+			    error-app-tag nat-zone-invalid;
+			}
+		    }
+		    default "0";
+		}
+		leaf mpls {
+			description "Enable/disable MPLS routing for the portchannel interface";
+                        type enumeration {
+				enum enable;
+				enum disable;
+			}
+		}
+            } /* end of list PORTCHANNEL_INTERFACE_LIST */
+
+            list PORTCHANNEL_INTERFACE_IPPREFIX_LIST {
+
+                key "name ip_prefix";
+
+                leaf name {
+                    /* key elements are mandatory by default */
+                    type leafref {
+                        path "/lag:sonic-portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST/lag:name";
+                    }
+                }
+
+                leaf ip_prefix {
+                    /* key elements are mandatory by default */
+                    type stypes:sonic-ip-prefix;
+                }
+            } /* end of list PORTCHANNEL_INTERFACE_IPPREFIX_LIST */
+
+        } /* end of container PORTCHANNEL_INTERFACE */
+
+    } /* end of container sonic-portchannel */
+
+} /* end of module sonic-portchannel */

--- a/tests/generic_config_updater/files/test-yang-models/sonic-types.yang
+++ b/tests/generic_config_updater/files/test-yang-models/sonic-types.yang
@@ -1,0 +1,188 @@
+module sonic-types {
+
+    yang-version 1.1;
+
+    namespace "http://github.com/Azure/sonic-head";
+    prefix sonic-types;
+
+    description "SONiC type for yang Models of SONiC OS";
+    /*
+     * Try to define only sonic specific types here. Rest can be written in
+     * respective YANG files.
+     */
+
+    revision 2019-07-01 {
+        description "First Revision";
+    }
+
+    typedef ip-family {
+        type enumeration {
+            enum IPv4;
+            enum IPv6;
+        }
+    }
+
+    typedef sonic-ip4-prefix {
+        type string {
+            pattern
+             '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+            +  '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])'
+            + '/(([0-9])|([1-2][0-9])|(3[0-2]))';
+        }
+    }
+
+    typedef sonic-ip6-prefix {
+        type string {
+            pattern '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}'
+                 + '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|'
+                 + '(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}'
+                 + '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))'
+                 + '(/(([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))';
+            pattern '(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|'
+                 + '((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)'
+                 + '(/.+)';
+        }
+    }
+
+    typedef sonic-ip-prefix {
+      type union {
+        type sonic-ip4-prefix;
+        type sonic-ip6-prefix;
+      }
+    }
+
+    typedef admin_status {
+        type enumeration {
+            enum up;
+            enum down;
+        }
+    }
+
+    typedef packet_action{
+        type enumeration {
+            enum DROP;
+            enum FORWARD;
+            enum REDIRECT;
+            enum DO_NOT_NAT;
+        }
+    }
+
+    typedef ip_type {
+        type enumeration {
+            enum ANY;
+            enum IP;
+            enum NON_IP;
+            enum IPV4;
+            enum IPV6;
+            enum IPv4ANY;
+            enum NON_IP4;
+            enum IPv6ANY;
+            enum NON_IPv6;
+            enum ARP;
+        }
+    }
+
+    typedef acl_table_type {
+        type enumeration {
+            enum L2;
+            enum L3;
+            enum L3V6;
+            enum MIRROR;
+            enum MIRRORV6;
+            enum MIRROR_DSCP;
+            enum CTRLPLANE;
+        }
+    }
+
+    typedef hwsku {
+        type string {
+            length 1..255;
+            /* Should we list all hwsku here */
+        }
+    }
+
+    typedef vlan_tagging_mode {
+        type enumeration {
+            enum tagged;
+            enum untagged;
+            enum priority_tagged;
+        }
+    }
+
+    typedef crm_threshold_type {
+        type string {
+            length 1..64;
+            pattern "percentage|used|free|PERCENTAGE|USED|FREE";
+        }
+    }
+
+    typedef admin_mode {
+        type enumeration {
+            enum enabled;
+            enum disabled;
+        }
+    }
+
+    typedef ip-protocol-type {
+        type enumeration {
+            enum TCP;
+            enum UDP;
+        }
+    }
+
+    typedef interface_type {
+        type enumeration {
+            enum CR;
+            enum CR2;
+            enum CR4;
+            enum SR;
+            enum SR2;
+            enum SR4;
+            enum LR;
+            enum LR4;
+            enum KR;
+            enum KR4;
+            enum CAUI;
+            enum GMII;
+            enum SFI;
+            enum XLAUI;
+            enum KR2;
+            enum CAUI4;
+            enum XAUI;
+            enum XFI;
+            enum XGMII;
+            enum none;
+        }
+    }
+
+    typedef tpid_type {
+        type string {
+            pattern "0x8100|0x9100|0x9200|0x88a8|0x88A8";
+        }
+    }
+
+    typedef feature_state {
+        type string {
+            pattern "enabled|disabled|always_enabled";
+        }
+    }
+    typedef meter_type {
+        type enumeration {
+            enum packets;
+            enum bytes;
+        }
+    }
+
+    typedef copp_packet_action {
+        type enumeration {
+            enum drop;
+            enum forward;
+            enum copy;
+            enum copy_cancel;
+            enum trap;
+            enum log;
+            enum deny;
+            enum transit;
+        }
+    }
+}

--- a/tests/generic_config_updater/files/test-yang-models/sonic-vlan.yang
+++ b/tests/generic_config_updater/files/test-yang-models/sonic-vlan.yang
@@ -1,0 +1,227 @@
+module sonic-vlan {
+
+    yang-version 1.1;
+
+	namespace "http://github.com/Azure/sonic-vlan";
+	prefix vlan;
+
+	import ietf-inet-types {
+		prefix inet;
+	}
+
+	import sonic-types {
+		prefix stypes;
+		revision-date 2019-07-01;
+	}
+
+	import sonic-extension {
+		prefix ext;
+		revision-date 2019-07-01;
+	}
+
+	import sonic-port {
+		prefix port;
+		revision-date 2019-07-01;
+	}
+
+	import sonic-portchannel {
+		prefix lag;
+	}
+
+	import sonic-vrf {
+		prefix vrf;
+	}
+
+	description "VLAN yang Module for SONiC OS";
+
+	revision 2021-04-22 {
+		description "Modify Vlan Member to include PortChannel along with Port";
+	}
+
+	revision 2021-03-30 {
+		description "Modify the type of vrf name";
+	}
+
+	revision 2019-07-01 {
+		description "First Revision";
+	}
+
+	container sonic-vlan {
+
+		container VLAN_INTERFACE {
+
+			description "VLAN_INTERFACE part of config_db.json";
+
+			list VLAN_INTERFACE_LIST {
+
+				description "VLAN INTERFACE part of config_db.json with vrf";
+
+				key "name";
+
+				leaf name {
+					type leafref {
+						path /vlan:sonic-vlan/vlan:VLAN/vlan:VLAN_LIST/vlan:name;
+					}
+				}
+
+				leaf vrf_name {
+					type leafref{
+						path "/vrf:sonic-vrf/vrf:VRF/vrf:VRF_LIST/vrf:name";
+					}
+				}
+
+				leaf nat_zone {
+					description "NAT Zone for the vlan interface";
+					type uint8 {
+						range "0..3" {
+							error-message "Invalid nat zone for the vlan interface.";
+							error-app-tag nat-zone-invalid;
+						}
+					}
+                                        default "0";
+				}
+				leaf mpls {
+					description "Enable/disable MPLS routing for the vlan interface";
+					type enumeration {
+						enum enable;
+						enum disable;
+					}
+				}
+			}
+			/* end of VLAN_INTERFACE_LIST */
+
+			list VLAN_INTERFACE_IPPREFIX_LIST {
+
+				key "name ip-prefix";
+
+				leaf name {
+					/* This node must be present in VLAN_INTERFACE_LIST */
+					must "(current() = ../../VLAN_INTERFACE_LIST[name=current()]/name)"
+					{
+						error-message "Must condition not satisfied, Try adding Vlan<vlanid>: {}, Example: 'Vlan100': {}";
+					}
+
+					type leafref {
+						path "/vlan:sonic-vlan/vlan:VLAN/vlan:VLAN_LIST/vlan:name";
+					}
+				}
+
+				leaf ip-prefix {
+					type union {
+						type stypes:sonic-ip4-prefix;
+						type stypes:sonic-ip6-prefix;
+					}
+				}
+
+				leaf scope {
+					type enumeration {
+						enum global;
+						enum local;
+					}
+				}
+
+				leaf family {
+
+					/* family leaf needed for backward compatibility
+					   Both ip4 and ip6 address are string in IETF RFC 6021,
+					   so must statement can check based on : or ., family
+					   should be IPv4 or IPv6 according.
+					 */
+
+					must "(contains(../ip-prefix, ':') and current()='IPv6') or
+						(contains(../ip-prefix, '.') and current()='IPv4')";
+					type stypes:ip-family;
+				}
+			}
+			/* end of VLAN_INTERFACE_LIST */
+		}
+		/* end of VLAN_INTERFACE container */
+
+		container VLAN {
+
+			description "VLAN part of config_db.json";
+
+			list VLAN_LIST {
+
+				key "name";
+        
+				leaf name {
+					type string {
+						pattern 'Vlan([0-9]{1,3}|[1-3][0-9]{3}|[4][0][0-8][0-9]|[4][0][9][0-4])';
+					}
+				}
+
+				leaf vlanid {
+					type uint16 {
+						range 1..4094;
+					}
+				}
+
+				leaf description {
+					type string {
+						length 1..255;
+					}
+				}
+
+				leaf-list dhcp_servers {
+					description "Configure the dhcp v4 servers";
+					type inet:ip-address;
+				}
+
+				leaf-list dhcpv6_servers {
+					description "Configure the dhcp v6 servers";
+					type inet:ipv6-address;
+				}
+
+				leaf mtu {
+					type uint16 {
+						range 1..9216;
+					}
+				}
+
+				leaf admin_status {
+					type stypes:admin_status;
+				}
+			}
+			/* end of VLAN_LIST */
+		}
+		/* end of container VLAN */
+
+		container VLAN_MEMBER {
+
+			description "VLAN_MEMBER part of config_db.json";
+
+			list VLAN_MEMBER_LIST {
+
+				key "name port";
+
+				leaf name {
+					type leafref {
+						path "/vlan:sonic-vlan/vlan:VLAN/vlan:VLAN_LIST/vlan:name";
+					}
+				}
+
+				leaf port {
+					/* key elements are mandatory by default */
+					type union {
+						type leafref {
+							path "/port:sonic-port/port:PORT/port:PORT_LIST/port:name";
+						}
+						type leafref {
+							path "/lag:sonic-portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST/lag:name";
+						}
+					}
+				}
+
+				leaf tagging_mode {
+					mandatory true;
+					type stypes:vlan_tagging_mode;
+				}
+			}
+            /* end of list VLAN_MEMBER_LIST */
+		}
+        /* end of container VLAN_MEMBER */
+	}
+    /* end of container sonic-vlan */
+}
+/* end of module sonic-vlan */

--- a/tests/generic_config_updater/files/test-yang-models/sonic-vrf.yang
+++ b/tests/generic_config_updater/files/test-yang-models/sonic-vrf.yang
@@ -1,0 +1,49 @@
+module sonic-vrf {
+    namespace "http://github.com/Azure/sonic-vrf";
+    prefix vrf;
+    
+    import sonic-extension {
+        prefix sonic-ext;
+    }
+
+    organization
+        "SONiC";
+
+    contact
+        "SONiC";
+
+    description
+        "SONIC VRF";
+
+    revision 2021-03-30 {
+        description
+            "Initial revision.";
+    }
+
+    container sonic-vrf {
+        container VRF {
+            description "Vrf configuration.";            
+
+            list VRF_LIST {
+                key "name";
+
+                leaf name {
+                    type string {
+                        pattern "Vrf[a-zA-Z0-9_-]+" {
+                            error-message "Invalid VRF name";
+                            error-app-tag vrf-name-invalid;
+                        }
+                    }
+                }   
+
+                leaf fallback {
+                    type  boolean;
+                    default false;
+                    description
+                        "Enable/disable fallback feature which is useful for specified VRF user to access internet through global/main route.";
+                }
+
+            } /* end of list VRF_LISt */
+        } /* end of container VRf */
+    } /* end of container sonic-vrf */
+}/* end of module sonic-vrf */

--- a/tests/generic_config_updater/generic_updater_test.py
+++ b/tests/generic_config_updater/generic_updater_test.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import unittest
 from unittest.mock import MagicMock, Mock, call
-from .gutest_helpers import create_side_effect_dict, Files
+from .gutest_helpers import create_side_effect_dict, Files, init_tests
 
 import generic_config_updater.generic_updater as gu
 import generic_config_updater.patch_sorter as ps
@@ -11,6 +11,8 @@ import generic_config_updater.patch_sorter as ps
 # import sys
 # sys.path.insert(0,'../../generic_config_updater')
 # import generic_updater as gu
+
+init_tests()
 
 class TestPatchApplier(unittest.TestCase):
     def test_apply__invalid_patch_producing_empty_tables__failure(self):

--- a/tests/generic_config_updater/gu_common_test.py
+++ b/tests/generic_config_updater/gu_common_test.py
@@ -4,8 +4,10 @@ import sonic_yang
 import unittest
 from unittest.mock import MagicMock, Mock
 
-from .gutest_helpers import create_side_effect_dict, Files
+from .gutest_helpers import create_side_effect_dict, Files, init_tests
 import generic_config_updater.gu_common as gu_common
+
+init_tests()
 
 class TestConfigWrapper(unittest.TestCase):
     def setUp(self):
@@ -15,7 +17,7 @@ class TestConfigWrapper(unittest.TestCase):
     def test_ctor__default_values_set(self):
         config_wrapper = gu_common.ConfigWrapper()
 
-        self.assertEqual("/usr/local/yang-models", gu_common.YANG_DIR)
+        self.assertEqual(gu_common.YANG_DIR, config_wrapper.yang_dir)
 
     def test_get_sonic_yang_as_json__returns_sonic_yang_as_json(self):
         # Arrange

--- a/tests/generic_config_updater/gutest_helpers.py
+++ b/tests/generic_config_updater/gutest_helpers.py
@@ -5,6 +5,10 @@ import shutil
 import sys
 import unittest
 from unittest.mock import MagicMock, Mock, call
+import generic_config_updater.gu_common as gu_common
+
+def init_tests():
+    gu_common.YANG_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "files", "test-yang-models")
 
 class MockSideEffectDict:
     def __init__(self, map):

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -3,9 +3,11 @@ import unittest
 from unittest.mock import MagicMock, Mock
 
 import generic_config_updater.patch_sorter as ps
-from .gutest_helpers import Files, create_side_effect_dict
+from .gutest_helpers import Files, create_side_effect_dict, init_tests
 from generic_config_updater.gu_common import ConfigWrapper, PatchWrapper, OperationWrapper, \
                                              GenericConfigUpdaterError, OperationType, JsonChange, PathAddressing
+
+init_tests()
 
 class TestDiff(unittest.TestCase):
     def test_apply_move__updates_current_config(self):


### PR DESCRIPTION
#### What I did
While running tests, do not rely on yang models on the box. Instead use the yang models in the `files/test-yang-models` directory.

This changes makes sure whenever the real YANG models change, our unit-test don't break.

Nightly builds should be used to capture issues with the real YANG models.

#### How I did it
Copied yang models that are needed for testing to the test folder

#### How to verify it
unit-tests

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

