### PR TITLE
[build] allowPartiallySucceededBuilds: true in sonic swss pytests download 

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -38,6 +38,7 @@ jobs:
       artifact: sonic-swss-pytests
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/master'
+      allowPartiallySucceededBuilds: true
     displayName: "Download sonic swss pytests"
 
   - checkout: self


### PR DESCRIPTION
… pytests

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Like https://github.com/Azure/sonic-utilities/pull/2043, while downloading sonic-swss-pytests artifact from Azure.sonic-swss pipeline, it will also try to download artifacts if the build is partially succeeded.

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

