### PR TITLE
[GCU] Supporting Groupings during path-xpath translation

### DIFF
--- a/tests/generic_config_updater/files/config_db_with_bgp_neighbor.json
+++ b/tests/generic_config_updater/files/config_db_with_bgp_neighbor.json
@@ -16,5 +16,17 @@
             "name": "bgp peer 65100",
             "ebgp_multihop_ttl": "3"
         }
+    },
+    "BGP_MONITORS": {
+        "5.6.7.8": {
+            "admin_status": "up",
+            "asn": "65000",
+            "holdtime": "180",
+            "keepalive": "60",
+            "local_addr": "10.0.0.11",
+            "name": "BGPMonitor",
+            "nhopself": "0",
+            "rrclient": "0"
+        }
     }
 }

--- a/tests/generic_config_updater/files/config_db_with_bgp_neighbor.json
+++ b/tests/generic_config_updater/files/config_db_with_bgp_neighbor.json
@@ -1,0 +1,20 @@
+{
+    "BGP_NEIGHBOR": {
+        "1.2.3.4": {
+            "admin_status": "up",
+            "asn": "65000",
+            "holdtime": "10",
+            "keepalive": "3",
+            "local_addr": "10.0.0.10",
+            "name": "ARISTA03T1",
+            "nhopself": "0",
+            "rrclient": "0"
+        },
+        "default|1.2.3.4": {
+            "local_asn": "65200",
+            "asn": "65100",
+            "name": "bgp peer 65100",
+            "ebgp_multihop_ttl": "3"
+        }
+    }
+}

--- a/tests/generic_config_updater/files/config_db_with_lldp.json
+++ b/tests/generic_config_updater/files/config_db_with_lldp.json
@@ -1,0 +1,14 @@
+{
+    "LLDP": {
+        "GLOBAL": {
+            "mode": "TRANSMIT",
+            "enabled": "true",
+            "hello_time": "12",
+            "multiplier": "5",
+            "supp_mgmt_address_tlv": "true",
+            "supp_system_capabilities_tlv": "false",
+            "system_name": "sonic",
+            "system_description": "sonic-system"
+        }
+    }
+}

--- a/tests/generic_config_updater/gu_common_test.py
+++ b/tests/generic_config_updater/gu_common_test.py
@@ -735,6 +735,12 @@ class TestPathAddressing(unittest.TestCase):
         check(path="/PORTCHANNEL_INTERFACE/PortChannel0001|1.1.1.1~124",
               xpath="/sonic-portchannel:sonic-portchannel/PORTCHANNEL_INTERFACE/PORTCHANNEL_INTERFACE_IPPREFIX_LIST[name='PortChannel0001'][ip_prefix='1.1.1.1/24']",
               config=Files.CONFIG_DB_WITH_PORTCHANNEL_INTERFACE)
+        check(path="/BGP_NEIGHBOR/1.2.3.4/holdtime",
+              xpath="/sonic-bgp-neighbor:sonic-bgp-neighbor/BGP_NEIGHBOR/BGP_NEIGHBOR_TEMPLATE_LIST[neighbor='1.2.3.4']/holdtime",
+              config=Files.CONFIG_DB_WITH_BGP_NEIGHBOR)
+        check(path="/BGP_NEIGHBOR/default|1.2.3.4/asn",
+              xpath="/sonic-bgp-neighbor:sonic-bgp-neighbor/BGP_NEIGHBOR/BGP_NEIGHBOR_LIST[vrf_name='default'][neighbor='1.2.3.4']/asn",
+              config=Files.CONFIG_DB_WITH_BGP_NEIGHBOR)
 
     def test_convert_xpath_to_path(self):
         def check(xpath, path, config=None):
