### PR TITLE
Add date to show version

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -476,7 +476,8 @@ This command displays relevant information as the SONiC and Linux kernel version
   Serial Number: MT1822K07815
   Model Number: MSN2700-CS2FO
   Hardware Rev: A1
-  Uptime: 14:40:15 up 3 min,  1 user,  load average: 1.26, 1.45, 0.66
+  Uptime: up 3 min,  1 user,  load average: 1.26, 1.45, 0.66
+  Date: Fri 22 Mar 2019 14:40:15
 
   Docker images:
   REPOSITORY                 TAG                 IMAGE ID            SIZE

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -476,7 +476,7 @@ This command displays relevant information as the SONiC and Linux kernel version
   Serial Number: MT1822K07815
   Model Number: MSN2700-CS2FO
   Hardware Rev: A1
-  Uptime:14:40:15 up 3 min,  1 user,  load average: 1.26, 1.45, 0.66
+  Uptime: 14:40:15 up 3 min,  1 user,  load average: 1.26, 1.45, 0.66
   Date: Fri 22 Mar 2019 14:40:15
 
   Docker images:

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -476,7 +476,7 @@ This command displays relevant information as the SONiC and Linux kernel version
   Serial Number: MT1822K07815
   Model Number: MSN2700-CS2FO
   Hardware Rev: A1
-  Uptime: up 3 min,  1 user,  load average: 1.26, 1.45, 0.66
+  Uptime:14:40:15 up 3 min,  1 user,  load average: 1.26, 1.45, 0.66
   Date: Fri 22 Mar 2019 14:40:15
 
   Docker images:

--- a/show/main.py
+++ b/show/main.py
@@ -14,6 +14,7 @@ from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
 from tabulate import tabulate
 from utilities_common import util_base
 from utilities_common.db import Db
+from datetime import date
 import utilities_common.constants as constants
 from utilities_common.general import load_db_config
 
@@ -1060,6 +1061,7 @@ def version(verbose):
     
     sys_uptime_cmd = "uptime"
     sys_uptime = subprocess.Popen(sys_uptime_cmd, shell=True, text=True, stdout=subprocess.PIPE)
+    sys_date = date.today()
 
     click.echo("\nSONiC Software Version: SONiC.{}".format(version_info['build_version']))
     click.echo("Distribution: Debian {}".format(version_info['debian_version']))
@@ -1075,6 +1077,7 @@ def version(verbose):
     click.echo("Model Number: {}".format(chassis_info['model']))
     click.echo("Hardware Revision: {}".format(chassis_info['revision']))
     click.echo("Uptime: {}".format(sys_uptime.stdout.read().strip()))
+    click.echo("Date: {}".format(sys_date.strftime("%a %d %b %Y")))
     click.echo("\nDocker images:")
     cmd = 'sudo docker images --format "table {{.Repository}}\\t{{.Tag}}\\t{{.ID}}\\t{{.Size}}"'
     p = subprocess.Popen(cmd, shell=True, text=True, stdout=subprocess.PIPE)

--- a/show/main.py
+++ b/show/main.py
@@ -1047,6 +1047,15 @@ def logging(process, lines, follow, verbose):
         run_command(cmd, display_cmd=verbose)
 
 
+def get_uptime():
+    sys_uptime_cmd = "uptime"
+    sys_uptime = subprocess.Popen(sys_uptime_cmd, shell=True, text=True, stdout=subprocess.PIPE)
+    # The 'uptime' command displays the current time as the 1st entry "hh:mm:ss {more info}"
+    # Split the output by the space character to remove the time from the output.
+    sys_uptime_without_time = sys_uptime.stdout.read().strip().split(' ', 1)[1]
+    return sys_uptime_without_time
+
+
 #
 # 'version' command ("show version")
 #
@@ -1058,11 +1067,6 @@ def version(verbose):
     version_info = device_info.get_sonic_version_info()
     platform_info = device_info.get_platform_info()
     chassis_info = platform.get_chassis_info()
