### PR TITLE
[ci] allow download partially succeeded builds for sonic-swss-pytests artifact

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -41,6 +41,7 @@ jobs:
       artifact: sonic-swss-pytests
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/master'
+      allowPartiallySucceededBuilds: true
     displayName: "Download sonic swss pytests"
 
   - checkout: self


### PR DESCRIPTION
#### What I did
Currently the latest sonic-swss-pytests has warning in armhf stage. We should allow download artifact from partially succeeded builds.
ref: https://dev.azure.com/mssonic/build/_build?definitionId=15&_a=summary&view=branches
#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

