### PR TITLE
Revert "Revert "[sonic-package-manager] support sonic-cli-gen and pac…

### DIFF
--- a/sonic_package_manager/main.py
+++ b/sonic_package_manager/main.py
@@ -414,10 +414,11 @@ def reset(ctx, name, force, yes, skip_host_plugins):
 
 @cli.command()
 @add_options(PACKAGE_COMMON_OPERATION_OPTIONS)
+@click.option('--keep-config', is_flag=True, help='Keep features configuration in CONFIG DB.')
 @click.argument('name')
 @click.pass_context
 @root_privileges_required
-def uninstall(ctx, name, force, yes):
+def uninstall(ctx, name, force, yes, keep_config):
     """ Uninstall package. """
 
     manager: PackageManager = ctx.obj
@@ -428,6 +429,7 @@ def uninstall(ctx, name, force, yes):
 
     uninstall_opts = {
         'force': force,
+        'keep_config': keep_config,
     }
 
     try:

--- a/sonic_package_manager/manager.py
+++ b/sonic_package_manager/manager.py
@@ -10,7 +10,10 @@ from typing import Any, Iterable, List, Callable, Dict, Optional
 
 import docker
 import filelock
+from config import config_mgmt
 from sonic_py_common import device_info
+
+from sonic_cli_gen.generator import CliGenerator
 
 from sonic_package_manager import utils
 from sonic_package_manager.constraint import (
@@ -45,7 +48,10 @@ from sonic_package_manager.service_creator.creator import (
     run_command
 )
 from sonic_package_manager.service_creator.feature import FeatureRegistry
-from sonic_package_manager.service_creator.sonic_db import SonicDB
+from sonic_package_manager.service_creator.sonic_db import (
+    INIT_CFG_JSON,
+    SonicDB
+)
 from sonic_package_manager.service_creator.utils import in_chroot
 from sonic_package_manager.source import (
     PackageSource,
@@ -435,13 +441,16 @@ class PackageManager:
 
     @under_lock
     @opt_check
-    def uninstall(self, name: str, force=False):
+    def uninstall(self, name: str,
+                  force: bool = False,
+                  keep_config: bool = False):
         """ Uninstall SONiC Package referenced by name. The uninstallation
         can be forced if force argument is True.
 
         Args:
             name: SONiC Package name.
             force: Force the installation.
+            keep_config: Keep feature configuration in databases.
         Raises:
             PackageManagerError
         """
@@ -482,7 +491,7 @@ class PackageManager:
             self._systemctl_action(package, 'stop')
             self._systemctl_action(package, 'disable')
             self._uninstall_cli_plugins(package)
-            self.service_creator.remove(package)
+            self.service_creator.remove(package, keep_config=keep_config)
             self.service_creator.generate_shutdown_sequence_files(
                 self._get_installed_packages_except(package)
             )
@@ -1000,9 +1009,13 @@ class PackageManager:
         docker_api = DockerApi(docker.from_env(), ProgressManager())
         registry_resolver = RegistryResolver()
         metadata_resolver = MetadataResolver(docker_api, registry_resolver)
+        cfg_mgmt = config_mgmt.ConfigMgmt(source=INIT_CFG_JSON)
+        cli_generator = CliGenerator(log)
         feature_registry = FeatureRegistry(SonicDB)
         service_creator = ServiceCreator(feature_registry,
-                                         SonicDB)
+                                         SonicDB,
+                                         cli_generator,
+                                         cfg_mgmt)
 
         return PackageManager(docker_api,
                               registry_resolver,

--- a/sonic_package_manager/manifest.py
+++ b/sonic_package_manager/manifest.py
@@ -205,7 +205,9 @@ class ManifestSchema:
             ManifestField('mandatory', DefaultMarshaller(bool), False),
             ManifestField('show', DefaultMarshaller(str), ''),
             ManifestField('config', DefaultMarshaller(str), ''),
-            ManifestField('clear', DefaultMarshaller(str), '')
+            ManifestField('clear', DefaultMarshaller(str), ''),
+            ManifestField('auto-generate-show', DefaultMarshaller(bool), False),
+            ManifestField('auto-generate-config', DefaultMarshaller(bool), False),
         ])
     ])
 

--- a/sonic_package_manager/metadata.py
+++ b/sonic_package_manager/metadata.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 
 import json
 import tarfile
