### PR TITLE
[generic-config-updater] Add caclrule validator

### DIFF
--- a/generic_config_updater/change_applier.py
+++ b/generic_config_updater/change_applier.py
@@ -107,7 +107,7 @@ class ChangeApplier:
 
         for cmd in lst_cmds:
             ret = self._invoke_cmd(cmd, old_cfg, upd_cfg, keys)
-            if ret:
+            if not ret:
                 log_error("service invoked: {} failed with ret={}".format(cmd, ret))
                 return ret
             log_debug("service invoked: {}".format(cmd))

--- a/generic_config_updater/generic_config_updater.conf.json
+++ b/generic_config_updater/generic_config_updater.conf.json
@@ -44,7 +44,7 @@
             "services_to_validate": [ "vlan-service" ]
         },
         "ACL_RULE": {
-            "services_to_validate": [ "caclrule-service" ]
+            "services_to_validate": [ "caclmgrd-service" ]
         }
     },
     "services": {
@@ -63,8 +63,8 @@
         "vlan-service": {
             "validate_commands": [ "generic_config_updater.services_validator.vlan_validator" ]
         },
-        "caclrule-service": {
-            "validate_commands": [ "generic_config_updater.services_validator.caclrule_validator" ]
+        "caclmgrd-service": {
+            "validate_commands": [ "generic_config_updater.services_validator.caclmgrd_validator" ]
         }
     }
 }

--- a/generic_config_updater/generic_config_updater.conf.json
+++ b/generic_config_updater/generic_config_updater.conf.json
@@ -42,6 +42,9 @@
         },
         "VLAN": {
             "services_to_validate": [ "vlan-service" ]
+        },
+        "ACL_RULE": {
+            "services_to_validate": [ "caclrule-service" ]
         }
     },
     "services": {
@@ -59,6 +62,9 @@
         },
         "vlan-service": {
             "validate_commands": [ "generic_config_updater.services_validator.vlan_validator" ]
+        },
+        "caclrule-service": {
+            "validate_commands": [ "generic_config_updater.services_validator.caclrule_validator" ]
         }
     }
 }

--- a/generic_config_updater/services_validator.py
+++ b/generic_config_updater/services_validator.py
@@ -93,8 +93,8 @@ def caclmgrd_validator(old_config, upd_config, keys):
         if (old_aclrule.get(key, {}) != upd_aclrule.get(key, {})):
             # caclmgrd will update in 0.5 sec when configuration stops,
             # we sleep 1 sec to make sure it does update.
-            rc = os.system("sleep 1s")
-            return rc == 0
+            time.sleep(1)
+            return True
     # No update to ACL_RULE.
     return True
 

--- a/generic_config_updater/services_validator.py
+++ b/generic_config_updater/services_validator.py
@@ -71,3 +71,16 @@ def vlan_validator(old_config, upd_config, keys):
     # No update to DHCP servers.
     return True
 
+def caclrule_validator(old_config, upd_config, keys):
+    old_caclrule = old_config.get("ACL_RULE", {})
+    upd_caclrule = upd_config.get("ACL_RULE", {})
+
+    for key in set(old_caclrule.keys()).union(set(upd_caclrule.keys())):
+        if (old_caclrule.get(key, {}) != upd_caclrule.get(key, {})):
+            # caclmgrd will update in 0.5 sec when configuration stops,
+            # we sleep 1 sec to make sure it does update.
+            rc = os.system("sleep 1s")
+            return rc == 0
+    # No update to ACL_RULE.
+    return True
+

--- a/tests/generic_config_updater/change_applier_test.py
+++ b/tests/generic_config_updater/change_applier_test.py
@@ -158,6 +158,7 @@ def system_health(old_cfg, new_cfg, keys):
     if svcs != None:
         assert svc_name in svcs
         svcs.remove(svc_name)
+    return True
 
 
 def _validate_keys(keys):
@@ -201,11 +202,13 @@ def _validate_svc(svc_name, old_cfg, new_cfg, keys):
 def acl_validate(old_cfg, new_cfg, keys):
     debug_print("acl_validate called")
     _validate_svc("acl_validate", old_cfg, new_cfg, keys)
+    return True
 
 
 def vlan_validate(old_cfg, new_cfg, keys):
     debug_print("vlan_validate called")
     _validate_svc("vlan_validate", old_cfg, new_cfg, keys)
+    return True
 
 
 class TestChangeApplier(unittest.TestCase):

