### PR TITLE
Fix sonic-installer failure due to missing import

### DIFF
--- a/sonic_installer/bootloader/uboot.py
+++ b/sonic_installer/bootloader/uboot.py
@@ -4,6 +4,7 @@ Bootloader implementation for uboot based platforms
 
 import platform
 import subprocess
+import os
 
 import click
 


### PR DESCRIPTION
Signed-off-by: Pavan Naregundi <pnaregundi@marvell.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixes #2089. 
Sonic-installer failure was seen due to missing import in uboot.py. 
 
#### How I did it
Fix is just adding missing import.

#### How to verify it
Fix has been tested for successful sonic installation from sonic-installer
 
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

