### PR TITLE
Fix wrong help message for cable length setting

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -4085,7 +4085,7 @@ def remove_pg(ctx, interface_name, pg_map):
 @click.argument('length', metavar='<length>', required=True)
 @click.pass_context
 def cable_length(ctx, interface_name, length):
-    """Set lossless PGs for the interface"""
+    """Set interface cable length"""
     config_db = ctx.obj["config_db"]
 
     if not is_dynamic_buffer_enabled(config_db):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Replace the wrong help message of "Set lossless PGs for the interface" with the right one "Set interface cable length"

#### How I did it
Update the help message to the relevant one on main.py 

#### How to verify it
Run the following command: "config interface cable-length Ethernet0 -h"

#### Previous command output (if the output of a command-line utility has changed)
Set lossless PGs for the interface

#### New command output (if the output of a command-line utility has changed)
Set interface cable length

