### PR TITLE
Try get port operational speed from STATE DB

### DIFF
--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -31,6 +31,7 @@ except KeyError:
 
 
 PORT_STATUS_TABLE_PREFIX = "PORT_TABLE:"
+PORT_STATE_TABLE_PREFIX = "PORT_TABLE|"
 PORT_TRANSCEIVER_TABLE_PREFIX = "TRANSCEIVER_INFO|"
 PORT_LANES_STATUS = "lanes"
 PORT_ALIAS = "alias"
@@ -148,6 +149,22 @@ def appl_db_port_status_get(appl_db, intf_name, status_type):
         status = ','.join(new_speed_list)
     return status
 
+def port_oper_speed_get(db, intf_name):
+    """
+    Get port oper speed
+    """
+    oper_speed = db.get(db.STATE_DB, PORT_STATE_TABLE_PREFIX + intf_name, PORT_SPEED)
+    if oper_speed is None or oper_speed == "N/A":
+        return appl_db_port_status_get(db, intf_name, PORT_SPEED)
+
+    return '{}G'.format(oper_speed[:-3])
+
+def port_oper_speed_get_raw(db, intf_name):
+    speed = db.get(db.STATE_DB, PORT_STATE_TABLE_PREFIX + intf_name, PORT_SPEED)
+    if speed is None:
+        speed = db.get(db.APPL_DB, PORT_STATUS_TABLE_PREFIX + intf_name, PORT_SPEED)
+    return speed
+
 def state_db_port_optics_get(state_db, intf_name, type):
     """
     Get optic type info for port
@@ -257,7 +274,7 @@ def po_speed_dict(po_int_dict, appl_db):
             agg_speed_list =  []
             po_list.append(key)
             if len(value) == 1:
-                interface_speed = appl_db.get(appl_db.APPL_DB, "PORT_TABLE:" + value[0], "speed")
+                interface_speed = port_oper_speed_get_raw(appl_db, value[0])
                 if interface_speed is None:
                     # If no speed was returned, append None without format
                     po_list.append(None)
@@ -266,7 +283,7 @@ def po_speed_dict(po_int_dict, appl_db):
                     po_list.append(interface_speed)
             elif len(value) > 1:
                 for intf in value:
-                    temp_speed = appl_db.get(appl_db.APPL_DB, "PORT_TABLE:" + intf, "speed")
+                    temp_speed = port_oper_speed_get_raw(appl_db, intf)
                     temp_speed = int(temp_speed) if temp_speed else 0
                     agg_speed_list.append(temp_speed)
                     interface_speed = sum(agg_speed_list)
@@ -405,7 +422,7 @@ class IntfStatus(object):
                     if self.intf_name is None or key in intf_fs:
                         table.append((key,
                                 appl_db_port_status_get(self.db, key, PORT_LANES_STATUS),
-                                appl_db_port_status_get(self.db, key, PORT_SPEED),
+                                port_oper_speed_get(self.db, key),
                                 appl_db_port_status_get(self.db, key, PORT_MTU_STATUS),
                                 appl_db_port_status_get(self.db, key, PORT_FEC),
                                 appl_db_port_status_get(self.db, key, PORT_ALIAS),
@@ -543,7 +560,7 @@ class IntfAutoNegStatus(object):
             self.intf_name = intf_name
 
     def display_autoneg_status(self):
-        
+
         self.get_intf_autoneg_status()
 
         # Sorting and tabulating the result table.
@@ -573,7 +590,7 @@ class IntfAutoNegStatus(object):
                     autoneg_mode = 'enabled' if autoneg_mode == 'on' else 'disabled'
                 table.append((key,
                               autoneg_mode,
-                              appl_db_port_status_get(self.db, key, PORT_SPEED),
+                              port_oper_speed_get(self.db, key),
                               appl_db_port_status_get(self.db, key, PORT_ADV_SPEEDS),
                               appl_db_port_status_get(self.db, key, PORT_INTERFACE_TYPE),
                               appl_db_port_status_get(self.db, key, PORT_ADV_INTERFACE_TYPES),

--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -160,6 +160,9 @@ def port_oper_speed_get(db, intf_name):
     return '{}G'.format(oper_speed[:-3])
 
 def port_oper_speed_get_raw(db, intf_name):
+    """
+    Get port raw speed. E.g. 100000, 50000 and so on.
+    """
     speed = db.get(db.STATE_DB, PORT_STATE_TABLE_PREFIX + intf_name, PORT_SPEED)
     if speed is None:
         speed = db.get(db.APPL_DB, PORT_STATUS_TABLE_PREFIX + intf_name, PORT_SPEED)

--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -164,7 +164,7 @@ def port_oper_speed_get_raw(db, intf_name):
     Get port raw speed. E.g. 100000, 50000 and so on.
     """
     speed = db.get(db.STATE_DB, PORT_STATE_TABLE_PREFIX + intf_name, PORT_SPEED)
