### PR TITLE
[202012] Stop PMON before stopping BGP while doing warmboot/fastboot

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -612,6 +612,13 @@ debug "Stopping radv service..."
 systemctl stop radv
 debug "Stopped radv service..."
 
+# Kill pmon before stopping BGP/teamd/swss/syncd to prevent error log
+if [[ "x$sonic_asic_type" == x"mellanox" ]]; then
+    debug "Stopping pmon ..."
+    systemctl stop pmon
+    debug "Stopped  pmon ..."
+fi
+
 # Kill bgpd to start the bgp graceful restart procedure
 debug "Stopping bgp ..."
 systemctl stop bgp

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -613,11 +613,9 @@ systemctl stop radv
 debug "Stopped radv service..."
 
 # Kill pmon before stopping BGP/teamd/swss/syncd to prevent error log
-if [[ "x$sonic_asic_type" == x"mellanox" ]]; then
-    debug "Stopping pmon ..."
-    systemctl stop pmon
-    debug "Stopped  pmon ..."
-fi
+debug "Stopping pmon ..."
+systemctl stop pmon
+debug "Stopped  pmon ..."
 
 # Kill bgpd to start the bgp graceful restart procedure
 debug "Stopping bgp ..."


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

This is the PR for 202012 only as https://github.com/Azure/sonic-buildimage/pull/10046 cannot be cherry-picked to 202012.

Stopping swss and syncd causes some driver module unloading. Those driver modules are depended by PMON. This could trigger ERROR logs in syslog like:

```
Failed to run thermal policy all fan and psu presence
```

#### How I did it

Adjust warmboot shutdown order in make file

#### How to verify it

Manual test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

