### PR TITLE
[sonic_installer] Use use_unix_socket_path=True in DB connector

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -144,7 +144,7 @@ def is_gearbox_configured():
     """
     Checks whether Gearbox is configured or not
     """
-    app_db = SonicV2Connector(use_unix_socket_path=True)
+    app_db = SonicV2Connector()
     app_db.connect(app_db.APPL_DB)
 
     keys = app_db.keys(app_db.APPL_DB, '*')
@@ -1057,7 +1057,7 @@ def version(verbose):
     version_info = device_info.get_sonic_version_info()
     platform_info = device_info.get_platform_info()
     chassis_info = platform.get_chassis_info()
-
+    
     sys_uptime_cmd = "uptime"
     sys_uptime = subprocess.Popen(sys_uptime_cmd, shell=True, text=True, stdout=subprocess.PIPE)
 
@@ -1132,7 +1132,7 @@ def techsupport(since, global_timeout, cmd_timeout, verbose, allow_process_stop,
 
     if since:
         cmd += " -s '{}'".format(since)
-
+    
     if debug_dump:
         cmd += " -d "
 
@@ -1237,7 +1237,7 @@ def snmp(ctx, db):
 
 # ("show runningconfiguration snmp community")
 @snmp.command('community')
-@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL,
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, 
               help="Display the output in JSON format")
 @clicommon.pass_db
 def community(db, json_output):
@@ -1258,7 +1258,7 @@ def community(db, json_output):
 
 # ("show runningconfiguration snmp contact")
 @snmp.command('contact')
-@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL,
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, 
               help="Display the output in JSON format")
 @clicommon.pass_db
 def contact(db, json_output):
@@ -1286,7 +1286,7 @@ def contact(db, json_output):
 
 # ("show runningconfiguration snmp location")
 @snmp.command('location')
-@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL,
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, 
               help="Display the output in JSON format")
 @clicommon.pass_db
 def location(db, json_output):
@@ -1313,13 +1313,13 @@ def location(db, json_output):
 
 # ("show runningconfiguration snmp user")
 @snmp.command('user')
-@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL,
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, 
               help="Display the output in JSON format")
 @clicommon.pass_db
 def users(db, json_output):
     """show SNMP running configuration user"""
     snmp_users = db.cfgdb.get_table('SNMP_USER')
