### PR TITLE
Remove the warning message appear when there are no ports on CONFIG DB

### DIFF
--- a/tests/interfaces_test.py
+++ b/tests/interfaces_test.py
@@ -294,29 +294,6 @@ class TestInterfaces(object):
         assert result.exit_code == 0
         assert result.output == show_interfaces_portchannel_in_alias_mode_output
         
-    @mock.patch('sonic_py_common.multi_asic.get_port_table', mock.MagicMock(return_value={}))
-    def test_supervisor_show_interfaces_alias_etp1_with_waring(self):
-        runner = CliRunner()
-        os.environ['SONIC_CLI_IFACE_MODE'] = "alias"
-        result = runner.invoke(show.cli.commands["interfaces"].commands["alias"], ["etp1"])
-        os.environ['SONIC_CLI_IFACE_MODE'] = "default"
-        print(result.exit_code)
-        print(result.output)
-        assert result.exit_code != 0
-        assert "Configuration database contains no ports" in result.output
-        
-    @mock.patch('sonic_py_common.multi_asic.get_port_table', mock.MagicMock(return_value={}))
-    @mock.patch('sonic_py_common.device_info.is_supervisor', mock.MagicMock(return_value=True))
-    def test_supervisor_show_interfaces_alias_etp1_without_waring(self):
-        runner = CliRunner()
-        os.environ['SONIC_CLI_IFACE_MODE'] = "alias"
-        result = runner.invoke(show.cli.commands["interfaces"].commands["alias"], ["etp1"])
-        os.environ['SONIC_CLI_IFACE_MODE'] = "default"
-        print(result.exit_code)
-        print(result.output)
-        assert result.exit_code != 0
-        assert "Configuration database contains no ports" not in result.output
-        
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")

--- a/tests/interfaces_test.py
+++ b/tests/interfaces_test.py
@@ -293,7 +293,28 @@ class TestInterfaces(object):
         traceback.print_tb(result.exc_info[2])
         assert result.exit_code == 0
         assert result.output == show_interfaces_portchannel_in_alias_mode_output
-        
+       
+    @mock.patch('sonic_py_common.multi_asic.get_port_table', mock.MagicMock(return_value={}))
+    def test_supervisor_show_interfaces_alias_etp1_with_waring(self):
+        runner = CliRunner()
+        os.environ['SONIC_CLI_IFACE_MODE'] = "alias"
+        result = runner.invoke(show.cli.commands["interfaces"].commands["alias"], ["etp1"])
+        os.environ['SONIC_CLI_IFACE_MODE'] = "default"
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+
+    @mock.patch('sonic_py_common.multi_asic.get_port_table', mock.MagicMock(return_value={}))
+    @mock.patch('sonic_py_common.device_info.is_supervisor', mock.MagicMock(return_value=True))
+    def test_supervisor_show_interfaces_alias_etp1_without_waring(self):
+        runner = CliRunner()
+        os.environ['SONIC_CLI_IFACE_MODE'] = "alias"
+        result = runner.invoke(show.cli.commands["interfaces"].commands["alias"], ["etp1"])
+        os.environ['SONIC_CLI_IFACE_MODE'] = "default"
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -131,8 +131,6 @@ class InterfaceAliasConverter(object):
 
 
         if not self.port_dict:
-            if not device_info.is_supervisor():
-                click.echo(message="Configuration database contains no ports")
             self.port_dict = {}
 
         for port_name in self.port_dict:

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -10,7 +10,7 @@ import json
 import netaddr
 
 from natsort import natsorted
-from sonic_py_common import multi_asic, device_info
+from sonic_py_common import multi_asic
 from utilities_common.db import Db
 from utilities_common.general import load_db_config
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Remove the warning of "Configuration database contains no ports" when ports table is empty.
Because when having a system with zero ports, this message appear per each access to ports tables on CONFIG DB

For example:

Run any cli command. For example  "show boot" or "show int st"

Observed behavior

root@r-sn4800-simx:/home/admin# show boot
Configuration database contains no ports
Configuration database contains no ports
Configuration database contains no ports


#### How I did it

Remove the warning and remove the unit test verify this warning 

#### How to verify it

Remove all the ports and verify there is no such warning in case of running "show interface status" CLi command

#### Previous command output (if the output of a command-line utility has changed)

Configuration database contains no ports
  Interface    Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin    Type    Asym PFC
-----------  -------  -------  -----  -----  -------  ------  ------  -------  ------  ----------
 
#### New command output (if the output of a command-line utility has changed)

  Interface    Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin    Type    Asym PFC
-----------  -------  -------  -----  -----  -------  ------  ------  -------  ------  ----------

