### PR TITLE
[sonic-package-manager] Drop 'expires_in'

### DIFF
--- a/sonic_package_manager/registry.py
+++ b/sonic_package_manager/registry.py
@@ -43,10 +43,9 @@ class AuthenticationService:
 
         content = json.loads(response.content)
         token = content['token']
-        expires_in = content['expires_in']
 
         log.debug(f'authentication token for bearer={bearer}: '
-                  f'token={token} expires_in={expires_in}')
+                  f'token={token}')
 
         return token
 


### PR DESCRIPTION
#### What I did

The 'expires_in' attribute for tokens is defined as optional and some
Docker repositories (notably ghcr.io) do not set it.

#### How I did it

Since 'expires_in' is not used anywhere in the code, we simply drop it.

#### How to verify it

Try to install a SONiC package from `ghcr.io`. E.g.:

```
sudo sonic-package-manager install --from-repository ghcr.io/kamelnetworks/sonic_exporter:main
```

#### Previous command output (if the output of a command-line utility has changed)

```
ghcr.io/kamelnetworks/sonic_exporter:main is going to be installed, continue? [y/N]: y
Failed to install ghcr.io/kamelnetworks/sonic_exporter:main: 'expires_in'
```

#### New command output (if the output of a command-line utility has changed)

Output as expected