### PR TITLE
Validation check correction while adding a member to PortChannel

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1790,11 +1790,11 @@ def add_portchannel_member(ctx, portchannel_name, port_name):
         ctx.fail("{} is not present.".format(portchannel_name))
 
     # Dont allow a port to be member of port channel if it is configured with an IP address
-    for key in db.get_table('INTERFACE').keys():
-        if type(key) != tuple:
+    for key,value in db.get_table('INTERFACE').items():
+        if type(key) == tuple:
             continue
-        if key[0] == port_name:
-            ctx.fail(" {} has ip address {} configured".format(port_name, key[1]))
+        if key == port_name:
+            ctx.fail(" {} has ip address configured".format(port_name))
             return
 
     # Dont allow a port to be member of port channel if it is configured as a VLAN member

--- a/tests/portchannel_test.py
+++ b/tests/portchannel_test.py
@@ -119,7 +119,7 @@ class TestPortChannel(object):
         print(result.exit_code)
         print(result.output)
         assert result.exit_code != 0
-        assert "Error:  Ethernet0 has ip address 14.14.0.1/24 configured" in result.output
+        assert "Error:  Ethernet0 has ip address configured" in result.output
 
     def test_add_portchannel_member_which_is_member_of_vlan(self):
         runner = CliRunner()


### PR DESCRIPTION
Corrected the validation check while adding a member to a PortChannel

This PR will fix the issue - https://github.com/Azure/sonic-buildimage/issues/9908

The CLI command should reject when trying to add member to a Portchannel when link-local is enabled in it.
```
root@sonic:/home/admin# config ipv6 enable link-local
root@sonic:/home/admin#
root@sonic:/home/admin# config portchannel add PortChannel0001
root@sonic:/home/admin#
root@sonic:/home/admin# config portchannel member add PortChannel0001 Ethernet64
Usage: config portchannel member add [OPTIONS] <portchannel_name> <port_name>
Try "config portchannel member add -h" for help.

Error:  Ethernet64 has ip address configured
root@sonic:/home/admin#
```

Signed-off-by: Akhilesh Samineni <akhilesh.samineni@broadcom.com>
