### PR TITLE
[ci] Fix pipeline on build_and_install_module

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -29,6 +29,7 @@ jobs:
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/master'
       allowPartiallySucceededBuilds: true
+      allowFailedBuilds: true
     displayName: "Download docker-sonic-vs artifact"
 
   - script: |

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -49,6 +49,9 @@ jobs:
 
   - script: |
       set -x
+      set -e
+      pwd
+      ls -R
       sudo .azure-pipelines/build_and_install_module.sh
 
       sudo apt-get install -y libhiredis0.14

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -52,7 +52,7 @@ jobs:
       set -e
       pwd
       ls -R
-      sudo .azure-pipelines/build_and_install_module.sh
+      sudo ./sonic-utilities/.azure-pipelines/build_and_install_module.sh
 
       sudo apt-get install -y libhiredis0.14
       ls -R ..

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -50,12 +50,9 @@ jobs:
   - script: |
       set -x
       set -e
-      pwd
-      ls -R
       sudo ./sonic-utilities/.azure-pipelines/build_and_install_module.sh
 
       sudo apt-get install -y libhiredis0.14
-      ls -R ..
       sudo dpkg -i --force-confask,confnew ../libswsscommon_1.0.0_amd64.deb || apt-get install -f
       sudo dpkg -i ../python3-swsscommon_1.0.0_amd64.deb
 

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -55,6 +55,7 @@ jobs:
       sudo .azure-pipelines/build_and_install_module.sh
 
       sudo apt-get install -y libhiredis0.14
+      ls -R ..
       sudo dpkg -i --force-confask,confnew ../libswsscommon_1.0.0_amd64.deb || apt-get install -f
       sudo dpkg -i ../python3-swsscommon_1.0.0_amd64.deb
 


### PR DESCRIPTION
#### What I did
1. upstream [Azure.sonic-swss](https://dev.azure.com/mssonic/build/_build?definitionId=15&_a=summary) keep failing at vstest, however the build artifacts should be good to download
2. Fix path of build_and_install_module

#### How I did it


#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

