### PR TITLE
[GCU] Adding unit-test where path and ref paths are under the same YANG container

### DIFF
--- a/tests/generic_config_updater/gu_common_test.py
+++ b/tests/generic_config_updater/gu_common_test.py
@@ -675,6 +675,20 @@ class TestPathAddressing(unittest.TestCase):
         # Assert
         self.assertEqual(expected, actual)
 
+    def test_find_ref_paths__path_and_ref_paths_are_under_same_yang_container__returns_ref_paths(self):
+        # Arrange
+        path = "/LOOPBACK_INTERFACE/Loopback0"
+        expected = [
+            "/LOOPBACK_INTERFACE/Loopback0|10.1.0.32~132",
+            "/LOOPBACK_INTERFACE/Loopback0|1100:1::32~1128",
+        ]
+
+        # Act
+        actual = self.path_addressing.find_ref_paths(path, Files.CONFIG_DB_WITH_LOOPBACK_INTERFACES)
+
+        # Assert
+        self.assertEqual(expected, actual)
+
     def test_find_ref_paths__does_not_remove_tables_without_yang(self):
         # Arrange
         config = Files.CONFIG_DB_AS_JSON # This has a table without yang named 'TABLE_WITHOUT_YANG'

--- a/tests/generic_config_updater/gu_common_test.py
+++ b/tests/generic_config_updater/gu_common_test.py
@@ -679,8 +679,8 @@ class TestPathAddressing(unittest.TestCase):
         # Arrange
         path = "/LOOPBACK_INTERFACE/Loopback0"
         expected = [
-            "/LOOPBACK_INTERFACE/Loopback0|10.1.0.32~132",
-            "/LOOPBACK_INTERFACE/Loopback0|1100:1::32~1128",
+            self.path_addressing.create_path(["LOOPBACK_INTERFACE", "Loopback0|10.1.0.32/32"]),
+            self.path_addressing.create_path(["LOOPBACK_INTERFACE", "Loopback0|1100:1::32/128"]),
         ]
 
         # Act


### PR DESCRIPTION
#### What I did
Did a debug session with Ping Mao and found this case is failing in her PR: https://github.com/Azure/sonic-buildimage/pull/9545 I think it is an interesting case and I added it explicitly to GCU.

Adding unit-test where path and ref paths are under the same YANG container

[sonic-loopback-interface.yang](https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/yang-models/sonic-loopback-interface.yang) has:
```yang
    container sonic-loopback-interface {
        container LOOPBACK_INTERFACE {
            list LOOPBACK_INTERFACE_LIST {
                ...
                leaf name{
                    type string;
                }
                ...
            list LOOPBACK_INTERFACE_IPPREFIX_LIST {
                leaf name{
                    ...
                    type leafref {
                        path "../../LOOPBACK_INTERFACE_LIST/name";
                    }
                }
               ...
```

#### How I did it
Unit-test added

#### How to verify it
unit-test

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