@@ -798,6 +804,12 @@ class TestPathAddressing(unittest.TestCase):
         check(xpath="/sonic-portchannel:sonic-portchannel/PORTCHANNEL_INTERFACE/PORTCHANNEL_INTERFACE_IPPREFIX_LIST[name='PortChannel0001'][ip_prefix='1.1.1.1/24']",
               path="/PORTCHANNEL_INTERFACE/PortChannel0001|1.1.1.1~124",
               config=Files.CONFIG_DB_WITH_PORTCHANNEL_INTERFACE)
+        check(xpath="/sonic-bgp-neighbor:sonic-bgp-neighbor/BGP_NEIGHBOR/BGP_NEIGHBOR_TEMPLATE_LIST[neighbor='1.2.3.4']/holdtime",
+              path="/BGP_NEIGHBOR/1.2.3.4/holdtime",
+              config=Files.CONFIG_DB_WITH_BGP_NEIGHBOR)
+        check(xpath="/sonic-bgp-neighbor:sonic-bgp-neighbor/BGP_NEIGHBOR/BGP_NEIGHBOR_LIST[vrf_name='default'][neighbor='1.2.3.4']/asn",
+              path="/BGP_NEIGHBOR/default|1.2.3.4/asn",
+              config=Files.CONFIG_DB_WITH_BGP_NEIGHBOR)
 
     def test_has_path(self):
         def check(config, path, expected):

--- a/tests/generic_config_updater/gu_common_test.py
+++ b/tests/generic_config_updater/gu_common_test.py
@@ -741,6 +741,12 @@ class TestPathAddressing(unittest.TestCase):
         check(path="/BGP_NEIGHBOR/default|1.2.3.4/asn",
               xpath="/sonic-bgp-neighbor:sonic-bgp-neighbor/BGP_NEIGHBOR/BGP_NEIGHBOR_LIST[vrf_name='default'][neighbor='1.2.3.4']/asn",
               config=Files.CONFIG_DB_WITH_BGP_NEIGHBOR)
+        check(path="/BGP_MONITORS/5.6.7.8/name",
+              xpath="/sonic-bgp-monitor:sonic-bgp-monitor/BGP_MONITORS/BGP_MONITORS_LIST[addr='5.6.7.8']/name",
+              config=Files.CONFIG_DB_WITH_BGP_NEIGHBOR)
+        check(path="/LLDP/GLOBAL/mode",
+              xpath="/sonic-lldp:sonic-lldp/LLDP/GLOBAL/mode",
+              config=Files.CONFIG_DB_WITH_LLDP)
 
     def test_convert_xpath_to_path(self):
         def check(xpath, path, config=None):
@@ -810,6 +816,12 @@ class TestPathAddressing(unittest.TestCase):
         check(xpath="/sonic-bgp-neighbor:sonic-bgp-neighbor/BGP_NEIGHBOR/BGP_NEIGHBOR_LIST[vrf_name='default'][neighbor='1.2.3.4']/asn",
               path="/BGP_NEIGHBOR/default|1.2.3.4/asn",
               config=Files.CONFIG_DB_WITH_BGP_NEIGHBOR)
+        check(xpath="/sonic-bgp-monitor:sonic-bgp-monitor/BGP_MONITORS/BGP_MONITORS_LIST[addr='5.6.7.8']/name",
+              path="/BGP_MONITORS/5.6.7.8/name",
+              config=Files.CONFIG_DB_WITH_BGP_NEIGHBOR)
+        check(xpath="/sonic-lldp:sonic-lldp/LLDP/GLOBAL/mode",
+              path="/LLDP/GLOBAL/mode",
+              config=Files.CONFIG_DB_WITH_LLDP)
 
     def test_has_path(self):
         def check(config, path, expected):


### PR DESCRIPTION
#### What I did
Fixes #2041

Supporting groupings during `config-db path` <-> `config-yang xpath` translation

This mimics the `config-db` <-> `config-yang`  translation as added by https://github.com/Azure/sonic-buildimage/pull/8318

#### How I did it
Handled groupings of leaf commands only as that's what is supported in sonic-yang-mgmt

#### How to verify it
unit-test

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