-    
-    sys_uptime_cmd = "uptime"
-    sys_uptime = subprocess.Popen(sys_uptime_cmd, shell=True, text=True, stdout=subprocess.PIPE)
-    hour_le = 9
-    sys_uptime_without_hour = sys_uptime.stdout.read().strip()[hour_le:]
     sys_date = datetime.now()
 
     click.echo("\nSONiC Software Version: SONiC.{}".format(version_info['build_version']))
@@ -1078,7 +1082,7 @@ def version(verbose):
     click.echo("Serial Number: {}".format(chassis_info['serial']))
     click.echo("Model Number: {}".format(chassis_info['model']))
     click.echo("Hardware Revision: {}".format(chassis_info['revision']))
-    click.echo("Uptime: {}".format(sys_uptime_without_hour))
+    click.echo("Uptime: {}".format(get_uptime()))
     click.echo("Date: {}".format(sys_date.strftime("%a %d %b %Y %X")))
     click.echo("\nDocker images:")
     cmd = 'sudo docker images --format "table {{.Repository}}\\t{{.Tag}}\\t{{.ID}}\\t{{.Size}}"'
@@ -1137,7 +1141,7 @@ def techsupport(since, global_timeout, cmd_timeout, verbose, allow_process_stop,
 
     if since:
         cmd += " -s '{}'".format(since)
-    
+
     if debug_dump:
         cmd += " -d "
 
@@ -1242,7 +1246,7 @@ def snmp(ctx, db):
 
 # ("show runningconfiguration snmp community")
 @snmp.command('community')
-@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, 
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL,
               help="Display the output in JSON format")
 @clicommon.pass_db
 def community(db, json_output):
@@ -1263,7 +1267,7 @@ def community(db, json_output):
 
 # ("show runningconfiguration snmp contact")
 @snmp.command('contact')
-@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, 
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL,
               help="Display the output in JSON format")
 @clicommon.pass_db
 def contact(db, json_output):
@@ -1291,7 +1295,7 @@ def contact(db, json_output):
 
 # ("show runningconfiguration snmp location")
 @snmp.command('location')
-@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, 
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL,
               help="Display the output in JSON format")
 @clicommon.pass_db
 def location(db, json_output):
@@ -1318,13 +1322,13 @@ def location(db, json_output):
 
 # ("show runningconfiguration snmp user")
 @snmp.command('user')
-@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, 
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL,
               help="Display the output in JSON format")
 @clicommon.pass_db
 def users(db, json_output):
     """show SNMP running configuration user"""
     snmp_users = db.cfgdb.get_table('SNMP_USER')
