### PR TITLE
[muxcable][show] enhance show mux status to show last switchover time

### DIFF
--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -304,7 +304,6 @@ def create_table_dump_per_port_status(db, print_data, muxcable_info_dict, muxcab
         last_switch_end_time = muxcable_metrics_dict[asic_index].get("linkmgrd_switch_standby_end")
     elif "linkmgrd_switch_active_end" in muxcable_metrics_dict[asic_index]: 
         last_switch_end_time = muxcable_metrics_dict[asic_index].get("linkmgrd_switch_active_end")
-    port_status_dict["MUX_CABLE"][port_name]["LAST_SWITCHOVER_TIME"] = last_switch_end_time    
 
     port_name = platform_sfputil_helper.get_interface_alias(port, db)
     print_port_data.append(port_name)
@@ -407,7 +406,7 @@ def status(db, port, json_output):
 
                     create_json_dump_per_port_status(db, port_status_dict, muxcable_info_dict,
                                                      muxcable_health_dict, muxcable_metrics_dict, asic_index, port)
-                    port_status_dict[]
+
                     click.echo("{}".format(json.dumps(port_status_dict, indent=4)))
                     sys.exit(STATUS_SUCCESSFUL)
                 else:

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -275,7 +275,7 @@ def get_switch_name(config_db):
         sys.exit(STATUS_FAIL)
 
 
-def create_json_dump_per_port_status(db, port_status_dict, muxcable_info_dict, muxcable_health_dict, asic_index, port):
+def create_json_dump_per_port_status(db, port_status_dict, muxcable_info_dict, muxcable_health_dict, muxcable_metrics_dict, asic_index, port):
 
     status_value = get_value_for_key_in_dict(muxcable_info_dict[asic_index], port, "state", "MUX_CABLE_TABLE")
     port_name = platform_sfputil_helper.get_interface_alias(port, db)
@@ -284,18 +284,33 @@ def create_json_dump_per_port_status(db, port_status_dict, muxcable_info_dict, m
     health_value = get_value_for_key_in_dict(muxcable_health_dict[asic_index], port, "state", "MUX_LINKMGR_TABLE")
     port_status_dict["MUX_CABLE"][port_name]["HEALTH"] = health_value
 
+    last_switch_end_time = ""
+    if "linkmgrd_switch_standby_end" in muxcable_metrics_dict[asic_index]:
+        last_switch_end_time = muxcable_metrics_dict[asic_index].get("linkmgrd_switch_standby_end")
+    elif "linkmgrd_switch_active_end" in muxcable_metrics_dict[asic_index]: 
+        last_switch_end_time = muxcable_metrics_dict[asic_index].get("linkmgrd_switch_active_end")
+    port_status_dict["MUX_CABLE"][port_name]["LAST_SWITCHOVER_TIME"] = last_switch_end_time
 
-def create_table_dump_per_port_status(db, print_data, muxcable_info_dict, muxcable_health_dict, asic_index, port):
+def create_table_dump_per_port_status(db, print_data, muxcable_info_dict, muxcable_health_dict, muxcable_metrics_dict, asic_index, port):
 
     print_port_data = []
 
     status_value = get_value_for_key_in_dict(muxcable_info_dict[asic_index], port, "state", "MUX_CABLE_TABLE")
     #status_value = get_value_for_key_in_tbl(y_cable_asic_table, port, "status")
     health_value = get_value_for_key_in_dict(muxcable_health_dict[asic_index], port, "state", "MUX_LINKMGR_TABLE")
+
+    last_switch_end_time = ""
+    if "linkmgrd_switch_standby_end" in muxcable_metrics_dict[asic_index]:
+        last_switch_end_time = muxcable_metrics_dict[asic_index].get("linkmgrd_switch_standby_end")
+    elif "linkmgrd_switch_active_end" in muxcable_metrics_dict[asic_index]: 
+        last_switch_end_time = muxcable_metrics_dict[asic_index].get("linkmgrd_switch_active_end")
+    port_status_dict["MUX_CABLE"][port_name]["LAST_SWITCHOVER_TIME"] = last_switch_end_time    
+
     port_name = platform_sfputil_helper.get_interface_alias(port, db)
     print_port_data.append(port_name)
     print_port_data.append(status_value)
     print_port_data.append(health_value)
+    print_port_data.append(last_switch_end_time)
     print_data.append(print_port_data)
 
 
@@ -336,9 +351,11 @@ def status(db, port, json_output):
 
     port_table_keys = {}
     port_health_table_keys = {}
+    port_metrics_table_keys = {}
     per_npu_statedb = {}
     muxcable_info_dict = {}
     muxcable_health_dict = {}
+    muxcable_metrics_dict = {}
 
     # Getting all front asic namespace and correspding config and state DB connector
 
@@ -352,6 +369,8 @@ def status(db, port, json_output):
             per_npu_statedb[asic_id].STATE_DB, 'MUX_CABLE_TABLE|*')
         port_health_table_keys[asic_id] = per_npu_statedb[asic_id].keys(
             per_npu_statedb[asic_id].STATE_DB, 'MUX_LINKMGR_TABLE|*')
+        port_metrics_table_keys[asic_id] = per_npu_statedb[asic_id].keys(
+            per_npu_statedb[asic_id].STATE_DB, 'MUX_METRICS_TABLE|*')
 
     if port is not None:
         asic_index = None
@@ -371,27 +390,33 @@ def status(db, port, json_output):
             per_npu_statedb[asic_index].STATE_DB, 'MUX_CABLE_TABLE|{}'.format(port))
         muxcable_health_dict[asic_index] = per_npu_statedb[asic_index].get_all(
             per_npu_statedb[asic_index].STATE_DB, 'MUX_LINKMGR_TABLE|{}'.format(port))
