### PR TITLE
[GCU] Marking fields under MIRROR_SESSION as create-only

### DIFF
--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -589,6 +589,7 @@ class CreateOnlyMoveValidator:
                 ["BGP_MONITORS", "*", "local_addr"],
                 ["BGP_MONITORS", "*", "nhopself"],
                 ["BGP_MONITORS", "*", "rrclient"],
+                ["MIRROR_SESSION", "*", "*"],
             ],
             path_addressing)
 

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -1033,6 +1033,15 @@ class TestCreateOnlyMoveValidator(unittest.TestCase):
                     "nhopself": "0",
                     "rrclient": "0"
                 }
+            },
+            "MIRROR_SESSION": {
+                "mirror_session_dscp": {
+                    "dscp": "5",
+                    "dst_ip": "2.2.2.2",
+                    "src_ip": "1.1.1.1",
+                    "ttl": "32",
+                    "type": "ERSPAN"
+                }
             }
         }
         expected = [
@@ -1058,6 +1067,11 @@ class TestCreateOnlyMoveValidator(unittest.TestCase):
             "/BGP_MONITORS/5.6.7.8/name",
             "/BGP_MONITORS/5.6.7.8/nhopself",
             "/BGP_MONITORS/5.6.7.8/rrclient",
+            "/MIRROR_SESSION/mirror_session_dscp/dscp",
+            "/MIRROR_SESSION/mirror_session_dscp/dst_ip",
+            "/MIRROR_SESSION/mirror_session_dscp/src_ip",
+            "/MIRROR_SESSION/mirror_session_dscp/ttl",
+            "/MIRROR_SESSION/mirror_session_dscp/type",
         ]
 
         actual = self.validator._get_create_only_paths(config)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix https://github.com/Azure/sonic-utilities/issues/2068

Changes to fields under MIRROR_SESSION using GCU are not reflected and removal will result in orchagent crash unless each key is deleted and added back. This means the fields are create-only.
#### How I did it
Mark the fields under MIRROR_SESSION as create-only
#### How to verify it
unit-test
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

