### PR TITLE
[GCU] Moving PatchSorter unit-test to json file to make it easier to read/maintain

### DIFF
--- a/tests/generic_config_updater/files/patch_sorter_test_failure.json
+++ b/tests/generic_config_updater/files/patch_sorter_test_failure.json
@@ -1,6 +1,6 @@
 {
     "EMPTYING_A_CONFIGDB_TABLE__FAILURE": {
-        "desc": "Emptying a configdb table fails because empty tables are not allowed in configdb.",
+        "desc": "Emptying a configdb table fails because empty tables are not allowed in configdb. User should remove whole table instead e.g. remove /ACL_TABLE in this case.",
         "current_config": {
             "ACL_TABLE": {
                 "EVERFLOW": {
@@ -39,7 +39,7 @@
         ]
     },
     "EMPTYING_MULTIPLE_CONFIGDB_TABLE__FAILURE": {
-        "desc": "Emptying multiple configdb table fails because empty tables are not allowed in configdb.",
+        "desc": "Emptying multiple configdb table fails because empty tables are not allowed in configdb. User should remove whole tables instead  e.g. remove /PORT and /ACL_TABLE in this case.",
         "current_config": {
             "ACL_TABLE": {
                 "EVERFLOW": {

--- a/tests/generic_config_updater/files/patch_sorter_test_failure.json
+++ b/tests/generic_config_updater/files/patch_sorter_test_failure.json
@@ -1,0 +1,71 @@
+{
+    "EMPTYING_A_CONFIGDB_TABLE__FAILURE": {
+        "desc": "Emptying a configdb table fails because empty tables are not allowed in configdb.",
+        "current_config": {
+            "ACL_TABLE": {
+                "EVERFLOW": {
+                    "policy_desc": "EVERFLOW",
+                    "ports": [
+                        "Ethernet0"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRROR"
+                }
+            },
+            "PORT": {
+                "Ethernet0": {
+                    "alias": "Eth1",
+                    "lanes": "65, 66, 67, 68",
+                    "description": "Ethernet0 100G link",
+                    "speed": "100000"
+                }
+            }
+        },
+        "patch": [
+            {"op": "remove", "path": "/ACL_TABLE/EVERFLOW"}
+        ],
+        "expected_error_substrings": [
+            "There is no possible sorting"
+        ]
+    },
+    "ADDING_AN_EMPTY_CONFIGDB_TABLE__FAILURE": {
+        "desc": "Adding an empty configdb table fail because empty tables are not allowed in configdb.",
+        "current_config": {},
+        "patch": [
+            {"op": "add", "path": "/VLAN", "value": {}}
+        ],
+        "expected_error_substrings": [
+            "There is no possible sorting"
+        ]
+    },
+    "EMPTYING_MULTIPLE_CONFIGDB_TABLE__FAILURE": {
+        "desc": "Emptying multiple configdb table fails because empty tables are not allowed in configdb.",
+        "current_config": {
+            "ACL_TABLE": {
+                "EVERFLOW": {
+                    "policy_desc": "EVERFLOW",
+                    "ports": [
+                        "Ethernet0"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRROR"
+                }
+            },
+            "PORT": {
+                "Ethernet0": {
+                    "alias": "Eth1",
+                    "lanes": "65, 66, 67, 68",
+                    "description": "Ethernet0 100G link",
+                    "speed": "100000"
+                }
+            }
+        },
+        "patch": [
+            {"op": "remove", "path": "/ACL_TABLE/EVERFLOW"},
+            {"op": "remove", "path": "/PORT/Ethernet0"}
+        ],
+        "expected_error_substrings": [
+            "There is no possible sorting"
+        ]
+    }
+}

--- a/tests/generic_config_updater/files/patch_sorter_test_success.json
+++ b/tests/generic_config_updater/files/patch_sorter_test_success.json
@@ -1,0 +1,2782 @@
+{
+    "ADD_2_ITEMS_WITH_DEPENDENCY_FROM_DIFFERENT_TABLES__SUCCESS": {
+        "desc": "Add 2 items with dependency from different tables success.",
+        "current_config": {
+            "VLAN_MEMBER": {
+                "Vlan1000|Ethernet4": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan1000|Ethernet8": {
+                    "tagging_mode": "untagged"
+                }
+            },
+            "VLAN": {
+                "Vlan1000": {
+                    "vlanid": "1000",
+                    "dhcp_servers": [
+                        "192.0.0.1",
+                        "192.0.0.2",
+                        "192.0.0.3",
+                        "192.0.0.4"
+                    ]
+                }
+            },
+            "ACL_TABLE": {
+                "DATAACL": {
+                    "policy_desc": "DATAACL",
+                    "ports": [
+                        "Ethernet4"
+                    ],
+                    "stage": "ingress",
+                    "type": "L3"
+                },
+                "EVERFLOW": {
+                    "policy_desc": "EVERFLOW",
+                    "ports": [
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRROR"
+                },
+                "EVERFLOWV6": {
+                    "policy_desc": "EVERFLOWV6",
+                    "ports": [
+                        "Ethernet4",
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRRORV6"
+                }
+            },
+            "PORT": {
+                "Ethernet4": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/4",
+                    "description": "Servers0:eth0",
+                    "index": "1",
+                    "lanes": "29,30,31,32",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                },
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/8",
+                    "description": "Servers1:eth0",
+                    "index": "2",
+                    "lanes": "33,34,35,36",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                }
+            }
+        },
+        "patch": [
+            {
+                "op": "add",
+                "path": "/VLAN_MEMBER/Vlan1000|Ethernet0",
+                "value": {
+                    "tagging_mode": "untagged"
+                }
+            },
+            {
+                "op": "add",
+                "path": "/PORT/Ethernet0",
+                "value": {
+                    "alias": "Eth1",
+                    "lanes": "65, 66, 67, 68",
+                    "description": "Ethernet0 100G link",
+                    "speed": "100000"
+                }
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "add",
+                    "path": "/PORT/Ethernet0",
+                    "value": {
+                        "alias": "Eth1",
+                        "lanes": "65, 66, 67, 68",
+                        "description": "Ethernet0 100G link",
+                        "speed": "100000"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/VLAN_MEMBER/Vlan1000|Ethernet0",
+                    "value": {
+                        "tagging_mode": "untagged"
+                    }
+                }
+            ]
+        ]
+    },
+    "ADD_2_ITEMS_WITH_DEPENDENCY_FROM_SAME_TABLE__SUCCESS": {
+        "desc": "Add 2 items with dependency from same table success.",
+        "current_config": {
+            "INTERFACE": {
+                "Ethernet9": {}
+            },
+            "PORT": {
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "eth8",
+                    "description": "Ethernet8",
+                    "fec": "rs",
+                    "lanes": "65",
+                    "mtu": "9000",
+                    "speed": "25000"
+                },
+                "Ethernet9": {
+                    "admin_status": "up",
+                    "alias": "eth9",
+                    "description": "Ethernet9",
+                    "fec": "rs",
+                    "lanes": "6",
+                    "mtu": "9000",
+                    "speed": "25000"
+                }
+            }
+        },
+        "patch": [
+            {
+                "op": "add",
+                "path": "/INTERFACE/Ethernet8",
+                "value": {}
+            },
+            {
+                "op": "add",
+                "path": "/INTERFACE/Ethernet8|10.0.0.1~130",
+                "value": {
+                    "family": "IPv4",
+                    "scope": "global"
+                }
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "add",
+                    "path": "/INTERFACE/Ethernet8",
+                    "value": {}
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/INTERFACE/Ethernet8|10.0.0.1~130",
+                    "value": {
+                        "family": "IPv4"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/INTERFACE/Ethernet8|10.0.0.1~130/scope",
+                    "value": "global"
+                }
+            ]
+        ]
+    },
+    "ADD_NEW_KEY_TO_EXISTING_TABLE__SUCCESS": {
+        "desc": "Add new key to existing table success.",
+        "current_config": {
+            "VLAN_MEMBER": {
+                "Vlan1000|Ethernet0": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan1000|Ethernet4": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan1000|Ethernet8": {
+                    "tagging_mode": "untagged"
+                }
+            },
+            "VLAN": {
+                "Vlan1000": {
+                    "vlanid": "1000",
+                    "dhcp_servers": [
+                        "192.0.0.1",
+                        "192.0.0.2",
+                        "192.0.0.3",
+                        "192.0.0.4"
+                    ]
+                }
+            },
+            "ACL_TABLE": {
+                "NO-NSW-PACL-V4": {
+                    "type": "L3",
+                    "policy_desc": "NO-NSW-PACL-V4",
+                    "ports": [
+                        "Ethernet0"
+                    ]
+                },
+                "DATAACL": {
+                    "policy_desc": "DATAACL",
+                    "ports": [
+                        "Ethernet4"
+                    ],
+                    "stage": "ingress",
+                    "type": "L3"
+                },
+                "EVERFLOW": {
+                    "policy_desc": "EVERFLOW",
+                    "ports": [
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRROR"
+                }
+            },
+            "PORT": {
+                "Ethernet0": {
+                    "alias": "Eth1",
+                    "lanes": "65, 66, 67, 68",
+                    "description": "Ethernet0 100G link",
+                    "speed": "100000"
+                },
+                "Ethernet4": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/4",
+                    "description": "Servers0:eth0",
+                    "index": "1",
+                    "lanes": "29,30,31,32",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                },
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/8",
+                    "description": "Servers1:eth0",
+                    "index": "2",
+                    "lanes": "33,34,35,36",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                }
+            }
+        },
+        "patch": [
+            {
+                "op": "add",
+                "path": "/ACL_TABLE/EVERFLOWV6",
+                "value": {
+                    "policy_desc": "EVERFLOWV6",
+                    "ports": [
+                        "Ethernet4",
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRRORV6"
+                }
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/EVERFLOWV6",
+                    "value": {
+                        "type": "MIRRORV6"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/EVERFLOWV6/policy_desc",
+                    "value": "EVERFLOWV6"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/EVERFLOWV6/ports",
+                    "value": [
+                        "Ethernet4"
+                    ]
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/EVERFLOWV6/ports/1",
+                    "value": "Ethernet8"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/EVERFLOWV6/stage",
+                    "value": "ingress"
+                }
+            ]
+        ]
+    },
+    "ADD_TABLE__SUCCESS": {
+        "desc": "Add table success.",
+        "current_config": {
+            "VLAN_MEMBER": {
+                "Vlan1000|Ethernet0": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan1000|Ethernet4": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan1000|Ethernet8": {
+                    "tagging_mode": "untagged"
+                }
+            },
+            "VLAN": {
+                "Vlan1000": {
+                    "vlanid": "1000",
+                    "dhcp_servers": [
+                        "192.0.0.1",
+                        "192.0.0.2",
+                        "192.0.0.3",
+                        "192.0.0.4"
+                    ]
+                }
+            },
+            "PORT": {
+                "Ethernet0": {
+                    "alias": "Eth1",
+                    "lanes": "65, 66, 67, 68",
+                    "description": "Ethernet0 100G link",
+                    "speed": "100000"
+                },
+                "Ethernet4": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/4",
+                    "description": "Servers0:eth0",
+                    "index": "1",
+                    "lanes": "29,30,31,32",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                },
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/8",
+                    "description": "Servers1:eth0",
+                    "index": "2",
+                    "lanes": "33,34,35,36",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                }
+            }
+        },
+        "patch": [
+            {
+                "op": "add",
+                "path": "/ACL_TABLE",
+                "value": {
+                    "NO-NSW-PACL-V4": {
+                        "type": "L3",
+                        "policy_desc": "NO-NSW-PACL-V4",
+                        "ports": [
+                            "Ethernet0"
+                        ]
+                    },
+                    "DATAACL": {
+                        "policy_desc": "DATAACL",
+                        "ports": [
+                            "Ethernet4"
+                        ],
+                        "stage": "ingress",
+                        "type": "L3"
+                    },
+                    "EVERFLOW": {
+                        "policy_desc": "EVERFLOW",
+                        "ports": [
+                            "Ethernet8"
+                        ],
+                        "stage": "ingress",
+                        "type": "MIRROR"
+                    },
+                    "EVERFLOWV6": {
+                        "policy_desc": "EVERFLOWV6",
+                        "ports": [
+                            "Ethernet4",
+                            "Ethernet8"
+                        ],
+                        "stage": "ingress",
+                        "type": "MIRRORV6"
+                    }
+                }
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE",
+                    "value": {
+                        "NO-NSW-PACL-V4": {
+                            "type": "L3"
+                        }
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/policy_desc",
+                    "value": "NO-NSW-PACL-V4"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports",
+                    "value": [
+                        "Ethernet0"
+                    ]
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/DATAACL",
+                    "value": {
+                        "type": "L3"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/DATAACL/policy_desc",
+                    "value": "DATAACL"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/DATAACL/ports",
+                    "value": [
+                        "Ethernet4"
+                    ]
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/DATAACL/stage",
+                    "value": "ingress"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/EVERFLOW",
+                    "value": {
+                        "type": "MIRROR"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/EVERFLOW/policy_desc",
+                    "value": "EVERFLOW"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/EVERFLOW/ports",
+                    "value": [
+                        "Ethernet8"
+                    ]
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/EVERFLOW/stage",
+                    "value": "ingress"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/EVERFLOWV6",
+                    "value": {
+                        "type": "MIRRORV6"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/EVERFLOWV6/policy_desc",
+                    "value": "EVERFLOWV6"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/EVERFLOWV6/ports",
+                    "value": [
+                        "Ethernet4"
+                    ]
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/EVERFLOWV6/ports/1",
+                    "value": "Ethernet8"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/EVERFLOWV6/stage",
+                    "value": "ingress"
+                }
+            ]
+        ]
+    },
+    "ADD_VALUE_TO_EXISTING_ARRAY__SUCCESS": {
+        "desc": "Add value to existing array success.",
+        "current_config": {
+            "VLAN_MEMBER": {
+                "Vlan1000|Ethernet0": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan1000|Ethernet4": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan1000|Ethernet8": {
+                    "tagging_mode": "untagged"
+                }
+            },
+            "VLAN": {
+                "Vlan1000": {
+                    "vlanid": "1000",
+                    "dhcp_servers": [
+                        "192.0.0.1",
+                        "192.0.0.2",
+                        "192.0.0.3",
+                        "192.0.0.4"
+                    ]
+                }
+            },
+            "ACL_TABLE": {
+                "NO-NSW-PACL-V4": {
+                    "type": "L3",
+                    "policy_desc": "NO-NSW-PACL-V4",
+                    "ports": [
+                        "Ethernet0"
+                    ]
+                },
+                "DATAACL": {
+                    "policy_desc": "DATAACL",
+                    "ports": [
+                        "Ethernet4"
+                    ],
+                    "stage": "ingress",
+                    "type": "L3"
+                },
+                "EVERFLOW": {
+                    "policy_desc": "EVERFLOW",
+                    "ports": [
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRROR"
+                },
+                "EVERFLOWV6": {
+                    "policy_desc": "EVERFLOWV6",
+                    "ports": [
+                        "Ethernet4",
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRRORV6"
+                }
+            },
+            "PORT": {
+                "Ethernet0": {
+                    "alias": "Eth1",
+                    "lanes": "65, 66, 67, 68",
+                    "description": "Ethernet0 100G link",
+                    "speed": "100000"
+                },
+                "Ethernet4": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/4",
+                    "description": "Servers0:eth0",
+                    "index": "1",
+                    "lanes": "29,30,31,32",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                },
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/8",
+                    "description": "Servers1:eth0",
+                    "index": "2",
+                    "lanes": "33,34,35,36",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                }
+            }
+        },
+        "patch": [
+            {
+                "op": "add",
+                "path": "/ACL_TABLE/EVERFLOWV6/ports/0",
+                "value": "Ethernet0"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/EVERFLOWV6/ports/0",
+                    "value": "Ethernet0"
+                }
+            ]
+        ]
+    },
+    "ADDING_CREATE_ONLY_FIELD__SUCCESS": {
+        "desc": "Adding create only field success.",
+        "current_config": {
+            "LOOPBACK_INTERFACE": {
+                "Loopback0": {},
+                "Loopback0|10.1.0.32/32": {},
+                "Loopback0|1100:1::32/128": {},
+                "Loopback1": {
+                    "vrf_name": "Vrf_02"
+                },
+                "Loopback1|20.2.0.32/32": {},
+                "Loopback1|2200:2::32/128": {}
+            },
+            "VRF": {
+                "Vrf_01": {},
+                "Vrf_02": {}
+            }
+        },
+        "patch": [
+            {
+                "op": "add",
+                "path": "/LOOPBACK_INTERFACE/Loopback0/vrf_name",
+                "value": "Vrf_01"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "remove",
+                    "path": "/LOOPBACK_INTERFACE/Loopback0|10.1.0.32~132"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/LOOPBACK_INTERFACE/Loopback0|1100:1::32~1128"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/LOOPBACK_INTERFACE/Loopback0|10.1.0.32~132",
+                    "value": {}
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/LOOPBACK_INTERFACE/Loopback1|2200:2::32~1128"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/LOOPBACK_INTERFACE/Loopback0|1100:1::32~1128",
+                    "value": {}
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/LOOPBACK_INTERFACE/Loopback0|10.1.0.32~132"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/LOOPBACK_INTERFACE/Loopback0|1100:1::32~1128"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/LOOPBACK_INTERFACE/Loopback0"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/LOOPBACK_INTERFACE/Loopback0",
+                    "value": {
+                        "vrf_name": "Vrf_01"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/LOOPBACK_INTERFACE/Loopback0|10.1.0.32~132",
+                    "value": {}
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/LOOPBACK_INTERFACE/Loopback0|1100:1::32~1128",
+                    "value": {}
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/LOOPBACK_INTERFACE/Loopback1|2200:2::32~1128",
+                    "value": {}
+                }
+            ]
+        ]
+    },
+    "DPB_1_TO_4__SUCCESS": {
+        "desc": "Dpb 1 to 4 success.",
+        "current_config": {
+            "PORT": {
+                "Ethernet0": {
+                    "alias": "Eth1",
+                    "lanes": "65, 66, 67, 68",
+                    "description": "Ethernet0 100G link",
+                    "speed": "100000"
+                }
+            },
+            "ACL_TABLE": {
+                "NO-NSW-PACL-V4": {
+                    "type": "L3",
+                    "policy_desc": "NO-NSW-PACL-V4",
+                    "ports": [
+                        "Ethernet0"
+                    ]
+                }
+            },
+            "VLAN_MEMBER": {
+                "Vlan100|Ethernet0": {
+                    "tagging_mode": "untagged"
+                }
+            },
+            "VLAN": {
+                "Vlan100": {
+                    "vlanid": "100",
+                    "dhcp_servers": [
+                        "192.0.0.1",
+                        "192.0.0.2",
+                        "192.0.0.3",
+                        "192.0.0.4"
+                    ]
+                }
+            }
+        },
+        "patch": [
+            {
+                "op": "add",
+                "path": "/VLAN_MEMBER/Vlan100|Ethernet1",
+                "value": {
+                    "tagging_mode": "untagged"
+                }
+            },
+            {
+                "op": "add",
+                "path": "/VLAN_MEMBER/Vlan100|Ethernet3",
+                "value": {
+                    "tagging_mode": "untagged"
+                }
+            },
+            {
+                "op": "add",
+                "path": "/VLAN_MEMBER/Vlan100|Ethernet2",
+                "value": {
+                    "tagging_mode": "untagged"
+                }
+            },
+            {
+                "op": "add",
+                "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports/1",
+                "value": "Ethernet1"
+            },
+            {
+                "op": "add",
+                "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports/2",
+                "value": "Ethernet2"
+            },
+            {
+                "op": "add",
+                "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports/3",
+                "value": "Ethernet3"
+            },
+            {
+                "op": "add",
+                "path": "/PORT/Ethernet3",
+                "value": {
+                    "alias": "Eth1/4",
+                    "lanes": "68",
+                    "description": "",
+                    "speed": "10000"
+                }
+            },
+            {
+                "op": "add",
+                "path": "/PORT/Ethernet2",
+                "value": {
+                    "alias": "Eth1/3",
+                    "lanes": "67",
+                    "description": "",
+                    "speed": "10000"
+                }
+            },
+            {
+                "op": "add",
+                "path": "/PORT/Ethernet1",
+                "value": {
+                    "alias": "Eth1/2",
+                    "lanes": "66",
+                    "description": "",
+                    "speed": "10000"
+                }
+            },
+            {
+                "op": "replace",
+                "path": "/PORT/Ethernet0/alias",
+                "value": "Eth1/1"
+            },
+            {
+                "op": "replace",
+                "path": "/PORT/Ethernet0/description",
+                "value": ""
+            },
+            {
+                "op": "replace",
+                "path": "/PORT/Ethernet0/lanes",
+                "value": "65"
+            },
+            {
+                "op": "replace",
+                "path": "/PORT/Ethernet0/speed",
+                "value": "10000"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "replace",
+                    "path": "/PORT/Ethernet0/alias",
+                    "value": "Eth1/1"
+                }
+            ],
+            [
+                {
+                    "op": "replace",
+                    "path": "/PORT/Ethernet0/description",
+                    "value": ""
+                }
+            ],
+            [
+                {
+                    "op": "replace",
+                    "path": "/PORT/Ethernet0/speed",
+                    "value": "10000"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE",
+                    "value": {
+                        "NO-NSW-PACL-V4": {
+                            "type": "L3"
+                        }
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports",
+                    "value": [
+                        "Ethernet0"
+                    ]
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/VLAN_MEMBER"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/policy_desc",
+                    "value": "NO-NSW-PACL-V4"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/PORT"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/PORT",
+                    "value": {
+                        "Ethernet0": {
+                            "alias": "Eth1/1",
+                            "lanes": "65",
+                            "description": "",
+                            "speed": "10000"
+                        }
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports",
+                    "value": [
+                        "Ethernet0"
+                    ]
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/VLAN_MEMBER",
+                    "value": {
+                        "Vlan100|Ethernet0": {
+                            "tagging_mode": "untagged"
+                        }
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/PORT/Ethernet3",
+                    "value": {
+                        "alias": "Eth1/4",
+                        "lanes": "68",
+                        "description": "",
+                        "speed": "10000"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports/1",
+                    "value": "Ethernet3"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/VLAN_MEMBER/Vlan100|Ethernet3",
+                    "value": {
+                        "tagging_mode": "untagged"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/PORT/Ethernet2",
+                    "value": {
+                        "alias": "Eth1/3",
+                        "lanes": "67",
+                        "description": "",
+                        "speed": "10000"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports/2",
+                    "value": "Ethernet2"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/VLAN_MEMBER/Vlan100|Ethernet2",
+                    "value": {
+                        "tagging_mode": "untagged"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/PORT/Ethernet1",
+                    "value": {
+                        "alias": "Eth1/2",
+                        "lanes": "66",
+                        "description": "",
+                        "speed": "10000"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports/1",
+                    "value": "Ethernet1"
+                }
+            ],
+            [
+                {
+                    "op": "replace",
+                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports",
+                    "value": [
+                        "Ethernet0",
+                        "Ethernet1",
+                        "Ethernet2",
+                        "Ethernet3"
+                    ]
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/VLAN_MEMBER/Vlan100|Ethernet1",
+                    "value": {
+                        "tagging_mode": "untagged"
+                    }
+                }
+            ]
+        ]
+    },
+    "DPB_4_TO_1__SUCCESS": {
+        "desc": "Dpb 4 to 1 success.",
+        "current_config": {
+            "PORT": {
+                "Ethernet0": {
+                    "alias": "Eth1/1",
+                    "lanes": "65",
+                    "description": "",
+                    "speed": "10000"
+                },
+                "Ethernet1": {
+                    "alias": "Eth1/2",
+                    "lanes": "66",
+                    "description": "",
+                    "speed": "10000"
+                },
+                "Ethernet2": {
+                    "alias": "Eth1/3",
+                    "lanes": "67",
+                    "description": "",
+                    "speed": "10000"
+                },
+                "Ethernet3": {
+                    "alias": "Eth1/4",
+                    "lanes": "68",
+                    "description": "",
+                    "speed": "10000"
+                }
+            },
+            "ACL_TABLE": {
+                "NO-NSW-PACL-V4": {
+                    "type": "L3",
+                    "policy_desc": "NO-NSW-PACL-V4",
+                    "ports": [
+                        "Ethernet0",
+                        "Ethernet1",
+                        "Ethernet2",
+                        "Ethernet3"
+                    ]
+                }
+            },
+            "VLAN_MEMBER": {
+                "Vlan100|Ethernet0": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan100|Ethernet1": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan100|Ethernet2": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan100|Ethernet3": {
+                    "tagging_mode": "untagged"
+                }
+            },
+            "VLAN": {
+                "Vlan100": {
+                    "vlanid": "100",
+                    "dhcp_servers": [
+                        "192.0.0.1",
+                        "192.0.0.2",
+                        "192.0.0.3",
+                        "192.0.0.4"
+                    ]
+                }
+            }
+        },
+        "patch": [
+            {
+                "op": "remove",
+                "path": "/VLAN_MEMBER/Vlan100|Ethernet1"
+            },
+            {
+                "op": "remove",
+                "path": "/VLAN_MEMBER/Vlan100|Ethernet3"
+            },
+            {
+                "op": "remove",
+                "path": "/VLAN_MEMBER/Vlan100|Ethernet2"
+            },
+            {
+                "op": "remove",
+                "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports/1"
+            },
+            {
+                "op": "remove",
+                "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports/1"
+            },
+            {
+                "op": "remove",
+                "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports/1"
+            },
+            {
+                "op": "remove",
+                "path": "/PORT/Ethernet3"
+            },
+            {
+                "op": "remove",
+                "path": "/PORT/Ethernet2"
+            },
+            {
+                "op": "remove",
+                "path": "/PORT/Ethernet1"
+            },
+            {
+                "op": "replace",
+                "path": "/PORT/Ethernet0/alias",
+                "value": "Eth1"
+            },
+            {
+                "op": "replace",
+                "path": "/PORT/Ethernet0/description",
+                "value": "Ethernet0 100G link"
+            },
+            {
+                "op": "replace",
+                "path": "/PORT/Ethernet0/lanes",
+                "value": "65, 66, 67, 68"
+            },
+            {
+                "op": "replace",
+                "path": "/PORT/Ethernet0/speed",
+                "value": "100000"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "replace",
+                    "path": "/PORT/Ethernet0/alias",
+                    "value": "Eth1"
+                }
+            ],
+            [
+                {
+                    "op": "replace",
+                    "path": "/PORT/Ethernet0/description",
+                    "value": "Ethernet0 100G link"
+                }
+            ],
+            [
+                {
+                    "op": "replace",
+                    "path": "/PORT/Ethernet0/speed",
+                    "value": "100000"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/PORT/Ethernet1/alias"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/PORT/Ethernet1/description"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/PORT/Ethernet2/alias"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/PORT/Ethernet2/description"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/PORT/Ethernet3/alias"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/PORT/Ethernet3/description"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports/1"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports/1"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports/1"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/VLAN_MEMBER/Vlan100|Ethernet1"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/PORT/Ethernet1"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/VLAN_MEMBER/Vlan100|Ethernet2"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/PORT/Ethernet2"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/VLAN_MEMBER/Vlan100|Ethernet3"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/PORT/Ethernet3"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/VLAN_MEMBER"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/PORT"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/PORT",
+                    "value": {
+                        "Ethernet0": {
+                            "alias": "Eth1",
+                            "lanes": "65, 66, 67, 68",
+                            "description": "Ethernet0 100G link",
+                            "speed": "100000"
+                        }
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports",
+                    "value": [
+                        "Ethernet0"
+                    ]
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/VLAN_MEMBER",
+                    "value": {
+                        "Vlan100|Ethernet0": {
+                            "tagging_mode": "untagged"
+                        }
+                    }
+                }
+            ]
+        ]
+    },
+    "EMPTY_PATCH__RETURNS_EMPTY_CHANGES_LIST": {
+        "desc": "Empty patch returns empty changes list.",
+        "current_config": {
+            "VLAN_MEMBER": {
+                "Vlan1000|Ethernet0": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan1000|Ethernet4": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan1000|Ethernet8": {
+                    "tagging_mode": "untagged"
+                }
+            },
+            "VLAN": {
+                "Vlan1000": {
+                    "vlanid": "1000",
+                    "dhcp_servers": [
+                        "192.0.0.1",
+                        "192.0.0.2",
+                        "192.0.0.3",
+                        "192.0.0.4"
+                    ]
+                }
+            },
+            "ACL_TABLE": {
+                "NO-NSW-PACL-V4": {
+                    "type": "L3",
+                    "policy_desc": "NO-NSW-PACL-V4",
+                    "ports": [
+                        "Ethernet0"
+                    ]
+                },
+                "DATAACL": {
+                    "policy_desc": "DATAACL",
+                    "ports": [
+                        "Ethernet4"
+                    ],
+                    "stage": "ingress",
+                    "type": "L3"
+                },
+                "EVERFLOW": {
+                    "policy_desc": "EVERFLOW",
+                    "ports": [
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRROR"
+                },
+                "EVERFLOWV6": {
+                    "policy_desc": "EVERFLOWV6",
+                    "ports": [
+                        "Ethernet4",
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRRORV6"
+                }
+            },
+            "PORT": {
+                "Ethernet0": {
+                    "alias": "Eth1",
+                    "lanes": "65, 66, 67, 68",
+                    "description": "Ethernet0 100G link",
+                    "speed": "100000"
+                },
+                "Ethernet4": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/4",
+                    "description": "Servers0:eth0",
+                    "index": "1",
+                    "lanes": "29,30,31,32",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                },
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/8",
+                    "description": "Servers1:eth0",
+                    "index": "2",
+                    "lanes": "33,34,35,36",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                }
+            }
+        },
+        "patch": [],
+        "expected_changes": []
+    },
+    "INTER_DEPENDENCY_WITHIN_SAME_TABLE__SUCCESS": {
+        "desc": "Inter dependency within same table success.",
+        "current_config": {
+            "VLAN_MEMBER": {
+                "Vlan1000|Ethernet0": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan1000|Ethernet4": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan1000|Ethernet8": {
+                    "tagging_mode": "untagged"
+                }
+            },
+            "VLAN": {
+                "Vlan1000": {
+                    "vlanid": "1000",
+                    "dhcp_servers": [
+                        "192.0.0.1",
+                        "192.0.0.2",
+                        "192.0.0.3",
+                        "192.0.0.4"
+                    ]
+                }
+            },
+            "ACL_TABLE": {
+                "NO-NSW-PACL-V4": {
+                    "type": "L3",
+                    "policy_desc": "NO-NSW-PACL-V4",
+                    "ports": [
+                        "Ethernet0"
+                    ]
+                },
+                "DATAACL": {
+                    "policy_desc": "DATAACL",
+                    "ports": [
+                        "Ethernet4"
+                    ],
+                    "stage": "ingress",
+                    "type": "L3"
+                },
+                "EVERFLOW": {
+                    "policy_desc": "EVERFLOW",
+                    "ports": [
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRROR"
+                },
+                "EVERFLOWV6": {
+                    "policy_desc": "EVERFLOWV6",
+                    "ports": [
+                        "Ethernet4",
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRRORV6"
+                }
+            },
+            "PORT": {
+                "Ethernet0": {
+                    "alias": "Eth1",
+                    "lanes": "65, 66, 67, 68",
+                    "description": "Ethernet0 100G link",
+                    "speed": "100000"
+                },
+                "Ethernet4": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/4",
+                    "description": "Servers0:eth0",
+                    "index": "1",
+                    "lanes": "29,30,31,32",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                },
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/8",
+                    "description": "Servers1:eth0",
+                    "index": "2",
+                    "lanes": "33,34,35,36",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                }
+            }
+        },
+        "patch": [
+            {
+                "op": "add",
+                "path": "/VLAN_INTERFACE",
+                "value": {
+                    "Vlan1000|fc02:1000::1/64": {},
+                    "Vlan1000|192.168.0.1/21": {},
+                    "Vlan1000": {}
+                }
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "add",
+                    "path": "/VLAN_INTERFACE",
+                    "value": {
+                        "Vlan1000": {}
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/VLAN_INTERFACE/Vlan1000|fc02:1000::1~164",
+                    "value": {}
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/VLAN_INTERFACE/Vlan1000|192.168.0.1~121",
+                    "value": {}
+                }
+            ]
+        ]
+    },
+    "MODIFY_ITEMS_WITH_DEPENDENCIES_USING_MUST__SUCCESS": {
+        "desc": "Modify items with dependencies using must success.",
+        "current_config": {
+            "CRM": {
+                "Config": {
+                    "acl_counter_high_threshold": "90",
+                    "acl_counter_low_threshold": "70",
+                    "acl_counter_threshold_type": "free"
+                }
+            }
+        },
+        "patch": [
+            {
+                "op": "replace",
+                "path": "/CRM/Config/acl_counter_low_threshold",
+                "value": "60"
+            },
+            {
+                "op": "replace",
+                "path": "/CRM/Config/acl_counter_high_threshold",
+                "value": "80"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "replace",
+                    "path": "/CRM/Config/acl_counter_high_threshold",
+                    "value": "80"
+                }
+            ],
+            [
+                {
+                    "op": "replace",
+                    "path": "/CRM/Config/acl_counter_low_threshold",
+                    "value": "60"
+                }
+            ]
+        ]
+    },
+    "MODIFY_VALUE_IN_EXISTING_ARRAY__SUCCESS": {
+        "desc": "Modify value in existing array success.",
+        "current_config": {
+            "VLAN_MEMBER": {
+                "Vlan1000|Ethernet0": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan1000|Ethernet4": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan1000|Ethernet8": {
+                    "tagging_mode": "untagged"
+                }
+            },
+            "VLAN": {
+                "Vlan1000": {
+                    "vlanid": "1000",
+                    "dhcp_servers": [
+                        "192.0.0.1",
+                        "192.0.0.2",
+                        "192.0.0.3",
+                        "192.0.0.4"
+                    ]
+                }
+            },
+            "ACL_TABLE": {
+                "NO-NSW-PACL-V4": {
+                    "type": "L3",
+                    "policy_desc": "NO-NSW-PACL-V4",
+                    "ports": [
+                        "Ethernet0"
+                    ]
+                },
+                "DATAACL": {
+                    "policy_desc": "DATAACL",
+                    "ports": [
+                        "Ethernet4"
+                    ],
+                    "stage": "ingress",
+                    "type": "L3"
+                },
+                "EVERFLOW": {
+                    "policy_desc": "EVERFLOW",
+                    "ports": [
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRROR"
+                },
+                "EVERFLOWV6": {
+                    "policy_desc": "EVERFLOWV6",
+                    "ports": [
+                        "Ethernet4",
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRRORV6"
+                }
+            },
+            "PORT": {
+                "Ethernet0": {
+                    "alias": "Eth1",
+                    "lanes": "65, 66, 67, 68",
+                    "description": "Ethernet0 100G link",
+                    "speed": "100000"
+                },
+                "Ethernet4": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/4",
+                    "description": "Servers0:eth0",
+                    "index": "1",
+                    "lanes": "29,30,31,32",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                },
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/8",
+                    "description": "Servers1:eth0",
+                    "index": "2",
+                    "lanes": "33,34,35,36",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                }
+            }
+        },
+        "patch": [
+            {
+                "op": "replace",
+                "path": "/ACL_TABLE/EVERFLOWV6/ports/0",
+                "value": "Ethernet0"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE/EVERFLOWV6/ports/0"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/EVERFLOWV6/ports/0",
+                    "value": "Ethernet0"
+                }
+            ]
+        ]
+    },
+    "MODIFY_VALUE_IN_EXISTING_TABLE__SUCCESS": {
+        "desc": "Modify value in existing table success.",
+        "current_config": {
+            "VLAN_MEMBER": {
+                "Vlan1000|Ethernet0": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan1000|Ethernet4": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan1000|Ethernet8": {
+                    "tagging_mode": "untagged"
+                }
+            },
+            "VLAN": {
+                "Vlan1000": {
+                    "vlanid": "1000",
+                    "dhcp_servers": [
+                        "192.0.0.1",
+                        "192.0.0.2",
+                        "192.0.0.3",
+                        "192.0.0.4"
+                    ]
+                }
+            },
+            "ACL_TABLE": {
+                "NO-NSW-PACL-V4": {
+                    "type": "L3",
+                    "policy_desc": "NO-NSW-PACL-V4",
+                    "ports": [
+                        "Ethernet0"
+                    ]
+                },
+                "DATAACL": {
+                    "policy_desc": "DATAACL",
+                    "ports": [
+                        "Ethernet4"
+                    ],
+                    "stage": "ingress",
+                    "type": "L3"
+                },
+                "EVERFLOW": {
+                    "policy_desc": "EVERFLOW",
+                    "ports": [
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRROR"
+                },
+                "EVERFLOWV6": {
+                    "policy_desc": "EVERFLOWV6",
+                    "ports": [
+                        "Ethernet4",
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRRORV6"
+                }
+            },
+            "PORT": {
+                "Ethernet0": {
+                    "alias": "Eth1",
+                    "lanes": "65, 66, 67, 68",
+                    "description": "Ethernet0 100G link",
+                    "speed": "100000"
+                },
+                "Ethernet4": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/4",
+                    "description": "Servers0:eth0",
+                    "index": "1",
+                    "lanes": "29,30,31,32",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                },
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/8",
+                    "description": "Servers1:eth0",
+                    "index": "2",
+                    "lanes": "33,34,35,36",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                }
+            }
+        },
+        "patch": [
+            {
+                "op": "replace",
+                "path": "/ACL_TABLE/EVERFLOW/stage",
+                "value": "egress"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "replace",
+                    "path": "/ACL_TABLE/EVERFLOW/stage",
+                    "value": "egress"
+                }
+            ]
+        ]
+    },
+    "PATCH_WITH_SINGLE_SIMPLE_OPERATION__RETURNS_ONE_CHANGE": {
+        "desc": "Patch with single simple operation returns one change.",
+        "current_config": {
+            "VLAN_MEMBER": {
+                "Vlan1000|Ethernet0": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan1000|Ethernet4": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan1000|Ethernet8": {
+                    "tagging_mode": "untagged"
+                }
+            },
+            "VLAN": {
+                "Vlan1000": {
+                    "vlanid": "1000",
+                    "dhcp_servers": [
+                        "192.0.0.1",
+                        "192.0.0.2",
+                        "192.0.0.3",
+                        "192.0.0.4"
+                    ]
+                }
+            },
+            "ACL_TABLE": {
+                "NO-NSW-PACL-V4": {
+                    "type": "L3",
+                    "policy_desc": "NO-NSW-PACL-V4",
+                    "ports": [
+                        "Ethernet0"
+                    ]
+                },
+                "DATAACL": {
+                    "policy_desc": "DATAACL",
+                    "ports": [
+                        "Ethernet4"
+                    ],
+                    "stage": "ingress",
+                    "type": "L3"
+                },
+                "EVERFLOW": {
+                    "policy_desc": "EVERFLOW",
+                    "ports": [
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRROR"
+                },
+                "EVERFLOWV6": {
+                    "policy_desc": "EVERFLOWV6",
+                    "ports": [
+                        "Ethernet4",
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRRORV6"
+                }
+            },
+            "PORT": {
+                "Ethernet0": {
+                    "alias": "Eth1",
+                    "lanes": "65, 66, 67, 68",
+                    "description": "Ethernet0 100G link",
+                    "speed": "100000"
+                },
+                "Ethernet4": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/4",
+                    "description": "Servers0:eth0",
+                    "index": "1",
+                    "lanes": "29,30,31,32",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                },
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/8",
+                    "description": "Servers1:eth0",
+                    "index": "2",
+                    "lanes": "33,34,35,36",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                }
+            }
+        },
+        "patch": [
+            {
+                "op": "remove",
+                "path": "/VLAN/Vlan1000/dhcp_servers/0"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "remove",
+                    "path": "/VLAN/Vlan1000/dhcp_servers/0"
+                }
+            ]
+        ]
+    },
+    "REMOVE_2_ITEMS_WITH_DEPENDENCY_FROM_DIFFERENT_TABLES__SUCCESS": {
+        "desc": "Remove 2 items with dependency from different tables success.",
+        "current_config": {
+            "VLAN_MEMBER": {
+                "Vlan1000|Ethernet0": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan1000|Ethernet4": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan1000|Ethernet8": {
+                    "tagging_mode": "untagged"
+                }
+            },
+            "VLAN": {
+                "Vlan1000": {
+                    "vlanid": "1000",
+                    "dhcp_servers": [
+                        "192.0.0.1",
+                        "192.0.0.2",
+                        "192.0.0.3",
+                        "192.0.0.4"
+                    ]
+                }
+            },
+            "ACL_TABLE": {
+                "DATAACL": {
+                    "policy_desc": "DATAACL",
+                    "ports": [
+                        "Ethernet4"
+                    ],
+                    "stage": "ingress",
+                    "type": "L3"
+                },
+                "EVERFLOW": {
+                    "policy_desc": "EVERFLOW",
+                    "ports": [
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRROR"
+                },
+                "EVERFLOWV6": {
+                    "policy_desc": "EVERFLOWV6",
+                    "ports": [
+                        "Ethernet4",
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRRORV6"
+                }
+            },
+            "PORT": {
+                "Ethernet0": {
+                    "alias": "Eth1",
+                    "lanes": "65, 66, 67, 68",
+                    "description": "Ethernet0 100G link",
+                    "speed": "100000"
+                },
+                "Ethernet4": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/4",
+                    "description": "Servers0:eth0",
+                    "index": "1",
+                    "lanes": "29,30,31,32",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                },
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/8",
+                    "description": "Servers1:eth0",
+                    "index": "2",
+                    "lanes": "33,34,35,36",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                }
+            }
+        },
+        "patch": [
+            {
+                "op": "remove",
+                "path": "/VLAN_MEMBER/Vlan1000|Ethernet0"
+            },
+            {
+                "op": "remove",
+                "path": "/PORT/Ethernet0"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "remove",
+                    "path": "/PORT/Ethernet0/alias"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/PORT/Ethernet0/description"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/VLAN_MEMBER/Vlan1000|Ethernet0"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/PORT/Ethernet0"
+                }
+            ]
+        ]
+    },
+    "REMOVE_2_ITEMS_WITH_DEPENDENCY_FROM_SAME_TABLE__SUCCESS": {
+        "desc": "Remove 2 items with dependency from same table success.",
+        "current_config": {
+            "INTERFACE": {
+                "Ethernet8": {},
+                "Ethernet8|10.0.0.1/30": {
+                    "family": "IPv4",
+                    "scope": "global"
+                },
+                "Ethernet9": {}
+            },
+            "PORT": {
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "eth8",
+                    "description": "Ethernet8",
+                    "fec": "rs",
+                    "lanes": "65",
+                    "mtu": "9000",
+                    "speed": "25000"
+                },
+                "Ethernet9": {
+                    "admin_status": "up",
+                    "alias": "eth9",
+                    "description": "Ethernet9",
+                    "fec": "rs",
+                    "lanes": "6",
+                    "mtu": "9000",
+                    "speed": "25000"
+                }
+            }
+        },
+        "patch": [
+            {
+                "op": "remove",
+                "path": "/INTERFACE/Ethernet8"
+            },
+            {
+                "op": "remove",
+                "path": "/INTERFACE/Ethernet8|10.0.0.1~130"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "remove",
+                    "path": "/INTERFACE/Ethernet8|10.0.0.1~130/family"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/INTERFACE/Ethernet8|10.0.0.1~130/scope"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/INTERFACE/Ethernet8|10.0.0.1~130"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/INTERFACE/Ethernet8"
+                }
+            ]
+        ]
+    },
+    "REMOVE_AN_ITEM_WITH_DEFAULT_VALUE__SUCCESS": {
+        "desc": "Remove an item with default value success.",
+        "current_config": {
+            "VLAN_MEMBER": {
+                "Vlan1000|Ethernet0": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan1000|Ethernet4": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan1000|Ethernet8": {
+                    "tagging_mode": "untagged"
+                }
+            },
+            "VLAN": {
+                "Vlan1000": {
+                    "vlanid": "1000",
+                    "dhcp_servers": [
+                        "192.0.0.1",
+                        "192.0.0.2",
+                        "192.0.0.3",
+                        "192.0.0.4"
+                    ]
+                }
+            },
+            "ACL_TABLE": {
+                "NO-NSW-PACL-V4": {
+                    "type": "L3",
+                    "policy_desc": "NO-NSW-PACL-V4",
+                    "ports": [
+                        "Ethernet0"
+                    ]
+                },
+                "DATAACL": {
+                    "policy_desc": "DATAACL",
+                    "ports": [
+                        "Ethernet4"
+                    ],
+                    "stage": "ingress",
+                    "type": "L3"
+                },
+                "EVERFLOW": {
+                    "policy_desc": "EVERFLOW",
+                    "ports": [
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRROR"
+                },
+                "EVERFLOWV6": {
+                    "policy_desc": "EVERFLOWV6",
+                    "ports": [
+                        "Ethernet4",
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRRORV6"
+                }
+            },
+            "PORT": {
+                "Ethernet0": {
+                    "alias": "Eth1",
+                    "lanes": "65, 66, 67, 68",
+                    "description": "Ethernet0 100G link",
+                    "speed": "100000"
+                },
+                "Ethernet4": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/4",
+                    "description": "Servers0:eth0",
+                    "index": "1",
+                    "lanes": "29,30,31,32",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                },
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/8",
+                    "description": "Servers1:eth0",
+                    "index": "2",
+                    "lanes": "33,34,35,36",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                }
+            }
+        },
+        "patch": [
+            {
+                "op": "remove",
+                "path": "/ACL_TABLE/EVERFLOW/stage"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE/EVERFLOW/stage"
+                }
+            ]
+        ]
+    },
+    "REMOVE_TABLE__SUCCESS": {
+        "desc": "Remove table success.",
+        "current_config": {
+            "VLAN_MEMBER": {
+                "Vlan1000|Ethernet0": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan1000|Ethernet4": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan1000|Ethernet8": {
+                    "tagging_mode": "untagged"
+                }
+            },
+            "VLAN": {
+                "Vlan1000": {
+                    "vlanid": "1000",
+                    "dhcp_servers": [
+                        "192.0.0.1",
+                        "192.0.0.2",
+                        "192.0.0.3",
+                        "192.0.0.4"
+                    ]
+                }
+            },
+            "ACL_TABLE": {
+                "NO-NSW-PACL-V4": {
+                    "type": "L3",
+                    "policy_desc": "NO-NSW-PACL-V4",
+                    "ports": [
+                        "Ethernet0"
+                    ]
+                },
+                "DATAACL": {
+                    "policy_desc": "DATAACL",
+                    "ports": [
+                        "Ethernet4"
+                    ],
+                    "stage": "ingress",
+                    "type": "L3"
+                },
+                "EVERFLOW": {
+                    "policy_desc": "EVERFLOW",
+                    "ports": [
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRROR"
+                },
+                "EVERFLOWV6": {
+                    "policy_desc": "EVERFLOWV6",
+                    "ports": [
+                        "Ethernet4",
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRRORV6"
+                }
+            },
+            "PORT": {
+                "Ethernet0": {
+                    "alias": "Eth1",
+                    "lanes": "65, 66, 67, 68",
+                    "description": "Ethernet0 100G link",
+                    "speed": "100000"
+                },
+                "Ethernet4": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/4",
+                    "description": "Servers0:eth0",
+                    "index": "1",
+                    "lanes": "29,30,31,32",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                },
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/8",
+                    "description": "Servers1:eth0",
+                    "index": "2",
+                    "lanes": "33,34,35,36",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                }
+            }
+        },
+        "patch": [
+            {
+                "op": "remove",
+                "path": "/ACL_TABLE"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/policy_desc"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE/DATAACL/policy_desc"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE/DATAACL/stage"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE/EVERFLOW/policy_desc"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE/EVERFLOW/stage"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE/EVERFLOWV6/policy_desc"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE/EVERFLOWV6/ports/0"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE/EVERFLOWV6/stage"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE/NO-NSW-PACL-V4"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE/DATAACL/ports"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE/DATAACL"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE/EVERFLOW/ports"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE/EVERFLOW"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE/EVERFLOWV6/ports"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE"
+                }
+            ]
+        ]
+    },
+    "REMOVING_CREATE_ONLY_FIELD__SUCCESS": {
+        "desc": "Removing create only field success.",
+        "current_config": {
+            "LOOPBACK_INTERFACE": {
+                "Loopback0": {},
+                "Loopback0|10.1.0.32/32": {},
+                "Loopback0|1100:1::32/128": {},
+                "Loopback1": {
+                    "vrf_name": "Vrf_02"
+                },
+                "Loopback1|20.2.0.32/32": {},
+                "Loopback1|2200:2::32/128": {}
+            },
+            "VRF": {
+                "Vrf_01": {},
+                "Vrf_02": {}
+            }
+        },
+        "patch": [
+            {
+                "op": "remove",
+                "path": "/LOOPBACK_INTERFACE/Loopback1/vrf_name"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "remove",
+                    "path": "/LOOPBACK_INTERFACE/Loopback1|2200:2::32~1128"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/LOOPBACK_INTERFACE/Loopback1|20.2.0.32~132"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/LOOPBACK_INTERFACE/Loopback1|2200:2::32~1128",
+                    "value": {}
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/LOOPBACK_INTERFACE/Loopback0|10.1.0.32~132"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/LOOPBACK_INTERFACE/Loopback1|20.2.0.32~132",
+                    "value": {}
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/LOOPBACK_INTERFACE/Loopback1|2200:2::32~1128"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/LOOPBACK_INTERFACE/Loopback1|20.2.0.32~132"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/LOOPBACK_INTERFACE/Loopback1"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/LOOPBACK_INTERFACE/Loopback0|10.1.0.32~132",
+                    "value": {}
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/LOOPBACK_INTERFACE/Loopback1",
+                    "value": {}
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/LOOPBACK_INTERFACE/Loopback1|20.2.0.32~132",
+                    "value": {}
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/LOOPBACK_INTERFACE/Loopback1|2200:2::32~1128",
+                    "value": {}
+                }
+            ]
+        ]
+    },
+    "REPLACE_MANDATORY_ITEM__SUCCESS": {
+        "desc": "Replace mandatory item success.",
+        "current_config": {
+            "VLAN_MEMBER": {
+                "Vlan1000|Ethernet0": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan1000|Ethernet4": {
+                    "tagging_mode": "untagged"
+                },
+                "Vlan1000|Ethernet8": {
+                    "tagging_mode": "untagged"
+                }
+            },
+            "VLAN": {
+                "Vlan1000": {
+                    "vlanid": "1000",
+                    "dhcp_servers": [
+                        "192.0.0.1",
+                        "192.0.0.2",
+                        "192.0.0.3",
+                        "192.0.0.4"
+                    ]
+                }
+            },
+            "ACL_TABLE": {
+                "NO-NSW-PACL-V4": {
+                    "type": "L3",
+                    "policy_desc": "NO-NSW-PACL-V4",
+                    "ports": [
+                        "Ethernet0"
+                    ]
+                },
+                "DATAACL": {
+                    "policy_desc": "DATAACL",
+                    "ports": [
+                        "Ethernet4"
+                    ],
+                    "stage": "ingress",
+                    "type": "L3"
+                },
+                "EVERFLOW": {
+                    "policy_desc": "EVERFLOW",
+                    "ports": [
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRROR"
+                },
+                "EVERFLOWV6": {
+                    "policy_desc": "EVERFLOWV6",
+                    "ports": [
+                        "Ethernet4",
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRRORV6"
+                }
+            },
+            "PORT": {
+                "Ethernet0": {
+                    "alias": "Eth1",
+                    "lanes": "65, 66, 67, 68",
+                    "description": "Ethernet0 100G link",
+                    "speed": "100000"
+                },
+                "Ethernet4": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/4",
+                    "description": "Servers0:eth0",
+                    "index": "1",
+                    "lanes": "29,30,31,32",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                },
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/8",
+                    "description": "Servers1:eth0",
+                    "index": "2",
+                    "lanes": "33,34,35,36",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                }
+            }
+        },
+        "patch": [
+            {
+                "op": "replace",
+                "path": "/ACL_TABLE/EVERFLOWV6/type",
+                "value": "L2"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "replace",
+                    "path": "/ACL_TABLE/EVERFLOWV6/type",
+                    "value": "L2"
+                }
+            ]
+        ]
+    },
+    "REPLACING_CREATE_ONLY_FIELD__SUCCESS": {
+        "desc": "Replacing create only field success.",
+        "current_config": {
+            "PORT": {
+                "Ethernet0": {
+                    "alias": "Eth1",
+                    "lanes": "65, 66, 67, 68",
+                    "description": "Ethernet0 100G link",
+                    "speed": "100000"
+                }
+            },
+            "ACL_TABLE": {
+                "NO-NSW-PACL-V4": {
+                    "type": "L3",
+                    "policy_desc": "NO-NSW-PACL-V4",
+                    "ports": [
+                        "Ethernet0"
+                    ]
+                }
+            },
+            "VLAN_MEMBER": {
+                "Vlan100|Ethernet0": {
+                    "tagging_mode": "untagged"
+                }
+            },
+            "VLAN": {
+                "Vlan100": {
+                    "vlanid": "100",
+                    "dhcp_servers": [
+                        "192.0.0.1",
+                        "192.0.0.2",
+                        "192.0.0.3",
+                        "192.0.0.4"
+                    ]
+                }
+            }
+        },
+        "patch": [
+            {
+                "op": "replace",
+                "path": "/PORT/Ethernet0/lanes",
+                "value": "67"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/VLAN_MEMBER"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports",
+                    "value": [
+                        "Ethernet0"
+                    ]
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE",
+                    "value": {
+                        "NO-NSW-PACL-V4": {
+                            "type": "L3"
+                        }
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/PORT"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/policy_desc",
+                    "value": "NO-NSW-PACL-V4"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/PORT",
+                    "value": {
+                        "Ethernet0": {
+                            "alias": "Eth1",
+                            "lanes": "67",
+                            "description": "Ethernet0 100G link",
+                            "speed": "100000"
+                        }
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports",
+                    "value": [
+                        "Ethernet0"
+                    ]
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/VLAN_MEMBER",
+                    "value": {
+                        "Vlan100|Ethernet0": {
+                            "tagging_mode": "untagged"
+                        }
+                    }
+                }
+            ]
+        ]
+    }
+}


### PR DESCRIPTION
#### What I did
Moved PatchSorter unit-test to json file to make it easier to read/maintain

In the future this test json file can be used for adding nightly tests.

While testing I had to set `skip_exact_change_list_match=True` because different runs of the same input produce correct but different changes. It is better to always generate the same steps for easier debugging. Created issue: #1976

#### How I did it
Copied to Json file the following:
- current_config i.e. current running config
- patch 
- expected change list

#### How to verify it
unit-tests

