### PR TITLE
[GCU] Marking fields under BGP_PEER_RANGE, BGP_MONITORS as create-only

### DIFF
--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -581,7 +581,6 @@ class CreateOnlyMoveValidator:
                 ["BGP_NEIGHBOR", "*", "local_addr"],
                 ["BGP_NEIGHBOR", "*", "nhopself"],
                 ["BGP_NEIGHBOR", "*", "rrclient"],
-                ["ACL_RULE", "*", "*"],
                 ["BGP_PEER_RANGE", "*", "*"],
                 ["BGP_MONITORS", "*", "holdtime"],
                 ["BGP_MONITORS", "*", "keepalive"],

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -581,6 +581,15 @@ class CreateOnlyMoveValidator:
                 ["BGP_NEIGHBOR", "*", "local_addr"],
                 ["BGP_NEIGHBOR", "*", "nhopself"],
                 ["BGP_NEIGHBOR", "*", "rrclient"],
+                ["ACL_RULE", "*", "*"],
+                ["BGP_PEER_RANGE", "*", "*"],
+                ["BGP_MONITORS", "*", "holdtime"],
+                ["BGP_MONITORS", "*", "keepalive"],
+                ["BGP_MONITORS", "*", "name"],
+                ["BGP_MONITORS", "*", "asn"],
+                ["BGP_MONITORS", "*", "local_addr"],
+                ["BGP_MONITORS", "*", "nhopself"],
+                ["BGP_MONITORS", "*", "rrclient"],
             ],
             path_addressing)
 

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -1011,6 +1011,37 @@ class TestCreateOnlyMoveValidator(unittest.TestCase):
                     "nhopself": "0",
                     "rrclient": "0"
                 }
+            },
+            "ACL_RULE": {
+                "V4-ACL-TABLE|Rule_20": {
+                    "PACKET_ACTION": "FORWARD",
+                    "DST_IP": "10.222.72.0/26",
+                    "SRC_IP": "10.222.0.0/15",
+                    "PRIORITY": "777780",
+                    "IP_TYPE": "IPv4ANY"
+                }
+            },
+            "BGP_PEER_RANGE": {
+                "BGPSLBPassive": {
+                    "ip_range": [
+                        "10.255.0.0/25"
+                    ],
+                    "name": "BGPSLBPassive",
+                    "peer_asn": "65543",
+                    "src_address": "10.1.0.32"
+                }
+            },
+            "BGP_MONITORS": {
+                "5.6.7.8": {
+                    "admin_status": "up",
+                    "asn": "65000",
+                    "holdtime": "180",
+                    "keepalive": "60",
+                    "local_addr": "10.0.0.11",
+                    "name": "BGPMonitor",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
             }
         }
         expected = [
@@ -1025,6 +1056,22 @@ class TestCreateOnlyMoveValidator(unittest.TestCase):
             "/BGP_NEIGHBOR/10.0.0.57/name",
             "/BGP_NEIGHBOR/10.0.0.57/nhopself",
             "/BGP_NEIGHBOR/10.0.0.57/rrclient",
+            "/ACL_RULE/V4-ACL-TABLE|Rule_20/PACKET_ACTION",
+            "/ACL_RULE/V4-ACL-TABLE|Rule_20/DST_IP",
+            "/ACL_RULE/V4-ACL-TABLE|Rule_20/SRC_IP",
+            "/ACL_RULE/V4-ACL-TABLE|Rule_20/PRIORITY",
+            "/ACL_RULE/V4-ACL-TABLE|Rule_20/IP_TYPE",
+            "/BGP_PEER_RANGE/BGPSLBPassive/ip_range",
+            "/BGP_PEER_RANGE/BGPSLBPassive/name",
+            "/BGP_PEER_RANGE/BGPSLBPassive/peer_asn",
+            "/BGP_PEER_RANGE/BGPSLBPassive/src_address",
+            "/BGP_MONITORS/5.6.7.8/asn",
+            "/BGP_MONITORS/5.6.7.8/holdtime",
+            "/BGP_MONITORS/5.6.7.8/keepalive",
+            "/BGP_MONITORS/5.6.7.8/local_addr",
+            "/BGP_MONITORS/5.6.7.8/name",
+            "/BGP_MONITORS/5.6.7.8/nhopself",
+            "/BGP_MONITORS/5.6.7.8/rrclient",
         ]
 
         actual = self.validator._get_create_only_paths(config)

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -1012,15 +1012,6 @@ class TestCreateOnlyMoveValidator(unittest.TestCase):
                     "rrclient": "0"
                 }
             },
-            "ACL_RULE": {
-                "V4-ACL-TABLE|Rule_20": {
-                    "PACKET_ACTION": "FORWARD",
-                    "DST_IP": "10.222.72.0/26",
-                    "SRC_IP": "10.222.0.0/15",
-                    "PRIORITY": "777780",
-                    "IP_TYPE": "IPv4ANY"
-                }
-            },
             "BGP_PEER_RANGE": {
                 "BGPSLBPassive": {
                     "ip_range": [
@@ -1056,11 +1047,6 @@ class TestCreateOnlyMoveValidator(unittest.TestCase):
             "/BGP_NEIGHBOR/10.0.0.57/name",
             "/BGP_NEIGHBOR/10.0.0.57/nhopself",
             "/BGP_NEIGHBOR/10.0.0.57/rrclient",
-            "/ACL_RULE/V4-ACL-TABLE|Rule_20/PACKET_ACTION",
-            "/ACL_RULE/V4-ACL-TABLE|Rule_20/DST_IP",
-            "/ACL_RULE/V4-ACL-TABLE|Rule_20/SRC_IP",
-            "/ACL_RULE/V4-ACL-TABLE|Rule_20/PRIORITY",
-            "/ACL_RULE/V4-ACL-TABLE|Rule_20/IP_TYPE",
             "/BGP_PEER_RANGE/BGPSLBPassive/ip_range",
             "/BGP_PEER_RANGE/BGPSLBPassive/name",
             "/BGP_PEER_RANGE/BGPSLBPassive/peer_asn",


### PR DESCRIPTION
#### What I did
Fixes #2029 #2062

Changes to fields under BGP_PEER_RANGE, BGP_MONITORS using GCU are not reflected unless each key is deleted and added back. This means the fields are create-only.

#### How I did it
Marked the fields under BGP_PEER_RANGE, BGP_MONITORS as create-only

#### How to verify it
unit-test

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

