### PR TITLE
[202012][warmboot] Migrate 10G ports during warm-reboot on s6100 (#2064)

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -72,6 +72,7 @@ class DBMigrator():
         version_info = device_info.get_sonic_version_info()
         asic_type = version_info.get('asic_type')
         self.asic_type = asic_type
+        self.hwsku = device_info.get_hwsku()
 
         if asic_type == "mellanox":
             from mellanox_buffer_migrator import MellanoxBufferMigrator
@@ -124,6 +125,43 @@ class DBMigrator():
                 self.configDB.set_entry(table, key[0], data[key])
                 if_db.append(key[0])
 
+    def migrate_mgmt_ports_on_s6100(self):
+        '''
+        During warm-reboot, add back two 10G management ports which got removed from 6100
+        to ensure no change in bcm.config from older image
+        '''
+        if device_info.is_warm_restart_enabled('swss') == False:
+            log.log_notice("Skip migration on {}, warm-reboot flag not set".format(self.hwsku))
+            return True
+
+        entries = {}
+        entries['Ethernet64'] = {'alias': 'tenGigE1/1', 'description': 'tenGigE1/1', 'index': '64', 'lanes': '129', 'mtu': '9100', 'pfc_asym': 'off', 'speed': '10000'}
+        entries['Ethernet65'] = {'alias': 'tenGigE1/2', 'description': 'tenGigE1/2', 'index': '65', 'lanes': '131', 'mtu': '9100', 'pfc_asym': 'off', 'speed': '10000'}
+        added_ports = 0
+        for portName in entries.keys():
+            if self.configDB.get_entry('PORT', portName):
+                log.log_notice("Skipping migration for port {} - entry exists".format(portName))
+                continue
+
+            log.log_notice("Migrating port {} to configDB for warm-reboot on {}".format(portName, self.hwsku))
+            self.configDB.set_entry('PORT', portName, entries[portName])
+
+            #Copy port to APPL_DB
+            key = 'PORT_TABLE:' + portName
+            for field, value in entries[portName].items():
+                self.appDB.set(self.appDB.APPL_DB, key, field, value)
+            self.appDB.set(self.appDB.APPL_DB, key, 'admin_status', 'down')
+            log.log_notice("Copied port {} to appdb".format(key))
+            added_ports += 1
+
+        #Update port count in APPL_DB
+        portCount = self.appDB.get(self.appDB.APPL_DB, 'PORT_TABLE:PortConfigDone', 'count')
+        if portCount != '':
+            total_count = int(portCount) + added_ports
+            self.appDB.set(self.appDB.APPL_DB, 'PORT_TABLE:PortConfigDone', 'count', str(total_count))
+            log.log_notice("Port count updated from {} to : {}".format(portCount, self.appDB.get(self.appDB.APPL_DB, 'PORT_TABLE:PortConfigDone', 'count')))
+        return True
+        
     def migrate_intf_table(self):
         '''
         Migrate all data from existing INTF table in APP DB during warmboot with IP Prefix
@@ -546,6 +584,10 @@ class DBMigrator():
                 self.configDB.set_entry(init_cfg_table, key, new_cfg)
 
         self.migrate_copp_table()
+        if self.asic_type == "broadcom" and 'Force10-S6100' in self.hwsku:            
+            self.migrate_mgmt_ports_on_s6100()
+        else:
+            log.log_notice("Asic Type: {}, Hwsku: {}".format(self.asic_type, self.hwsku))
 
         # To migrate buffer on Mellanox platforms
         # For legacy branches, this is the only place it can be called because


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
Cherry-pick https://github.com/Azure/sonic-utilities/pull/2064 to 202012 branch

#### What I did
Changes include db-migration logic to add back 10G ports on 6100 during warm-reboot from earlier image to ensure config and app DB are in sync with new port_config.ini

#### How I did it
Set configdb manually and update corresponding new entries in appdb

#### How to verify it
Fixes https://github.com/Azure/sonic-buildimage/issues/9976

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

