### PR TITLE
[show][muxcable] fix the sudo access error for show muxcable metrics

### DIFF
--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -1037,7 +1037,7 @@ def metrics(db, port, json_output):
     for namespace in namespaces:
         asic_id = multi_asic.get_asic_index_from_namespace(namespace)
         # replace these with correct macros
-        per_npu_statedb[asic_id] = swsscommon.SonicV2Connector(use_unix_socket_path=True, namespace=namespace)
+        per_npu_statedb[asic_id] = swsscommon.SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
         per_npu_statedb[asic_id].connect(per_npu_statedb[asic_id].STATE_DB)
 
         metrics_table_keys[asic_id] = per_npu_statedb[asic_id].keys(


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This change is required for such behavior with the command below, which works okay if you try with sudo
```
vdahiya@sonic:~$ show mux metrics Ethernet0
Traceback (most recent call last):
  File "/usr/local/bin/show", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/show/muxcable.py", line 1041, in metrics
    per_npu_statedb[asic_id].connect(per_npu_statedb[asic_id].STATE_DB)
  File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 1515, in connect
    return _swsscommon.SonicV2Connector_Native_connect(self, db_name, retry_on)
RuntimeError: Unable to connect to redis (unix-socket): Cannot assign requested address
```
#### How I did it

#### How to verify it
with the change, no need for sudo, tested on an arista 7050cx3 lab device
```
vdahiya@sonic:~$ show mux metrics Ethernet0
PORT       EVENT                         TIME
---------  ----------------------------  ---------------------------
Ethernet0  linkmgrd_switch_active_start  2022-Feb-28 18:49:59.350302
Ethernet0  xcvrd_switch_active_start     2022-Feb-28 18:49:59.354076
Ethernet0  xcvrd_switch_active_end       2022-Feb-28 18:49:59.357925
Ethernet0  linkmgrd_switch_active_end    2022-Feb-28 18:49:59.359198
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

