### PR TITLE
[Command-Reference] Add CLI docs for route flow counter

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -57,6 +57,7 @@
 * [Flow Counters](#flow-counters)
   * [Flow Counters show commands](#flow-counters-show-commands)
   * [Flow Counters clear commands](#flow-counters-clear-commands)
+  * [Flow Counters config commands](#flow-counters-config-commands)
 * [Gearbox](#gearbox)
   * [Gearbox show commands](#gearbox-show-commands)
 * [Interfaces](#interfaces)
@@ -3133,9 +3134,10 @@ Go Back To [Beginning of the document](#) or [Beginning of this section](#featur
 
 ## Flow Counters
 
-This section explains all the Flow Counters show commands and clear commands that are supported in SONiC. Flow counters are usually used for debugging, troubleshooting and performance enhancement processes. Flow counters supports case like:
+This section explains all the Flow Counters show commands, clear commands and config commands that are supported in SONiC. Flow counters are usually used for debugging, troubleshooting and performance enhancement processes. Flow counters supports case like:
 
   - Host interface traps (number of received traps per Trap ID)
+  - Routes matching the configured prefix pattern (number of hits and number of bytes)
 
 ### Flow Counters show commands
 
@@ -3165,6 +3167,50 @@ Because clear (see below) is handled on a per-user basis different users may see
     asic1         dhcp        200    3,000  45.25/s
   ```
 
+**show flowcnt-route stats**
+
+This command is used to show the current statistics for route flow patterns. 
+
+Because clear (see below) is handled on a per-user basis different users may see different counts.
+
+- Usage:
+  ```
+  show flowcnt-route stats
+  show flowcnt-route stats pattern <route_pattern> [--vrf <vrf>]
+  show flowcnt-route stats route <route_prefix> [--vrf <vrf>]
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ show flowcnt-route stats
+  Route pattern       VRF               Matched routes           Packets          Bytes
+  --------------------------------------------------------------------------------------
+  3.3.0.0/16          default           3.3.1.0/24               100              4543
+                                        3.3.2.3/32               3443             929229
+                                        3.3.0.0/16               0                0
+  2000::/64           default           2000::1/128              100              4543
+  ```
+
+The "pattern" subcommand is used to display the route flow counter statistics by route pattern.
+
+- Example:
+  ```
+  admin@sonic:~$ show flowcnt-route stats pattern 3.3.0.0/16
+  Route pattern       VRF               Matched routes           Packets          Bytes
+  --------------------------------------------------------------------------------------
+  3.3.0.0/16          default           3.3.1.0/24               100              4543
+                                        3.3.2.3/32               3443             929229
+                                        3.3.0.0/16               0                0
+  ```
+
+The "route" subcommand is used to display the route flow counter statistics by route prefix.
+  ```
+  admin@sonic:~$ show flowcnt-route stats route 3.3.3.2/32 --vrf Vrf_1
+  Route                     VRF              Route Pattern           Packets          Bytes
+  -----------------------------------------------------------------------------------------
+  3.3.3.2/32                Vrf_1            3.3.0.0/16              100              4543
+  ```
+
 ### Flow Counters clear commands
 
 **sonic-clear flowcnt-trap**
@@ -3181,6 +3227,70 @@ This command is used to clear the current statistics for the registered host int
   admin@sonic:~$ sonic-clear flowcnt-trap
   Trap Flow Counters were successfully cleared
   ```
+
+**sonic-clear flowcnt-route**
+
+This command is used to clear the current statistics for the route flow counter. This is done on a per-user basis.
+
+- Usage:
+  ```
+  sonic-clear flowcnt-route
+  sonic-clear flowcnt-route pattern <route_pattern> [--vrf <vrf>]
+  sonic-clear flowcnt-route route <prefix> [--vrf <vrf>]
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sonic-clear flowcnt-route
+  Route Flow Counters were successfully cleared
+  ```
+
+The "pattern" subcommand is used to clear the route flow counter statistics by route pattern.
+
+- Example:
+  ```
+  admin@sonic:~$ sonic-clear flowcnt-route pattern 3.3.0.0/16 --vrf Vrf_1
+  Flow Counters of all routes matching the configured route pattern were successfully cleared
+  ```
+
+The "route" subcommand is used to clear the route flow counter statistics by route prefix.
+
+- Example:
+  ```
+  admin@sonic:~$ sonic-clear flowcnt-route route 3.3.3.2/32 --vrf Vrf_1
+  Flow Counters of the specified route were successfully cleared
+  ```
+
+### Flow Counters config commands
+
+**config flowcnt-route pattern add**
+
+This command is used to add or update the route pattern which is used by route flow counter to match route entries.
+
+- Usage:
+  ```
+  config flowcnt-route pattern add <prefix> [--vrf <vrf>] [--max <max_match_count>]
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ config flowcnt-route pattern add --vrf Vrf_1 --max 50 2.2.0.0/16
+  ```
+
+**config flowcnt-route pattern remove**
+
+This command is used to remove the route pattern which is used by route flow counter to match route entries.
+
+- Usage:
+  ```
+  config flowcnt-route pattern remove <prefix> [--vrf <vrf>]
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ config flowcnt-route pattern remove --vrf Vrf_1 2.2.0.0/16
+  ```
+
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#flow-counters)
 ## Gearbox

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -3274,7 +3274,7 @@ This command is used to add or update the route pattern which is used by route f
 
 - Example:
   ```
-  admin@sonic:~$ config flowcnt-route pattern add --vrf Vrf_1 --max 50 2.2.0.0/16
+  admin@sonic:~$ config flowcnt-route pattern add 2.2.0.0/16 --vrf Vrf_1 --max 50
   ```
 
 **config flowcnt-route pattern remove**
@@ -3288,7 +3288,7 @@ This command is used to remove the route pattern which is used by route flow cou
 
 - Example:
   ```
-  admin@sonic:~$ config flowcnt-route pattern remove --vrf Vrf_1 2.2.0.0/16
+  admin@sonic:~$ config flowcnt-route pattern remove 2.2.0.0/16 --vrf Vrf_1
   ```
 
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

HLD: https://github.com/Azure/SONiC/pull/908

#### What I did

Add CLIs document for route flow counter feature, CLI PR: https://github.com/Azure/sonic-utilities/pull/2031

#### How I did it

Add CLIs document for route flow counter feature

#### How to verify it

Run build

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

Enable/disable configuration:

```
counterpoll flowcnt-route  <enable | disable>
Example:
admin@sonic:~$ counterpoll flowcnt-route enable
```

Polling interval configuration:

```
counterpoll flowcnt-route interval <time_in_msec> // default - 1000ms
Example:
admin@sonic:~$ counterpoll flowcnt-route interval 2000
```

Show configuration:

```
counterpoll show
Example:
admin@sonic:~$ counterpoll show
Type                              Interval (in ms)          Status
--------------------------        ------------------        --------
FLOW_CNT_ROUTE_STAT               default(10000)            disable
```

Config route pattern:

```
config flowcnt-route pattern <add | remove> [--vrf <vrf>] [--max <route-max>] <prefix-pattern>    // configure route pattern
Example:
admin@sonic:~$ config flowcnt-route pattern add --vrf Vrf_1 --max 50 2.2.0.0/16
Route Pattern Flow Counter configuration is successful

admin@sonic:~$ config flowcnt-route pattern remove --vrf Vrf_1 2.2.0.0/16
Route Pattern Flow Counter configuration is successful
```

Show configuration:

```
show flowcnt-route config
Example:
admin@sonic:~$ show flowcnt-route config
Route pattern          VRF                 Max
-----------------------------------------------
3.3.0.0/16             default             50
```

Show counters value:

```
show flowcnt-route stats   // show statistics of all route flow counters
Example:
admin@sonic:~$ show flowcnt-route stats
Route pattern       VRF               Matched routes           Packets          Bytes
--------------------------------------------------------------------------------------
3.3.0.0/16          default           3.3.1.0/24               100              4543
                                      3.3.2.3/32               3443             929229
                                      3.3.0.0/16               0                0


show flowcnt-route stats pattern [<prefix-pattern> [ --vrf <vrf>] ]   // show statistics of all routes matching the configured route pattern
Example:
admin@sonic:~$ show flowcnt-route stats pattern 3.3.0.0/16
Route pattern       VRF               Matched routes           Packets          Bytes
--------------------------------------------------------------------------------------
3.3.0.0/16          default           3.3.1.0/24               100              4543
                                      3.3.2.3/32               3443             929229
                                      3.3.0.0/16               0                0

show flowcnt-route stats route [<prefix> [ --vrf <vrf>] ]             // show statistics of the specific route matching the configured route pattern
Example:
admin@sonic:~$ show flowcnt-route stats route 3.3.3.2/32 --vrf Vrf_1
Route                     VRF              Route Pattern           Packets          Bytes
-----------------------------------------------------------------------------------------
3.3.3.2/32                Vrf_1            3.3.0.0/16              100              4543
```

Clear counters:

```
sonic-clear flowcnt-route    // clear all route flow counters
Example:
admin@sonic:~$ sonic-clear flowcnt-route
Route Flow Counters were successfully cleared

sonic-clear flowcnt-route pattern  [<prefix-pattern> [ --vrf <vrf>] ]   // clear flow counters of all routes matching the configured route pattern
Example:
admin@sonic:~$ sonic-clear flowcnt-route pattern 3.3.0.0/16 --vrf Vrf_1
Flow Counters of all routes matching the configured route pattern were successfully cleared

sonic-clear flowcnt-route route [<prefix> [ --vrf <vrf>] ]  // clear flow counters of the specific route matching the configured prefix
Example:
admin@sonic:~$ sonic-clear flowcnt-route route 3.3.3.2/32 --vrf Vrf_1
Flow Counters of the specified route were successfully cleared
```