### PR TITLE
Update the example for pfcwd start command

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2052,7 +2052,7 @@ def start(action, restoration_time, ports, detection_time, verbose):
     Start PFC watchdog on port(s). To config all ports, use all as input.
 
     Example:
-        config pfcwd start --action drop ports all detection-time 400 --restoration-time 400
+        config pfcwd start --action drop all 400 --restoration-time 400
     """
     cmd = "pfcwd start"
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -6154,8 +6154,8 @@ This command starts PFC Watchdog
 
 - Usage:
   ```
-  config pfcwd start --action drop ports all detection-time 400 --restoration-time 400
-  config pfcwd start --action forward ports Ethernet0 Ethernet8 detection-time 400
+  config pfcwd start --action drop all 400 --restoration-time 400
+  config pfcwd start --action forward Ethernet0 Ethernet8 400
   ```
 
 **config pfcwd stop**

--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -455,7 +455,7 @@ class Start(object):
 
         Example:
 
-        sudo pfcwd start --action drop ports all detection-time 400 --restoration-time 400
+        sudo pfcwd start --action drop all 400 --restoration-time 400
 
         """
         PfcwdCli(db).start(

--- a/tests/pfcwd_test.py
+++ b/tests/pfcwd_test.py
@@ -118,7 +118,7 @@ class TestPfcwd(object):
 
     @patch('pfcwd.main.os')
     def test_pfcwd_start_actions(self, mock_os):
-        # pfcwd start --action fwd --restoration-time 200 Ethernet0 200
+        # pfcwd start --action forward --restoration-time 200 Ethernet0 200
         import pfcwd.main as pfcwd
         runner = CliRunner()
         db = Db()


### PR DESCRIPTION
… it says invalid options. Update it with a correct command

Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
The example of pfcwd start command in start function comments is a little confused, after execution, it says invalid options. 
Update it with a correct command.
The output of the current example is:
admin@vlab-01:~$ sudo pfcwd start --action drop ports all detection-time 400 --restoration-time 400
Failed to run command, invalid options:
ports
detection-time

#### How I did it
Update the example with a correct one in pfcwd start function comments which is also usage info for pfcwd start command.

#### How to verify it
Enter SONiC DUT, input the following command:
sudo pfcwd start --help
sudo pfcwd start --action drop all 400 --restoration-time 400

#### Previous command output (if the output of a command-line utility has changed)
admin@vlab-01:~$ sudo pfcwd start --help
Usage: pfcwd start [OPTIONS] [PORTS]... DETECTION_TIME

  Start PFC watchdog on port(s). To config all ports, use all as input.

  Example:

  sudo pfcwd start --action drop ports all detection-time 400 --restoration-
  time 400

Options:
  -a, --action [drop|forward|alert]
  -r, --restoration-time INTEGER RANGE
  --help                          Show this message and exit.

#### New command output (if the output of a command-line utility has changed)

admin@vlab-01:~$ sudo pfcwd start --help
Usage: pfcwd start [OPTIONS] [PORTS]... DETECTION_TIME

  Start PFC watchdog on port(s). To config all ports, use all as input.

  Example:

  start --action drop all 400 --restoration-time 400

Options:
  -a, --action [drop|forward|alert]
  -r, --restoration-time INTEGER RANGE
  --help                          Show this message and exit.