-from typing import Dict
+from typing import Dict, Optional
 
 from sonic_package_manager import utils
 from sonic_package_manager.errors import MetadataError
@@ -54,6 +54,7 @@ class Metadata:
 
     manifest: Manifest
     components: Dict[str, Version] = field(default_factory=dict)
+    yang_module_str: Optional[str] = None
 
 
 class MetadataResolver:
@@ -163,5 +164,6 @@ class MetadataResolver:
                 except ValueError as err:
                     raise MetadataError(f'Failed to parse component version: {err}')
 
-        return Metadata(Manifest.marshal(manifest_dict), components)
+        yang_module_str = sonic_metadata.get('yang-module')
 
+        return Metadata(Manifest.marshal(manifest_dict), components, yang_module_str)

--- a/sonic_package_manager/service_creator/creator.py
+++ b/sonic_package_manager/service_creator/creator.py
@@ -8,16 +8,23 @@ from collections import defaultdict
 from typing import Dict, Type
 
 import jinja2 as jinja2
+from config.config_mgmt import ConfigMgmt
 from prettyprinter import pformat
 from toposort import toposort_flatten, CircularDependencyError
 
+from config.config_mgmt import sonic_cfggen
+from sonic_cli_gen.generator import CliGenerator
 from sonic_package_manager import utils
 from sonic_package_manager.logger import log
 from sonic_package_manager.package import Package
-from sonic_package_manager.service_creator import ETC_SONIC_PATH
+from sonic_package_manager.service_creator import (
+    ETC_SONIC_PATH,
+    SONIC_CLI_COMMANDS,
+)
 from sonic_package_manager.service_creator.feature import FeatureRegistry
 from sonic_package_manager.service_creator.sonic_db import SonicDB
 from sonic_package_manager.service_creator.utils import in_chroot
+
 
 SERVICE_FILE_TEMPLATE = 'sonic.service.j2'
 TIMER_UNIT_TEMPLATE = 'timer.unit.j2'
@@ -116,16 +123,22 @@ class ServiceCreator:
 
     def __init__(self,
                  feature_registry: FeatureRegistry,
-                 sonic_db: Type[SonicDB]):
+                 sonic_db: Type[SonicDB],
+                 cli_gen: CliGenerator,
+                 cfg_mgmt: ConfigMgmt):
         """ Initialize ServiceCreator with:
 
         Args:
             feature_registry: FeatureRegistry object.
             sonic_db: SonicDB interface.
+            cli_gen: CliGenerator instance.
+            cfg_mgmt: ConfigMgmt instance.
          """
 
         self.feature_registry = feature_registry
         self.sonic_db = sonic_db
+        self.cli_gen = cli_gen
+        self.cfg_mgmt = cfg_mgmt
 
     def create(self,
                package: Package,
@@ -151,25 +164,27 @@ class ServiceCreator:
             self.generate_systemd_service(package)
             self.generate_dump_script(package)
             self.generate_service_reconciliation_file(package)
-
+            self.install_yang_module(package)
             self.set_initial_config(package)
+            self.install_autogen_cli_all(package)
             self._post_operation_hook()
 
             if register_feature:
-                self.feature_registry.register(package.manifest,
-                                               state, owner)
+                self.feature_registry.register(package.manifest, state, owner)
         except (Exception, KeyboardInterrupt):
-            self.remove(package, register_feature)
+            self.remove(package, deregister_feature=register_feature)
             raise
 
     def remove(self,
                package: Package,
-               deregister_feature: bool = True):
+               deregister_feature: bool = True,
+               keep_config: bool = False):
         """ Uninstall SONiC service provided by the package.
 
         Args:
             package: Package object to uninstall.
             deregister_feature: Wether to deregister this package from FEATURE table.
+            keep_config: Whether to remove package configuration.
 
         Returns:
             None
@@ -183,11 +198,16 @@ class ServiceCreator:
         remove_if_exists(os.path.join(DEBUG_DUMP_SCRIPT_LOCATION, f'{name}'))
         remove_if_exists(os.path.join(ETC_SONIC_PATH, f'{name}_reconcile'))
         self.update_dependent_list_file(package, remove=True)
+
+        if deregister_feature and not keep_config:
+            self.remove_config(package)
+
+        self.uninstall_autogen_cli_all(package)
+        self.uninstall_yang_module(package)
         self._post_operation_hook()
 
         if deregister_feature:
             self.feature_registry.deregister(package.manifest['service']['name'])
-            self.remove_config(package)
 
     def generate_container_mgmt(self, package: Package):
         """ Generates container management script under /usr/bin/<service>.sh for package.