+        muxcable_metrics_dict[asic_index] = per_npu_statedb[asic_index].get_all(
+            per_npu_statedb[asic_index].STATE_DB, 'MUX_METRICS_TABLE|{}'.format(port))
         if muxcable_info_dict[asic_index] is not None:
             logical_key = "MUX_CABLE_TABLE|{}".format(port)
             logical_health_key = "MUX_LINKMGR_TABLE|{}".format(port)
+            logical_metrics_key = "MUX_METRICS_TABLE|{}".format(port)
             if logical_key in port_table_keys[asic_index] and logical_health_key in port_health_table_keys[asic_index]:
+                
+                if logical_metrics_key not in port_metrics_table_keys[asic_index]: 
+                    muxcable_metrics_dict[asic_index] = {}
 
                 if json_output:
                     port_status_dict = {}
                     port_status_dict["MUX_CABLE"] = {}
 
                     create_json_dump_per_port_status(db, port_status_dict, muxcable_info_dict,
-                                                     muxcable_health_dict, asic_index, port)
-
+                                                     muxcable_health_dict, muxcable_metrics_dict, asic_index, port)
+                    port_status_dict[]
                     click.echo("{}".format(json.dumps(port_status_dict, indent=4)))
                     sys.exit(STATUS_SUCCESSFUL)
                 else:
                     print_data = []
 
                     create_table_dump_per_port_status(db, print_data, muxcable_info_dict,
-                                                      muxcable_health_dict, asic_index, port)
+                                                      muxcable_health_dict, muxcable_metrics_dict, asic_index, port)
 
-                    headers = ['PORT', 'STATUS', 'HEALTH']
+                    headers = ['PORT', 'STATUS', 'HEALTH', 'LAST_SWITCHOVER_TIME']
 
                     click.echo(tabulate(print_data, headers=headers))
                     sys.exit(STATUS_SUCCESSFUL)
@@ -416,8 +441,12 @@ def status(db, port, json_output):
                         per_npu_statedb[asic_id].STATE_DB, 'MUX_CABLE_TABLE|{}'.format(port))
                     muxcable_health_dict[asic_id] = per_npu_statedb[asic_id].get_all(
                         per_npu_statedb[asic_id].STATE_DB, 'MUX_LINKMGR_TABLE|{}'.format(port))
+                    muxcable_metrics_dict[asic_id] = per_npu_statedb[asic_id].get_all(
+                        per_npu_statedb[asic_id].STATE_DB, 'MUX_METRICS_TABLE|{}'.format(port))
+                    if not muxcable_metrics_dict[asic_id]: 
+                        muxcable_metrics_dict[asic_id] = {}
                     create_json_dump_per_port_status(db, port_status_dict, muxcable_info_dict,
-                                                     muxcable_health_dict, asic_id, port)
+                                                     muxcable_health_dict, muxcable_metrics_dict, asic_id, port)
 
             click.echo("{}".format(json.dumps(port_status_dict, indent=4)))
         else:
@@ -430,11 +459,14 @@ def status(db, port, json_output):
                         per_npu_statedb[asic_id].STATE_DB, 'MUX_LINKMGR_TABLE|{}'.format(port))
                     muxcable_info_dict[asic_id] = per_npu_statedb[asic_id].get_all(
                         per_npu_statedb[asic_id].STATE_DB, 'MUX_CABLE_TABLE|{}'.format(port))
-
+                    muxcable_metrics_dict[asic_id] = per_npu_statedb[asic_id].get_all(
+                        per_npu_statedb[asic_id].STATE_DB, 'MUX_METRICS_TABLE|{}'.format(port))
+                    if not muxcable_metrics_dict[asic_id]: 
+                        muxcable_metrics_dict[asic_id] = {}
                     create_table_dump_per_port_status(db, print_data, muxcable_info_dict,
-                                                      muxcable_health_dict, asic_id, port)
+                                                      muxcable_health_dict, muxcable_metrics_dict, asic_id, port)
 
-            headers = ['PORT', 'STATUS', 'HEALTH']
+            headers = ['PORT', 'STATUS', 'HEALTH', 'LAST_SWITCHOVER_TIME']
             click.echo(tabulate(print_data, headers=headers))
 
         sys.exit(STATUS_SUCCESSFUL)

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -25,9 +25,9 @@ import show.main as show
 
 
 tabular_data_status_output_expected = """\
-PORT        STATUS    HEALTH
-----------  --------  ---------
-Ethernet0   active    healthy
+PORT        STATUS    HEALTH     LAST_SWITCHOVER_TIME
+----------  --------  ---------  ---------------------------
+Ethernet0   active    healthy    2021-May-13 10:01:15.696728
 Ethernet4   standby   healthy
 Ethernet8   standby   unhealthy
 Ethernet12  unknown   unhealthy
@@ -36,9 +36,9 @@ Ethernet32  active    healthy
 """
 
 tabular_data_status_output_expected_alias = """\
-PORT    STATUS    HEALTH
-------  --------  ---------
-etp1    active    healthy
+PORT    STATUS    HEALTH     LAST_SWITCHOVER_TIME
+------  --------  ---------  ---------------------------
+etp1    active    healthy    2021-May-13 10:01:15.696728
 etp2    standby   healthy
 etp3    standby   unhealthy
 etp4    unknown   unhealthy
@@ -51,27 +51,33 @@ json_data_status_output_expected = """\
     "MUX_CABLE": {
         "Ethernet0": {
             "STATUS": "active",
-            "HEALTH": "healthy"
+            "HEALTH": "healthy",
+            "LAST_SWITCHOVER_TIME": "2021-May-13 10:01:15.696728"
         },
         "Ethernet4": {
             "STATUS": "standby",
-            "HEALTH": "healthy"
+            "HEALTH": "healthy",
+            "LAST_SWITCHOVER_TIME": ""
         },
         "Ethernet8": {
             "STATUS": "standby",
-            "HEALTH": "unhealthy"
+            "HEALTH": "unhealthy",
+            "LAST_SWITCHOVER_TIME": ""
         },
         "Ethernet12": {
             "STATUS": "unknown",
-            "HEALTH": "unhealthy"
+            "HEALTH": "unhealthy",
+            "LAST_SWITCHOVER_TIME": ""
         },
         "Ethernet16": {
             "STATUS": "standby",
-            "HEALTH": "healthy"
+            "HEALTH": "healthy",
+            "LAST_SWITCHOVER_TIME": ""
         },
         "Ethernet32": {
             "STATUS": "active",
-            "HEALTH": "healthy"
+            "HEALTH": "healthy",
+            "LAST_SWITCHOVER_TIME": ""
         }
     }
 }
