### PR TITLE
[201911][port2alias]: Include mock port_config.ini files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         'sonic-utilities-tests': ['acl_input/*',
                                   'db_migrator_input/config_db/*.json',
                                   'db_migrator_input/init_cfg.json',
+                                  'mock_tables/*.ini',
                                   'mock_tables/*.py',
                                   'mock_tables/*.json',
                                   'mock_tables/asic0/*',


### PR DESCRIPTION
to sonic-utilities-test.

Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Include mock port_config.ini files in sonic-utilities-test.
https://github.com/Azure/sonic-utilities/pull/1954 - added unit-test for port2alias which added mock port_config files.
But these new files were not included in the package.

#### How I did it
Update setup.py file to include *.ini files in mock_tables.
#### How to verify it
Unit-test passes.
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

