### PR TITLE
[fwutil] fixing exception when fwutil running without sudo

### DIFF
--- a/fwutil/main.py
+++ b/fwutil/main.py
@@ -37,8 +37,11 @@ ROOT_UID = 0
 
 # ========================= Variables ==========================================
 
-pdp = PlatformDataProvider()
-log_helper = LogHelper()
+try:
+    pdp = PlatformDataProvider()
+    log_helper = LogHelper()
+except ValueError as e:
+    exit("Root privileges are required")
 
 # ========================= Helper functions ===================================
 


### PR DESCRIPTION
Signed-off-by: Taras Keryk <tarasx.keryk@intel.com>

#### What I did
I  added the additional check for PlatformDataProvider usage 
#### How I did it
I added  try..except  in  for  PlatformDataProvider usage, that require sudo 
#### How to verify it
Now, when we runing fwutil without sudo, we are going to have a message "Root privileges are required"
#### Previous command output (if the output of a command-line utility has changed)
admin@sonic:/usr/local/lib/python3.9/dist-packages/fwutil$ fwutil show status
Traceback (most recent call last):
  File "/usr/local/bin/fwutil", line 5, in <module>
    from fwutil.main import cli
  File "/usr/local/lib/python3.9/dist-packages/fwutil/__init__.py", line 3, in <module>
    from . import main
  File "/usr/local/lib/python3.9/dist-packages/fwutil/main.py", line 41
    pdp = PlatformDataProvider()
IndentationError: unexpected indent
admin@sonic:/usr/local/lib/python3.9/dist-packages/fwutil$ fwutil 
Traceback (most recent call last):
  File "/usr/local/bin/fwutil", line 5, in <module>
    from fwutil.main import cli
  File "/usr/local/lib/python3.9/dist-packages/fwutil/__init__.py", line 3, in <module>
    from . import main
  File "/usr/local/lib/python3.9/dist-packages/fwutil/main.py", line 41
    pdp = PlatformDataProvider()
IndentationError: unexpected indent
admin@sonic:/usr/local/lib/python3.9/dist-packages/fwutil$ sudo vi main.py 
admin@sonic:/usr/local/lib/python3.9/dist-packages/fwutil$ fwutil 
Error: bios_version N/A, dmidecode not found
Traceback (most recent call last):
  File "/usr/lib/python3.9/logging/config.py", line 564, in configure
    handler = self.configure_handler(handlers[name])
  File "/usr/lib/python3.9/logging/config.py", line 745, in configure_handler
    result = factory(**kwargs)
  File "/usr/lib/python3.9/logging/handlers.py", line 153, in __init__
    BaseRotatingHandler.__init__(self, filename, mode, encoding=encoding,
  File "/usr/lib/python3.9/logging/handlers.py", line 58, in __init__
    logging.FileHandler.__init__(self, filename, mode=mode,
  File "/usr/lib/python3.9/logging/__init__.py", line 1142, in __init__
    StreamHandler.__init__(self, self._open())
  File "/usr/lib/python3.9/logging/__init__.py", line 1171, in _open
    return open(self.baseFilename, self.mode, encoding=self.encoding,
PermissionError: [Errno 13] Permission denied: '/var/log/platform.log'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/bin/fwutil", line 5, in <module>
    from fwutil.main import cli
  File "/usr/local/lib/python3.9/dist-packages/fwutil/__init__.py", line 3, in <module>
    from . import main
  File "/usr/local/lib/python3.9/dist-packages/fwutil/main.py", line 41, in <module>
    pdp = PlatformDataProvider()
  File "/usr/local/lib/python3.9/dist-packages/fwutil/lib.py", line 162, in __init__
    self.chassis_component_map = self.__get_chassis_component_map()
  File "/usr/local/lib/python3.9/dist-packages/fwutil/lib.py", line 168, in __get_chassis_component_map
    chassis_name = self.__chassis.get_name()
  File "/usr/local/lib/python3.9/dist-packages/sonic_platform/chassis.py", line 146, in get_name
    return self._eeprom.modelstr()
  File "/usr/local/lib/python3.9/dist-packages/sonic_platform/chassis.py", line 54, in _eeprom
    self.__eeprom = Eeprom()
  File "/usr/local/lib/python3.9/dist-packages/sonic_platform/eeprom.py", line 50, in __init__
    logging.config.dictConfig(config_dict)
  File "/usr/lib/python3.9/logging/config.py", line 809, in dictConfig
    dictConfigClass(config).configure()
  File "/usr/lib/python3.9/logging/config.py", line 571, in configure
    raise ValueError('Unable to configure handler '
ValueError: Unable to configure handler 'file'
#### New command output (if the output of a command-line utility has changed)
admin@sonic:/usr/local/lib/python3.9/dist-packages/fwutil$ fwutil 
Root privileges are required
