### PR TITLE
[config/config_mgmt.py]: Fix dpb issue with upper case mac in device_metadata.

### DIFF
--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -872,6 +872,27 @@ class ConfigMgmtDPB(ConfigMgmt):
             # we do not allow updates right now
             if isinstance(diff, list) and isinstance(outp, dict):
                 return changed
+            '''
+            libYang converts ietf yang types to lower case internally, which
+            creates false config diff for us while DPB.
+
+            Example:
+            For DEVICE_METADATA['localhost']['mac'] type is yang:mac-address.
+            Libyang converts from 'XX:XX:XX:E4:B3:DD' -> 'xx:xx:xx:e4:b3:dd'
+            so args for this functions will be:
+
+            diff = DEVICE_METADATA['localhost']['mac']
+            where DEVICE_METADATA': {'localhost': {'mac': ['XX:XX:XX:E4:B3:DD', 'xx:xx:xx:e4:b3:dd']}}}
+            Note: above dict is representation of diff in config given by diffJson
+            library.
+            out = 'XX:XX:XX:e4:b3:dd'
+            inp = 'xx:xx:xx:E4:B3:DD'
+
+            With below check, we will avoid processing of such config diff for DPB.
+            '''
+            if isinstance(diff, list) and isinstance(outp, str) and \
+              inp.lower() == outp.lower():
+                return changed
 
             idx = -1
             for key in diff:


### PR DESCRIPTION

libYang converts ietf yang types to lower case internally,which
creates false config diff for us while DPB.
This PR fixes the issue by not precessing false diff.

Related issue"
https://github.com/Azure/sonic-buildimage/issues/9478

Signed-off-by: Praveen Chaudhary <pchaudhary@linkedin.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
fixes issue: https://github.com/Azure/sonic-buildimage/issues/9478

#### How I did it
            libYang converts ietf yang types to lower case internally,which
            creates false config diff for us while DPB.

            Example:
            For DEVICE_METADATA['localhost']['mac'] type is yang:mac-address.
            Libyang converts from 'XX:XX:XX:E4:B3:DD' -> 'xx:xx:xx:e4:b3:dd'
            
            so args for function _recurCreateConfig in this case will be:

            diff = DEVICE_METADATA['localhost']['mac']
            where DEVICE_METADATA': {'localhost': {'mac': ['XX:XX:XX:E4:B3:DD', 'xx:xx:xx:e4:b3:dd']}}}
            Note: above dict is representation of diff in config given by diffJson
            library.
            out = 'XX:XX:XX:e4:b3:dd'
            inp = 'xx:xx:xx:E4:B3:DD'

            I add a check to avoid processing of such config diff for DPB.

#### How to verify it

Added a unit test. Build time.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