@@ -308,7 +328,6 @@ class ServiceCreator:
             remove: True if update for removal process.
         Returns:
             None.
-
         """
 
         name = package.manifest['service']['name']
@@ -476,13 +495,11 @@ class ServiceCreator:
             cfg = conn.get_config()
             new_cfg = init_cfg.copy()
             utils.deep_update(new_cfg, cfg)
+            self.validate_config(new_cfg)
             conn.mod_config(new_cfg)
 
     def remove_config(self, package):
-        """ Remove configuration based on init-cfg tables, so having
-        init-cfg even with tables without keys might be a good idea.
-        TODO: init-cfg should be validated with yang model
-        TODO: remove config from tables known to yang model
+        """ Remove configuration based on package YANG module.
 
         Args:
             package: Package object remove initial configuration for.
@@ -490,14 +507,131 @@ class ServiceCreator:
             None
         """
 
-        init_cfg = package.manifest['package']['init-cfg']
-        if not init_cfg:
+        if not package.metadata.yang_module_str:
             return
 
-        for conn in self.sonic_db.get_connectors():
-            for table in init_cfg:
-                for key in init_cfg[table]:
-                    conn.set_entry(table, key, None)
+        module_name = self.cfg_mgmt.get_module_name(package.metadata.yang_module_str)
+        for tablename, module in self.cfg_mgmt.sy.confDbYangMap.items():
+            if module.get('module') != module_name:
+                continue
+
+            for conn in self.sonic_db.get_connectors():
+                keys = conn.get_table(tablename).keys()
+                for key in keys:
+                    conn.set_entry(tablename, key, None)
+
+    def validate_config(self, config):
+        """ Validate configuration through YANG.
+
+        Args:
+            config: Config DB data.
+        Returns:
+            None.
+        Raises:
+            Exception: if config does not pass YANG validation.
+        """
+
+        config = sonic_cfggen.FormatConverter.to_serialized(config)
+        log.debug(f'validating configuration {pformat(config)}')
+        # This will raise exception if configuration is not valid.
+        # NOTE: loadData() modifies the state of ConfigMgmt instance.
+        # This is not desired for configuration validation only purpose.
+        # Although the config loaded into ConfigMgmt instance is not
+        # interesting in this application so we don't care.
+        self.cfg_mgmt.loadData(config)
+
+    def install_yang_module(self, package: Package):
+        """ Install package's yang module in the system.
+
+        Args:
+            package: Package object.
+        Returns:
+            None
+        """
+
+        if not package.metadata.yang_module_str:
+            return
+
+        self.cfg_mgmt.add_module(package.metadata.yang_module_str)
+
+    def uninstall_yang_module(self, package: Package):
+        """ Uninstall package's yang module in the system.
+
+        Args:
+            package: Package object.
+        Returns:
+            None
+        """
+
+        if not package.metadata.yang_module_str:
+            return
+
+        module_name = self.cfg_mgmt.get_module_name(package.metadata.yang_module_str)
+        self.cfg_mgmt.remove_module(module_name)
+
+    def install_autogen_cli_all(self, package: Package):
+        """ Install autogenerated CLI plugins for package.
+
+        Args:
+            package: Package
+        Returns:
+            None
+        """
+
+        for command in SONIC_CLI_COMMANDS:
+            self.install_autogen_cli(package, command)
+
+    def uninstall_autogen_cli_all(self, package: Package):
+        """ Remove autogenerated CLI plugins for package.
+
+        Args:
+            package: Package
+        Returns:
+            None
+        """
+
+        for command in SONIC_CLI_COMMANDS:
+            self.uninstall_autogen_cli(package, command)
+
+    def install_autogen_cli(self, package: Package, command: str):
+        """ Install autogenerated CLI plugins for package for particular command.
+
+        Args:
+            package: Package.
+            command: Name of command to generate CLI for.
+        Returns:
+            None
+        """
+
+        if package.metadata.yang_module_str is None:
+            return
+        if f'auto-generate-{command}' not in package.manifest['cli']:
+            return
+        if not package.manifest['cli'][f'auto-generate-{command}']:
+            return
+        module_name = self.cfg_mgmt.get_module_name(package.metadata.yang_module_str)
+        self.cli_gen.generate_cli_plugin(command, module_name)
+        log.debug(f'{command} command line interface autogenerated for {module_name}')
+
+    def uninstall_autogen_cli(self, package: Package, command: str):
+        """ Uninstall autogenerated CLI plugins for package for particular command.
+
+        Args:
+            package: Package.
+            command: Name of command to remove CLI.
+        Returns:
+            None
+        """
+
+        if package.metadata.yang_module_str is None:
+            return
+        if f'auto-generate-{command}' not in package.manifest['cli']:
+            return
+        if not package.manifest['cli'][f'auto-generate-{command}']:
+            return
+        module_name = self.cfg_mgmt.get_module_name(package.metadata.yang_module_str)
+        self.cli_gen.remove_cli_plugin(command, module_name)
+        log.debug(f'{command} command line interface removed for {module_name}')
 
     def _post_operation_hook(self):
         """ Common operations executed after service is created/removed. """