-    if speed is None:
+    if speed is None or speed == "N/A":
         speed = db.get(db.APPL_DB, PORT_STATUS_TABLE_PREFIX + intf_name, PORT_SPEED)
     return speed
 

--- a/scripts/portstat
+++ b/scripts/portstat
@@ -29,7 +29,7 @@ try:
     if os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] == "multi_asic":
         import mock_tables.mock_multi_asic
         mock_tables.dbconnector.load_namespace_config()
-           
+
 except KeyError:
     pass
 
@@ -118,6 +118,7 @@ COUNTER_TABLE_PREFIX = "COUNTERS:"
 COUNTERS_PORT_NAME_MAP = "COUNTERS_PORT_NAME_MAP"
 
 PORT_STATUS_TABLE_PREFIX = "PORT_TABLE:"
+PORT_STATE_TABLE_PREFIX = "PORT_TABLE|"
 PORT_OPER_STATUS_FIELD = "oper_status"
 PORT_ADMIN_STATUS_FIELD = "admin_status"
 PORT_STATUS_VALUE_UP = 'UP'
@@ -144,7 +145,7 @@ class Portstat(object):
     @multi_asic_util.run_on_multi_asic
     def collect_stat(self):
         """
-        Collect the statisitics from all the asics present on the 
+        Collect the statisitics from all the asics present on the
         device and store in a dict
         """
 
@@ -210,10 +211,13 @@ class Portstat(object):
             Get the port speed
         """
         # Get speed from APPL_DB
-        full_table_id = PORT_STATUS_TABLE_PREFIX + port_name
         for ns in self.multi_asic.get_ns_list_based_on_options():
             self.db = multi_asic.connect_to_all_dbs_for_ns(ns)
-            speed = self.db.get(self.db.APPL_DB, full_table_id, PORT_SPEED_FIELD)
+            full_table_id = PORT_STATE_TABLE_PREFIX + port_name
+            speed = self.db.get(self.db.STATE_DB, full_table_id, PORT_SPEED_FIELD)
+            if speed is None or speed == STATUS_NA:
+                full_table_id = PORT_STATUS_TABLE_PREFIX + port_name
+                speed = self.db.get(self.db.APPL_DB, full_table_id, PORT_SPEED_FIELD)
             if speed is not None:
                 return int(speed)
         return STATUS_NA
@@ -227,7 +231,7 @@ class Portstat(object):
             self.db = multi_asic.connect_to_all_dbs_for_ns(ns)
             admin_state = self.db.get(self.db.APPL_DB, full_table_id, PORT_ADMIN_STATUS_FIELD)
             oper_state = self.db.get(self.db.APPL_DB, full_table_id, PORT_OPER_STATUS_FIELD)
-            
+
             if admin_state is None or oper_state is None:
                 continue
             if admin_state.upper() == PORT_STATUS_VALUE_DOWN:
@@ -378,7 +382,7 @@ class Portstat(object):
 
             print("Time Since Counters Last Cleared............... " + str(cnstat_old_dict.get('time')))
 
- 
+
     def cnstat_diff_print(self, cnstat_new_dict, cnstat_old_dict, ratestat_dict, intf_list, use_json, print_all, errors_only, rates_only, detail=False):
         """
             Print the difference between two cnstat results.