--- a/tests/generic_config_updater/service_validator_test.py
+++ b/tests/generic_config_updater/service_validator_test.py
@@ -63,46 +63,69 @@ test_data = [
 test_caclrule = [
         { "old": {}, "upd": {}, "cmd": "" },
         {
-            "old": { "ACL_RULE": {
-                "XXX": { "SRC_IP": "10.10.10.10/16",
-                         "PRIORITY": "9999",
-                         "PACKET_ACTION": "ACCEPT"} } },
-            "upd": { "ACL_RULE": {
-                "XXX": { "SRC_IP": "10.10.10.10/16",
-                         "PRIORITY": "9999",
-                         "PACKET_ACTION": "ACCEPT"} } },
+            "old": {
+                "ACL_TABLE": { "XXX": { "type": "CTRLPLANE" } },
+                "ACL_RULE": { "XXX|RULE_1": { "SRC_IP": "10.10.10.10/16" } }
+            },
+            "upd": {
+                "ACL_TABLE": { "XXX": { "type": "CTRLPLANE" } },
+                "ACL_RULE": { "XXX|RULE_1": { "SRC_IP": "10.10.10.10/16" } }
+            },
             "cmd": ""
         },
         {
-            "old": { "ACL_RULE": {
-                "XXX": { "SRC_IP": "10.10.10.10/16",
-                         "PRIORITY": "9999",
-                         "PACKET_ACTION": "ACCEPT"} } },
-            "upd": { "ACL_RULE": {
-                "XXX": { "SRC_IP": "11.11.11.11/16",
-                         "PRIORITY": "9999",
-                         "PACKET_ACTION": "ACCEPT"} } },
+            "old": {
+                "ACL_TABLE": {
+                    "XXX": { "type": "CTRLPLANE" },
+                    "YYY": { "type": "L3" }
+                },
+                "ACL_RULE": {
+                    "XXX|RULE_1": { "SRC_IP": "10.10.10.10/16" },
+                    "YYY|RULE_1": { "SRC_IP": "192.168.1.10/32" }
+                }
+            },
+            "upd": {
+                "ACL_TABLE": {
+                    "XXX": { "type": "CTRLPLANE" }
+                },
+                "ACL_RULE": {
+                    "XXX|RULE_1": { "SRC_IP": "10.10.10.10/16" }
+                }
+            },
+            "cmd": ""
+        },
+        {
+            "old": {
+                "ACL_TABLE": { "XXX": { "type": "CTRLPLANE" } },
+                "ACL_RULE": { "XXX|RULE_1": { "SRC_IP": "10.10.10.10/16" } }
+            },
+            "upd": {
+                "ACL_TABLE": { "XXX": { "type": "CTRLPLANE" } },
+                "ACL_RULE": { "XXX|RULE_1": { "SRC_IP": "11.11.11.11/16" } }
+            },
             "cmd": "sleep 1s"
         },
         {
-            "old": { "ACL_RULE": {
-                "XXX": { "SRC_IP": "10.10.10.10/16",
-                         "PRIORITY": "9999",
-                         "PACKET_ACTION": "ACCEPT"} } },
-            "upd": { "ACL_RULE": {
-                "XXX": { "SRC_IP": "10.10.10.10/16",
-                         "PRIORITY": "9999",
-                         "PACKET_ACTION": "ACCEPT" },
-                "YYY": { "SRC_IP": "12.12.12.12/16",
-                         "PRIORITY": "9998",
-                         "PACKET_ACTION": "ACCEPT"} } },
+            "old": {
+                "ACL_TABLE": { "XXX": { "type": "CTRLPLANE" } },
+                "ACL_RULE": {
+                    "XXX|RULE_1": { "SRC_IP": "10.10.10.10/16" }
+                }
+            },
+            "upd": {
+                "ACL_TABLE": { "XXX": { "type": "CTRLPLANE" } },
+                "ACL_RULE": {
+                    "XXX|RULE_1": { "SRC_IP": "10.10.10.10/16" },
+                    "XXX|RULE_2": { "SRC_IP": "12.12.12.12/16" }
+                }
+            },
             "cmd": "sleep 1s"
         },
         {
-            "old": { "ACL_RULE": {
-                "XXX": { "SRC_IP": "10.10.10.10/16",
-                         "PRIORITY": "9999",
-                         "PACKET_ACTION": "ACCEPT"} } },
+            "old": {
+                "ACL_TABLE": { "XXX": { "type": "CTRLPLANE" } },
+                "ACL_RULE": { "XXX|RULE_1": { "SRC_IP": "10.10.10.10/16" } }
+            },
             "upd": {},
             "cmd": "sleep 1s"
         },

--- a/tests/generic_config_updater/service_validator_test.py
+++ b/tests/generic_config_updater/service_validator_test.py
@@ -6,7 +6,7 @@ import unittest
 from collections import defaultdict
 from unittest.mock import patch
 
-from generic_config_updater.services_validator import vlan_validator, rsyslog_validator
+from generic_config_updater.services_validator import vlan_validator, rsyslog_validator, caclrule_validator
 import generic_config_updater.gu_common
 
 
@@ -60,6 +60,54 @@ test_data = [
         }
     ]
 
+test_caclrule = [
+        { "old": {}, "upd": {}, "cmd": "" },
+        {
+            "old": { "ACL_RULE": {
+                "XXX": { "SRC_IP": "10.10.10.10/16",
+                         "PRIORITY": "9999",
+                         "PACKET_ACTION": "ACCEPT"} } },
+            "upd": { "ACL_RULE": {
+                "XXX": { "SRC_IP": "10.10.10.10/16",
+                         "PRIORITY": "9999",
+                         "PACKET_ACTION": "ACCEPT"} } },
+            "cmd": ""
+        },
+        {
+            "old": { "ACL_RULE": {
+                "XXX": { "SRC_IP": "10.10.10.10/16",
+                         "PRIORITY": "9999",
+                         "PACKET_ACTION": "ACCEPT"} } },
+            "upd": { "ACL_RULE": {
+                "XXX": { "SRC_IP": "11.11.11.11/16",
+                         "PRIORITY": "9999",
+                         "PACKET_ACTION": "ACCEPT"} } },
+            "cmd": "sleep 1s"
+        },
+        {
+            "old": { "ACL_RULE": {
+                "XXX": { "SRC_IP": "10.10.10.10/16",
+                         "PRIORITY": "9999",
+                         "PACKET_ACTION": "ACCEPT"} } },
+            "upd": { "ACL_RULE": {
+                "XXX": { "SRC_IP": "10.10.10.10/16",
+                         "PRIORITY": "9999",
+                         "PACKET_ACTION": "ACCEPT" },
+                "YYY": { "SRC_IP": "12.12.12.12/16",
+                         "PRIORITY": "9998",
+                         "PACKET_ACTION": "ACCEPT"} } },
+            "cmd": "sleep 1s"
+        },
+        {
+            "old": { "ACL_RULE": {
+                "XXX": { "SRC_IP": "10.10.10.10/16",
+                         "PRIORITY": "9999",
+                         "PACKET_ACTION": "ACCEPT"} } },
+            "upd": {},
+            "cmd": "sleep 1s"
+        },
+    ]
+
 test_rsyslog_fail = [
         # Fail the calls, to get the entire fail path calls invoked
         #
@@ -80,13 +128,20 @@ class TestServiceValidator(unittest.TestCase):
 
         mock_os_sys.side_effect = mock_os_system_call
 
-        i = 0
         for entry in test_data:
             if entry["cmd"]:
                 os_system_calls.append({"cmd": entry["cmd"], "rc": 0 })
             msg = "case failed: {}".format(str(entry))
 
             vlan_validator(entry["old"], entry["upd"], None)
+
+
+        for entry in test_caclrule:
+            if entry["cmd"]:
+                os_system_calls.append({"cmd": entry["cmd"], "rc": 0 })
+            msg = "case failed: {}".format(str(entry))
+
+            caclrule_validator(entry["old"], entry["upd"], None)
 
 
         # Test failure case

--- a/tests/generic_config_updater/service_validator_test.py
+++ b/tests/generic_config_updater/service_validator_test.py
@@ -6,7 +6,7 @@ import unittest
 from collections import defaultdict
 from unittest.mock import patch
 
-from generic_config_updater.services_validator import vlan_validator, rsyslog_validator, caclrule_validator
+from generic_config_updater.services_validator import vlan_validator, rsyslog_validator, caclmgrd_validator
 import generic_config_updater.gu_common
 
 
@@ -164,7 +164,7 @@ class TestServiceValidator(unittest.TestCase):
                 os_system_calls.append({"cmd": entry["cmd"], "rc": 0 })
             msg = "case failed: {}".format(str(entry))
 
-            caclrule_validator(entry["old"], entry["upd"], None)
+            caclmgrd_validator(entry["old"], entry["upd"], None)
 
 
         # Test failure case

--- a/tests/generic_config_updater/service_validator_test.py
+++ b/tests/generic_config_updater/service_validator_test.py
@@ -14,6 +14,8 @@ import generic_config_updater.gu_common
 #
 os_system_calls = []
 os_system_call_index = 0
+time_sleep_calls = []
+time_sleep_call_index = 0
 msg = ""
 
 def mock_os_system_call(cmd):
@@ -25,6 +27,15 @@ def mock_os_system_call(cmd):
 
     assert cmd == entry["cmd"], msg
     return entry["rc"]
+
+def mock_time_sleep_call(sleep_time):
+    global time_sleep_calls, time_sleep_call_index
+
+    assert time_sleep_call_index < len(time_sleep_calls)
+    entry = time_sleep_calls[time_sleep_call_index]
+    time_sleep_call_index += 1
+
+    assert sleep_time == entry["sleep_time"], msg
 
 
 test_data = [
@@ -61,7 +72,7 @@ test_data = [
     ]
 
 test_caclrule = [
-        { "old": {}, "upd": {}, "cmd": "" },
+        { "old": {}, "upd": {}, "sleep_time": 0 },
         {
             "old": {
                 "ACL_TABLE": { "XXX": { "type": "CTRLPLANE" } },
@@ -71,7 +82,7 @@ test_caclrule = [
                 "ACL_TABLE": { "XXX": { "type": "CTRLPLANE" } },
                 "ACL_RULE": { "XXX|RULE_1": { "SRC_IP": "10.10.10.10/16" } }
             },
-            "cmd": ""
+            "sleep_time": 0
         },
         {
             "old": {
@@ -92,7 +103,7 @@ test_caclrule = [
                     "XXX|RULE_1": { "SRC_IP": "10.10.10.10/16" }
                 }
             },
-            "cmd": ""
+            "sleep_time": 0
         },
         {
             "old": {
@@ -103,7 +114,7 @@ test_caclrule = [
                 "ACL_TABLE": { "XXX": { "type": "CTRLPLANE" } },
                 "ACL_RULE": { "XXX|RULE_1": { "SRC_IP": "11.11.11.11/16" } }
             },
-            "cmd": "sleep 1s"
+            "sleep_time": 1
         },
         {
             "old": {
@@ -119,7 +130,7 @@ test_caclrule = [
                     "XXX|RULE_2": { "SRC_IP": "12.12.12.12/16" }
                 }
             },
-            "cmd": "sleep 1s"
+            "sleep_time": 1
         },
         {
             "old": {
@@ -127,7 +138,7 @@ test_caclrule = [
                 "ACL_RULE": { "XXX|RULE_1": { "SRC_IP": "10.10.10.10/16" } }
             },
             "upd": {},
-            "cmd": "sleep 1s"
+            "sleep_time": 1
         },
     ]
 
@@ -141,12 +152,10 @@ test_rsyslog_fail = [
         { "cmd": "systemctl restart rsyslog", "rc": 1 },         # restart again; fails
     ]
 
-
 class TestServiceValidator(unittest.TestCase):
 
     @patch("generic_config_updater.change_applier.os.system")
-    def test_change_apply(self, mock_os_sys):
-        global os_system_expected_cmd
+    def test_change_apply_os_system(self, mock_os_sys):
         global os_system_calls, os_system_call_index
 
         mock_os_sys.side_effect = mock_os_system_call
@@ -159,13 +168,6 @@ class TestServiceValidator(unittest.TestCase):
             vlan_validator(entry["old"], entry["upd"], None)
 
 
-        for entry in test_caclrule:
-            if entry["cmd"]:
-                os_system_calls.append({"cmd": entry["cmd"], "rc": 0 })
-            msg = "case failed: {}".format(str(entry))
-
-            caclmgrd_validator(entry["old"], entry["upd"], None)
-
 
         # Test failure case
         #
@@ -174,4 +176,17 @@ class TestServiceValidator(unittest.TestCase):
 
         rc = rsyslog_validator("", "", "")
         assert not rc, "rsyslog_validator expected to fail"
+
+    @patch("generic_config_updater.services_validator.time.sleep")
+    def test_change_apply_time_sleep(self, mock_time_sleep):
+        global time_sleep_calls, time_sleep_call_index
+
+        mock_time_sleep.side_effect = mock_time_sleep_call
+
+        for entry in test_caclrule:
+            if entry["sleep_time"]:
+                time_sleep_calls.append({"sleep_time": entry["sleep_time"]})
+            msg = "case failed: {}".format(str(entry))
+
+            caclmgrd_validator(entry["old"], entry["upd"], None)
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
After the json patch could be gathered in some way, it should fix nightly random failure issue.
#### What I did
When gcu make change to control plane ACL_RULE, the iptables doen't change immediately. There is a delay because caclmgr will update in 0.5 sec if no more update being made to config. So I add a caclrule validator to make sure the iptable is updated.
#### How I did it
When caclrule is being changed, add a 1sec sleep to make sure caclmgr does update.
#### How to verify it
Run sonic-utilities unit test
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

