### PR TITLE
[counterpoll] Display the correct default poll interval for watermark counters

### DIFF
--- a/counterpoll/main.py
+++ b/counterpoll/main.py
@@ -375,13 +375,13 @@ def show():
     if rif_info:
         data.append(["RIF_STAT", rif_info.get("POLL_INTERVAL", DEFLT_1_SEC), rif_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if queue_wm_info:
-        data.append(["QUEUE_WATERMARK_STAT", queue_wm_info.get("POLL_INTERVAL", DEFLT_10_SEC), queue_wm_info.get("FLEX_COUNTER_STATUS", DISABLE)])
+        data.append(["QUEUE_WATERMARK_STAT", queue_wm_info.get("POLL_INTERVAL", DEFLT_60_SEC), queue_wm_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if pg_wm_info:
-        data.append(["PG_WATERMARK_STAT", pg_wm_info.get("POLL_INTERVAL", DEFLT_10_SEC), pg_wm_info.get("FLEX_COUNTER_STATUS", DISABLE)])
+        data.append(["PG_WATERMARK_STAT", pg_wm_info.get("POLL_INTERVAL", DEFLT_60_SEC), pg_wm_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if pg_drop_info:
         data.append(['PG_DROP_STAT', pg_drop_info.get("POLL_INTERVAL", DEFLT_10_SEC), pg_drop_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if buffer_pool_wm_info:
-        data.append(["BUFFER_POOL_WATERMARK_STAT", buffer_pool_wm_info.get("POLL_INTERVAL", DEFLT_10_SEC), buffer_pool_wm_info.get("FLEX_COUNTER_STATUS", DISABLE)])
+        data.append(["BUFFER_POOL_WATERMARK_STAT", buffer_pool_wm_info.get("POLL_INTERVAL", DEFLT_60_SEC), buffer_pool_wm_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if acl_info:
         data.append([ACL, pg_drop_info.get("POLL_INTERVAL", DEFLT_10_SEC), acl_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if tunnel_info:

--- a/tests/counterpoll_test.py
+++ b/tests/counterpoll_test.py
@@ -17,16 +17,16 @@ from .mock_tables import dbconnector
 
 import counterpoll.main as counterpoll
 
-expected_counterpoll_show = """Type                    Interval (in ms)  Status
+expected_counterpoll_show = """Type                  Interval (in ms)    Status
 --------------------  ------------------  --------
-QUEUE_STAT                         10000  enable
-PORT_STAT                           1000  enable
-PORT_BUFFER_DROP                   60000  enable
-QUEUE_WATERMARK_STAT               60000  enable
-PG_WATERMARK_STAT                  60000  enable
-PG_DROP_STAT                       10000  enable
-ACL                                10000  enable
-FLOW_CNT_TRAP_STAT                 10000  enable
+QUEUE_STAT            10000               enable
+PORT_STAT             1000                enable
+PORT_BUFFER_DROP      60000               enable
+QUEUE_WATERMARK_STAT  default (60000)     enable
+PG_WATERMARK_STAT     default (60000)     enable
+PG_DROP_STAT          10000               enable
+ACL                   10000               enable
+FLOW_CNT_TRAP_STAT    10000               enable
 """
 
 class TestCounterpoll(object):

--- a/tests/counterpoll_test.py
+++ b/tests/counterpoll_test.py
@@ -22,8 +22,8 @@ expected_counterpoll_show = """Type                    Interval (in ms)  Status
 QUEUE_STAT                         10000  enable
 PORT_STAT                           1000  enable
 PORT_BUFFER_DROP                   60000  enable
-QUEUE_WATERMARK_STAT               10000  enable
-PG_WATERMARK_STAT                  10000  enable
+QUEUE_WATERMARK_STAT               60000  enable
+PG_WATERMARK_STAT                  60000  enable
 PG_DROP_STAT                       10000  enable
 ACL                                10000  enable
 FLOW_CNT_TRAP_STAT                 10000  enable

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -1576,11 +1576,9 @@
         "FLEX_COUNTER_STATUS": "enable"
     },
     "FLEX_COUNTER_TABLE|QUEUE_WATERMARK": {
-        "POLL_INTERVAL": "10000",
         "FLEX_COUNTER_STATUS": "enable"
     },
     "FLEX_COUNTER_TABLE|PG_WATERMARK": {
-        "POLL_INTERVAL": "10000",
         "FLEX_COUNTER_STATUS": "enable"
     },
     "FLEX_COUNTER_TABLE|PG_DROP": {


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
Azure/sonic-swss#2031 updated the flex counter polling interval to 60s for watermark counters but the show command wasn't updated to reflect the correct default value

#### What I did
Display the correct poll interval for watermark related counters in the 'counterpoll show' command

#### How I did it
Update the default interval to be the same as the one updated by the Orchs

#### How to verify it
Issue "counterpoll show", the queue, pg and buffer pool watermark should show default 60s
Updated the counterpoll unit tests to reflect the same