@@ -528,7 +532,7 @@ Examples:
   portstat -c -t test
   portstat -t test
   portstat -d -t test
-  portstat -e 
+  portstat -e
   portstat
   portstat -r
   portstat -R

--- a/scripts/portstat
+++ b/scripts/portstat
@@ -211,9 +211,9 @@ class Portstat(object):
             Get the port speed
         """
         # Get speed from APPL_DB
+        full_table_id = PORT_STATE_TABLE_PREFIX + port_name
         for ns in self.multi_asic.get_ns_list_based_on_options():
             self.db = multi_asic.connect_to_all_dbs_for_ns(ns)
-            full_table_id = PORT_STATE_TABLE_PREFIX + port_name
             speed = self.db.get(self.db.STATE_DB, full_table_id, PORT_SPEED_FIELD)
             if speed is None or speed == STATUS_NA:
                 speed = self.db.get(self.db.APPL_DB, full_table_id, PORT_SPEED_FIELD)

--- a/scripts/portstat
+++ b/scripts/portstat
@@ -211,12 +211,13 @@ class Portstat(object):
             Get the port speed
         """
         # Get speed from APPL_DB
-        full_table_id = PORT_STATE_TABLE_PREFIX + port_name
+        state_db_table_id = PORT_STATE_TABLE_PREFIX + port_name
+        app_db_table_id = PORT_STATUS_TABLE_PREFIX + port_name
         for ns in self.multi_asic.get_ns_list_based_on_options():
             self.db = multi_asic.connect_to_all_dbs_for_ns(ns)
-            speed = self.db.get(self.db.STATE_DB, full_table_id, PORT_SPEED_FIELD)
+            speed = self.db.get(self.db.STATE_DB, state_db_table_id, PORT_SPEED_FIELD)
             if speed is None or speed == STATUS_NA:
-                speed = self.db.get(self.db.APPL_DB, full_table_id, PORT_SPEED_FIELD)
+                speed = self.db.get(self.db.APPL_DB, app_db_table_id, PORT_SPEED_FIELD)
             if speed is not None:
                 return int(speed)
         return STATUS_NA

--- a/scripts/portstat
+++ b/scripts/portstat
@@ -216,7 +216,6 @@ class Portstat(object):
             full_table_id = PORT_STATE_TABLE_PREFIX + port_name
             speed = self.db.get(self.db.STATE_DB, full_table_id, PORT_SPEED_FIELD)
             if speed is None or speed == STATUS_NA:
-                full_table_id = PORT_STATUS_TABLE_PREFIX + port_name
                 speed = self.db.get(self.db.APPL_DB, full_table_id, PORT_SPEED_FIELD)
             if speed is not None:
                 return int(speed)

--- a/scripts/voqutil
+++ b/scripts/voqutil
@@ -32,6 +32,7 @@ except KeyError:
 # ========================== Common VOQ util logic ==========================
 
 SYSTEM_PORT_TABLE_PREFIX = swsscommon.APP_SYSTEM_PORT_TABLE_NAME + ":"
+SYSTEM_STATE_PORT_TABLE_PREFIX = swsscommon.STATE_PORT_TABLE_NAME + "|"
 SYSTEM_PORT_ID = "system_port_id"
 SYSTEM_PORT_CORE = "core_index"
 SYSTEM_PORT_CORE_PORT = "core_port_index"
@@ -95,6 +96,7 @@ def appl_db_keys_get_system_port(appl_db, system_port_name):
 
     return appl_db_keys
 