-    snmp_user_header = ['User', "Permission Type", "Type", "Auth Type", "Auth Password", "Encryption Type", 
+    snmp_user_header = ['User', "Permission Type", "Type", "Auth Type", "Auth Password", "Encryption Type",
                         "Encryption Password"]
     snmp_user_body = []
     if json_output:
@@ -1337,7 +1341,7 @@ def users(db, json_output):
             snmp_user_encryption_type = snmp_users[snmp_user].get('SNMP_USER_ENCRYPTION_TYPE', 'Null')
             snmp_user_encryption_password = snmp_users[snmp_user].get('SNMP_USER_ENCRYPTION_PASSWORD', 'Null')
             snmp_user_type = snmp_users[snmp_user].get('SNMP_USER_TYPE', 'Null')
-            snmp_user_body.append([snmp_user, snmp_user_permissions_type, snmp_user_type, snmp_user_auth_type, 
+            snmp_user_body.append([snmp_user, snmp_user_permissions_type, snmp_user_type, snmp_user_auth_type,
                                    snmp_user_auth_password, snmp_user_encryption_type, snmp_user_encryption_password])
         click.echo(tabulate(natsorted(snmp_user_body), snmp_user_header))
 
@@ -1354,7 +1358,7 @@ def show_run_snmp(db, ctx):
     snmp_contact_body = []
     snmp_comm_header = ["Community String", "Community Type"]
     snmp_comm_body = []
-    snmp_user_header = ['User', "Permission Type", "Type", "Auth Type", "Auth Password", "Encryption Type", 
+    snmp_user_header = ['User', "Permission Type", "Type", "Auth Type", "Auth Password", "Encryption Type",
                         "Encryption Password"]
     snmp_user_body = []
     try:
@@ -1388,7 +1392,7 @@ def show_run_snmp(db, ctx):
         snmp_user_encryption_type = snmp_users[snmp_user].get('SNMP_USER_ENCRYPTION_TYPE', 'Null')
         snmp_user_encryption_password = snmp_users[snmp_user].get('SNMP_USER_ENCRYPTION_PASSWORD', 'Null')
         snmp_user_type = snmp_users[snmp_user].get('SNMP_USER_TYPE', 'Null')
-        snmp_user_body.append([snmp_user, snmp_user_permissions_type, snmp_user_type, snmp_user_auth_type, 
+        snmp_user_body.append([snmp_user, snmp_user_permissions_type, snmp_user_type, snmp_user_auth_type,
                                snmp_user_auth_password, snmp_user_encryption_type, snmp_user_encryption_password])
     click.echo(tabulate(natsorted(snmp_user_body), snmp_user_header))
 

--- a/show/main.py
+++ b/show/main.py
@@ -14,7 +14,7 @@ from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
 from tabulate import tabulate
 from utilities_common import util_base
 from utilities_common.db import Db
-from datetime import date
+from datetime import datetime
 import utilities_common.constants as constants
 from utilities_common.general import load_db_config
 
@@ -1061,7 +1061,9 @@ def version(verbose):
     
     sys_uptime_cmd = "uptime"
     sys_uptime = subprocess.Popen(sys_uptime_cmd, shell=True, text=True, stdout=subprocess.PIPE)
-    sys_date = date.today()
+    hour_le = 9
+    sys_uptime_without_hour = sys_uptime.stdout.read().strip()[hour_le:]
+    sys_date = datetime.now()
 
     click.echo("\nSONiC Software Version: SONiC.{}".format(version_info['build_version']))
     click.echo("Distribution: Debian {}".format(version_info['debian_version']))
@@ -1076,8 +1078,8 @@ def version(verbose):
     click.echo("Serial Number: {}".format(chassis_info['serial']))
     click.echo("Model Number: {}".format(chassis_info['model']))
     click.echo("Hardware Revision: {}".format(chassis_info['revision']))
-    click.echo("Uptime: {}".format(sys_uptime.stdout.read().strip()))
-    click.echo("Date: {}".format(sys_date.strftime("%a %d %b %Y")))
+    click.echo("Uptime: {}".format(sys_uptime_without_hour))
+    click.echo("Date: {}".format(sys_date.strftime("%a %d %b %Y %X")))
     click.echo("\nDocker images:")
     cmd = 'sudo docker images --format "table {{.Repository}}\\t{{.Tag}}\\t{{.ID}}\\t{{.Size}}"'
     p = subprocess.Popen(cmd, shell=True, text=True, stdout=subprocess.PIPE)

--- a/show/main.py
+++ b/show/main.py
@@ -1050,10 +1050,10 @@ def logging(process, lines, follow, verbose):
 def get_uptime():
     sys_uptime_cmd = "uptime"
     sys_uptime = subprocess.Popen(sys_uptime_cmd, shell=True, text=True, stdout=subprocess.PIPE)
-    # The 'uptime' command displays the current time as the 1st entry "hh:mm:ss {more info}"
+    # The 'uptime' command displays the current time as the 1st entry "hh:mm:ss <more info>"
     # Split the output by the space character to remove the time from the output.
-    sys_uptime_without_time = sys_uptime.stdout.read().strip().split(' ', 1)[1]
-    return sys_uptime_without_time
+    sys_uptime_no_time = sys_uptime.stdout.read().strip().split(' ', 1)[1]
+    return sys_uptime_no_time
 
 
 #

--- a/show/main.py
+++ b/show/main.py
@@ -1047,15 +1047,6 @@ def logging(process, lines, follow, verbose):
         run_command(cmd, display_cmd=verbose)
 
 
-def get_uptime():
-    sys_uptime_cmd = "uptime"
-    sys_uptime = subprocess.Popen(sys_uptime_cmd, shell=True, text=True, stdout=subprocess.PIPE)
-    # The 'uptime' command displays the current time as the 1st entry "hh:mm:ss <more info>"
-    # Split the output by the space character to remove the time from the output.
-    sys_uptime_no_time = sys_uptime.stdout.read().strip().split(' ', 1)[1]
-    return sys_uptime_no_time
-
-
 #
 # 'version' command ("show version")
 #
@@ -1067,6 +1058,10 @@ def version(verbose):
     version_info = device_info.get_sonic_version_info()
     platform_info = device_info.get_platform_info()
     chassis_info = platform.get_chassis_info()
+
+    sys_uptime_cmd = "uptime"
+    sys_uptime = subprocess.Popen(sys_uptime_cmd, shell=True, text=True, stdout=subprocess.PIPE)
+
     sys_date = datetime.now()
 
     click.echo("\nSONiC Software Version: SONiC.{}".format(version_info['build_version']))
@@ -1082,7 +1077,7 @@ def version(verbose):
     click.echo("Serial Number: {}".format(chassis_info['serial']))
     click.echo("Model Number: {}".format(chassis_info['model']))
     click.echo("Hardware Revision: {}".format(chassis_info['revision']))
-    click.echo("Uptime: {}".format(get_uptime()))
+    click.echo("Uptime: {}".format(sys_uptime.stdout.read().strip()))
     click.echo("Date: {}".format(sys_date.strftime("%a %d %b %Y %X")))
     click.echo("\nDocker images:")
     cmd = 'sudo docker images --format "table {{.Repository}}\\t{{.Tag}}\\t{{.ID}}\\t{{.Size}}"'


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Add the current date attribute to the "show version" output that includes the current date and hour on the switch.

#### How I did it

In sonic-utilities, in the "version" subcommand, print of the current date will be added using "datetime" from the "datetime" library.

#### How to verify it

Execute "show version" command and verify "Date" row under the "Uptime" row.

#### Previous command output (if the output of a command-line utility has changed)

admin@sonic:~$ show version
SONiC Software Version: SONiC.HEAD.32-https://github.com/EdenGri/sonic-utilities/commit/21ea29a23f1f1b4a3ce294e6cbdaee4388047231
Distribution: Debian 9.8
Kernel: 4.9.0-8-amd64
Build commit: https://github.com/EdenGri/sonic-utilities/commit/21ea29a23f1f1b4a3ce294e6cbdaee4388047231
Build date: Fri Mar 22 01:55:48 UTC 2019
Built by: johnar@jenkins-worker-4

Platform: x86_64-mlnx_msn2700-r0
HwSKU: Mellanox-SN2700
ASIC: mellanox
ASIC Count: 1
Serial Number: MT1822K07815
Model Number: MSN2700-CS2FO
Hardware Rev: A1
Uptime: 14:40:15 up 3 min, 1 user, load average: 1.26, 1.45, 0.66
...

#### New command output (if the output of a command-line utility has changed)

admin@sonic:~$ show version
SONiC Software Version: SONiC.HEAD.32-https://github.com/EdenGri/sonic-utilities/commit/21ea29a23f1f1b4a3ce294e6cbdaee4388047231
Distribution: Debian 9.8
Kernel: 4.9.0-8-amd64
Build commit: https://github.com/EdenGri/sonic-utilities/commit/21ea29a23f1f1b4a3ce294e6cbdaee4388047231
Build date: Fri Mar 22 01:55:48 UTC 2019
Built by: johnar@jenkins-worker-4

Platform: x86_64-mlnx_msn2700-r0
HwSKU: Mellanox-SN2700
ASIC: mellanox
ASIC Count: 1
Serial Number: MT1822K07815
Model Number: MSN2700-CS2FO
Hardware Rev: A1
Uptime: 14:40:15 up 3 min, 1 user, load average: 1.26, 1.45, 0.66
Date: Tue 22 Feb 2022 14:40:15
...
