### PR TITLE
[GCU] Using simulated config instead of target config when validating replace operation in NoDependencyMoveValidator

### DIFF
--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -544,10 +544,12 @@ class NoDependencyMoveValidator:
         simulated_config = move.apply(diff.current_config)
         deleted_paths, added_paths = self._get_paths(diff.current_config, simulated_config, [])
 
+        # For deleted paths, we check the current config has no dependencies between nodes under the removed path
         if not self._validate_paths_config(deleted_paths, diff.current_config):
             return False
 
-        if not self._validate_paths_config(added_paths, diff.target_config):
+        # For added paths, we check the simulated config has no dependencies between nodes under the added path
+        if not self._validate_paths_config(added_paths, simulated_config):
             return False
 
         return True
@@ -1013,7 +1015,7 @@ class MemoizationSorter:
         self.move_wrapper = move_wrapper
         self.mem = {}
 
-    def rec(self, diff):
+    def sort(self, diff):
         if diff.has_no_diff():
             return []
 

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -1054,6 +1054,37 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
         # Act and assert
         self.assertTrue(self.validator.validate(move, diff))
 
+    def test_validate__replace_list_item_different_location_than_target_and_no_deps__true(self):
+        # Arrange
+        current_config = {
+            "VLAN": {
+                "Vlan100": {
+                    "vlanid": "100",
+                    "dhcp_servers": [
+                        "192.0.0.1",
+                        "192.0.0.2"
+                    ]
+                }
+            }
+        }
+        target_config = {
+            "VLAN": {
+                "Vlan100": {
+                    "vlanid": "100",
+                    "dhcp_servers": [
+                        "192.0.0.3"
+                    ]
+                }
+            }
+        }
+        diff = ps.Diff(current_config, target_config)
+        # the target tokens point to location 0 which exist in target_config
+        # but the replace operation is operating on location 1 in current_config
+        move = ps.JsonMove(diff, OperationType.REPLACE, ["VLAN", "Vlan100", "dhcp_servers", 1], ["VLAN", "Vlan100", "dhcp_servers", 0])
+
+        # Act and assert
+        self.assertTrue(self.validator.validate(move, diff))
+
     def prepare_config(self, config, patch):
         return patch.apply(config)
 


### PR DESCRIPTION
#### What I did
Using `SimulatedConfig` instead of `TargetConfig` for validating a move using `NoDependencyMoveValidator`

SimulatedConfig: config after applying the given move
TargetConfig: the final config state that's required by the patch

The problem is if the moves is to update a list item, the list item location in the `TargetConfig` might have different location in the `CurrentConfig`.

The reason for that is the `TargetConfig` has the final outcome after applying the `patch`, but the move might be just making a small change towards this goal.

Example:
Assume current_config
```
{
    "VLAN": {
        "Vlan100": {
            "vlanid": "100",
            "dhcp_servers": [
                "192.0.0.1",
                "192.0.0.2"
            ]
        }
    }
}
```
TargetConfig:
```
{
    "VLAN": {
        "Vlan100": {
            "vlanid": "100",
            "dhcp_servers": [
                "192.0.0.3"
            ]
        }
    }
}
```
Move:
```python
ps.JsonMove(diff, OperationType.REPLACE, ["VLAN", "Vlan100", "dhcp_servers", 1], ["VLAN", "Vlan100", "dhcp_servers", 0])
```


The move means:
```
Replace the value in CurrentConfig that has path `/VLAN/Vlan100/dhcp_servers/1` with
the value from the TargetConfig that has the path `/VLAN/Vlan100/dhcp_servers/0`
```
Notice how the array index in CurrentConfig does not exist in TargetConfig

Instead of using TargetConfig to validate, use SimulatedConfig which is the config after applying the move. In this case it would be:
```
{
    "VLAN": {
        "Vlan100": {
            "vlanid": "100",
            "dhcp_servers": [
                "192.0.0.1",
                "192.0.0.3"
            ]
        }
    }
}
```

#### How I did it
Replace `diff.target_config` with `simulated_config`

#### How to verify it
added a unit-test