-    snmp_user_header = ['User', "Permission Type", "Type", "Auth Type", "Auth Password", "Encryption Type",
+    snmp_user_header = ['User', "Permission Type", "Type", "Auth Type", "Auth Password", "Encryption Type", 
                         "Encryption Password"]
     snmp_user_body = []
     if json_output:
@@ -1332,7 +1332,7 @@ def users(db, json_output):
             snmp_user_encryption_type = snmp_users[snmp_user].get('SNMP_USER_ENCRYPTION_TYPE', 'Null')
             snmp_user_encryption_password = snmp_users[snmp_user].get('SNMP_USER_ENCRYPTION_PASSWORD', 'Null')
             snmp_user_type = snmp_users[snmp_user].get('SNMP_USER_TYPE', 'Null')
-            snmp_user_body.append([snmp_user, snmp_user_permissions_type, snmp_user_type, snmp_user_auth_type,
+            snmp_user_body.append([snmp_user, snmp_user_permissions_type, snmp_user_type, snmp_user_auth_type, 
                                    snmp_user_auth_password, snmp_user_encryption_type, snmp_user_encryption_password])
         click.echo(tabulate(natsorted(snmp_user_body), snmp_user_header))
 
@@ -1349,7 +1349,7 @@ def show_run_snmp(db, ctx):
     snmp_contact_body = []
     snmp_comm_header = ["Community String", "Community Type"]
     snmp_comm_body = []
-    snmp_user_header = ['User', "Permission Type", "Type", "Auth Type", "Auth Password", "Encryption Type",
+    snmp_user_header = ['User', "Permission Type", "Type", "Auth Type", "Auth Password", "Encryption Type", 
                         "Encryption Password"]
     snmp_user_body = []
     try:
@@ -1383,7 +1383,7 @@ def show_run_snmp(db, ctx):
         snmp_user_encryption_type = snmp_users[snmp_user].get('SNMP_USER_ENCRYPTION_TYPE', 'Null')
         snmp_user_encryption_password = snmp_users[snmp_user].get('SNMP_USER_ENCRYPTION_PASSWORD', 'Null')
         snmp_user_type = snmp_users[snmp_user].get('SNMP_USER_TYPE', 'Null')
-        snmp_user_body.append([snmp_user, snmp_user_permissions_type, snmp_user_type, snmp_user_auth_type,
+        snmp_user_body.append([snmp_user, snmp_user_permissions_type, snmp_user_type, snmp_user_auth_type, 
                                snmp_user_auth_password, snmp_user_encryption_type, snmp_user_encryption_password])
     click.echo(tabulate(natsorted(snmp_user_body), snmp_user_header))
 

--- a/show/main.py
+++ b/show/main.py
@@ -144,7 +144,7 @@ def is_gearbox_configured():
     """
     Checks whether Gearbox is configured or not
     """
-    app_db = SonicV2Connector()
+    app_db = SonicV2Connector(use_unix_socket_path=True)
     app_db.connect(app_db.APPL_DB)
 
     keys = app_db.keys(app_db.APPL_DB, '*')
@@ -1057,7 +1057,7 @@ def version(verbose):
     version_info = device_info.get_sonic_version_info()
     platform_info = device_info.get_platform_info()
     chassis_info = platform.get_chassis_info()
-    
+
     sys_uptime_cmd = "uptime"
     sys_uptime = subprocess.Popen(sys_uptime_cmd, shell=True, text=True, stdout=subprocess.PIPE)
 
@@ -1132,7 +1132,7 @@ def techsupport(since, global_timeout, cmd_timeout, verbose, allow_process_stop,
 
     if since:
         cmd += " -s '{}'".format(since)
-    
+
     if debug_dump:
         cmd += " -d "
 
@@ -1237,7 +1237,7 @@ def snmp(ctx, db):
 
 # ("show runningconfiguration snmp community")
 @snmp.command('community')
-@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, 
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL,
               help="Display the output in JSON format")
 @clicommon.pass_db
 def community(db, json_output):
@@ -1258,7 +1258,7 @@ def community(db, json_output):
 
 # ("show runningconfiguration snmp contact")
 @snmp.command('contact')
-@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, 
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL,
               help="Display the output in JSON format")
 @clicommon.pass_db
 def contact(db, json_output):
@@ -1286,7 +1286,7 @@ def contact(db, json_output):
 
 # ("show runningconfiguration snmp location")
 @snmp.command('location')
-@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, 
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL,
               help="Display the output in JSON format")
 @clicommon.pass_db
 def location(db, json_output):
@@ -1313,13 +1313,13 @@ def location(db, json_output):
 
 # ("show runningconfiguration snmp user")
 @snmp.command('user')
-@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, 
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL,
               help="Display the output in JSON format")
 @clicommon.pass_db
 def users(db, json_output):
     """show SNMP running configuration user"""
     snmp_users = db.cfgdb.get_table('SNMP_USER')
-    snmp_user_header = ['User', "Permission Type", "Type", "Auth Type", "Auth Password", "Encryption Type", 
+    snmp_user_header = ['User', "Permission Type", "Type", "Auth Type", "Auth Password", "Encryption Type",
                         "Encryption Password"]
     snmp_user_body = []
     if json_output:
@@ -1332,7 +1332,7 @@ def users(db, json_output):
             snmp_user_encryption_type = snmp_users[snmp_user].get('SNMP_USER_ENCRYPTION_TYPE', 'Null')
             snmp_user_encryption_password = snmp_users[snmp_user].get('SNMP_USER_ENCRYPTION_PASSWORD', 'Null')
             snmp_user_type = snmp_users[snmp_user].get('SNMP_USER_TYPE', 'Null')
-            snmp_user_body.append([snmp_user, snmp_user_permissions_type, snmp_user_type, snmp_user_auth_type, 
+            snmp_user_body.append([snmp_user, snmp_user_permissions_type, snmp_user_type, snmp_user_auth_type,
                                    snmp_user_auth_password, snmp_user_encryption_type, snmp_user_encryption_password])
         click.echo(tabulate(natsorted(snmp_user_body), snmp_user_header))
 
@@ -1349,7 +1349,7 @@ def show_run_snmp(db, ctx):
     snmp_contact_body = []
     snmp_comm_header = ["Community String", "Community Type"]
     snmp_comm_body = []
-    snmp_user_header = ['User', "Permission Type", "Type", "Auth Type", "Auth Password", "Encryption Type", 
+    snmp_user_header = ['User', "Permission Type", "Type", "Auth Type", "Auth Password", "Encryption Type",
                         "Encryption Password"]
     snmp_user_body = []
     try:
@@ -1383,7 +1383,7 @@ def show_run_snmp(db, ctx):
         snmp_user_encryption_type = snmp_users[snmp_user].get('SNMP_USER_ENCRYPTION_TYPE', 'Null')
         snmp_user_encryption_password = snmp_users[snmp_user].get('SNMP_USER_ENCRYPTION_PASSWORD', 'Null')
         snmp_user_type = snmp_users[snmp_user].get('SNMP_USER_TYPE', 'Null')
-        snmp_user_body.append([snmp_user, snmp_user_permissions_type, snmp_user_type, snmp_user_auth_type, 
+        snmp_user_body.append([snmp_user, snmp_user_permissions_type, snmp_user_type, snmp_user_auth_type,
                                snmp_user_auth_password, snmp_user_encryption_type, snmp_user_encryption_password])
     click.echo(tabulate(natsorted(snmp_user_body), snmp_user_header))
 

--- a/sonic_installer/common.py
+++ b/sonic_installer/common.py
@@ -20,16 +20,22 @@ WORKDIR_NAME = 'work'
 DOCKERDIR_NAME = 'docker'
 
 # Run bash command and print output to stdout
-def run_command(command):
+def run_command(command, display_cmd=True, exit_on_failure=True):
     click.echo(click.style("Command: ", fg='cyan') + click.style(command, fg='green'))
 
     proc = subprocess.Popen(command, shell=True, text=True, stdout=subprocess.PIPE)
     (out, _) = proc.communicate()
 
-    click.echo(out)
+    if display_cmd:
+        click.echo(out)
 
     if proc.returncode != 0:
-        sys.exit(proc.returncode)
+        if exit_on_failure:
+            sys.exit(proc.returncode)
+        else:
+            raise RuntimeError("Failed to execute {}: rc={}", command, proc.returncode)
+
+    return out
 
 # Run bash command and return output, raise if it fails
 def run_command_or_raise(argv, raise_exception=True):

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -205,7 +205,7 @@ def get_container_image_id_all(image_name):
 
 
 def hget_warm_restart_table(db_name, table_name, warm_app_name, key):
-    db = SonicV2Connector()
+    db = SonicV2Connector(use_unix_socket_path=True)
     db.connect(db_name, False)
     _hash = table_name + db.get_db_separator(db_name) + warm_app_name
     client = db.get_redis_client(db_name)
@@ -213,7 +213,7 @@ def hget_warm_restart_table(db_name, table_name, warm_app_name, key):
 
 
 def hdel_warm_restart_table(db_name, table_name, warm_app_name, key):
-    db = SonicV2Connector()
+    db = SonicV2Connector(use_unix_socket_path=True)
     db.connect(db_name, False)
     _hash = table_name + db.get_db_separator(db_name) + warm_app_name
     client = db.get_redis_client(db_name)
@@ -735,7 +735,7 @@ def upgrade_docker(container_name, url, cleanup_image, skip_check, tag, warm):
 
     warm_configured = False
     # warm restart enable/disable config is put in stateDB, not persistent across cold reboot, not saved to config_DB.json file
-    state_db = SonicV2Connector(host='127.0.0.1')
+    state_db = SonicV2Connector(use_unix_socket_path=True)
     state_db.connect(state_db.STATE_DB, False)
     TABLE_NAME_SEPARATOR = '|'
     prefix = 'WARM_RESTART_ENABLE_TABLE' + TABLE_NAME_SEPARATOR

--- a/tests/sonic_installer_tests.py
+++ b/tests/sonic_installer_tests.py
@@ -1,0 +1,11 @@
+from sonic_installer.main import sonic_installer
+from click.testing import CliRunner
+from unittest.mock import patch, Mock
+
+@patch("sonic_installer.main.run_command")
+@patch("sonic_installer.main.SonicV2Connector")
+def test_upgrade_docker_use_unix_socket_path(sonicv2connector, run_command, fs):
+    runner = CliRunner()
+    fs.create_file('docker.gz')
+    result = runner.invoke(sonic_installer.commands['upgrade-docker'], ['swss', 'docker.gz', '-y'])
+    sonicv2connector.assert_called_with(use_unix_socket_path=True)

--- a/tests/sonic_installer_tests.py
+++ b/tests/sonic_installer_tests.py
@@ -7,5 +7,7 @@ from unittest.mock import patch, Mock
 def test_upgrade_docker_use_unix_socket_path(sonicv2connector, run_command, fs):
     runner = CliRunner()
     fs.create_file('docker.gz')
-    result = runner.invoke(sonic_installer.commands['upgrade-docker'], ['swss', 'docker.gz', '-y'])
+    result = runner.invoke(sonic_installer.commands['upgrade-docker'], ['swss', 'docker.gz', '-y', '--warm', '--dont-wait'])
     sonicv2connector.assert_called_with(use_unix_socket_path=True)
+    print(result.exception)
+    assert result.exit_code == 0


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Use unix socket instead of TCP to localhost since interfaces-config.service restart might interrupt the connection.

#### How I did it

Use unix socket.

#### How to verify it

Restart interfaces-config.service when executing sonic_installer command.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