+
 def appl_db_system_port_status_get(appl_db, system_port_name, status_type):
     """
     Get the system port status
@@ -106,6 +108,19 @@ def appl_db_system_port_status_get(appl_db, system_port_name, status_type):
     if status_type == SYSTEM_PORT_SPEED and status != "N/A":
        status = '{}G'.format(status[:-3])
     return status
+
+
+def port_oper_speed_get(db, system_port_name):
+    """
+    Get port oper speed
+    """
+    full_table_id = SYSTEM_STATE_PORT_TABLE_PREFIX + system_port_name
+    oper_speed = db.get(db.STATE_DB, full_table_id, SYSTEM_PORT_SPEED)
+    if oper_speed is None or oper_speed == "N/A":
+        return appl_db_system_port_status_get(db, system_port_name, SYSTEM_PORT_SPEED)
+
+    return '{}G'.format(oper_speed[:-3])
+
 
 def chassis_app_db_keys_get_system_neigh(chassis_app_db):
     """
@@ -208,7 +223,7 @@ class SystemPortStatus(object):
                         appl_db_system_port_status_get(self.db, key, SYSTEM_PORT_SWITCH_ID),
                         appl_db_system_port_status_get(self.db, key, SYSTEM_PORT_CORE),
                         appl_db_system_port_status_get(self.db, key, SYSTEM_PORT_CORE_PORT),
-                        appl_db_system_port_status_get(self.db, key, SYSTEM_PORT_SPEED)))
+                        port_oper_speed_get(self.db, key)))
 
         return table
 
@@ -247,7 +262,7 @@ class SystemNeighStatus(object):
         i = {}
         table = []
         key = []
-        
+
         if self.ipaddress is not None:
             if not is_ipv4_address(self.ipaddress) and not is_ipv6_address(self.ipaddress):
                 print("{} is not valid ip address\n".format(self.ipaddress))
@@ -262,7 +277,7 @@ class SystemNeighStatus(object):
             nbr = key_tokens[-1].strip()
             intf = '|'.join(key_tokens[1:-1])
             key = '|'.join(key_tokens[1:])
-            if ((self.ipaddress is None or nbr in self.ipaddress) and 
+            if ((self.ipaddress is None or nbr in self.ipaddress) and
                 (self.asicname is None or self.asicname in intf)):
                 table.append((intf, nbr,
                                 chassis_app_db_system_neigh_status_get(self.db, key, SYSTEM_NEIGH_MAC),
@@ -322,8 +337,8 @@ class SystemLagStatus(object):
         for i in self.chassis_app_db_keys_system_lag:
             key_tokens = re.split('\|', i)
             key = '|'.join(key_tokens[1:])
-            if ((self.system_lag_name is None or key in intf_fs) and 
-                (self.asicname is None or self.asicname in key) and 
+            if ((self.system_lag_name is None or key in intf_fs) and
+                (self.asicname is None or self.asicname in key) and
                 (self.hostname is None or self.hostname in key)):
                 mkeys = chassis_app_db_keys_get_system_lag_member(self.db, key, '')
                 members.clear()

--- a/tests/mock_tables/appl_db.json
+++ b/tests/mock_tables/appl_db.json
@@ -62,7 +62,7 @@
         "lanes": "93,94,95,96",
         "alias": "etp29",
         "description": "ARISTA01T1:Ethernet1",
-        "speed": "40000",
+        "speed": "100000",
         "oper_status": "up",
         "pfc_asym": "off",
         "mtu": "9100",

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -645,6 +645,9 @@
     "PORT_TABLE|Ethernet0": {
         "supported_speeds": "10000,25000,40000,100000"
     },
+    "PORT_TABLE|Ethernet112": {
+        "speed": "40000"
+    },
     "PCIE_DEVICE|00:01.0": {
         "correctable|BadDLLP": "0",
         "correctable|BadTLP": "0",


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
HLD change: https://github.com/Azure/SONiC/pull/932

#### What I did

Part of the fix for issue https://github.com/Azure/sonic-buildimage/issues/9595

#### How I did it

For script intfutil, portstat, voqutil, try to get port operational speed from STATE_DB first. If speed value is not present or is "N/A" in STATE DB, try to get port operational speed from APPL_DB, this is for backward compatible

#### How to verify it

Extend existing unit test cases

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