--- a/sonic_package_manager/service_creator/feature.py
+++ b/sonic_package_manager/service_creator/feature.py
@@ -144,15 +144,3 @@ class FeatureRegistry:
             'has_global_scope': str(manifest['service']['host-service']),
             'has_timer': str(manifest['service']['delayed']),
         }
-
-    def _get_tables(self):
-        tables = []
-        running = self._sonic_db.running_table(FEATURE)
-        if running is not None:  # it's Ok if there is no database container running
-            tables.append(running)
-        persistent = self._sonic_db.persistent_table(FEATURE)
-        if persistent is not None:  # it's Ok if there is no config_db.json
-            tables.append(persistent)
-        tables.append(self._sonic_db.initial_table(FEATURE))  # init_cfg.json is must
-
-        return tables

--- a/tests/sonic_package_manager/conftest.py
+++ b/tests/sonic_package_manager/conftest.py
@@ -7,6 +7,8 @@ from unittest.mock import Mock, MagicMock
 import pytest
 from docker_image.reference import Reference
 
+from config.config_mgmt import ConfigMgmt
+
 from sonic_package_manager.database import PackageDatabase, PackageEntry
 from sonic_package_manager.manager import DockerApi, PackageManager
 from sonic_package_manager.manifest import Manifest
@@ -62,7 +64,17 @@ def mock_service_creator():
 
 @pytest.fixture
 def mock_sonic_db():
-    yield Mock()
+    yield MagicMock()
+
+
+@pytest.fixture
+def mock_config_mgmt():
+    yield MagicMock()
+
+
+@pytest.fixture
+def mock_cli_gen():
+    yield MagicMock()
 
 
 @pytest.fixture
@@ -107,7 +119,7 @@ def fake_metadata_resolver():
                          'before': ['swss'],
                      }
             )
-            self.add('Azure/docker-test', '1.6.0', 'test-package', '1.6.0')
+            self.add('Azure/docker-test', '1.6.0', 'test-package', '1.6.0', yang='TEST')
             self.add('Azure/docker-test-2', '1.5.0', 'test-package-2', '1.5.0')
             self.add('Azure/docker-test-2', '2.0.0', 'test-package-2', '2.0.0')
             self.add('Azure/docker-test-3', 'latest', 'test-package-3', '1.6.0')
@@ -124,23 +136,26 @@ def fake_metadata_resolver():
         def from_registry(self, repository: str, reference: str):
             manifest = Manifest.marshal(self.metadata_store[repository][reference]['manifest'])
             components = self.metadata_store[repository][reference]['components']
-            return Metadata(manifest, components)
+            yang = self.metadata_store[repository][reference]['yang']
+            return Metadata(manifest, components, yang)
 
         def from_local(self, image: str):
             ref = Reference.parse(image)
             manifest = Manifest.marshal(self.metadata_store[ref['name']][ref['tag']]['manifest'])
             components = self.metadata_store[ref['name']][ref['tag']]['components']
-            return Metadata(manifest, components)
+            yang = self.metadata_store[ref['name']][ref['tag']]['yang']
+            return Metadata(manifest, components, yang)
 
         def from_tarball(self, filepath: str) -> Manifest:
             path, ref = filepath.split(':')
             manifest = Manifest.marshal(self.metadata_store[path][ref]['manifest'])
             components = self.metadata_store[path][ref]['components']
