### PR TITLE
[GCU] Turning port admin down before some critical port changes

### DIFF
--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -273,7 +273,7 @@ class PathAddressing:
         return JsonPointer.from_parts(tokens).path
 
     def has_path(self, doc, path):
-        return self.get_from_path is not None
+        return self.get_from_path(doc, path) is not None
 
     def get_from_path(self, doc, path):
         return JsonPointer(path).get(doc, default=None)

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -273,7 +273,7 @@ class PathAddressing:
         return JsonPointer.from_parts(tokens).path
 
     def has_path(self, doc, path):
-        return JsonPointer(path).get(doc, default=None) is not None
+        return self.get_from_path is not None
 
     def get_from_path(self, doc, path):
         return JsonPointer(path).get(doc, default=None)

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -554,7 +554,8 @@ class PathAddressing:
             # Source: Check examples in https://netopeer.liberouter.org/doc/libyang/master/html/howto_x_path.html
             return [f"{token}[.='{value}']"]
 
-        raise ValueError("Token not found")
+        raise ValueError(f"Path token not found.\n  model: {model}\n  token_index: {token_index}\n  " + \
+                         f"path_tokens: {path_tokens}\n  config: {config}")
 
     def _extractKey(self, tableKey, keys):
         keyList = keys.split()
@@ -718,7 +719,8 @@ class PathAddressing:
             list_idx = list_config.index(leaf_list_value)
             return [leaf_list_name, list_idx]
 
-        raise Exception("no leaf")
+        raise ValueError(f"Xpath token not found.\n  model: {model}\n  token_index: {token_index}\n  " + \
+                         f"xpath_tokens: {xpath_tokens}\n  config: {config}")
 
     def _extract_key_dict(self, list_token):
         # Example: VLAN_MEMBER_LIST[name='Vlan1000'][port='Ethernet8']

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -275,6 +275,9 @@ class PathAddressing:
     def has_path(self, doc, path):
         return JsonPointer(path).get(doc, default=None) is not None
 
+    def get_from_path(self, doc, path):
+        return JsonPointer(path).get(doc, default=None)
+
     def get_xpath_tokens(self, xpath):
         """
         Splits the given xpath into tokens by '/'.

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -278,6 +278,9 @@ class PathAddressing:
     def get_from_path(self, doc, path):
         return JsonPointer(path).get(doc, default=None)
 
+    def is_config_different(self, path, current, target):
+        return self.get_from_path(current, path) != self.get_from_path(target, path)
+
     def get_xpath_tokens(self, xpath):
         """
         Splits the given xpath into tokens by '/'.

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -333,7 +333,7 @@ class MoveWrapper:
             for newmove in extender.extend(move, diff):
                 yield newmove
 
