### PR TITLE
[build-failure-fix] [GCU] Sort referrer paths alphabetically

### DIFF
--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -423,6 +423,7 @@ class PathAddressing:
                 ref_paths.append(ref_path)
                 ref_paths_set.add(ref_path)
 
+        ref_paths.sort()
         return ref_paths
 
     def _get_inner_leaf_xpaths(self, xpath, sy):

--- a/tests/generic_config_updater/gu_common_test.py
+++ b/tests/generic_config_updater/gu_common_test.py
@@ -639,13 +639,13 @@ class TestPathAddressing(unittest.TestCase):
         # Arrange
         path = "/PORT"
         expected = [
+            "/ACL_TABLE/DATAACL/ports/0",
+            "/ACL_TABLE/EVERFLOW/ports/0",
+            "/ACL_TABLE/EVERFLOWV6/ports/0",
+            "/ACL_TABLE/EVERFLOWV6/ports/1",
             "/ACL_TABLE/NO-NSW-PACL-V4/ports/0",
             "/VLAN_MEMBER/Vlan1000|Ethernet0",
-            "/ACL_TABLE/DATAACL/ports/0",
-            "/ACL_TABLE/EVERFLOWV6/ports/0",
             "/VLAN_MEMBER/Vlan1000|Ethernet4",
-            "/ACL_TABLE/EVERFLOW/ports/0",
-            "/ACL_TABLE/EVERFLOWV6/ports/1",
             "/VLAN_MEMBER/Vlan1000|Ethernet8"
         ]
 
@@ -659,14 +659,14 @@ class TestPathAddressing(unittest.TestCase):
         # Arrange
         path = ""
         expected = [
+            "/ACL_TABLE/DATAACL/ports/0",
+            "/ACL_TABLE/EVERFLOW/ports/0",
+            "/ACL_TABLE/EVERFLOWV6/ports/0",
+            "/ACL_TABLE/EVERFLOWV6/ports/1",
+            "/ACL_TABLE/NO-NSW-PACL-V4/ports/0",
             "/VLAN_MEMBER/Vlan1000|Ethernet0",
             "/VLAN_MEMBER/Vlan1000|Ethernet4",
             "/VLAN_MEMBER/Vlan1000|Ethernet8",
-            "/ACL_TABLE/NO-NSW-PACL-V4/ports/0",
-            "/ACL_TABLE/DATAACL/ports/0",
-            "/ACL_TABLE/EVERFLOWV6/ports/0",
-            "/ACL_TABLE/EVERFLOW/ports/0",
-            "/ACL_TABLE/EVERFLOWV6/ports/1",
         ]
 
         # Act


### PR DESCRIPTION
#### What I did
Make sure the same order is always returned while getting the referrer paths i.e. data dependencies.

#### How I did it
Sort the returned list.

#### How to verify it
unit-tests

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