-            return Metadata(manifest, components)
+            yang = self.metadata_store[path][ref]['yang']
+            return Metadata(manifest, components, yang)
 
         def add(self, repo, reference, name, version, components=None,
                 warm_shutdown=None, fast_shutdown=None,
-                processes=None):
+                processes=None, yang=None):
             repo_dict = self.metadata_store.setdefault(repo, {})
             repo_dict[reference] = {
                 'manifest': {
@@ -157,6 +172,7 @@ def fake_metadata_resolver():
                     'processes': processes or [],
                 },
                 'components': components or {},
+                'yang': yang,
             }
 
     yield FakeMetadataResolver()
@@ -252,7 +268,7 @@ def fake_db(fake_metadata_resolver):
         description='SONiC Package Manager Test Package',
         default_reference='1.6.0',
         installed=False,
-        built_in=False
+        built_in=False,
     )
     add_package(
         content,
@@ -402,8 +418,8 @@ def sonic_fs(fs):
 
 @pytest.fixture(autouse=True)
 def patch_pkgutil():
-    with mock.patch('pkgutil.get_loader'):
-        yield
+    with mock.patch('pkgutil.get_loader') as loader:
+        yield loader
 
 
 @pytest.fixture

--- a/tests/sonic_package_manager/test_service_creator.py
+++ b/tests/sonic_package_manager/test_service_creator.py
@@ -60,13 +60,25 @@ def manifest():
     })
 
 
-def test_service_creator(sonic_fs, manifest, package_manager, mock_feature_registry, mock_sonic_db):
-    creator = ServiceCreator(mock_feature_registry, mock_sonic_db)
+@pytest.fixture()
+def service_creator(mock_feature_registry,
+                    mock_sonic_db,
+                    mock_cli_gen,
+                    mock_config_mgmt):
+    yield ServiceCreator(
+        mock_feature_registry,
+        mock_sonic_db,
+        mock_cli_gen,
+        mock_config_mgmt
+    )
+
+
+def test_service_creator(sonic_fs, manifest, service_creator, package_manager):
     entry = PackageEntry('test', 'azure/sonic-test')
     package = Package(entry, Metadata(manifest))
     installed_packages = package_manager._get_installed_packages_and(package)
-    creator.create(package)
-    creator.generate_shutdown_sequence_files(installed_packages)
+    service_creator.create(package)
+    service_creator.generate_shutdown_sequence_files(installed_packages)
 
     assert sonic_fs.exists(os.path.join(ETC_SONIC_PATH, 'swss_dependent'))
     assert sonic_fs.exists(os.path.join(DOCKER_CTL_SCRIPT_LOCATION, 'test.sh'))