-class ConfigFilter:
+class JsonPointerFilter:
     """
     A filtering class to get the paths matching the filter from the given config.
     The patterns:
@@ -450,14 +450,14 @@ class RequiredValueIdentifier:
         for setting in self.settings:
             required_pattern = setting["required_pattern"]
             required_parent_pattern = required_pattern[:-1]
-            # replace the '@' with '*' so it can be used as a ConfigFilter
+            # replace the '@' with '*' so it can be used as a JsonPointerFilter
             required_parent_pattern_with_asterisk = [token.replace("@", "*") for token in required_parent_pattern]
-            setting["required_parent_filter"] = ConfigFilter([required_parent_pattern_with_asterisk], path_addressing)
+            setting["required_parent_filter"] = JsonPointerFilter([required_parent_pattern_with_asterisk], path_addressing)
             setting["required_field_name"] = required_pattern[-1]
             for index, token in enumerate(required_pattern):
                 if token == "@":
                     setting["common_key_index"] = index
-            setting["requiring_filter"] = ConfigFilter(setting["requiring_patterns"], path_addressing)
+            setting["requiring_filter"] = JsonPointerFilter(setting["requiring_patterns"], path_addressing)
 
 
     def get_required_value_data(self, configs):
@@ -565,7 +565,7 @@ class CreateOnlyMoveValidator:
         self.path_addressing = path_addressing
 
         # TODO: create-only fields are hard-coded for now, it should be moved to YANG models
-        self.create_only_filter = ConfigFilter([
+        self.create_only_filter = JsonPointerFilter([
                 ["PORT", "*", "lanes"],
                 ["LOOPBACK_INTERFACE", "*", "vrf_name"],
                 ["BGP_NEIGHBOR", "*", "holdtime"],

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -1137,7 +1137,7 @@ class RequiredValueMoveExtender:
         # }
         data = self.identifier.get_required_value_data([current_config, simulated_config, target_config])
 
-        # If move is changing a requiring path at the same time as the required path,
+        # If move is changing a requiring path while the required path does not have the required value,
         # flip the required path to the required value
         # E.g. if the move is changing the port to admin up from down at the same time as
         #      port-critical changes, flip the port to admin down

--- a/tests/generic_config_updater/files/config_db_with_port_critical.json
+++ b/tests/generic_config_updater/files/config_db_with_port_critical.json
@@ -1,0 +1,49 @@
+{
+    "PORT": {
+        "Ethernet4": {
+            "admin_status": "up",
+            "alias": "fortyGigE0/4",
+            "description": "Servers0:eth0",
+            "index": "1",
+            "lanes": "29,30,31,32",
+            "mtu": "9100",
+            "pfc_asym": "off",
+            "speed": "40000"
+        },
+        "Ethernet8": {
+            "admin_status": "up",
+            "alias": "fortyGigE0/8",
+            "description": "Servers1:eth0",
+            "index": "2",
+            "lanes": "33,34,35,36",
+            "pfc_asym": "off",
+            "speed": "40000"
+        },
+        "Ethernet12": {
+            "admin_status": "down",
+            "alias": "fortyGigE0/12",
+            "description": "Servers2:eth0",
+            "index": "3",
+            "lanes": "37,38,39,40",
+            "mtu": "9100",
+            "pfc_asym": "off",
+            "speed": "40000"
+        },
+        "Ethernet16": {
+            "alias": "fortyGigE0/16",
+            "description": "Servers3:eth0",
+            "index": "4",
+            "lanes": "41,42,43,44",
+            "pfc_asym": "off",
+            "speed": "40000"
+        }
+    },
+    "BUFFER_PG": {
+        "Ethernet4|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet12|0": {
+            "profile": "ingress_lossy_profile"
+        }
+    }
+}

--- a/tests/generic_config_updater/files/patch_sorter_test_success.json
+++ b/tests/generic_config_updater/files/patch_sorter_test_success.json
@@ -2812,6 +2812,89 @@
             ]
         ]
     },
+    "ADDING_LOOPBACK0_VRF_NAME__DELETES_LOOPBACK0_AND_IPS_DOES_NOT_AFFECT_OTHER_TABLES": {
+        "desc": ["Adding loopback vrf name, deletes loopback0 and the associated ips. ",
+                 "It does not affect other tables."],
+        "current_config": {
+            "CABLE_LENGTH": {
+                "AZURE": {
+                    "Ethernet0": "0m",
+                    "Ethernet100": "0m"
+                }
+            },
+            "LOOPBACK_INTERFACE": {
+                "Loopback0": {},
+                "Loopback0|10.1.0.32/32": {},
+                "Loopback0|1100:1::32/128": {}
+            },
+            "VRF": {
+                "Vrf_01": {},
+                "Vrf_02": {}
+            },
+            "PORT": {
+                "Ethernet0": {
+                    "lanes": "25,26,27,28",
+                    "speed": "10000"
+                },
+                "Ethernet100": {
+                    "lanes": "121,122,123,124",
+                    "speed": "10000"
+                }
+            }
+        },
+        "patch": [
+            {
+                "op": "add",
+                "path": "/LOOPBACK_INTERFACE/Loopback0/vrf_name",
+                "value": "Vrf_01"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "remove",
+                    "path": "/LOOPBACK_INTERFACE/Loopback0|10.1.0.32~132"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/LOOPBACK_INTERFACE/Loopback0|1100:1::32~1128"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/LOOPBACK_INTERFACE"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/LOOPBACK_INTERFACE",
+                    "value": {
+                        "Loopback0":{
+                            "vrf_name": "Vrf_01"
+                        }
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/LOOPBACK_INTERFACE/Loopback0|10.1.0.32~132",
+                    "value": {}
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/LOOPBACK_INTERFACE/Loopback0|1100:1::32~1128",
+                    "value": {}
+                }
+            ]
+        ]
+    },
     "ADDING_BGP_NEIGHBORS": {
         "current_config": {
             "BGP_NEIGHBOR": {

--- a/tests/generic_config_updater/files/patch_sorter_test_success.json
+++ b/tests/generic_config_updater/files/patch_sorter_test_success.json
@@ -4606,122 +4606,6 @@
             [
                 {
                     "op": "add",
-                    "path": "/BGP_NEIGHBOR/10.0.0.33",
-                    "value": {
-                        "admin_status": "up"
-                    }
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/BGP_NEIGHBOR/10.0.0.33/asn",
-                    "value": "64001"
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/BGP_NEIGHBOR/10.0.0.33/holdtime",
-                    "value": "10"
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/BGP_NEIGHBOR/10.0.0.33/keepalive",
-                    "value": "3"
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/BGP_NEIGHBOR/10.0.0.33/local_addr",
-                    "value": "10.0.0.32"
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/BGP_NEIGHBOR/10.0.0.33/name",
-                    "value": "ARISTA01T0"
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/BGP_NEIGHBOR/10.0.0.33/nhopself",
-                    "value": "0"
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/BGP_NEIGHBOR/10.0.0.33/rrclient",
-                    "value": "0"
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/BGP_NEIGHBOR/fc00::42",
-                    "value": {
-                        "admin_status": "up"
-                    }
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/BGP_NEIGHBOR/fc00::42/asn",
-                    "value": "64001"
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/BGP_NEIGHBOR/fc00::42/holdtime",
-                    "value": "10"
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/BGP_NEIGHBOR/fc00::42/keepalive",
-                    "value": "3"
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/BGP_NEIGHBOR/fc00::42/local_addr",
-                    "value": "fc00::41"
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/BGP_NEIGHBOR/fc00::42/name",
-                    "value": "ARISTA01T0"
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/BGP_NEIGHBOR/fc00::42/nhopself",
-                    "value": "0"
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/BGP_NEIGHBOR/fc00::42/rrclient",
-                    "value": "0"
-                }
-            ],
-            [
-                {
-                    "op": "add",
                     "path": "/BUFFER_PG/Ethernet64|3-4",
                     "value": {
                         "profile": "pg_lossless_40000_40m_profile"
@@ -4850,6 +4734,38 @@
                     "op": "add",
                     "path": "/PORT/Ethernet64/admin_status",
                     "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.33",
+                    "value": {
+                        "admin_status": "up",
+                        "asn": "64001",
+                        "holdtime": "10",
+                        "keepalive": "3",
+                        "local_addr": "10.0.0.32",
+                        "name": "ARISTA01T0",
+                        "nhopself": "0",
+                        "rrclient": "0"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::42",
+                    "value": {
+                        "admin_status": "up",
+                        "asn": "64001",
+                        "holdtime": "10",
+                        "keepalive": "3",
+                        "local_addr": "fc00::41",
+                        "name": "ARISTA01T0",
+                        "nhopself": "0",
+                        "rrclient": "0"
+                    }
                 }
             ]
         ]

--- a/tests/generic_config_updater/files/patch_sorter_test_success.json
+++ b/tests/generic_config_updater/files/patch_sorter_test_success.json
@@ -2812,89 +2812,6 @@
             ]
         ]
     },
-    "ADDING_LOOPBACK0_VRF_NAME__DELETES_LOOPBACK0_AND_IPS_DOES_NOT_AFFECT_OTHER_TABLES": {
-        "desc": ["Adding loopback vrf name, deletes loopback0 and the associated ips. ",
-                 "It does not affect other tables."],
-        "current_config": {
-            "CABLE_LENGTH": {
-                "AZURE": {
-                    "Ethernet0": "0m",
-                    "Ethernet100": "0m"
-                }
-            },
-            "LOOPBACK_INTERFACE": {
-                "Loopback0": {},
-                "Loopback0|10.1.0.32/32": {},
-                "Loopback0|1100:1::32/128": {}
-            },
-            "VRF": {
-                "Vrf_01": {},
-                "Vrf_02": {}
-            },
-            "PORT": {
-                "Ethernet0": {
-                    "lanes": "25,26,27,28",
-                    "speed": "10000"
-                },
-                "Ethernet100": {
-                    "lanes": "121,122,123,124",
-                    "speed": "10000"
-                }
-            }
-        },
-        "patch": [
-            {
-                "op": "add",
-                "path": "/LOOPBACK_INTERFACE/Loopback0/vrf_name",
-                "value": "Vrf_01"
-            }
-        ],
-        "expected_changes": [
-            [
-                {
-                    "op": "remove",
-                    "path": "/LOOPBACK_INTERFACE/Loopback0|10.1.0.32~132"
-                }
-            ],
-            [
-                {
-                    "op": "remove",
-                    "path": "/LOOPBACK_INTERFACE/Loopback0|1100:1::32~1128"
-                }
-            ],
-            [
-                {
-                    "op": "remove",
-                    "path": "/LOOPBACK_INTERFACE"
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/LOOPBACK_INTERFACE",
-                    "value": {
-                        "Loopback0":{
-                            "vrf_name": "Vrf_01"
-                        }
-                    }
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/LOOPBACK_INTERFACE/Loopback0|10.1.0.32~132",
-                    "value": {}
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/LOOPBACK_INTERFACE/Loopback0|1100:1::32~1128",
-                    "value": {}
-                }
-            ]
-        ]
-    },
     "ADDING_BGP_NEIGHBORS": {
         "current_config": {
             "BGP_NEIGHBOR": {
@@ -2971,6 +2888,1885 @@
                         "nhopself": "0",
                         "rrclient": "0"
                     }
+                }
+            ]
+        ]
+    },
+    "PORT_CRITICAL_CHANGE_AND_PORT_IS_ADMIN_UP": {
+        "desc": "Port critical change and the port is already admin up",
+        "current_config": {
+            "PORT": {
+                "Ethernet4": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/4",
+                    "description": "Servers0:eth0",
+                    "index": "1",
+                    "lanes": "29,30,31,32",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                }
+            },
+            "BUFFER_PROFILE": {
+                "egress_lossy_profile": {
+                    "dynamic_th": "3",
+                    "pool": "egress_lossy_pool",
+                    "size": "1518"
+                }
+            },
+            "BUFFER_POOL": {
+                "egress_lossy_pool": {
+                    "mode": "dynamic",
+                    "size": "7326924",
+                    "type": "egress"
+                }
+            }
+        },
+        "patch": [
+            {
+                "op": "add",
+                "path": "/BUFFER_PG",
+                "value": {
+                    "Ethernet4|0": {
+                        "profile": "egress_lossy_profile"
+                    }
+                }
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "replace",
+                    "path": "/PORT/Ethernet4/admin_status",
+                    "value": "down"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BUFFER_PG",
+                    "value": {
+                        "Ethernet4|0": {
+                            "profile": "egress_lossy_profile"
+                        }
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "replace",
+                    "path": "/PORT/Ethernet4/admin_status",
+                    "value": "up"
+                }
+            ]
+        ]
+    },
+    "PORT_CRITICAL_CONFIG_AND_ADDING_ADMIN_UP_PORT": {
+        "desc": "Port critical change and the port with admin up is added in the same patch.",
+        "current_config": {
+            "BUFFER_PROFILE": {
+                "egress_lossy_profile": {
+                    "dynamic_th": "3",
+                    "pool": "egress_lossy_pool",
+                    "size": "1518"
+                }
+            },
+            "BUFFER_POOL": {
+                "egress_lossy_pool": {
+                    "mode": "dynamic",
+                    "size": "7326924",
+                    "type": "egress"
+                }
+            }
+        },
+        "patch": [
+            {
+                "op": "add",
+                "path": "/PORT",
+                "value": {
+                    "Ethernet4": {
+                        "admin_status": "up",
+                        "alias": "fortyGigE0/4",
+                        "description": "Servers0:eth0",
+                        "index": "1",
+                        "lanes": "29,30,31,32",
+                        "mtu": "9100",
+                        "pfc_asym": "off",
+                        "speed": "40000"
+                    }
+                }
+            },
+            {
+                "op": "add",
+                "path": "/BUFFER_PG",
+                "value": {
+                    "Ethernet4|0": {
+                        "profile": "egress_lossy_profile"
+                    }
+                }
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "add",
+                    "path": "/PORT",
+                    "value": {
+                        "Ethernet4": {
+                            "admin_status": "down",
+                            "alias": "fortyGigE0/4",
+                            "description": "Servers0:eth0",
+                            "index": "1",
+                            "lanes": "29,30,31,32",
+                            "mtu": "9100",
+                            "pfc_asym": "off",
+                            "speed": "40000"
+                        }
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BUFFER_PG",
+                    "value": {
+                        "Ethernet4|0": {
+                            "profile": "egress_lossy_profile"
+                        }
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "replace",
+                    "path": "/PORT/Ethernet4/admin_status",
+                    "value": "up"
+                }
+            ]
+        ]
+    },
+    "ADD_RACK": {
+        "desc": "Add a rack and all its related settings",
+        "current_config": {
+            "ACL_TABLE": {
+                "EVERFLOW": {
+                    "policy_desc": "EVERFLOW",
+                    "ports": [
+                        "Ethernet68",
+                        "Ethernet72"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRROR"
+                },
+                "EVERFLOWV6": {
+                    "policy_desc": "EVERFLOWV6",
+                    "ports": [
+                        "Ethernet68",
+                        "Ethernet72"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRRORV6"
+                }
+            },
+            "BGP_NEIGHBOR": {
+                "10.0.0.1": {
+                    "asn": "65200",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "10.0.0.0",
+                    "name": "ARISTA01T2",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "10.0.0.5": {
+                    "asn": "65200",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "10.0.0.4",
+                    "name": "ARISTA03T2",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "10.0.0.9": {
+                    "asn": "65200",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "10.0.0.8",
+                    "name": "ARISTA05T2",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "10.0.0.13": {
+                    "asn": "65200",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "10.0.0.12",
+                    "name": "ARISTA07T2",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "10.0.0.17": {
+                    "asn": "65200",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "10.0.0.16",
+                    "name": "ARISTA09T2",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "10.0.0.21": {
+                    "asn": "65200",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "10.0.0.20",
+                    "name": "ARISTA11T2",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "10.0.0.25": {
+                    "asn": "65200",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "10.0.0.24",
+                    "name": "ARISTA13T2",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "10.0.0.29": {
+                    "asn": "65200",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "10.0.0.28",
+                    "name": "ARISTA15T2",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "10.0.0.35": {
+                    "asn": "64002",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "10.0.0.34",
+                    "name": "ARISTA02T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "10.0.0.37": {
+                    "asn": "64003",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "10.0.0.36",
+                    "name": "ARISTA03T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "10.0.0.39": {
+                    "asn": "64004",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "10.0.0.38",
+                    "name": "ARISTA04T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "10.0.0.41": {
+                    "asn": "64005",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "10.0.0.40",
+                    "name": "ARISTA05T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "10.0.0.43": {
+                    "asn": "64006",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "10.0.0.42",
+                    "name": "ARISTA06T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "10.0.0.45": {
+                    "asn": "64007",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "10.0.0.44",
+                    "name": "ARISTA07T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "10.0.0.47": {
+                    "asn": "64008",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "10.0.0.46",
+                    "name": "ARISTA08T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "10.0.0.49": {
+                    "asn": "64009",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "10.0.0.48",
+                    "name": "ARISTA09T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "10.0.0.51": {
+                    "asn": "64010",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "10.0.0.50",
+                    "name": "ARISTA10T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "10.0.0.53": {
+                    "asn": "64011",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "10.0.0.52",
+                    "name": "ARISTA11T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "10.0.0.55": {
+                    "asn": "64012",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "10.0.0.54",
+                    "name": "ARISTA12T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "10.0.0.57": {
+                    "asn": "64013",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "10.0.0.56",
+                    "name": "ARISTA13T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "10.0.0.59": {
+                    "asn": "64014",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "10.0.0.58",
+                    "name": "ARISTA14T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "10.0.0.61": {
+                    "asn": "64015",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "10.0.0.60",
+                    "name": "ARISTA15T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "10.0.0.63": {
+                    "asn": "64016",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "10.0.0.62",
+                    "name": "ARISTA16T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "fc00::1a": {
+                    "asn": "65200",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::19",
+                    "name": "ARISTA07T2",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "fc00::2": {
+                    "asn": "65200",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::1",
+                    "name": "ARISTA01T2",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "fc00::2a": {
+                    "asn": "65200",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::29",
+                    "name": "ARISTA11T2",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "fc00::3a": {
+                    "asn": "65200",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::39",
+                    "name": "ARISTA15T2",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "fc00::4a": {
+                    "asn": "64003",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::49",
+                    "name": "ARISTA03T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "fc00::4e": {
+                    "asn": "64004",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::4d",
+                    "name": "ARISTA04T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "fc00::5a": {
+                    "asn": "64007",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::59",
+                    "name": "ARISTA07T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "fc00::5e": {
+                    "asn": "64008",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::5d",
+                    "name": "ARISTA08T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "fc00::6a": {
+                    "asn": "64011",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::69",
+                    "name": "ARISTA11T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "fc00::6e": {
+                    "asn": "64012",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::6d",
+                    "name": "ARISTA12T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "fc00::7a": {
+                    "asn": "64015",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::79",
+                    "name": "ARISTA15T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "fc00::7e": {
+                    "asn": "64016",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::7d",
+                    "name": "ARISTA16T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "fc00::12": {
+                    "asn": "65200",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::11",
+                    "name": "ARISTA05T2",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "fc00::22": {
+                    "asn": "65200",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::21",
+                    "name": "ARISTA09T2",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "fc00::32": {
+                    "asn": "65200",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::31",
+                    "name": "ARISTA13T2",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "fc00::46": {
+                    "asn": "64002",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::45",
+                    "name": "ARISTA02T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "fc00::52": {
+                    "asn": "64005",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::51",
+                    "name": "ARISTA05T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "fc00::56": {
+                    "asn": "64006",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::55",
+                    "name": "ARISTA06T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "fc00::62": {
+                    "asn": "64009",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::61",
+                    "name": "ARISTA09T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "fc00::66": {
+                    "asn": "64010",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::65",
+                    "name": "ARISTA10T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "fc00::72": {
+                    "asn": "64013",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::71",
+                    "name": "ARISTA13T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "fc00::76": {
+                    "asn": "64014",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::75",
+                    "name": "ARISTA14T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                },
+                "fc00::a": {
+                    "asn": "65200",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::9",
+                    "name": "ARISTA03T2",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            },
+            "BUFFER_PG": {
+                "Ethernet68|0": {
+                    "profile": "ingress_lossy_profile"
+                },
+                "Ethernet68|3-4": {
+                    "profile": "pg_lossless_40000_40m_profile"
+                },
+                "Ethernet72|0": {
+                    "profile": "ingress_lossy_profile"
+                },
+                "Ethernet72|3-4": {
+                    "profile": "pg_lossless_40000_40m_profile"
+                }
+            },
+            "BUFFER_POOL": {
+                "egress_lossless_pool": {
+                    "mode": "static",
+                    "size": "12766208",
+                    "type": "egress"
+                },
+                "egress_lossy_pool": {
+                    "mode": "dynamic",
+                    "size": "7326924",
+                    "type": "egress"
+                },
+                "ingress_lossless_pool": {
+                    "mode": "dynamic",
+                    "size": "12766208",
+                    "type": "ingress"
+                }
+            },
+            "BUFFER_PROFILE": {
+                "egress_lossless_profile": {
+                    "pool": "egress_lossless_pool",
+                    "size": "0",
+                    "static_th": "12766208"
+                },
+                "egress_lossy_profile": {
+                    "dynamic_th": "3",
+                    "pool": "egress_lossy_pool",
+                    "size": "1518"
+                },
+                "ingress_lossy_profile": {
+                    "dynamic_th": "3",
+                    "pool": "ingress_lossless_pool",
+                    "size": "0"
+                },
+                "pg_lossless_40000_40m_profile": {
+                    "dynamic_th": "-3",
+                    "pool": "ingress_lossless_pool",
+                    "size": "56368",
+                    "xoff": "55120",
+                    "xon": "18432",
+                    "xon_offset": "2496"
+                },
+                "pg_lossless_40000_300m_profile": {
+                    "dynamic_th": "-3",
+                    "pool": "ingress_lossless_pool",
+                    "size": "56368",
+                    "xoff": "55120",
+                    "xon": "18432",
+                    "xon_offset": "2496"
+                }
+            },
+            "BUFFER_QUEUE": {
+                "Ethernet52|0-2": {
+                    "profile": "egress_lossy_profile"
+                },
+                "Ethernet52|3-4": {
+                    "profile": "egress_lossless_profile"
+                },
+                "Ethernet52|5-6": {
+                    "profile": "egress_lossy_profile"
+                },
+                "Ethernet56|0-2": {
+                    "profile": "egress_lossy_profile"
+                },
+                "Ethernet56|3-4": {
+                    "profile": "egress_lossless_profile"
+                },
+                "Ethernet56|5-6": {
+                    "profile": "egress_lossy_profile"
+                },
+                "Ethernet60|0-2": {
+                    "profile": "egress_lossy_profile"
+                },
+                "Ethernet60|3-4": {
+                    "profile": "egress_lossless_profile"
+                },
+                "Ethernet60|5-6": {
+                    "profile": "egress_lossy_profile"
+                },
+                "Ethernet68|0-2": {
+                    "profile": "egress_lossy_profile"
+                },
+                "Ethernet68|3-4": {
+                    "profile": "egress_lossless_profile"
+                },
+                "Ethernet68|5-6": {
+                    "profile": "egress_lossy_profile"
+                },
+                "Ethernet72|0-2": {
+                    "profile": "egress_lossy_profile"
+                },
+                "Ethernet72|3-4": {
+                    "profile": "egress_lossless_profile"
+                },
+                "Ethernet72|5-6": {
+                    "profile": "egress_lossy_profile"
+                }
+            },
+            "DEVICE_NEIGHBOR": {
+                "Ethernet52": {
+                    "name": "ARISTA13T2",
+                    "port": "Ethernet2"
+                },
+                "Ethernet56": {
+                    "name": "ARISTA15T2",
+                    "port": "Ethernet1"
+                },
+                "Ethernet60": {
+                    "name": "ARISTA15T2",
+                    "port": "Ethernet2"
+                },
+                "Ethernet68": {
+                    "name": "ARISTA02T0",
+                    "port": "Ethernet1"
+                },
+                "Ethernet72": {
+                    "name": "ARISTA03T0",
+                    "port": "Ethernet1"
+                }
+            },
+            "DSCP_TO_TC_MAP": {
+                "AZURE": {
+                    "0": "1",
+                    "1": "1",
+                    "10": "1",
+                    "11": "1",
+                    "12": "1",
+                    "13": "1",
+                    "14": "1",
+                    "15": "1",
+                    "16": "1",
+                    "17": "1",
+                    "18": "1",
+                    "19": "1",
+                    "2": "1",
+                    "20": "1",
+                    "21": "1",
+                    "22": "1",
+                    "23": "1",
+                    "24": "1",
+                    "25": "1",
+                    "26": "1",
+                    "27": "1",
+                    "28": "1",
+                    "29": "1",
+                    "3": "3",
+                    "30": "1",
+                    "31": "1",
+                    "32": "1",
+                    "33": "1",
+                    "34": "1",
+                    "35": "1",
+                    "36": "1",
+                    "37": "1",
+                    "38": "1",
+                    "39": "1",
+                    "4": "4",
+                    "40": "1",
+                    "41": "1",
+                    "42": "1",
+                    "43": "1",
+                    "44": "1",
+                    "45": "1",
+                    "46": "5",
+                    "47": "1",
+                    "48": "6",
+                    "49": "1",
+                    "5": "2",
+                    "50": "1",
+                    "51": "1",
+                    "52": "1",
+                    "53": "1",
+                    "54": "1",
+                    "55": "1",
+                    "56": "1",
+                    "57": "1",
+                    "58": "1",
+                    "59": "1",
+                    "6": "1",
+                    "60": "1",
+                    "61": "1",
+                    "62": "1",
+                    "63": "1",
+                    "7": "1",
+                    "8": "0",
+                    "9": "1"
+                }
+            },
+            "INTERFACE": {
+                "Ethernet68": {},
+                "Ethernet68|10.0.0.34/31": {},
+                "Ethernet68|FC00::45/126": {},
+                "Ethernet72": {},
+                "Ethernet72|10.0.0.36/31": {},
+                "Ethernet72|FC00::49/126": {}
+            },
+            "MAP_PFC_PRIORITY_TO_QUEUE": {
+                "AZURE": {
+                    "0": "0",
+                    "1": "1",
+                    "2": "2",
+                    "3": "3",
+                    "4": "4",
+                    "5": "5",
+                    "6": "6",
+                    "7": "7"
+                }
+            },
+            "PORT": {
+                "Ethernet52": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/52",
+                    "description": "ARISTA13T2:Ethernet2",
+                    "index": "13",
+                    "lanes": "49,50,51,52",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000",
+                    "tpid": "0x8100"
+                },
+                "Ethernet56": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/56",
+                    "description": "ARISTA15T2:Ethernet1",
+                    "index": "14",
+                    "lanes": "57,58,59,60",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000",
+                    "tpid": "0x8100"
+                },
+                "Ethernet60": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/60",
+                    "description": "ARISTA15T2:Ethernet2",
+                    "index": "15",
+                    "lanes": "61,62,63,64",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000",
+                    "tpid": "0x8100"
+                },
+                "Ethernet64": {
+                    "alias": "fortyGigE0/64",
+                    "description": "fortyGigE0/64",
+                    "index": "16",
+                    "lanes": "69,70,71,72",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000",
+                    "tpid": "0x8100"
+                },
+                "Ethernet68": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/68",
+                    "description": "ARISTA02T0:Ethernet1",
+                    "index": "17",
+                    "lanes": "65,66,67,68",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000",
+                    "tpid": "0x8100"
+                },
+                "Ethernet72": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/72",
+                    "description": "ARISTA03T0:Ethernet1",
+                    "index": "18",
+                    "lanes": "73,74,75,76",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000",
+                    "tpid": "0x8100"
+                }
+            },
+            "PORT_QOS_MAP": {
+                "Ethernet52": {
+                    "dscp_to_tc_map": "AZURE",
+                    "pfc_enable": "3,4",
+                    "pfc_to_queue_map": "AZURE",
+                    "tc_to_pg_map": "AZURE",
+                    "tc_to_queue_map": "AZURE"
+                },
+                "Ethernet56": {
+                    "dscp_to_tc_map": "AZURE",
+                    "pfc_enable": "3,4",
+                    "pfc_to_queue_map": "AZURE",
+                    "tc_to_pg_map": "AZURE",
+                    "tc_to_queue_map": "AZURE"
+                },
+                "Ethernet60": {
+                    "dscp_to_tc_map": "AZURE",
+                    "pfc_enable": "3,4",
+                    "pfc_to_queue_map": "AZURE",
+                    "tc_to_pg_map": "AZURE",
+                    "tc_to_queue_map": "AZURE"
+                },
+                "Ethernet68": {
+                    "dscp_to_tc_map": "AZURE",
+                    "pfc_enable": "3,4",
+                    "pfc_to_queue_map": "AZURE",
+                    "tc_to_pg_map": "AZURE",
+                    "tc_to_queue_map": "AZURE"
+                },
+                "Ethernet72": {
+                    "dscp_to_tc_map": "AZURE",
+                    "pfc_enable": "3,4",
+                    "pfc_to_queue_map": "AZURE",
+                    "tc_to_pg_map": "AZURE",
+                    "tc_to_queue_map": "AZURE"
+                }
+            },
+            "TC_TO_PRIORITY_GROUP_MAP": {
+                "AZURE": {
+                    "0": "0",
+                    "1": "0",
+                    "2": "0",
+                    "3": "3",
+                    "4": "4",
+                    "5": "0",
+                    "6": "0",
+                    "7": "7"
+                }
+            },
+            "TC_TO_QUEUE_MAP": {
+                "AZURE": {
+                    "0": "0",
+                    "1": "1",
+                    "2": "2",
+                    "3": "3",
+                    "4": "4",
+                    "5": "5",
+                    "6": "6",
+                    "7": "7"
+                }
+            }
+        },
+        "patch": [
+            {
+                "op": "add",
+                "path": "/PORT/Ethernet64/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "replace",
+                "path": "/PORT/Ethernet64/description",
+                "value": "ARISTA01T0:Ethernet1"
+            },
+            {
+                "op": "add",
+                "path": "/BUFFER_QUEUE/Ethernet64|0-2",
+                "value": {
+                    "profile": "egress_lossy_profile"
+                }
+            },
+            {
+                "op": "add",
+                "path": "/BUFFER_QUEUE/Ethernet64|3-4",
+                "value": {
+                    "profile": "egress_lossless_profile"
+                }
+            },
+            {
+                "op": "add",
+                "path": "/BUFFER_QUEUE/Ethernet64|5-6",
+                "value": {
+                    "profile": "egress_lossy_profile"
+                }
+            },
+            {
+                "op": "add",
+                "path": "/ACL_TABLE/EVERFLOWV6/ports/0",
+                "value": "Ethernet64"
+            },
+            {
+                "op": "add",
+                "path": "/ACL_TABLE/EVERFLOW/ports/0",
+                "value": "Ethernet64"
+            },
+            {
+                "op": "add",
+                "path": "/INTERFACE/Ethernet64",
+                "value": {}
+            },
+            {
+                "op": "add",
+                "path": "/INTERFACE/Ethernet64|10.0.0.32~131",
+                "value": {}
+            },
+            {
+                "op": "add",
+                "path": "/INTERFACE/Ethernet64|FC00::41~1126",
+                "value": {}
+            },
+            {
+                "op": "add",
+                "path": "/PORT_QOS_MAP/Ethernet64",
+                "value": {
+                    "dscp_to_tc_map": "AZURE",
+                    "pfc_enable": "3,4",
+                    "pfc_to_queue_map": "AZURE",
+                    "tc_to_pg_map": "AZURE",
+                    "tc_to_queue_map": "AZURE"
+                }
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/10.0.0.33",
+                "value": {
+                    "admin_status": "up",
+                    "asn": "64001",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "10.0.0.32",
+                    "name": "ARISTA01T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/fc00::42",
+                "value": {
+                    "admin_status": "up",
+                    "asn": "64001",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::41",
+                    "name": "ARISTA01T0",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/fc00::6a/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/10.0.0.1/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/10.0.0.17/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/fc00::56/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/fc00::62/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/fc00::76/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/10.0.0.41/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/10.0.0.25/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/fc00::5e/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/fc00::52/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/fc00::7a/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/10.0.0.35/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/10.0.0.63/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/10.0.0.53/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/fc00::32/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/fc00::22/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/10.0.0.9/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/fc00::6e/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/10.0.0.29/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/10.0.0.47/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/10.0.0.21/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/fc00::72/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/10.0.0.13/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/10.0.0.5/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/10.0.0.39/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/10.0.0.61/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/10.0.0.55/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/10.0.0.37/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/fc00::5a/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/fc00::66/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/fc00::46/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/fc00::4e/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/fc00::2a/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/fc00::2/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/10.0.0.49/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/10.0.0.59/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/fc00::1a/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/fc00::12/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/fc00::4a/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/10.0.0.45/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/fc00::7e/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/10.0.0.43/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/fc00::3a/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/10.0.0.51/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/10.0.0.57/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/BGP_NEIGHBOR/fc00::a/admin_status",
+                "value": "up"
+            },
+            {
+                "op": "add",
+                "path": "/DEVICE_NEIGHBOR/Ethernet64",
+                "value": {
+                    "name": "ARISTA01T0",
+                    "port": "Ethernet1"
+                }
+            },
+            {
+                "op": "add",
+                "path": "/BUFFER_PG/Ethernet64|3-4",
+                "value": {
+                    "profile": "pg_lossless_40000_40m_profile"
+                }
+            },
+            {
+                "op": "add",
+                "path": "/BUFFER_PG/Ethernet64|0",
+                "value": {
+                    "profile": "ingress_lossy_profile"
+                }
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/EVERFLOW/ports/0",
+                    "value": "Ethernet64"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/EVERFLOWV6/ports/0",
+                    "value": "Ethernet64"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.1/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.5/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.9/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.13/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.17/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.21/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.25/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.29/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.35/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.37/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.39/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.41/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.43/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.45/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.47/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.49/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.51/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.53/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.55/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.57/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.59/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.61/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.63/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::1a/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::2/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::2a/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::3a/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::4a/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::4e/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::5a/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::5e/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::6a/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::6e/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::7a/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::7e/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::12/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::22/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::32/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::46/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::52/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::56/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::62/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::66/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::72/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::76/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::a/admin_status",
+                    "value": "up"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.33",
+                    "value": {
+                        "admin_status": "up"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.33/asn",
+                    "value": "64001"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.33/holdtime",
+                    "value": "10"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.33/keepalive",
+                    "value": "3"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.33/local_addr",
+                    "value": "10.0.0.32"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.33/name",
+                    "value": "ARISTA01T0"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.33/nhopself",
+                    "value": "0"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/10.0.0.33/rrclient",
+                    "value": "0"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::42",
+                    "value": {
+                        "admin_status": "up"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::42/asn",
+                    "value": "64001"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::42/holdtime",
+                    "value": "10"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::42/keepalive",
+                    "value": "3"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::42/local_addr",
+                    "value": "fc00::41"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::42/name",
+                    "value": "ARISTA01T0"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::42/nhopself",
+                    "value": "0"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BGP_NEIGHBOR/fc00::42/rrclient",
+                    "value": "0"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BUFFER_PG/Ethernet64|3-4",
+                    "value": {
+                        "profile": "pg_lossless_40000_40m_profile"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BUFFER_PG/Ethernet64|0",
+                    "value": {
+                        "profile": "ingress_lossy_profile"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BUFFER_QUEUE/Ethernet64|0-2",
+                    "value": {
+                        "profile": "egress_lossy_profile"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BUFFER_QUEUE/Ethernet64|3-4",
+                    "value": {
+                        "profile": "egress_lossless_profile"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/BUFFER_QUEUE/Ethernet64|5-6",
+                    "value": {
+                        "profile": "egress_lossy_profile"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/DEVICE_NEIGHBOR/Ethernet64",
+                    "value": {
+                        "name": "ARISTA01T0"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/DEVICE_NEIGHBOR/Ethernet64/port",
+                    "value": "Ethernet1"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/INTERFACE/Ethernet64",
+                    "value": {}
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/INTERFACE/Ethernet64|10.0.0.32~131",
+                    "value": {}
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/INTERFACE/Ethernet64|FC00::41~1126",
+                    "value": {}
+                }
+            ],
+            [
+                {
+                    "op": "replace",
+                    "path": "/PORT/Ethernet64/description",
+                    "value": "ARISTA01T0:Ethernet1"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/PORT_QOS_MAP/Ethernet64",
+                    "value": {
+                        "dscp_to_tc_map": "AZURE"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/PORT_QOS_MAP/Ethernet64/pfc_enable",
+                    "value": "3,4"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/PORT_QOS_MAP/Ethernet64/pfc_to_queue_map",
+                    "value": "AZURE"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/PORT_QOS_MAP/Ethernet64/tc_to_pg_map",
+                    "value": "AZURE"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/PORT_QOS_MAP/Ethernet64/tc_to_queue_map",
+                    "value": "AZURE"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/PORT/Ethernet64/admin_status",
+                    "value": "up"
                 }
             ]
         ]

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -698,16 +698,51 @@ class TestRequiredValueIdentifier(unittest.TestCase):
                     "scheduler": "scheduler.0"
                 }
             },
+            "BUFFER_PORT_INGRESS_PROFILE_LIST": {
+                "Ethernet0": {
+                    "profile_list": ["ingress_lossy_profile"]
+                },
+                "Ethernet4": {
+                    "profile_list": ["ingress_lossy_profile"]
+                },
+            },
+            "BUFFER_PORT_EGRESS_PROFILE_LIST": {
+                "Ethernet4": {
+                    "profile_list": ["egress_lossless_profile", "egress_lossy_profile"]
+                },
+                "Ethernet8": {
+                    "profile_list": ["ingress_lossy_profile"]
+                },
+            },
+            "PORT_QOS_MAP": {
+                "Ethernet4": {
+                    "dscp_to_tc_map": "AZURE",
+                    "pfc_enable": "3,4",
+                    "pfc_to_queue_map": "AZURE",
+                    "tc_to_pg_map": "AZURE",
+                    "tc_to_queue_map": "AZURE"
+                },
+                "Ethernet12": {
+                    "dscp_to_tc_map": "AZURE",
+                    "pfc_enable": "3,4",
+                    "pfc_to_queue_map": "AZURE",
+                    "tc_to_pg_map": "AZURE",
+                    "tc_to_queue_map": "AZURE"
+                },
+            },
             "PORT": {
                 "Ethernet4": {}
             }
         }
-        port_name = "Ethernet4"
         expected = OrderedDict([
             ('/BUFFER_PG/Ethernet4|0', [('/PORT/Ethernet4/admin_status', 'down')]),
+            ('/BUFFER_PORT_EGRESS_PROFILE_LIST/Ethernet4', [('/PORT/Ethernet4/admin_status', 'down')]),
+            ('/BUFFER_PORT_INGRESS_PROFILE_LIST/Ethernet4', [('/PORT/Ethernet4/admin_status', 'down')]),
             ('/BUFFER_QUEUE/Ethernet4|1', [('/PORT/Ethernet4/admin_status', 'down')]),
+            ('/PORT_QOS_MAP/Ethernet4', [('/PORT/Ethernet4/admin_status', 'down')]),
             ('/QUEUE/Ethernet4|2', [('/PORT/Ethernet4/admin_status', 'down')]),
-            ('/QUEUE/Ethernet4|7-8', [('/PORT/Ethernet4/admin_status', 'down')])])
+            ('/QUEUE/Ethernet4|7-8', [('/PORT/Ethernet4/admin_status', 'down')]),
+        ])
 
         actual = identifier.get_required_value_data([config])
 

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -1319,7 +1319,7 @@ class TestRequiredValueMoveValidator(unittest.TestCase):
         self.operation_wrapper = OperationWrapper()
         path_addressing = PathAddressing()
         self.validator = ps.RequiredValueMoveValidator(path_addressing)
-        self.validator.identifier.settings[0]["requiring_filter"] = ps.ConfigFilter([
+        self.validator.identifier.settings[0]["requiring_filter"] = ps.JsonPointerFilter([
                 ["BUFFER_PG", "@|*"],
                 ["PORT", "@", "mtu"]
             ],
@@ -2036,7 +2036,7 @@ class TestRequiredValueMoveExtender(unittest.TestCase):
     def setUp(self):
         path_addressing = PathAddressing()
         self.extender = ps.RequiredValueMoveExtender(path_addressing, OperationWrapper())
-        self.extender.identifier.settings[0]["requiring_filter"] = ps.ConfigFilter([
+        self.extender.identifier.settings[0]["requiring_filter"] = ps.JsonPointerFilter([
                 ["BUFFER_PG", "@|*"],
                 ["PORT", "@", "mtu"]
             ],

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -2821,6 +2821,9 @@ class TestPatchSorter(unittest.TestCase):
         data = Files.PATCH_SORTER_TEST_SUCCESS
         skip_exact_change_list_match = False
         for test_case_name in data:
+            # Skipping ADD RACK case until fixing issue https://github.com/Azure/sonic-utilities/issues/2034
+            if test_case_name == "ADD_RACK":
+                continue
             with self.subTest(name=test_case_name):
                 self.run_single_success_case(data[test_case_name], skip_exact_change_list_match)
 

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -669,6 +669,47 @@ class TestMoveWrapper(unittest.TestCase):
         # Assert
         self.assertIs(self.any_diff, actual)
 
+class TestPortCriticalConfigIdentifier(unittest.TestCase):
+    def test_hard_coded_port_critical_paths(self):
+        identifier = ps.PortCriticalConfigIdentifier(PathAddressing())
+        config = {
+            "BUFFER_PG": {
+                "Ethernet4|0": {
+                    "profile": "ingress_lossy_profile"
+                },
+                "Ethernet8|3-4": {
+                    "profile": "pg_lossless_40000_40m_profile"
+                }
+            },
+            "BUFFER_QUEUE": {
+                "Ethernet0|5-6": {
+                    "profile": "egress_lossless_profile"
+                },
+                "Ethernet4|1": {
+                    "profile": "egress_lossy_profile"
+                }
+            },
+            "QUEUE": {
+                "Ethernet4|2": {
+                    "scheduler": "scheduler.0"
+                },
+                "Ethernet4|7-8": {
+                    "scheduler": "scheduler.0"
+                }
+            }
+        }
+        port_name = "Ethernet4"
+        expected = [
+            "/BUFFER_PG/Ethernet4|0",
+            "/BUFFER_QUEUE/Ethernet4|1",
+            "/QUEUE/Ethernet4|2",
+            "/QUEUE/Ethernet4|7-8"
+        ]
+
+        actual = list(identifier._identify_critical_config([config], port_name))
+
+        self.assertEqual(expected, actual)
+
 class TestDeleteWholeConfigMoveValidator(unittest.TestCase):
     def setUp(self):
         self.operation_wrapper = OperationWrapper()
@@ -1270,6 +1311,470 @@ class TestNoEmptyTableMoveValidator(unittest.TestCase):
         # Act and assert
         self.assertTrue(self.validator.validate(move, diff))
 
+class TestPortCriticalMoveValidator(unittest.TestCase):
+    def setUp(self):
+        self.operation_wrapper = OperationWrapper()
+        self.validator = ps.PortCriticalMoveValidator(PathAddressing())
+        self.validator.port_critical_config_identifier.port_critical_filter = ps.ConfigFilter([
+            ["BUFFER_PG", "@|*"],
+            ["PORT", "@", "mtu"]
+        ])
+
+    def test_validate__critical_port_change(self):
+        # Each test format:
+        #   "<test-name>": {
+        #       "expected": "<True|False>",
+        #       "config": <config>,
+        #       "move": <move>,
+        #       "target_config": <OPTIONAL> <target-config-if-different-than-applying-move-to-config>
+        #   }
+        # Each test is testing different flag of:
+        #  - port-up: if port is up or not in current_config
+        #  - status-changing: if admin_status is changing from any state to another
+        #  - under-port: if the port-critical config is under port
+        #  - port-exist: if the port already exist in current_config
+        test_cases = self._get_critical_port_change_test_cases()
+        for test_case_name in test_cases:
+            with self.subTest(name=test_case_name):
+                self._run_single_test(test_cases[test_case_name])
+
+    def _run_single_test(self, test_case):
+        # Arrange
+        expected = test_case['expected']
+        current_config = test_case['config']
+        move = test_case['move']
+        target_config = test_case.get('target_config', move.apply(current_config))
+        diff = ps.Diff(current_config, target_config)
+
+        # Act and Assert
+        self.assertEqual(expected, self.validator.validate(move, diff))
+
+    def _get_critical_port_change_test_cases(self):
+        # port-up  status-changing  under-port  port-exist  verdict
+        # 1        1                1           1           0
+        # 1        1                1           0           invalid - port cannot be up while it does not exist
+        # 1        1                0           1           0
+        # 1        1                0           0           invalid - port cannot be up while it does not exist
+        # 1        0                1           1           0
+        # 1        0                1           0           invalid - port cannot be up while it does not exist
+        # 1        0                0           1           0
+        # 1        0                0           0           invalid - port cannot be up while it does not exist
+        # 0        1                1           1           0
+        # 0        1                1           0           0    can be 1?
+        # 0        1                0           1           0
+        # 0        1                0           0           0
+        # 0        0                1           1           1
+        # 0        0                1           0           1
+        # 0        0                0           1           1
+        # 0        0                0           0           invalid - port does not exist anyway
+        return {
+            "PORT_UP__STATUS_CHANGING__UNDER_PORT__PORT_EXIST": {
+                "expected": False,
+                "config": Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                "move": ps.JsonMove.from_operation({
+                    "op": "replace",
+                    "path": "/PORT/Ethernet4",
+                    "value": { # only admin_status and mtu are different
+                        "admin_status": "down", # <== status changing
+                        "alias": "fortyGigE0/4",
+                        "description": "Servers0:eth0",
+                        "index": "1",
+                        "lanes": "29,30,31,32",
+                        "mtu": "9000", # <== critical config under port
+                        "pfc_asym": "off",
+                        "speed": "40000"
+                    }
+                })
+            },
+            # cannot test "port-up, status-changing, under-port, not port-exist"
+            #   because if port does not exist, it cannot be admin up
+            "PORT_UP__STATUS_CHANGING__NOT_UNDER_PORT__PORT_EXIST": {
+                "expected": False,
+                "config": Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                "move": ps.JsonMove.from_operation({
+                    "op": "replace",
+                    "path": "",
+                    "value": self._apply_operations(Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                            [
+                                # status-changing
+                                {"op":"replace", "path":"/PORT/Ethernet4/admin_status", "value": "down"},
+                                # port-critical config is not under port
+                                {"op":"replace", "path":"/BUFFER_PG/Ethernet4|0/profile", "value": "egress_lossy_profile"},
+                            ])
+                })
+            },
+            # cannot test "port-up, status-changing, not under-port, not port-exist"
+            #   because if port does not exist, it cannot be admin up
+            "PORT_UP__NOT_STATUS_CHANGING__UNDER_PORT__PORT_EXIST": {
+                "expected": False,
+                "config": Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                "move": ps.JsonMove.from_operation({
+                    "op": "replace",
+                    "path": "/PORT/Ethernet4/mtu",
+                    "value": "9000"
+                })
+            },
+            # cannot test "port-up, not status-changing, under-port, not port-exist"
+            #   because if port does not exist, it cannot be admin up
+            "PORT_UP__NOT_STATUS_CHANGING__NOT_UNDER_PORT__PORT_EXIST": {
+                "expected": False,
+                "config": Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                "move": ps.JsonMove.from_operation({
+                    "op":"replace",
+                    "path":"/BUFFER_PG/Ethernet4|0/profile",
+                    "value": "egress_lossy_profile"
+                })
+            },
+            # cannot test "port-up, not status-changing, not under-port, not port-exist"
+            #   because if port does not exist, it cannot be admin up
+            "NOT_PORT_UP__STATUS_CHANGING__UNDER_PORT__PORT_EXIST": {
+                "expected": False,
+                "config": Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                "move": ps.JsonMove.from_operation({
+                    "op": "add",
+                    "path": "/PORT/Ethernet12",
+                    "value": {
+                        "admin_status": "up", # <== status changing
+                        "alias": "fortyGigE0/12",
+                        "description": "Servers2:eth0",
+                        "index": "3",
+                        "lanes": "37,38,39,40",
+                        "mtu": "9000", # <== critical config under port
+                        "pfc_asym": "off",
+                        "speed": "40000"
+                    }
+                })
+            },
+            "NOT_PORT_UP__STATUS_CHANGING__UNDER_PORT__NOT_PORT_EXIST": {
+                "expected": False,
+                "config": Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                "move": ps.JsonMove.from_operation({
+                    "op": "add",
+                    "path": "/PORT/Ethernet20",
+                    "value": {
+                        "admin_status": "up", # <== status-changing from not-existing i.e "down" to "up"
+                        "alias": "fortyGigE0/20",
+                        "description": "Servers4:eth0",
+                        "index": "5",
+                        "mtu": "9100",  # <== critical config under port
+                        "lanes": "45,46,47,48",
+                        "pfc_asym": "off",
+                        "speed": "40000"
+                    }
+                })
+            },
+            "NOT_PORT_UP__STATUS_CHANGING__NOT_UNDER_PORT__PORT_EXIST": {
+                "expected": False,
+                "config": Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                "move": ps.JsonMove.from_operation({
+                    "op": "replace",
+                    "path": "",
+                    "value": self._apply_operations(Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                        [
+                            # status-changing
+                            {"op":"replace", "path":"/PORT/Ethernet12/admin_status", "value": "up"},
+                            # port-critical config is not under port
+                            {"op":"replace", "path":"/BUFFER_PG/Ethernet4|0/profile", "value": "egress_lossy_profile"},
+                        ]
+                    )
+                })
+            },
+            "NOT_PORT_UP__STATUS_CHANGING__NOT_UNDER_PORT__NOT_PORT_EXIST": {
+                "expected": False,
+                "config": Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                "move": ps.JsonMove.from_operation({
+                    "op": "replace",
+                    "path": "",
+                    "value": self._apply_operations(Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                        [
+                            # status-changing
+                            {
+                                "op":"add",
+                                "path":"/PORT/Ethernet20",
+                                "value": {
+                                    "admin_status": "up", # <== status-changing from not-existing i.e. "down" to "up"
+                                    "alias": "fortyGigE0/20",
+                                    "description": "Servers4:eth0",
+                                    "index": "5",
+                                    "lanes": "45,46,47,48",
+                                    "pfc_asym": "off",
+                                    "speed": "40000"
+                                }
+                            },
+                            # port-critical config is not under port
+                            {
+                                "op":"add",
+                                "path":"/BUFFER_PG/Ethernet20|0",
+                                "value": {
+                                    "profile": "ingress_lossy_profile"
+                                }
+                            },
+                        ]
+                    )
+                })
+            },
+            "NOT_PORT_UP__NOT_STATUS_CHANGING__UNDER_PORT__PORT_EXIST": {
+                "expected": True,
+                "config": Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                "move": ps.JsonMove.from_operation({
+                    "op": "replace",
+                    "path": "/PORT/Ethernet12/mtu",
+                    "value": "9000"
+                })
+            },
+            "NOT_PORT_UP__NOT_STATUS_CHANGING__UNDER_PORT__NOT_PORT_EXIST": {
+                "expected": True,
+                "config": Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                "move": ps.JsonMove.from_operation({
+                    "op": "add",
+                    "path": "/PORT/Ethernet20",
+                    "value": {
+                        "alias": "fortyGigE0/20",
+                        "description": "Servers4:eth0",
+                        "index": "5",
+                        "mtu": "9100",  # <== critical config under port
+                        "lanes": "45,46,47,48",
+                        "pfc_asym": "off",
+                        "speed": "40000"
+                    }
+                })
+            },
+            "NOT_PORT_UP__NOT_STATUS_CHANGING__NOT_UNDER_PORT__PORT_EXIST": {
+                "expected": True,
+                "config": Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                "move": ps.JsonMove.from_operation({
+                    "op":"replace",
+                    "path":"/BUFFER_PG/Ethernet12|0/profile",
+                    "value": "egress_lossy_profile"
+                })
+            },
+            # cannot test "not port-up, not status-changing, not under-port, not port-exist"
+            #   because if port does not exist, it cannot be admin up
+
+            # The following set of cases check validation failure when a move is turning a port admin up, while still
+            # some critical changes not included at all in the move
+            "NOT_PORT_UP__STATUS_CHANGING__UNDER_PORT__PORT_EXIST__NOT_ALL_CRITICAL_CHANGES_INCLUDED": {
+                "expected": False,
+                "config": Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                "target_config": self._apply_operations(Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                    [
+                        # The following critical change is not part of the move below.
+                        {"op": "replace", "path": "/PORT/Ethernet12/mtu", "value": "9000"}
+                    ]),
+                "move": ps.JsonMove.from_operation({"op":"replace", "path":"/PORT/Ethernet12/admin_status", "value": "up"})
+            },
+            "NOT_PORT_UP__STATUS_CHANGING__UNDER_PORT__NOT_PORT_EXIST__NOT_ALL_CRITICAL_CHANGES_INCLUDED": {
+                "expected": False,
+                "config": Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                "target_config": self._apply_operations(Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                    [
+                        {
+                            "op": "add",
+                            "path": "/PORT/Ethernet20",
+                            "value": {
+                                "admin_status": "up", # <== status-changing from not-existing i.e "down" to "up"
+                                "alias": "fortyGigE0/20",
+                                "description": "Servers4:eth0",
+                                "index": "5",
+                                "mtu": "9100",  # <== critical config under port which is not part of the move below
+                                "lanes": "45,46,47,48",
+                                "pfc_asym": "off",
+                                "speed": "40000"
+                            }
+                        }
+                    ]),
+                "move": ps.JsonMove.from_operation({
+                    "op": "add",
+                    "path": "/PORT/Ethernet20",
+                    "value": {
+                        "admin_status": "up", # <== status-changing from not-existing i.e "down" to "up"
+                        "alias": "fortyGigE0/20",
+                        "description": "Servers4:eth0",
+                        "index": "5",
+                        # "mtu": "9100", # <== critical change is left out
+                        "lanes": "45,46,47,48",
+                        "pfc_asym": "off",
+                        "speed": "40000"
+                    }
+                })
+            },
+            "NOT_PORT_UP__STATUS_CHANGING__NOT_UNDER_PORT__PORT_EXIST__NOT_ALL_CRITICAL_CHANGES_INCLUDED": {
+                "expected": False,
+                "config": Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                "target_config": self._apply_operations(Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                    [
+                        # The following critical change is not part of the move below
+                        {"op":"replace", "path":"/BUFFER_PG/Ethernet12|0/profile", "value": "egress_lossy_profile"},
+                    ]),
+                "move": ps.JsonMove.from_operation({"op":"replace", "path":"/PORT/Ethernet12/admin_status", "value": "up"})
+            },
+            "NOT_PORT_UP__STATUS_CHANGING__NOT_UNDER_PORT__NOT_PORT_EXIST__NOT_ALL_CRITICAL_CHANGES_INCLUDED": {
+                "expected": False,
+                "config": Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                "target_config": self._apply_operations(Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                    [
+                        {
+                            "op":"add",
+                            "path":"/BUFFER_PG/Ethernet20|0",
+                            "value": {
+                                "profile": "ingress_lossy_profile"
+                            }
+                        },
+                        {
+                            "op": "add",
+                            "path": "/PORT/Ethernet20",
+                            "value": {
+                                "admin_status": "up", # <== status-changing from not-existing i.e "down" to "up"
+                                "alias": "fortyGigE0/20",
+                                "description": "Servers4:eth0",
+                                "index": "5",
+                                "lanes": "45,46,47,48",
+                                "pfc_asym": "off",
+                                "speed": "40000"
+                            }
+                        }
+                    ]),
+                "move": ps.JsonMove.from_operation({
+                    "op": "add",
+                    "path": "/PORT/Ethernet20",
+                    "value": {
+                        "admin_status": "up", # <== status-changing from not-existing i.e "down" to "up"
+                        "alias": "fortyGigE0/20",
+                        "description": "Servers4:eth0",
+                        "index": "5",
+                        # "mtu": "9100", # <== critical change is left out
+                        "lanes": "45,46,47,48",
+                        "pfc_asym": "off",
+                        "speed": "40000"
+                    }
+                })
+            },
+            # Additional cases trying different operation to port-critical config i.e. REPLACE, REMOVE, ADD
+            "PORT_UP__NOT_STATUS_CHANGING__UNDER_PORT__PORT_EXIST__REMOVE": {
+                "expected": False,
+                "config": Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                "move": ps.JsonMove.from_operation({
+                    "op": "remove",
+                    "path": "/PORT/Ethernet4/mtu"
+                })
+            },
+            "PORT_UP__NOT_STATUS_CHANGING__UNDER_PORT__PORT_EXIST__ADD": {
+                "expected": False,
+                "config": Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                "move": ps.JsonMove.from_operation({
+                    "op": "add",
+                    "path": "/PORT/Ethernet8/mtu",
+                    "value": "9000"
+                })
+            },
+            "PORT_UP__NOT_STATUS_CHANGING__NOT_UNDER_PORT__PORT_EXIST__REMOVE": {
+                "expected": False,
+                "config": Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                "move": ps.JsonMove.from_operation({
+                    "op":"remove",
+                    "path":"/BUFFER_PG/Ethernet4|0/profile"
+                })
+            },
+            "PORT_UP__NOT_STATUS_CHANGING__NOT_UNDER_PORT__PORT_EXIST__ADD": {
+                "expected": False,
+                "config": Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                "move": ps.JsonMove.from_operation({
+                    "op":"add",
+                    "path":"/BUFFER_PG/Ethernet8|0",
+                    "value":{
+                        "profile": "ingress_lossy_profile"
+                    }
+                })
+            },
+            "NOT_PORT_UP__NOT_STATUS_CHANGING__UNDER_PORT__PORT_EXIST__REMOVE": {
+                "expected": True,
+                "config": Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                "move": ps.JsonMove.from_operation({
+                    "op": "remove",
+                    "path": "/PORT/Ethernet12/mtu"
+                })
+            },
+            "NOT_PORT_UP__NOT_STATUS_CHANGING__UNDER_PORT__PORT_EXIST__ADD": {
+                "expected": True,
+                "config": Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                "move": ps.JsonMove.from_operation({
+                    "op": "add",
+                    "path": "/PORT/Ethernet16/mtu",
+                    "value": "9000"
+                })
+            },
+            "NOT_PORT_UP__NOT_STATUS_CHANGING__NOT_UNDER_PORT__PORT_EXIST__REMOVE": {
+                "expected": True,
+                "config": Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                "move": ps.JsonMove.from_operation({
+                    "op":"remove",
+                    "path":"/BUFFER_PG/Ethernet12|0"
+                })
+            },
+            "NOT_PORT_UP__NOT_STATUS_CHANGING__NOT_UNDER_PORT__PORT_EXIST__ADD": {
+                "expected": True,
+                "config": Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                "move": ps.JsonMove.from_operation({
+                    "op":"add",
+                    "path":"/BUFFER_PG/Ethernet16|0",
+                    "value": {
+                        "profile": "ingress_lossy_profile"
+                    }
+                })
+            },
+        }
+
+    def test_validate__no_critical_port_changes(self):
+        # Each test format:
+        #   "<test-name>": {
+        #       "expected": "<True|False>",
+        #       "config": <config>,
+        #       "move": <move>,
+        #       "target_config": <OPTIONAL> <target-config-if-different-than-applying-move-to-config>
+        #   }
+        # Each test is testing different flag of:
+        #  - port-up: if port is up or not in current_config
+        #  - status-changing: if admin_status is changing from any state to another
+        #  - under-port: if the port-critical config is under port
+        #  - port-exist: if the port already exist in current_config
+        test_cases = self._get_no_critical_port_change_test_cases()
+        for test_case_name in test_cases:
+            with self.subTest(name=test_case_name):
+                self._run_single_test(test_cases[test_case_name])
+
+    def _get_no_critical_port_change_test_cases(self):
+        return {
+            "REPLACE_NON_CRITICAL_CONFIG": {
+                "expected": True,
+                "config": Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                "move": ps.JsonMove.from_operation({
+                    "op": "replace",
+                    "path": "/PORT/Ethernet4/description",
+                    "value": "desc4"
+                })
+            },
+            "REMOVE_NON_CRITICAL_CONFIG": {
+                "expected": True,
+                "config": Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                "move": ps.JsonMove.from_operation({
+                    "op": "remove",
+                    "path": "/PORT/Ethernet4/description"
+                })
+            },
+            "ADD_NON_CRITICAL_CONFIG": {
+                "expected": True,
+                "config": Files.CONFIG_DB_WITH_PORT_CRITICAL,
+                "move": ps.JsonMove.from_operation({
+                    "op": "add",
+                    "path": "/PORT/Ethernet8/description",
+                    "value": "desc8"
+                })
+            },
+        }
+
+    def _apply_operations(self, config, operations):
+        return jsonpatch.JsonPatch(operations).apply(config)
+
 class TestLowLevelMoveGenerator(unittest.TestCase):
     def setUp(self):
         path_addressing = PathAddressing()
@@ -1521,6 +2026,401 @@ class TestLowLevelMoveGenerator(unittest.TestCase):
             target_config = tc_patch.apply(target_config)
 
         return ps.Diff(current_config, target_config)
+
+class TestPortCriticalMoveExtender(unittest.TestCase):
+    def setUp(self):
+        self.extender = ps.PortCriticalMoveExtender(PathAddressing(), OperationWrapper())
+        self.extender.port_critical_config_identifier.port_critical_filter = ps.ConfigFilter([
+            ["BUFFER_PG", "@|*"],
+            ["PORT", "@", "mtu"]
+        ])
+
+    def test_extend__remove_whole_config__no_extended_moves(self):
+        # Arrange
+        move = ps.JsonMove.from_operation({"op":"remove", "path":""})
+        diff = ps.Diff(Files.ANY_CONFIG_DB, Files.ANY_OTHER_CONFIG_DB)
+        expected = []
+
+        # Act
+        actual = self.extender.extend(move, diff)
+
+        # Assert
+        self._verify_moves(expected, actual)
+
+    def test_extend__port_up_and_no_critical_move__no_extended_moves(self):
+        # Arrange
+        move = ps.JsonMove.from_operation({"op":"replace", "path":"/PORT/Ethernet4/description", "value":"desc4"})
+        current_config = Files.CONFIG_DB_WITH_PORT_CRITICAL
+        target_config = move.apply(current_config)
+        diff = ps.Diff(current_config, target_config)
+        expected = []
+
+        # Act
+        actual = self.extender.extend(move, diff)
+
+        # Assert
+        self._verify_moves(expected, actual)
+
+    def test_extend__port_up_and_critical_move__turn_admin_status_down(self):
+        # Arrange
+        move = ps.JsonMove.from_operation({"op":"replace", "path":"/PORT/Ethernet4/mtu", "value":"9000"})
+        current_config = Files.CONFIG_DB_WITH_PORT_CRITICAL
+        target_config = move.apply(current_config)
+        diff = ps.Diff(current_config, target_config)
+        expected = [{"op":"replace", "path":"/PORT/Ethernet4/admin_status", "value":"down"}]
+
+        # Act
+        actual = self.extender.extend(move, diff)
+
+        # Assert
+        self._verify_moves(expected, actual)
+
+    def test_extend__port_turn_up_and_no_critical_move__no_extended_moves(self):
+        # Arrange
+        move = ps.JsonMove.from_operation({"op":"replace", "path":"/PORT/Ethernet12/admin_status", "value":"up"})
+        current_config = Files.CONFIG_DB_WITH_PORT_CRITICAL
+        target_config = move.apply(current_config)
+        diff = ps.Diff(current_config, target_config)
+        expected = []
+
+        # Act
+        actual = self.extender.extend(move, diff)
+
+        # Assert
+        self._verify_moves(expected, actual)
+
+    def test_extend__port_turn_up_and_critical_move__flip_to_turn_down(self):
+        # Arrange
+        move = ps.JsonMove.from_operation({
+            "op":"replace",
+            "path":"/PORT/Ethernet12",
+            "value":{
+                "admin_status": "up", # <== Turn admin_status up
+                "alias": "fortyGigE0/12",
+                "description": "Servers2:eth0",
+                "index": "3",
+                "lanes": "37,38,39,40",
+                "mtu": "9000", # <== Critical move
+                "pfc_asym": "off",
+                "speed": "40000"
+            },
+        })
+        current_config = Files.CONFIG_DB_WITH_PORT_CRITICAL
+        target_config = move.apply(current_config)
+        diff = ps.Diff(current_config, target_config)
+        expected = [{
+            "op":"replace",
+            "path":"/PORT/Ethernet12",
+            "value":{
+                "admin_status": "down", # <== Leave admin_status as down
+                "alias": "fortyGigE0/12",
+                "description": "Servers2:eth0",
+                "index": "3",
+                "lanes": "37,38,39,40",
+                "mtu": "9000", # <== Critical move
+                "pfc_asym": "off",
+                "speed": "40000"
+            },
+        }]
+
+        # Act
+        actual = self.extender.extend(move, diff)
+
+        # Assert
+        self._verify_moves(expected, actual)
+
+    def test_extend__multi_port_turn_up_and_critical_move__multi_flip_to_turn_down(self):
+        # Arrange
+        current_config = Files.CONFIG_DB_WITH_PORT_CRITICAL
+        target_config = self._apply_operations(Files.CONFIG_DB_WITH_PORT_CRITICAL, [
+            {"op":"replace", "path":"/PORT/Ethernet12/admin_status", "value":"up"},
+            {"op":"add", "path":"/PORT/Ethernet16/admin_status", "value":"up"},
+            {"op":"add", "path":"/PORT/Ethernet12/mtu", "value":"9000"},
+            # Will not be part of the move, only in the final target config
+            {"op":"add", "path":"/PORT/Ethernet16/mtu", "value":"9000"}, 
+        ])
+        move = ps.JsonMove.from_operation({
+            "op":"replace",
+            "path":"/PORT",
+            # Following value is for the PORT part of the config
+            "value": self._apply_operations(Files.CONFIG_DB_WITH_PORT_CRITICAL["PORT"], [
+                {"op":"replace", "path":"/Ethernet12/admin_status", "value":"up"},
+                {"op":"add", "path":"/Ethernet16/admin_status", "value":"up"},
+                {"op":"add", "path":"/Ethernet12/mtu", "value":"9000"},
+            ])
+        })
+        diff = ps.Diff(current_config, target_config)
+        expected = [{
+            "op":"replace",
+            "path":"/PORT",
+            # Following value is for the PORT part of the config
+            "value": self._apply_operations(Files.CONFIG_DB_WITH_PORT_CRITICAL["PORT"], [
+                {"op":"replace", "path":"/Ethernet12/admin_status", "value":"down"},
+                {"op":"add", "path":"/Ethernet16/admin_status", "value":"down"},
+                {"op":"add", "path":"/Ethernet12/mtu", "value":"9000"},
+            ])
+        }]
+
+        # Act
+        actual = self.extender.extend(move, diff)
+
+        # Assert
+        self._verify_moves(expected, actual)
+
+    def test_extend__multiple_changes__multiple_extend_moves(self):
+        # Arrange
+        current_config = Files.CONFIG_DB_WITH_PORT_CRITICAL
+        target_config = self._apply_operations(Files.CONFIG_DB_WITH_PORT_CRITICAL, [
+            {"op":"replace", "path":"/BUFFER_PG/Ethernet4|0/profile", "value": "egress_lossy_profile"},
+            {"op": "add", "path": "/PORT/Ethernet8/mtu", "value": "9000"},
+            {
+                "op": "add",
+                "path": "/PORT/Ethernet20", # <== adding a non-existing port
+                "value": {
+                    "admin_status": "up", # <== status-changing from not-existing i.e "down" to "up"
+                    "alias": "fortyGigE0/20",
+                    "description": "Servers4:eth0",
+                    "index": "5",
+                    "mtu": "9100",  # <== critical config under port
+                    "lanes": "45,46,47,48",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                }
+            },
+            {"op":"replace", "path":"/PORT/Ethernet12/admin_status", "value":"up"},
+            {"op":"add", "path":"/PORT/Ethernet16/admin_status", "value":"up"},
+            {"op":"add", "path":"/PORT/Ethernet12/mtu", "value":"9000"},
+            # Will not be part of the move, only in the final target config
+            {"op":"add", "path":"/PORT/Ethernet16/mtu", "value":"9000"}, 
+        ])
+        move = ps.JsonMove.from_operation({
+            "op":"replace",
+            "path":"",
+            "value": self._apply_operations(Files.CONFIG_DB_WITH_PORT_CRITICAL, [
+                {"op":"replace", "path":"/BUFFER_PG/Ethernet4|0/profile", "value": "egress_lossy_profile"},
+                {"op": "add", "path": "/PORT/Ethernet8/mtu", "value": "9000"},
+                {
+                    "op": "add",
+                    "path": "/PORT/Ethernet20", # <== adding a non-existing port
+                    "value": {
+                        "admin_status": "up", # <== status-changing from not-existing i.e "down" to "up"
+                        "alias": "fortyGigE0/20",
+                        "description": "Servers4:eth0",
+                        "index": "5",
+                        "mtu": "9100",  # <== critical config under port
+                        "lanes": "45,46,47,48",
+                        "pfc_asym": "off",
+                        "speed": "40000"
+                    }
+                },
+                {"op":"replace", "path":"/PORT/Ethernet12/admin_status", "value":"up"},
+                {"op":"add", "path":"/PORT/Ethernet16/admin_status", "value":"up"},
+                {"op":"add", "path":"/PORT/Ethernet12/mtu", "value":"9000"},
+            ])
+        })
+        diff = ps.Diff(current_config, target_config)
+        expected = [
+            {"op":"replace", "path":"/PORT/Ethernet4/admin_status", "value":"down"},
+            {"op":"replace", "path":"/PORT/Ethernet8/admin_status", "value":"down"},
+            {
+                "op":"replace",
+                "path":"",
+                "value": self._apply_operations(Files.CONFIG_DB_WITH_PORT_CRITICAL, [
+                    {"op":"replace", "path":"/BUFFER_PG/Ethernet4|0/profile", "value": "egress_lossy_profile"},
+                    {"op": "add", "path": "/PORT/Ethernet8/mtu", "value": "9000"},
+                    {
+                        "op": "add",
+                        "path": "/PORT/Ethernet20", # <== adding a non-existing port
+                        "value": {
+                            "admin_status": "down", # <== flipping to down admin_status
+                            "alias": "fortyGigE0/20",
+                            "description": "Servers4:eth0",
+                            "index": "5",
+                            "mtu": "9100",  # <== critical config under port
+                            "lanes": "45,46,47,48",
+                            "pfc_asym": "off",
+                            "speed": "40000"
+                        }
+                    },
+                    {"op":"replace", "path":"/PORT/Ethernet12/admin_status", "value":"down"},
+                    {"op":"add", "path":"/PORT/Ethernet16/admin_status", "value":"down"},
+                    {"op":"add", "path":"/PORT/Ethernet12/mtu", "value":"9000"},
+                ])
+            }
+        ]
+
+        # Act
+        actual = self.extender.extend(move, diff)
+
+        # Assert
+        self._verify_moves(expected, actual)
+
+    def _verify_moves(self, ex_ops, moves):
+        moves_ops = [list(move.patch)[0] for move in moves]
+        self.assertCountEqual(ex_ops, moves_ops)
+
+    def _apply_operations(self, config, operations):
+        return jsonpatch.JsonPatch(operations).apply(config)
+
+    def test_flip_admin_down_move(self):
+        test_cases = {
+            "ADD_ADMIN_STATUS": {
+                "move": ps.JsonMove.from_operation({"op":"add", "path":"/PORT/Ethernet200/admin_status", "value": "up"}),
+                "port_names": ["Ethernet200"],
+                "expected": ps.JsonMove.from_operation({"op":"add", "path":"/PORT/Ethernet200/admin_status", "value": "down"})
+            },
+            "ADD_ETHERNET": {
+                "move": ps.JsonMove.from_operation({"op":"add", "path":"/PORT/Ethernet200", "value": {
+                    "admin_status": "up",
+                }}),
+                "port_names": ["Ethernet200"],
+                "expected": ps.JsonMove.from_operation({"op":"add", "path":"/PORT/Ethernet200", "value": {
+                    "admin_status": "down",
+                }})
+            },
+            "ADD_ETHERNET_NO_ADMIN_STATUS": {
+                "move": ps.JsonMove.from_operation({"op":"add", "path":"/PORT/Ethernet200", "value": {
+                    "admin_status": "up",
+                }}),
+                "port_names": ["Ethernet200"],
+                "expected": ps.JsonMove.from_operation({"op":"add", "path":"/PORT/Ethernet200", "value": {
+                    "admin_status": "down",
+                }})
+            },
+            "ADD_PORT": {
+                "move": ps.JsonMove.from_operation({"op":"add", "path":"/PORT", "value": {
+                    "Ethernet200":{
+                        "admin_status": "up",
+                    }
+                }}),
+                "port_names": ["Ethernet200"],
+                "expected": ps.JsonMove.from_operation({"op":"add", "path":"/PORT", "value": {
+                    "Ethernet200":{
+                        "admin_status": "down",
+                    }
+                }})
+            },
+            "ADD_WHOLE_CONFIG": {
+                "move": ps.JsonMove.from_operation({"op":"add", "path":"", "value": {
+                    "PORT": {
+                        "Ethernet200": {
+                            "admin_status": "up",
+                        }
+                    }
+                }}),
+                "port_names": ["Ethernet200"],
+                "expected": ps.JsonMove.from_operation({"op":"add", "path":"", "value": {
+                    "PORT": {
+                        "Ethernet200":{
+                            "admin_status": "down",
+                        }
+                    }
+                }}),
+            },
+            "ADD_WHOLE_CONFIG_NO_ADMIN_STATUS": {
+                "move": ps.JsonMove.from_operation({"op":"add", "path":"", "value": {
+                    "PORT": {
+                        "Ethernet200": {
+                        }
+                    }
+                }}),
+                "port_names": ["Ethernet200"],
+                "expected": ps.JsonMove.from_operation({"op":"add", "path":"", "value": {
+                    "PORT": {
+                        "Ethernet200":{
+                            "admin_status": "down",
+                        }
+                    }
+                }}),
+            },
+            "REPLACE_ADMIN_STATUS": {
+                "move": ps.JsonMove.from_operation({"op":"replace", "path":"/PORT/Ethernet200/admin_status", "value": "up"}),
+                "port_names": ["Ethernet200"],
+                "expected": ps.JsonMove.from_operation({"op":"replace", "path":"/PORT/Ethernet200/admin_status", "value": "down"})
+            },
+            "REPLACE_ETHERNET": {
+                "move": ps.JsonMove.from_operation({"op":"replace", "path":"/PORT/Ethernet200", "value": {
+                    "admin_status": "up",
+                }}),
+                "port_names": ["Ethernet200"],
+                "expected": ps.JsonMove.from_operation({"op":"replace", "path":"/PORT/Ethernet200", "value": {
+                    "admin_status": "down",
+                }})
+            },
+            "REPLACE_PORT": {
+                "move": ps.JsonMove.from_operation({"op":"replace", "path":"/PORT", "value": {
+                    "Ethernet200":{
+                        "admin_status": "up",
+                    }
+                }}),
+                "port_names": ["Ethernet200"],
+                "expected": ps.JsonMove.from_operation({"op":"replace", "path":"/PORT", "value": {
+                    "Ethernet200":{
+                        "admin_status": "down",
+                    }
+                }})
+            },
+            "REPLACE_WHOLE_CONFIG": {
+                "move": ps.JsonMove.from_operation({"op":"replace", "path":"", "value": {
+                    "PORT": {
+                        "Ethernet200": {
+                            "admin_status": "up",
+                        }
+                    }
+                }}),
+                "port_names": ["Ethernet200"],
+                "expected": ps.JsonMove.from_operation({"op":"replace", "path":"", "value": {
+                    "PORT": {
+                        "Ethernet200":{
+                            "admin_status": "down",
+                        }
+                    }
+                }}),
+            },
+            "MULTIPLE_PORTS" :{
+                "move": ps.JsonMove.from_operation({"op":"replace", "path":"", "value": {
+                    "PORT": {
+                        "Ethernet200": {
+                            "admin_status": "up",
+                        },
+                        "Ethernet300": {
+                            "admin_status": "down",
+                        },
+                        "Ethernet400": {
+                            "admin_status": "up",
+                        },
+                        "Ethernet500": {
+                        },
+                    }
+                }}),
+                "port_names": ["Ethernet200", "Ethernet300", "Ethernet400", "Ethernet500"],
+                "expected": ps.JsonMove.from_operation({"op":"replace", "path":"", "value": {
+                    "PORT": {
+                        "Ethernet200": {
+                            "admin_status": "down",
+                        },
+                        "Ethernet300": {
+                            "admin_status": "down",
+                        },
+                        "Ethernet400": {
+                            "admin_status": "down",
+                        },
+                        "Ethernet500": {
+                            "admin_status": "down",
+                        },
+                    }
+                }}),
+            },
+        }
+
+        for test_case_name, test_case in test_cases.items():
+            with self.subTest(name=test_case_name):
+                move = test_case["move"]
+                port_names = test_case["port_names"]
+                expected = test_case["expected"]
+
+                actual = self.extender._flip_admin_down_move(move, port_names)
+                self.assertEqual(expected, actual)
 
 class TestUpperLevelMoveExtender(unittest.TestCase):
     def setUp(self):
@@ -1832,12 +2732,16 @@ class TestSortAlgorithmFactory(unittest.TestCase):
         config_wrapper = ConfigWrapper()
         factory = ps.SortAlgorithmFactory(OperationWrapper(), config_wrapper, PathAddressing(config_wrapper))
         expected_generators = [ps.LowLevelMoveGenerator]
-        expected_extenders = [ps.UpperLevelMoveExtender, ps.DeleteInsteadOfReplaceMoveExtender, ps.DeleteRefsMoveExtender]
+        expected_extenders = [ps.PortCriticalMoveExtender,
+                              ps.UpperLevelMoveExtender,
+                              ps.DeleteInsteadOfReplaceMoveExtender,
+                              ps.DeleteRefsMoveExtender]
         expected_validator = [ps.DeleteWholeConfigMoveValidator,
                               ps.FullConfigMoveValidator,
                               ps.NoDependencyMoveValidator,
                               ps.UniqueLanesMoveValidator,
                               ps.CreateOnlyMoveValidator,
+                              ps.PortCriticalMoveValidator,
                               ps.NoEmptyTableMoveValidator]
 
         # Act

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -1314,11 +1314,13 @@ class TestNoEmptyTableMoveValidator(unittest.TestCase):
 class TestPortCriticalMoveValidator(unittest.TestCase):
     def setUp(self):
         self.operation_wrapper = OperationWrapper()
-        self.validator = ps.PortCriticalMoveValidator(PathAddressing())
+        path_addressing = PathAddressing()
+        self.validator = ps.PortCriticalMoveValidator(path_addressing)
         self.validator.port_critical_config_identifier.port_critical_filter = ps.ConfigFilter([
-            ["BUFFER_PG", "@|*"],
-            ["PORT", "@", "mtu"]
-        ])
+                ["BUFFER_PG", "@|*"],
+                ["PORT", "@", "mtu"]
+            ],
+            path_addressing)
 
     def test_validate__critical_port_change(self):
         # Each test format:
@@ -2029,11 +2031,13 @@ class TestLowLevelMoveGenerator(unittest.TestCase):
 
 class TestPortCriticalMoveExtender(unittest.TestCase):
     def setUp(self):
-        self.extender = ps.PortCriticalMoveExtender(PathAddressing(), OperationWrapper())
+        path_addressing = PathAddressing()
+        self.extender = ps.PortCriticalMoveExtender(path_addressing, OperationWrapper())
         self.extender.port_critical_config_identifier.port_critical_filter = ps.ConfigFilter([
-            ["BUFFER_PG", "@|*"],
-            ["PORT", "@", "mtu"]
-        ])
+                ["BUFFER_PG", "@|*"],
+                ["PORT", "@", "mtu"]
+            ],
+            path_addressing)
 
     def test_extend__remove_whole_config__no_extended_moves(self):
         # Arrange


### PR DESCRIPTION
#### What I did
Fixes #1930 

Issue can be summarized into these 2 case:
* A patch can contain an operation to turn port `admin up` -- do at the end
* A patch that modifies config that needs the port to be down -- start by bringing the port down then do the update then bring it back up

#### How I did it
The configs that need the port to be down, we will call them `critical-port` configs.

* Added a move validator to validate `critical-port` configs, which does the following
  * If a port is up, make sure the move does not make changes to related `critical-port` configs
  * If the move is turning a port up, make sure there is no `critical-port` config are still left in the patch

* Added a move extender to `critical-port` changes:
  * If a port is up, bring down if there are critical-port changes
  * If the move is turning a port up, flip it to down if there are still `critical-port` configs left. In other words, do not turn the port back up until all `critical-port` changes are in done.

#### How to verify it
* Added `AddRack` unit-test to `tests/generic_config_updater/files/patch_sorter_test_success.json`
* Other unit-tests

#### Previous command output (if the output of a command-line utility has changed)
Check issue #1930 for old sorting order

#### New command output (if the output of a command-line utility has changed)
Check  `AddRack` unit-test to `tests/generic_config_updater/files/patch_sorter_test_success.json` for new sorting-order