@@ -82,27 +88,33 @@ json_data_status_output_expected_alias = """\
     "MUX_CABLE": {
         "etp1": {
             "STATUS": "active",
-            "HEALTH": "healthy"
+            "HEALTH": "healthy",
+            "LAST_SWITCHOVER_TIME": "2021-May-13 10:01:15.696728"
         },
         "etp2": {
             "STATUS": "standby",
-            "HEALTH": "healthy"
+            "HEALTH": "healthy",
+            "LAST_SWITCHOVER_TIME": ""
         },
         "etp3": {
             "STATUS": "standby",
-            "HEALTH": "unhealthy"
+            "HEALTH": "unhealthy",
+            "LAST_SWITCHOVER_TIME": ""
         },
         "etp4": {
             "STATUS": "unknown",
-            "HEALTH": "unhealthy"
+            "HEALTH": "unhealthy",
+            "LAST_SWITCHOVER_TIME": ""
         },
         "etp5": {
             "STATUS": "standby",
-            "HEALTH": "healthy"
+            "HEALTH": "healthy",
+            "LAST_SWITCHOVER_TIME": ""
         },
         "etp9": {
             "STATUS": "active",
-            "HEALTH": "healthy"
+            "HEALTH": "healthy",
+            "LAST_SWITCHOVER_TIME": ""
         }
     }
 }


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
 
Enhance ```show muxcable status``` to show last switchover time as well

sign-off: Jing Zhang zhangjing@microsoft.com
#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)
```
~$ show mux status 
PORT         STATUS    HEALTH
-----------  --------  ---------
Ethernet0    standby   unhealthy
Ethernet4    standby   unhealthy
Ethernet8    standby   unhealthy
Ethernet12   standby   unhealthy
Ethernet16   standby   unhealthy
Ethernet20   standby   unhealthy
Ethernet40   standby   unhealthy
Ethernet44   standby   unhealthy
Ethernet48   standby   unhealthy
Ethernet52   standby   unhealthy
Ethernet56   standby   unhealthy
Ethernet60   standby   unhealthy
Ethernet64   standby   unhealthy
Ethernet68   standby   unhealthy
Ethernet72   standby   unhealthy
Ethernet76   standby   unhealthy
Ethernet80   standby   unhealthy
Ethernet84   standby   unhealthy
Ethernet104  standby   unhealthy
Ethernet108  standby   unhealthy
Ethernet112  standby   unhealthy
Ethernet116  standby   unhealthy
Ethernet120  standby   unhealthy
Ethernet124  standby   unhealthy
```
#### New command output (if the output of a command-line utility has changed)
```
~$ show mux status
PORT         STATUS    HEALTH     LAST_SWITCHOVER_TIME
-----------  --------  ---------  ---------------------------
Ethernet0    standby   unhealthy  2022-Feb-14 16:47:06.813350
Ethernet4    standby   unhealthy  2022-Feb-14 16:47:07.309137
Ethernet8    standby   unhealthy  2022-Feb-14 16:47:07.373696
Ethernet12   standby   unhealthy  2022-Feb-14 16:47:06.430575
Ethernet16   standby   unhealthy  2022-Feb-14 16:47:08.131454
Ethernet20   standby   unhealthy  2022-Feb-14 16:47:07.180982
Ethernet40   standby   unhealthy  2022-Feb-14 16:47:07.335020
Ethernet44   standby   unhealthy  2022-Feb-14 16:47:07.222463
Ethernet48   standby   unhealthy  2022-Feb-14 16:47:07.354632
Ethernet52   standby   unhealthy  2022-Feb-14 16:47:06.826954
Ethernet56   standby   unhealthy  2022-Feb-14 16:47:07.230414
Ethernet60   standby   unhealthy  2022-Feb-14 16:47:07.235581
Ethernet64   standby   unhealthy  2022-Feb-14 16:47:07.315676
Ethernet68   standby   unhealthy  2022-Feb-14 16:47:08.544206
Ethernet72   standby   unhealthy  2022-Feb-14 16:47:07.325918
Ethernet76   standby   unhealthy  2022-Feb-14 16:47:07.368308
Ethernet80   standby   unhealthy  2022-Feb-14 16:47:08.534758
Ethernet84   standby   unhealthy  2022-Feb-14 16:47:07.824009
Ethernet104  standby   unhealthy  2022-Feb-14 16:47:06.814654
Ethernet108  standby   unhealthy  2022-Feb-14 16:47:07.340556
Ethernet112  standby   unhealthy  2022-Feb-14 16:47:07.361900
Ethernet116  standby   unhealthy  2022-Feb-14 16:47:06.820994
Ethernet120  standby   unhealthy  2022-Feb-14 16:47:07.177181
Ethernet124  standby   unhealthy  2022-Feb-14 16:47:06.837251
```