@@ -82,73 +94,116 @@ def test_service_creator(sonic_fs, manifest, package_manager, mock_feature_regis
     assert read_file('test_reconcile') == 'test-process test-process-3'
 
 
-def test_service_creator_with_timer_unit(sonic_fs, manifest, mock_feature_registry, mock_sonic_db):
-    creator = ServiceCreator(mock_feature_registry, mock_sonic_db)
+def test_service_creator_with_timer_unit(sonic_fs, manifest, service_creator):
     entry = PackageEntry('test', 'azure/sonic-test')
     package = Package(entry, Metadata(manifest))
-    creator.create(package)
+    service_creator.create(package)
 
     assert not sonic_fs.exists(os.path.join(SYSTEMD_LOCATION, 'test.timer'))
 
     manifest['service']['delayed'] = True
     package = Package(entry, Metadata(manifest))
-    creator.create(package)
+    service_creator.create(package)
 
     assert sonic_fs.exists(os.path.join(SYSTEMD_LOCATION, 'test.timer'))
 
 
-def test_service_creator_with_debug_dump(sonic_fs, manifest, mock_feature_registry, mock_sonic_db):
-    creator = ServiceCreator(mock_feature_registry, mock_sonic_db)
+def test_service_creator_with_debug_dump(sonic_fs, manifest, service_creator):
     entry = PackageEntry('test', 'azure/sonic-test')
     package = Package(entry, Metadata(manifest))
-    creator.create(package)
+    service_creator.create(package)
 
     assert not sonic_fs.exists(os.path.join(DEBUG_DUMP_SCRIPT_LOCATION, 'test'))
 
     manifest['package']['debug-dump'] = '/some/command'
     package = Package(entry, Metadata(manifest))
-    creator.create(package)
+    service_creator.create(package)
 
     assert sonic_fs.exists(os.path.join(DEBUG_DUMP_SCRIPT_LOCATION, 'test'))
 
 
-def test_service_creator_initial_config(sonic_fs, manifest, mock_feature_registry, mock_sonic_db):
-    mock_connector = Mock()
-    mock_connector.get_config = Mock(return_value={})
-    mock_sonic_db.get_connectors = Mock(return_value=[mock_connector])
+def test_service_creator_yang(sonic_fs, manifest, mock_sonic_db,
+                              mock_config_mgmt, service_creator):
+    test_yang = 'TEST YANG'
+    test_yang_module = 'sonic-test'
 
-    creator = ServiceCreator(mock_feature_registry, mock_sonic_db)
+    mock_connector = Mock()
+    mock_sonic_db.get_connectors = Mock(return_value=[mock_connector])
+    mock_connector.get_table = Mock(return_value={'key_a': {'field_1': 'value_1'}})
+    mock_connector.get_config = Mock(return_value={
+        'TABLE_A': mock_connector.get_table('')
+    })
 
     entry = PackageEntry('test', 'azure/sonic-test')
-    package = Package(entry, Metadata(manifest))
-    creator.create(package)
+    package = Package(entry, Metadata(manifest, yang_module_str=test_yang))
+    service_creator.create(package)
 
-    assert not sonic_fs.exists(os.path.join(DEBUG_DUMP_SCRIPT_LOCATION, 'test'))
+    mock_config_mgmt.add_module.assert_called_with(test_yang)
+    mock_config_mgmt.get_module_name = Mock(return_value=test_yang_module)
 
     manifest['package']['init-cfg'] = {
         'TABLE_A': {
             'key_a': {
-                'field_1': 'value_1',
+                'field_1': 'new_value_1',
                 'field_2': 'value_2'
             },
         },
     }
-    package = Package(entry, Metadata(manifest))
+    package = Package(entry, Metadata(manifest, yang_module_str=test_yang))
 
-    creator.create(package)
+    service_creator.create(package)
+
+    mock_config_mgmt.add_module.assert_called_with(test_yang)
+
     mock_connector.mod_config.assert_called_with(
         {
             'TABLE_A': {
-	            'key_a': {
-	                'field_1': 'value_1',
-	                'field_2': 'value_2',
-	            },
-	        },
-	    }
+                'key_a': {
+                    'field_1': 'value_1',
+                    'field_2': 'value_2',
+                },
+            },
+        }
     )
 
-    creator.remove(package)
+    mock_config_mgmt.sy.confDbYangMap = {
+        'TABLE_A': {'module': test_yang_module}
+    }
+
+    service_creator.remove(package)
     mock_connector.set_entry.assert_called_with('TABLE_A', 'key_a', None)
+    mock_config_mgmt.remove_module.assert_called_with(test_yang_module)
+
+
+def test_service_creator_autocli(sonic_fs, manifest, mock_cli_gen,
+                                 mock_config_mgmt, service_creator):
+    test_yang = 'TEST YANG'
+    test_yang_module = 'sonic-test'
+
+    manifest['cli']['auto-generate-show'] = True
+    manifest['cli']['auto-generate-config'] = True
+
+    entry = PackageEntry('test', 'azure/sonic-test')
+    package = Package(entry, Metadata(manifest, yang_module_str=test_yang))
+    mock_config_mgmt.get_module_name = Mock(return_value=test_yang_module)
+    service_creator.create(package)
+
+    mock_cli_gen.generate_cli_plugin.assert_has_calls(
+        [
+            call('show', test_yang_module),
+            call('config', test_yang_module),
+        ],
+        any_order=True
+    )
+
+    service_creator.remove(package)
+    mock_cli_gen.remove_cli_plugin.assert_has_calls(
+        [
+            call('show', test_yang_module),
+            call('config', test_yang_module),
+        ],
+        any_order=True
+    )
 
 
 def test_feature_registration(mock_sonic_db, manifest):


### PR DESCRIPTION
…kages with YANG model (#1650)" (#1972)"

This reverts commit fe00bbf63283ca6f3842e470b88cdc5b6d266a0d.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Revert previos revert, since the proposed fix has been merged - https://github.com/Azure/sonic-buildimage/pull/9587

#### How I did it

Revert the revert.

#### How to verify it

Run build an on the switch.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

