### PR TITLE
[show] add support for hwstatus in show muxcable status (#1961)

### DIFF
--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -29,8 +29,18 @@ VENDOR_MODEL_REGEX = re.compile(r"CAC\w{3}321P2P\w{2}MS")
 
 # Helper functions
 
+
 def db_connect(db_name, namespace=EMPTY_NAMESPACE):
     return swsscommon.DBConnector(db_name, REDIS_TIMEOUT_MSECS, True, namespace)
+
+
+target_dict = { "NIC":"0",
+                "TORA":"1",
+                "TORB":"2",
+                "LOCAL":"3"}
+
+def parse_target(target):
+    return target_dict.get(target, None)
 
 def get_value_for_key_in_dict(mdict, port, key, table_name):
     value = mdict.get(key, None)
@@ -38,6 +48,7 @@ def get_value_for_key_in_dict(mdict, port, key, table_name):
         click.echo("could not retrieve key {} value for port {} inside table {}".format(key, port, table_name))
         sys.exit(CONFIG_FAIL)
     return value
+
 
 def delete_all_keys_in_db_table(db_type, table_name):
 
@@ -55,13 +66,13 @@ def delete_all_keys_in_db_table(db_type, table_name):
             table[asic_id]._del(key)
 
 
-def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_name, rsp_table_name, port, cmd_timeout_secs, arg=None):
+def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_name, cmd_arg_table_name, rsp_table_name, port, cmd_timeout_secs, param_dict=None, arg=None):
 
     res_dict = {}
     state_db, appl_db = {}, {}
     firmware_rsp_tbl, firmware_rsp_tbl_keys = {}, {}
     firmware_rsp_sub_tbl = {}
-    firmware_cmd_tbl = {}
+    firmware_cmd_tbl, firmware_cmd_arg_tbl = {}, {}
 
     CMD_TIMEOUT_SECS = cmd_timeout_secs
 
@@ -74,6 +85,8 @@ def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_
         state_db[asic_id] = db_connect("STATE_DB", namespace)
         appl_db[asic_id] = db_connect("APPL_DB", namespace)
         firmware_cmd_tbl[asic_id] = swsscommon.Table(appl_db[asic_id], cmd_table_name)
+        if cmd_arg_table_name is not None:
+            firmware_cmd_arg_tbl[asic_id] = swsscommon.Table(appl_db[asic_id], cmd_arg_table_name)
         firmware_rsp_sub_tbl[asic_id] = swsscommon.SubscriberStateTable(state_db[asic_id], rsp_table_name)
         firmware_rsp_tbl[asic_id] = swsscommon.Table(state_db[asic_id], rsp_table_name)
         firmware_rsp_tbl_keys[asic_id] = firmware_rsp_tbl[asic_id].getKeys()
@@ -108,6 +121,11 @@ def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_
         cmd_arg = "null"
     else:
         cmd_arg = str(arg)
+
+    if param_dict is not None:
+        for key, value in param_dict.items():
+            fvs = swsscommon.FieldValuePairs([(str(key), str(value))])
+            firmware_cmd_arg_tbl[asic_index].set(port, fvs)
 
     fvs = swsscommon.FieldValuePairs([(cmd_name, cmd_arg)])
     firmware_cmd_tbl[asic_index].set(port, fvs)
@@ -161,7 +179,6 @@ def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_
                 # check if xcvrd got a probe command
                 result = fvp_dict[rsp_name]
 
-
                 if result == exp_rsp:
                     res_dict[1] = result
                     res_dict[0] = 0
@@ -186,6 +203,7 @@ def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_
 
     return res_dict
 
+
 def get_value_for_key_in_config_tbl(config_db, port, key, table):
     info_dict = {}
     info_dict = config_db.get_entry(table, port)
@@ -200,6 +218,7 @@ def get_value_for_key_in_config_tbl(config_db, port, key, table):
 #
 # 'muxcable' command ("config muxcable")
 #
+
 
 @click.group(name='muxcable', cls=clicommon.AliasedGroup)
 def muxcable():
@@ -416,35 +435,96 @@ def prbs():
 
 
 @prbs.command()
-@click.argument('port', required=True, default=None, type=click.INT)
-@click.argument('target', required=True, default=None, type=click.INT)
+@click.argument('port', required=True, default=None)
+@click.argument('target', metavar='<target> NIC TORA TORB LOCAL', required=True, default=None, type=click.Choice(["NIC", "TORA", "TORB", "LOCAL"]))
 @click.argument('mode_value', required=True, default=None, type=click.INT)
-@click.argument('lane_map', required=True, default=None, type=click.INT)
-def enable(port, target, mode_value, lane_map):
-    """Enable PRBS mode on a port"""
+@click.argument('lane_mask', required=True, default=None, type=click.INT)
+@click.argument('prbs_direction', metavar='<PRBS_DIRECTION> PRBS_DIRECTION_BOTH = 0 PRBS_DIRECTION_GENERATOR = 1 PRBS_DIRECTION_CHECKER = 2', required=False, default="0", type=click.Choice(["0", "1", "2"]))
+@clicommon.pass_db
+def enable(db, port, target, mode_value, lane_mask, prbs_direction):
+    """Enable PRBS mode on a port args port target mode_value lane_mask prbs_direction
+       example sudo config mux prbs enable Ethernet48 0 3 3 0
+    """
 
-    import sonic_y_cable.y_cable
-    res = sonic_y_cable.y_cable.enable_prbs_mode(port, target, mode_value, lane_map)
-    if res != True:
-        click.echo("PRBS config unsuccesful")
-        sys.exit(CONFIG_FAIL)
-    click.echo("PRBS config sucessful")
-    sys.exit(CONFIG_SUCCESSFUL)
+    port = platform_sfputil_helper.get_interface_name(port, db)
+
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD")
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD_ARG")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_PRBS_RSP")
+
+    if port is not None:
+        click.confirm(('Muxcable at port {} will be changed to PRBS mode {} state; disable traffic Continue?'.format(
+            port, mode_value)), abort=True)
+
+        res_dict = {}
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+        param_dict = {}
+        target = parse_target(target)
+        param_dict["target"] = target
+        param_dict["mode_value"] = mode_value
+        param_dict["lane_mask"] = lane_mask
+        param_dict["direction"] = prbs_direction
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "config_prbs", "status", "True", "XCVRD_CONFIG_PRBS_CMD", "XCVRD_CONFIG_PRBS_CMD_ARG", "XCVRD_CONFIG_PRBS_RSP", port, 30, param_dict, "enable")
+
+        rc = res_dict[0]
+
+        port = platform_sfputil_helper.get_interface_alias(port, db)
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD")
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD_ARG")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_PRBS_RSP")
+
+        if rc == 0:
+            click.echo("Success in PRBS mode port {} to {}".format(port, mode_value))
+        else:
+            click.echo("ERR: Unable to set PRBS mode port {} to {}".format(port, mode_value))
+            sys.exit(CONFIG_FAIL)
 
 
 @prbs.command()
-@click.argument('port', required=True, default=None, type=click.INT)
-@click.argument('target', required=True, default=None, type=click.INT)
-def disable(port, target):
-    """Disable PRBS mode on a port"""
+@click.argument('port', required=True, default=None)
+@click.argument('target', metavar='<target> NIC TORA TORB LOCAL', required=True, default=None, type=click.Choice(["NIC", "TORA", "TORB", "LOCAL"]))
+@click.argument('prbs_direction',  metavar='<PRBS_DIRECTION> PRBS_DIRECTION_BOTH = 0 PRBS_DIRECTION_GENERATOR = 1 PRBS_DIRECTION_CHECKER = 2', required=False, default="0", type=click.Choice(["0", "1", "2"]))
+@clicommon.pass_db
+def disable(db, port, target, prbs_direction):
+    """Disable PRBS mode on a port
+       example sudo config mux prbs disable Ethernet48 0
+    """
+    port = platform_sfputil_helper.get_interface_name(port, db)
 
-    import sonic_y_cable.y_cable
-    res = sonic_y_cable.y_cable.disable_prbs_mode(port, target)
-    if res != True:
-        click.echo("PRBS disable unsuccesful")
-        sys.exit(CONFIG_FAIL)
-    click.echo("PRBS disable sucessful")
-    sys.exit(CONFIG_SUCCESSFUL)
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD")
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD_ARG")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_PRBS_RSP")
+
+    if port is not None:
+        click.confirm(('Muxcable at port {} will be changed to disable PRBS mode {} target; disable traffic Continue?'.format(
+            port, target)), abort=True)
+
+        res_dict = {}
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+        param_dict = {}
+        target = parse_target(target)
+        param_dict["target"] = target
+        param_dict["direction"] = prbs_direction
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "config_prbs", "status", "True", "XCVRD_CONFIG_PRBS_CMD", "XCVRD_CONFIG_PRBS_CMD_ARG", "XCVRD_CONFIG_PRBS_RSP", port, 30, param_dict, "disable")
+
+        rc = res_dict[0]
+
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD")
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD_ARG")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_PRBS_RSP")
+
+        port = platform_sfputil_helper.get_interface_alias(port, db)
+        if rc == 0:
+            click.echo("Success in disable PRBS mode port {} on target {}".format(port, target))
+        else:
+            click.echo("ERR: Unable to disable PRBS mode port {} on target {}".format(port, target))
+            sys.exit(CONFIG_FAIL)
 
 
 @muxcable.group(cls=clicommon.AbbreviationGroup)
@@ -454,34 +534,89 @@ def loopback():
 
 
 @loopback.command()
-@click.argument('port', required=True, default=None, type=click.INT)
-@click.argument('target', required=True, default=None, type=click.INT)
-@click.argument('lane_map', required=True, default=None, type=click.INT)
-def enable(port, target, lane_map):
-    """Enable loopback mode on a port"""
+@click.argument('port', required=True, default=None)
+@click.argument('target', metavar='<target> NIC TORA TORB LOCAL', required=True, default=None, type=click.Choice(["NIC", "TORA", "TORB", "LOCAL"]))
+@click.argument('lane_mask', required=True, default=None, type=click.INT)
+@click.argument('mode_value', required=False, metavar='<Loop mode> 1 LOOPBACK_MODE_NEAR_END 2 LOOPBACK_MODE_FAR_END', default="1", type=click.Choice(["1", "2"]))
+@clicommon.pass_db
+def enable(db, port, target, lane_mask, mode_value):
+    """Enable loopback mode on a port args port target lane_map mode_value"""
 
-    import sonic_y_cable.y_cable
-    res = sonic_y_cable.y_cable.enable_loopback_mode(port, target, lane_map)
-    if res != True:
-        click.echo("loopback config unsuccesful")
-        sys.exit(CONFIG_FAIL)
-    click.echo("loopback config sucessful")
-    sys.exit(CONFIG_SUCCESSFUL)
+    port = platform_sfputil_helper.get_interface_name(port, db)
+
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_LOOP_CMD")
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_LOOP_CMD_ARG")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_LOOP_RSP")
+
+    if port is not None:
+        click.confirm(('Muxcable at port {} will be changed to LOOP mode {} state; disable traffic Continue?'.format(
+            port, mode_value)), abort=True)
+
+        res_dict = {}
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+        param_dict = {}
+        target = parse_target(target)
+        param_dict["target"] = target
+        param_dict["mode_value"] = mode_value
+        param_dict["lane_mask"] = lane_mask
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "config_loop", "status", "True", "XCVRD_CONFIG_LOOP_CMD", "XCVRD_CONFIG_LOOP_CMD_ARG", "XCVRD_CONFIG_LOOP_RSP", port, 30, param_dict, "enable")
+
+        rc = res_dict[0]
+
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_LOOP_CMD")
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_LOOP_CMD_ARG")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_LOOP_RSP")
+
+        port = platform_sfputil_helper.get_interface_alias(port, db)
+        if rc == 0:
+            click.echo("Success in LOOP mode port {} to {}".format(port, mode_value))
+        else:
+            click.echo("ERR: Unable to set LOOP mode port {} to {}".format(port, mode_value))
+            sys.exit(CONFIG_FAIL)
 
 
 @loopback.command()
-@click.argument('port', required=True, default=None, type=click.INT)
-@click.argument('target', required=True, default=None, type=click.INT)
-def disable(port, target):
+@click.argument('port', required=True, default=None)
+@click.argument('target', metavar='<target> NIC TORA TORB LOCAL', required=True, default=None, type=click.Choice(["NIC", "TORA", "TORB", "LOCAL"]))
+@clicommon.pass_db
+def disable(db, port, target):
     """Disable loopback mode on a port"""
 
-    import sonic_y_cable.y_cable
-    res = sonic_y_cable.y_cable.disable_loopback_mode(port, target)
-    if res != True:
-        click.echo("loopback disable unsuccesful")
-        sys.exit(CONFIG_FAIL)
-    click.echo("loopback disable sucessful")
-    sys.exit(CONFIG_SUCCESSFUL)
+    port = platform_sfputil_helper.get_interface_name(port, db)
+
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_LOOP_CMD")
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_LOOP_CMD_ARG")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_LOOP_RSP")
+
+    if port is not None:
+        click.confirm(('Muxcable at port {} will be changed to disable LOOP mode {} state; disable traffic Continue?'.format(
+            port, target)), abort=True)
+
+        res_dict = {}
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+        param_dict = {}
+        target = parse_target(target)
+        param_dict["target"] = target
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "config_loop", "status", "True", "XCVRD_CONFIG_LOOP_CMD", "XCVRD_CONFIG_LOOP_CMD_ARG", "XCVRD_CONFIG_LOOP_RSP", port, 30, param_dict, "disable")
+
+        rc = res_dict[0]
+
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_LOOP_CMD")
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_LOOP_CMD_ARG")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_LOOP_RSP")
+
+        port = platform_sfputil_helper.get_interface_alias(port, db)
+        if rc == 0:
+            click.echo("Success in disable LOOP mode port {} to {}".format(port, target))
+        else:
+            click.echo("ERR: Unable to set disable LOOP mode port {} to {}".format(port, target))
+            sys.exit(CONFIG_FAIL)
 
 
 @muxcable.group(cls=clicommon.AbbreviationGroup)
@@ -506,9 +641,10 @@ def state(db, state, port):
         click.confirm(('Muxcable at port {} will be changed to {} state. Continue?'.format(port, state)), abort=True)
 
         res_dict = {}
-        res_dict [0] = CONFIG_FAIL
-        res_dict [1] = "unknown"
-        res_dict = update_and_get_response_for_xcvr_cmd("config","result", "True", "XCVRD_CONFIG_HWMODE_DIR_CMD", "XCVRD_CONFIG_HWMODE_DIR_RSP", port, 1, state)
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "config", "result", "True", "XCVRD_CONFIG_HWMODE_DIR_CMD", None, "XCVRD_CONFIG_HWMODE_DIR_RSP", port, 1, None, state)
 
         rc = res_dict[0]
 
@@ -554,10 +690,11 @@ def state(db, state, port):
                 continue
 
             res_dict = {}
-            res_dict [0] = CONFIG_FAIL
-            res_dict [1] = 'unknown'
+            res_dict[0] = CONFIG_FAIL
+            res_dict[1] = 'unknown'
 
-            res_dict = update_and_get_response_for_xcvr_cmd("config","result", "True", "XCVRD_CONFIG_HWMODE_DIR_CMD", "XCVRD_CONFIG_HWMODE_DIR_RSP", port, 1, state)
+            res_dict = update_and_get_response_for_xcvr_cmd(
+                "config", "result", "True", "XCVRD_CONFIG_HWMODE_DIR_CMD", None, "XCVRD_CONFIG_HWMODE_DIR_RSP", port, 1, None, state)
 
             rc = res_dict[0]
 
@@ -584,7 +721,6 @@ def setswitchmode(db, state, port):
 
     port = platform_sfputil_helper.get_interface_name(port, db)
 
-
     delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_HWMODE_SWMODE_CMD")
     delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_HWMODE_SWMODE_RSP")
 
@@ -592,9 +728,10 @@ def setswitchmode(db, state, port):
         click.confirm(('Muxcable at port {} will be changed to {} switching mode. Continue?'.format(port, state)), abort=True)
 
         res_dict = {}
-        res_dict [0] = CONFIG_FAIL
-        res_dict [1] = "unknown"
-        res_dict = update_and_get_response_for_xcvr_cmd("config", "result", "True", "XCVRD_CONFIG_HWMODE_SWMODE_CMD", "XCVRD_CONFIG_HWMODE_SWMODE_RSP", port, 1, state)
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "config", "result", "True", "XCVRD_CONFIG_HWMODE_SWMODE_CMD", None, "XCVRD_CONFIG_HWMODE_SWMODE_RSP", port, 1, None, state)
 
         rc = res_dict[0]
 
@@ -640,9 +777,10 @@ def setswitchmode(db, state, port):
                 continue
 
             res_dict = {}
-            res_dict [0] = CONFIG_FAIL
-            res_dict [1] = "unknown"
-            res_dict = update_and_get_response_for_xcvr_cmd("config", "result", "True", "XCVRD_CONFIG_HWMODE_SWMODE_CMD", "XCVRD_CONFIG_HWMODE_SWMODE_RSP", port, 1, state)
+            res_dict[0] = CONFIG_FAIL
+            res_dict[1] = "unknown"
+            res_dict = update_and_get_response_for_xcvr_cmd(
+                "config", "result", "True", "XCVRD_CONFIG_HWMODE_SWMODE_CMD", None, "XCVRD_CONFIG_HWMODE_SWMODE_RSP", port, 1, None, state)
 
             rc = res_dict[0]
 
@@ -681,9 +819,10 @@ def download(db, fwfile, port):
     if port is not None and port != "all":
 
         res_dict = {}
-        res_dict [0] = CONFIG_FAIL
-        res_dict [1] = "unknown"
-        res_dict = update_and_get_response_for_xcvr_cmd("download_firmware", "status", "0", "XCVRD_DOWN_FW_CMD", "XCVRD_DOWN_FW_RSP", port, 1000, fwfile)
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "download_firmware", "status", "0", "XCVRD_DOWN_FW_CMD", None, "XCVRD_DOWN_FW_RSP", port, 1000, None, fwfile)
 
         rc = res_dict[0]
 
@@ -730,9 +869,10 @@ def download(db, fwfile, port):
 
             res_dict = {}
 
-            res_dict [0] = CONFIG_FAIL
-            res_dict [1] = "unknown"
-            res_dict = update_and_get_response_for_xcvr_cmd("download_firmware", "status", "0", "XCVRD_DOWN_FW_CMD", "XCVRD_DOWN_FW_RSP", port, 1000, fwfile)
+            res_dict[0] = CONFIG_FAIL
+            res_dict[1] = "unknown"
+            res_dict = update_and_get_response_for_xcvr_cmd(
+                "download_firmware", "status", "0", "XCVRD_DOWN_FW_CMD", "XCVRD_DOWN_FW_RSP", port, 1000, fwfile)
 
             rc = res_dict[0]
 
@@ -753,21 +893,28 @@ def download(db, fwfile, port):
 @firmware.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
 @click.argument('fwfile', metavar='<firmware_file>', required=False, default=None)
+@click.option('--nonhitless', 'nonhitless', required=False, is_flag=True, type=click.BOOL)
 @clicommon.pass_db
-def activate(db, port, fwfile):
+def activate(db, port, fwfile, nonhitless):
     """Config muxcable firmware activate"""
 
     port = platform_sfputil_helper.get_interface_name(port, db)
 
     delete_all_keys_in_db_table("STATE_DB", "XCVRD_ACTI_FW_RSP")
     delete_all_keys_in_db_table("APPL_DB", "XCVRD_ACTI_FW_CMD")
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_ACTI_FW_CMD_ARG")
 
     if port is not None and port != "all":
 
         res_dict = {}
-        res_dict [0] = CONFIG_FAIL
-        res_dict [1] = "unknown"
-        res_dict = update_and_get_response_for_xcvr_cmd("activate_firmware", "status", "0", "XCVRD_ACTI_FW_CMD", "XCVRD_ACTI_FW_RSP", port, 60, fwfile)
+        param_dict = {}
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+        if nonhitless:
+            param_dict["hitless"] = "1"
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "activate_firmware", "status", "0", "XCVRD_ACTI_FW_CMD", "XCVRD_ACTI_FW_CMD_ARG", "XCVRD_ACTI_FW_RSP", port, 60, param_dict, fwfile)
 
         rc = res_dict[0]
 
@@ -813,12 +960,14 @@ def activate(db, port, fwfile):
 
             res_dict = {}
 
-            res_dict [0] = CONFIG_FAIL
-            res_dict [1] = "unknown"
-            res_dict = update_and_get_response_for_xcvr_cmd("activate_firmware", "status", "0", "XCVRD_ACTI_FW_CMD", "XCVRD_ACTI_FW_RSP", port, 60, fwfile)
+            res_dict[0] = CONFIG_FAIL
+            res_dict[1] = "unknown"
+            res_dict = update_and_get_response_for_xcvr_cmd(
+                "activate_firmware", "status", "0", "XCVRD_ACTI_FW_CMD", None, "XCVRD_ACTI_FW_RSP", port, 60, None, fwfile)
 
             delete_all_keys_in_db_table("STATE_DB", "XCVRD_ACTI_FW_RSP")
             delete_all_keys_in_db_table("APPL_DB", "XCVRD_ACTI_FW_CMD")
+            delete_all_keys_in_db_table("APPL_DB", "XCVRD_ACTI_FW_CMD_ARG")
 
             rc = res_dict[0]
 
@@ -848,9 +997,10 @@ def rollback(db, port, fwfile):
     if port is not None and port != "all":
 
         res_dict = {}
-        res_dict [0] = CONFIG_FAIL
-        res_dict [1] = "unknown"
-        res_dict = update_and_get_response_for_xcvr_cmd("rollback_firmware", "status", "0", "XCVRD_ROLL_FW_CMD", "XCVRD_ROLL_FW_RSP", port, 60, fwfile)
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "rollback_firmware", "status", "0", "XCVRD_ROLL_FW_CMD", None, "XCVRD_ROLL_FW_RSP", port, 60, None, fwfile)
 
         delete_all_keys_in_db_table("STATE_DB", "XCVRD_ROLL_FW_RSP")
         delete_all_keys_in_db_table("APPL_DB", "XCVRD_ROLL_FW_CMD")
@@ -896,9 +1046,10 @@ def rollback(db, port, fwfile):
 
             res_dict = {}
 
-            res_dict [0] = CONFIG_FAIL
-            res_dict [1] = "unknown"
-            res_dict = update_and_get_response_for_xcvr_cmd("rollback_firmware", "status", "0", "XCVRD_ROLL_FW_CMD", "XCVRD_ROLL_FW_RSP", port, 60, fwfile)
+            res_dict[0] = CONFIG_FAIL
+            res_dict[1] = "unknown"
+            res_dict = update_and_get_response_for_xcvr_cmd(
+                "rollback_firmware", "status", "0", "XCVRD_ROLL_FW_CMD", None, "XCVRD_ROLL_FW_RSP", port, 60, None, fwfile)
 
             delete_all_keys_in_db_table("STATE_DB", "XCVRD_ROLL_FW_RSP")
             delete_all_keys_in_db_table("APPL_DB", "XCVRD_ROLL_FW_CMD")
@@ -914,3 +1065,128 @@ def rollback(db, port, fwfile):
                 rc_exit = CONFIG_FAIL
 
         sys.exit(rc_exit)
+
+
+@muxcable.command()
+@click.argument('port', required=True, default=None)
+@click.argument('target', metavar='<target> NIC TORA TORB LOCAL', required=True, default=None, type=click.Choice(["NIC", "TORA", "TORB", "LOCAL"]))
+@clicommon.pass_db
+def reset(db, port, target):
+    """reset a target on the cable NIC TORA TORB Local """
+
+    port = platform_sfputil_helper.get_interface_name(port, db)
+
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD")
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD_ARG")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_PRBS_RSP")
+
+    if port is not None:
+        click.confirm(('Muxcable at port {} will be reset; CAUTION: disable traffic Continue?'.format(port)), abort=True)
+
+        res_dict = {}
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+        param_dict = {}
+        target = parse_target(target)
+        param_dict["target"] = target
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "config_prbs", "status", "True", "XCVRD_CONFIG_PRBS_CMD", "XCVRD_CONFIG_PRBS_CMD_ARG", "XCVRD_CONFIG_PRBS_RSP", port, 30, param_dict, "reset")
+
+        rc = res_dict[0]
+
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD")
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD_ARG")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_PRBS_RSP")
+
+        port = platform_sfputil_helper.get_interface_alias(port, db)
+        if rc == 0:
+            click.echo("Success in reset port {}".format(port))
+        else:
+            click.echo("ERR: Unable to reset port {}".format(port))
+            sys.exit(CONFIG_FAIL)
+
+
+@muxcable.command()
+@click.argument('port', required=True, default=None)
+@click.argument('target', metavar='<target> NIC TORA TORB LOCAL', required=True, default=None, type=click.Choice(["NIC", "TORA", "TORB", "LOCAL"]))
+@click.argument('mode', required=True, metavar='<mode> 0 disable 1 enable',  default=True, type=click.Choice(["0", "1"]))
+@clicommon.pass_db
+def set_anlt(db, port, target, mode):
+    """Enable anlt mode on a port args port <target> NIC TORA TORB LOCAL enable/disable 1/0"""
+
+    port = platform_sfputil_helper.get_interface_name(port, db)
+
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD")
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD_ARG")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_PRBS_RSP")
+
+    if port is not None:
+        click.confirm(
+            ('Muxcable at port {} will be changed to enable/disable anlt mode {} state; disable traffic Continue?'.format(port, mode)), abort=True)
+
+        res_dict = {}
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+        param_dict = {}
+        target = parse_target(target)
+        param_dict["target"] = target
+        param_dict["mode"] = mode
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "config_prbs", "status", "True", "XCVRD_CONFIG_PRBS_CMD", "XCVRD_CONFIG_PRBS_CMD_ARG", "XCVRD_CONFIG_PRBS_RSP", port, 30, param_dict, "anlt")
+
+        rc = res_dict[0]
+
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD")
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD_ARG")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_PRBS_RSP")
+
+        port = platform_sfputil_helper.get_interface_alias(port, db)
+        if rc == 0:
+            click.echo("Success in anlt enable/disable port {} to {}".format(port, mode))
+        else:
+            click.echo("ERR: Unable to set anlt enable/disable port {} to {}".format(port, mode))
+            sys.exit(CONFIG_FAIL)
+
+@muxcable.command()
+@click.argument('port', required=True, default=None)
+@click.argument('target', metavar='<target> NIC TORA TORB LOCAL', required=True, default=None, type=click.Choice(["NIC", "TORA", "TORB", "LOCAL"]))
+@click.argument('mode', required=True, metavar='<mode> FEC_MODE_NONE 0 FEC_MODE_RS 1 FEC_MODE_FC 2',  default=True, type=click.Choice(["0", "1", "2"]))
+@clicommon.pass_db
+def set_fec(db, port, target, mode):
+    """Enable fec mode on a port args port <target>  NIC TORA TORB LOCAL <mode_value> FEC_MODE_NONE 0 FEC_MODE_RS 1 FEC_MODE_FC 2 """
+
+    port = platform_sfputil_helper.get_interface_name(port, db)
+
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD")
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD_ARG")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_PRBS_RSP")
+
+    if port is not None:
+        click.confirm(
+            ('Muxcable at port {} will be changed to enable/disable fec mode {} state; disable traffic Continue?'.format(port, mode)), abort=True)
+
+        res_dict = {}
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+        param_dict = {}
+        target = parse_target(target)
+        param_dict["target"] = target
+        param_dict["mode"] = mode
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "config_prbs", "status", "True", "XCVRD_CONFIG_PRBS_CMD", "XCVRD_CONFIG_PRBS_CMD_ARG", "XCVRD_CONFIG_PRBS_RSP", port, 30, param_dict, "fec")
+
+        rc = res_dict[0]
+
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD")
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_CONFIG_PRBS_CMD_ARG")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_CONFIG_PRBS_RSP")
+
+        port = platform_sfputil_helper.get_interface_alias(port, db)
+        if rc == 0:
+            click.echo("Success in fec enable/disable port {} to {}".format(port, mode))
+        else:
+            click.echo("ERR: Unable to set fec enable/disable port {} to {}".format(port, mode))
+            sys.exit(CONFIG_FAIL)

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -25,26 +25,27 @@ import show.main as show
 
 
 tabular_data_status_output_expected = """\
-PORT        STATUS    HEALTH     LAST_SWITCHOVER_TIME
-----------  --------  ---------  ---------------------------
-Ethernet0   active    healthy    2021-May-13 10:01:15.696728
-Ethernet4   standby   healthy
-Ethernet8   standby   unhealthy
-Ethernet12  unknown   unhealthy
-Ethernet16  standby   healthy
-Ethernet32  active    healthy
+PORT        STATUS    HEALTH     HWSTATUS      LAST_SWITCHOVER_TIME
+----------  --------  ---------  ------------  ---------------------------
+Ethernet0   active    healthy    inconsistent  2021-May-13 10:01:15.696728
+Ethernet4   standby   healthy    consistent
+Ethernet8   standby   unhealthy  consistent
+Ethernet12  unknown   unhealthy  inconsistent
+Ethernet16  standby   healthy    consistent
+Ethernet32  active    healthy    inconsistent
 """
 
 tabular_data_status_output_expected_alias = """\
-PORT    STATUS    HEALTH     LAST_SWITCHOVER_TIME
-------  --------  ---------  ---------------------------
-etp1    active    healthy    2021-May-13 10:01:15.696728
-etp2    standby   healthy
-etp3    standby   unhealthy
-etp4    unknown   unhealthy
-etp5    standby   healthy
-etp9    active    healthy
+PORT    STATUS    HEALTH     HWSTATUS      LAST_SWITCHOVER_TIME
+------  --------  ---------  ------------  ---------------------------
+etp1    active    healthy    inconsistent  2021-May-13 10:01:15.696728
+etp2    standby   healthy    consistent
+etp3    standby   unhealthy  consistent
+etp4    unknown   unhealthy  inconsistent
+etp5    standby   healthy    consistent
+etp9    active    healthy    inconsistent
 """
+
 
 json_data_status_output_expected = """\
 {
@@ -52,31 +53,37 @@ json_data_status_output_expected = """\
         "Ethernet0": {
             "STATUS": "active",
             "HEALTH": "healthy",
+            "HWSTATUS": "inconsistent",
             "LAST_SWITCHOVER_TIME": "2021-May-13 10:01:15.696728"
         },
         "Ethernet4": {
             "STATUS": "standby",
             "HEALTH": "healthy",
+            "HWSTATUS": "consistent",
             "LAST_SWITCHOVER_TIME": ""
         },
         "Ethernet8": {
             "STATUS": "standby",
             "HEALTH": "unhealthy",
+            "HWSTATUS": "consistent",
             "LAST_SWITCHOVER_TIME": ""
         },
         "Ethernet12": {
             "STATUS": "unknown",
             "HEALTH": "unhealthy",
+            "HWSTATUS": "inconsistent",
             "LAST_SWITCHOVER_TIME": ""
         },
         "Ethernet16": {
             "STATUS": "standby",
             "HEALTH": "healthy",
+            "HWSTATUS": "consistent",
             "LAST_SWITCHOVER_TIME": ""
         },
         "Ethernet32": {
             "STATUS": "active",
             "HEALTH": "healthy",
+            "HWSTATUS": "inconsistent",
             "LAST_SWITCHOVER_TIME": ""
         }
     }
@@ -89,31 +96,37 @@ json_data_status_output_expected_alias = """\
         "etp1": {
             "STATUS": "active",
             "HEALTH": "healthy",
+            "HWSTATUS": "inconsistent",
             "LAST_SWITCHOVER_TIME": "2021-May-13 10:01:15.696728"
         },
         "etp2": {
             "STATUS": "standby",
             "HEALTH": "healthy",
+            "HWSTATUS": "consistent",
             "LAST_SWITCHOVER_TIME": ""
         },
         "etp3": {
             "STATUS": "standby",
             "HEALTH": "unhealthy",
+            "HWSTATUS": "consistent",
             "LAST_SWITCHOVER_TIME": ""
         },
         "etp4": {
             "STATUS": "unknown",
             "HEALTH": "unhealthy",
+            "HWSTATUS": "inconsistent",
             "LAST_SWITCHOVER_TIME": ""
         },
         "etp5": {
             "STATUS": "standby",
             "HEALTH": "healthy",
+            "HWSTATUS": "consistent",
             "LAST_SWITCHOVER_TIME": ""
         },
         "etp9": {
             "STATUS": "active",
             "HEALTH": "healthy",
+            "HWSTATUS": "inconsistent",
             "LAST_SWITCHOVER_TIME": ""
         }
     }
@@ -354,27 +367,27 @@ Credo     CACL1X321P2PA1M
 """
 
 show_muxcable_hwmode_muxdirection_active_expected_output = """\
-Port        Direction
-----------  -----------
-Ethernet12  active
+Port        Direction    Presence
+----------  -----------  ----------
+Ethernet12  active       True
 """
 
 show_muxcable_hwmode_muxdirection_active_expected_output_alias = """\
-Port    Direction
-------  -----------
-etp4    active
+Port    Direction    Presence
+------  -----------  ----------
+etp4    active       True
 """
 
 show_muxcable_hwmode_muxdirection_standby_expected_output = """\
-Port        Direction
-----------  -----------
-Ethernet12  standby
+Port        Direction    Presence
+----------  -----------  ----------
+Ethernet12  standby      True
 """
 
 show_muxcable_hwmode_muxdirection_standby_expected_output_alias = """\
-Port    Direction
-------  -----------
-etp4    standby
+Port    Direction    Presence
+------  -----------  ----------
+etp4    standby      True
 """
 
 show_muxcable_firmware_version_expected_output = """\
@@ -453,6 +466,9 @@ class TestMuxcable(object):
         #show.muxcable.platform_sfputil.logical = mock.Mock(return_value=["Ethernet0", "Ethernet4"])
         print("SETUP")
 
+    @mock.patch('show.muxcable.get_hwmode_mux_direction_port', mock.MagicMock(return_value=({ 0 :"active",
+                                                                                              1  :"standby",
+                                                                                              2 : "True"})))
     def test_muxcable_status(self):
         runner = CliRunner()
         db = Db()
@@ -461,6 +477,9 @@ class TestMuxcable(object):
         assert result.exit_code == 0
         assert result.output == tabular_data_status_output_expected
 
+    @mock.patch('show.muxcable.get_hwmode_mux_direction_port', mock.MagicMock(return_value=({ 0 :"active",
+                                                                                              1  :"standby",
+                                                                                              2 : "True"})))
     def test_muxcable_status_alias(self):
         runner = CliRunner()
         db = Db()
@@ -471,6 +490,9 @@ class TestMuxcable(object):
         assert result.exit_code == 0
         assert result.output == tabular_data_status_output_expected_alias
 
+    @mock.patch('show.muxcable.get_hwmode_mux_direction_port', mock.MagicMock(return_value=({ 0 :"active",
+                                                                                              1  :"standby",
+                                                                                              2 : "True"})))
     def test_muxcable_status_json(self):
         runner = CliRunner()
         db = Db()
@@ -480,6 +502,9 @@ class TestMuxcable(object):
         assert result.exit_code == 0
         assert result.output == json_data_status_output_expected
 
+    @mock.patch('show.muxcable.get_hwmode_mux_direction_port', mock.MagicMock(return_value=({ 0 :"active",
+                                                                                              1  :"standby",
+                                                                                              2 : "True"})))
     def test_muxcable_status_json_alias(self):
         runner = CliRunner()
         db = Db()
@@ -540,6 +565,9 @@ class TestMuxcable(object):
 
         assert result.exit_code == 1
 
+    @mock.patch('show.muxcable.get_hwmode_mux_direction_port', mock.MagicMock(return_value=({ 0 :"active",
+                                                                                              1  :"standby",
+                                                                                              2 : "True"})))
     def test_muxcable_status_json_with_correct_port(self):
         runner = CliRunner()
         db = Db()
@@ -549,6 +577,9 @@ class TestMuxcable(object):
 
         assert result.exit_code == 0
 
+    @mock.patch('show.muxcable.get_hwmode_mux_direction_port', mock.MagicMock(return_value=({ 0 :"active",
+                                                                                              1  :"standby",
+                                                                                              2 : "True"})))
     def test_muxcable_status_json_with_correct_port_alias(self):
         runner = CliRunner()
         db = Db()
@@ -561,6 +592,9 @@ class TestMuxcable(object):
         assert result.exit_code == 0
 
 
+    @mock.patch('show.muxcable.get_hwmode_mux_direction_port', mock.MagicMock(return_value=({ 0 :"active",
+                                                                                              1  :"standby",
+                                                                                              2 : "True"})))
     def test_muxcable_status_json_port_incorrect_index(self):
         runner = CliRunner()
         db = Db()
@@ -576,6 +610,9 @@ class TestMuxcable(object):
 
         result = runner.invoke(show.cli.commands["muxcable"], obj=db)
 
+    @mock.patch('show.muxcable.get_hwmode_mux_direction_port', mock.MagicMock(return_value=({ 0 :"active",
+                                                                                              1  :"standby",
+                                                                                              2 : "True"})))
     def test_muxcable_status_json_with_incorrect_port(self):
         runner = CliRunner()
         db = Db()
@@ -621,6 +658,9 @@ class TestMuxcable(object):
 
         assert result.exit_code == 1
 
+    @mock.patch('show.muxcable.get_hwmode_mux_direction_port', mock.MagicMock(return_value=({ 0 :"active",
+                                                                                              1  :"standby",
+                                                                                              2 : "True"})))
     def test_muxcable_status_json_port_eth0(self):
         runner = CliRunner()
         db = Db()
@@ -820,6 +860,12 @@ class TestMuxcable(object):
 
         assert result.exit_code == 0
 
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "active"}))
+    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={0: 0,
+                                                                          1: "active"}))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
     @mock.patch('os.geteuid', mock.MagicMock(return_value=0))
     @mock.patch('sonic_y_cable.y_cable.get_eye_info', mock.MagicMock(return_value=[0, 0]))
     def test_show_muxcable_eye_info(self):
@@ -827,62 +873,160 @@ class TestMuxcable(object):
         db = Db()
 
         result = runner.invoke(show.cli.commands["muxcable"].commands["eyeinfo"],
-                               ["0", "0"], obj=db)
+                               ["Ethernet0", "NIC"], obj=db)
 
         assert result.exit_code == 0
 
-    @mock.patch('os.geteuid', mock.MagicMock(return_value=0))
-    @mock.patch('sonic_y_cable.y_cable.get_ber_info', mock.MagicMock(return_value=[0, 0]))
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={0: 0,
+                                                                          1: "active"}))
+    def test_show_mux_debugdeumpregisters(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["debugdumpregisters"],
+                               ["Ethernet0"], obj=db)
+
+        assert result.exit_code == 0
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={0: 0,
+                                                                          1: "active"}))
+    def test_show_mux_pcsstatistics(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["pcsstatistics"],
+                               ["Ethernet0", "NIC"], obj=db)
+
+        assert result.exit_code == 0
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={0: 0,
+                                                                          1: "active"}))
+    def test_show_mux_fecstatistics(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["fecstatistics"],
+                               ["Ethernet0", "NIC"], obj=db)
+
+        assert result.exit_code == 0
+
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    @mock.patch('show.muxcable.get_event_logs', mock.MagicMock(return_value={0: 0,
+                                                                          2: "log"}))
+    def test_show_mux_event_log(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["event-log"],
+                               ["Ethernet0"], obj=db)
+
+        assert result.exit_code == 0
+
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={0: 0,
+                                                                          1: "active"}))
+    def test_show_mux_get_fec_anlt_speed(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["get-fec-anlt-speed"],
+                               ["Ethernet0"], obj=db)
+
+        assert result.exit_code == 0
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "active"}))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
     def test_show_muxcable_ber_info(self):
         runner = CliRunner()
         db = Db()
 
         result = runner.invoke(show.cli.commands["muxcable"].commands["berinfo"],
-                               ["0", "0"], obj=db)
+                               ["Ethernet0", "NIC"], obj=db)
 
         assert result.exit_code == 0
 
-    @mock.patch('os.geteuid', mock.MagicMock(return_value=0))
-    @mock.patch('sonic_y_cable.y_cable.enable_prbs_mode', mock.MagicMock(return_value=1))
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "active"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
     def test_config_muxcable_enable_prbs(self):
         runner = CliRunner()
         db = Db()
 
         result = runner.invoke(config.config.commands["muxcable"].commands["prbs"].commands["enable"],
-                               ["0", "0", "0", "0"], obj=db)
+                               ["Ethernet0", "NIC", "0", "0"], obj=db)
 
         assert result.exit_code == 0
 
-    @mock.patch('os.geteuid', mock.MagicMock(return_value=0))
-    @mock.patch('sonic_y_cable.y_cable.enable_loopback_mode', mock.MagicMock(return_value=1))
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "active"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
     def test_config_muxcable_enable_loopback(self):
         runner = CliRunner()
         db = Db()
 
         result = runner.invoke(config.config.commands["muxcable"].commands["loopback"].commands["enable"],
-                               ["0", "0", "0"], obj=db)
+                               ["Ethernet0", "NIC", "0"], obj=db)
 
         assert result.exit_code == 0
 
-    @mock.patch('os.geteuid', mock.MagicMock(return_value=0))
-    @mock.patch('sonic_y_cable.y_cable.disable_prbs_mode', mock.MagicMock(return_value=1))
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "active"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
     def test_config_muxcable_disble_prbs(self):
         runner = CliRunner()
         db = Db()
 
         result = runner.invoke(config.config.commands["muxcable"].commands["prbs"].commands["disable"],
-                               ["0", "0"], obj=db)
+                               ["Ethernet0", "NIC"], obj=db)
 
         assert result.exit_code == 0
 
-    @mock.patch('os.geteuid', mock.MagicMock(return_value=0))
-    @mock.patch('sonic_y_cable.y_cable.disable_loopback_mode', mock.MagicMock(return_value=1))
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "active"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
     def test_config_muxcable_disable_loopback(self):
         runner = CliRunner()
         db = Db()
 
         result = runner.invoke(config.config.commands["muxcable"].commands["loopback"].commands["disable"],
-                               ["0", "0"], obj=db)
+                               ["Ethernet0", "NIC"], obj=db)
 
         assert result.exit_code == 0
 
@@ -940,6 +1084,10 @@ class TestMuxcable(object):
     @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
                                                                                                       1: "active"}))
+    @mock.patch('show.muxcable.get_hwmode_mux_direction_port', mock.MagicMock(return_value={0: 0,
+                                                                                            1: "active",
+                                                                                            2: "True"}))
+    @mock.patch('show.muxcable.check_port_in_mux_cable_table', mock.MagicMock(return_value=True))
     @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
     @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
@@ -960,6 +1108,10 @@ class TestMuxcable(object):
     @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
                                                                                                       1: "active"}))
+    @mock.patch('show.muxcable.get_hwmode_mux_direction_port', mock.MagicMock(return_value={0: 0,
+                                                                                            1: "active",
+                                                                                            2: "True"}))
+    @mock.patch('show.muxcable.check_port_in_mux_cable_table', mock.MagicMock(return_value=True))
     @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
     @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
@@ -982,6 +1134,10 @@ class TestMuxcable(object):
     @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
                                                                                                       1: "standby"}))
+    @mock.patch('show.muxcable.get_hwmode_mux_direction_port', mock.MagicMock(return_value={0: 0,
+                                                                                            1: "standby",
+                                                                                            2: "True"}))
+    @mock.patch('show.muxcable.check_port_in_mux_cable_table', mock.MagicMock(return_value=True))
     @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
     @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
@@ -1000,6 +1156,10 @@ class TestMuxcable(object):
     @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
                                                                                                       1: "standby"}))
+    @mock.patch('show.muxcable.get_hwmode_mux_direction_port', mock.MagicMock(return_value={0: 0,
+                                                                                            1: "standby",
+                                                                                            2: "True"}))
+    @mock.patch('show.muxcable.check_port_in_mux_cable_table', mock.MagicMock(return_value=True))
     @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
     @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
@@ -1020,6 +1180,10 @@ class TestMuxcable(object):
     @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
                                                                                                       1: "standby"}))
+    @mock.patch('show.muxcable.get_hwmode_mux_direction_port', mock.MagicMock(return_value={0: 0,
+                                                                                            1: "standby",
+                                                                                            2: "True"}))
+    @mock.patch('show.muxcable.check_port_in_mux_cable_table', mock.MagicMock(return_value=True))
     @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
     @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
@@ -1042,6 +1206,578 @@ class TestMuxcable(object):
     @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
                                                                                                       1: "sucess"}))
+    @mock.patch('show.muxcable.get_hwmode_mux_direction_port', mock.MagicMock(return_value={0: 0,
+                                                                                            1: "sucess",
+                                                                                            2: "True"}))
+    @mock.patch('show.muxcable.check_port_in_mux_cable_table', mock.MagicMock(return_value=True))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.check_mux_direction', mock.MagicMock(return_value=(2)))
+    @mock.patch('re.match', mock.MagicMock(return_value=(True)))
+    def test_show_muxcable_hwmode_muxdirection_standby(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["hwmode"].commands["muxdirection"], obj=db)
+        assert result.exit_code == 0
+
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "sucess"}))
+    @mock.patch('show.muxcable.get_hwmode_mux_direction_port', mock.MagicMock(return_value={0: 0,
+                                                                                            1: "sucess",
+                                                                                            2: "True"}))
+    @mock.patch('config.muxcable.swsscommon.DBConnector', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.Table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.Select', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.SubscriberStateTable', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.check_mux_direction', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.toggle_mux_to_torA', mock.MagicMock(return_value=(True)))
+    @mock.patch('sonic_y_cable.y_cable.toggle_mux_to_torB', mock.MagicMock(return_value=(True)))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    def test_config_muxcable_hwmode_state_port_active(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["muxcable"].commands["hwmode"].commands["state"],
+                               ["active", "Ethernet12"], obj=db)
+        assert result.exit_code == 0
+
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "sucess"}))
+    @mock.patch('show.muxcable.get_hwmode_mux_direction_port', mock.MagicMock(return_value={0: 0,
+                                                                                            1: "sucess",
+                                                                                            2: "True"}))
+    @mock.patch('config.muxcable.swsscommon.DBConnector', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.Table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.Select', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.SubscriberStateTable', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.check_mux_direction', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.toggle_mux_to_torA', mock.MagicMock(return_value=(True)))
+    @mock.patch('sonic_y_cable.y_cable.toggle_mux_to_torB', mock.MagicMock(return_value=(True)))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    def test_config_muxcable_hwmode_state_active(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["muxcable"].commands["hwmode"].commands["state"],
+                               ["active", "all"], obj=db)
+        assert result.exit_code == 0
+
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "standby"}))
+    @mock.patch('show.muxcable.get_hwmode_mux_direction_port', mock.MagicMock(return_value={0: 0,
+                                                                                            1: "standby",
+                                                                                            2: "True"}))
+    @mock.patch('config.muxcable.swsscommon.DBConnector', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.Table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.Select', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.SubscriberStateTable', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.check_mux_direction', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.toggle_mux_to_torA', mock.MagicMock(return_value=(True)))
+    @mock.patch('sonic_y_cable.y_cable.toggle_mux_to_torB', mock.MagicMock(return_value=(True)))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    def test_config_muxcable_hwmode_state_port_standby(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["muxcable"].commands["hwmode"].commands["state"],
+                               ["standby", "Ethernet12"], obj=db)
+        assert result.exit_code == 0
+
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "standby"}))
+    @mock.patch('show.muxcable.get_hwmode_mux_direction_port', mock.MagicMock(return_value={0: 0,
+                                                                                            1: "standby",
+                                                                                            2: "True"}))
+    @mock.patch('config.muxcable.swsscommon.DBConnector', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.Table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.Select', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.SubscriberStateTable', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.check_mux_direction', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.toggle_mux_to_torA', mock.MagicMock(return_value=(True)))
+    @mock.patch('sonic_y_cable.y_cable.toggle_mux_to_torB', mock.MagicMock(return_value=(True)))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    def test_config_muxcable_hwmode_state_standby(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["muxcable"].commands["hwmode"].commands["state"],
+                               ["standby", "all"], obj=db)
+        assert result.exit_code == 0
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    @mock.patch('show.muxcable.get_response_for_version', mock.MagicMock(return_value={"version_self_active": "0.6MS",
+                                                                                           "version_self_inactive": "0.6MS",
+                                                                                           "version_self_next": "0.6MS",
+                                                                                           "version_peer_active": "0.6MS",
+                                                                                           "version_peer_inactive": "0.6MS",
+                                                                                           "version_peer_next": "0.6MS",
+                                                                                           "version_nic_active": "0.6MS",
+                                                                                           "version_nic_inactive": "0.6MS",
+                                                                                           "version_nic_next": "0.6MS"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    @mock.patch('sonic_y_cable.y_cable.get_firmware_version', mock.MagicMock(return_value={"version_active": "0.6MS",
+                                                                                           "version_inactive": "0.6MS",
+                                                                                           "version_next": "0.6MS"}))
+    def test_show_muxcable_firmware_version(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["firmware"].commands["version"], [
+                               "Ethernet0"], obj=db)
+        assert result.exit_code == 0
+        assert result.output == show_muxcable_firmware_version_expected_output
+
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "sucess"}))
+    @mock.patch('config.muxcable.swsscommon.DBConnector', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.Table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.Select', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.SubscriberStateTable', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    @mock.patch('sonic_y_cable.y_cable.download_fimware', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.FIRMWARE_DOWNLOAD_SUCCESS', mock.MagicMock(return_value=(1)))
+    def test_config_muxcable_download_firmware(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["muxcable"].commands["firmware"].commands["download"], [
+                               "fwfile", "Ethernet0"], obj=db)
+        assert result.exit_code == 0
+
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "sucess"}))
+    @mock.patch('config.muxcable.swsscommon.DBConnector', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.Table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.Select', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.swsscommon.SubscriberStateTable', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    @mock.patch('sonic_y_cable.y_cable.activate_firmware', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.FIRMWARE_ACTIVATE_SUCCESS', mock.MagicMock(return_value=(1)))
+    def test_config_muxcable_activate_firmware(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["muxcable"].commands["firmware"].commands["activate"], [
+                               "Ethernet0"], obj=db)
+        assert result.exit_code == 0
+
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "sucess"}))
+    @mock.patch("config.muxcable.swsscommon.DBConnector", mock.MagicMock(return_value=0))
+    @mock.patch("config.muxcable.swsscommon.Table", mock.MagicMock(return_value=0))
+    @mock.patch("config.muxcable.swsscommon.Select", mock.MagicMock(return_value=0))
+    @mock.patch("config.muxcable.swsscommon.SubscriberStateTable", mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    @mock.patch('sonic_y_cable.y_cable.rollback_firmware', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.FIRMWARE_ROLLBACK_SUCCESS', mock.MagicMock(return_value=(1)))
+    def test_config_muxcable_rollback_firmware(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["muxcable"].commands["firmware"].commands["rollback"], [
+                               "Ethernet0"], obj=db)
+        assert result.exit_code == 0
+
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    def test_show_muxcable_metrics_port(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["metrics"],
+                               ["Ethernet0"], obj=db)
+        assert result.exit_code == 0
+        assert result.output == show_muxcable_metrics_expected_output
+
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    def test_show_muxcable_metrics_port_alias(self):
+        runner = CliRunner()
+        db = Db()
+
+        os.environ['SONIC_CLI_IFACE_MODE'] = "alias"
+        result = runner.invoke(show.cli.commands["muxcable"].commands["metrics"],
+                               ["etp1"], obj=db)
+
+        os.environ['SONIC_CLI_IFACE_MODE'] = "default"
+        assert result.exit_code == 0
+        assert result.output == show_muxcable_metrics_expected_output_alias
+
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    def test_show_muxcable_metrics_port_json(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["metrics"],
+                               ["Ethernet0", "--json"], obj=db)
+        assert result.exit_code == 0
+        assert result.output == show_muxcable_metrics_expected_output_json
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    @mock.patch('show.muxcable.get_response_for_version', mock.MagicMock(return_value={"version_self_active": "0.6MS",
+                                                                                           "version_self_inactive": "0.6MS",
+                                                                                           "version_self_next": "0.6MS",
+                                                                                           "version_peer_active": "0.6MS",
+                                                                                           "version_peer_inactive": "0.6MS",
+                                                                                           "version_peer_next": "0.6MS",
+                                                                                           "version_nic_active": "0.6MS",
+                                                                                           "version_nic_inactive": "0.6MS",
+                                                                                           "version_nic_next": "0.6MS"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    @mock.patch('sonic_y_cable.y_cable.get_firmware_version', mock.MagicMock(return_value={"version_active": "0.6MS",
+                                                                                           "version_inactive": "0.6MS",
+                                                                                           "version_next": "0.6MS"}))
+    def test_show_muxcable_firmware_active_version(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["firmware"].commands["version"], [
+                               "Ethernet0", "--active"], obj=db)
+        assert result.exit_code == 0
+        assert result.output == show_muxcable_firmware_version_active_expected_output
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        print("TEARDOWN")
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "active"}))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    def test_show_muxcable_ber_info(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["berinfo"],
+                               ["Ethernet0", "NIC"], obj=db)
+
+        assert result.exit_code == 0
+
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "active"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    def test_config_muxcable_enable_prbs(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["muxcable"].commands["prbs"].commands["enable"],
+                               ["Ethernet0", "NIC", "0", "0"], obj=db)
+
+        assert result.exit_code == 0
+
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "active"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    def test_config_muxcable_enable_loopback(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["muxcable"].commands["loopback"].commands["enable"],
+                               ["Ethernet0", "NIC", "0"], obj=db)
+
+        assert result.exit_code == 0
+
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "active"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    def test_config_muxcable_disble_prbs(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["muxcable"].commands["prbs"].commands["disable"],
+                               ["Ethernet0", "NIC"], obj=db)
+
+        assert result.exit_code == 0
+
+    @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "active"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
+    def test_config_muxcable_disable_loopback(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["muxcable"].commands["loopback"].commands["disable"],
+                               ["Ethernet0", "NIC"], obj=db)
+
+        assert result.exit_code == 0
+
+    @mock.patch('sonic_y_cable.y_cable.get_part_number', mock.MagicMock(return_value=("CACL1X321P2PA1M")))
+    @mock.patch('sonic_y_cable.y_cable.get_vendor', mock.MagicMock(return_value=("Credo          ")))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value=1))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    def test_show_muxcable_cableinfo(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["cableinfo"],
+                               ["Ethernet0"], obj=db)
+
+        assert result.exit_code == 0
+        assert result.output == expected_muxcable_cableinfo_output
+
+    @mock.patch('sonic_y_cable.y_cable.get_part_number', mock.MagicMock(return_value=(False)))
+    @mock.patch('sonic_y_cable.y_cable.get_vendor', mock.MagicMock(return_value=(False)))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value=1))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    def test_show_muxcable_cableinfo_incorrect_port(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["cableinfo"],
+                               ["Ethernet0"], obj=db)
+        assert result.exit_code == 1
+
+    @mock.patch('sonic_y_cable.y_cable.get_part_number', mock.MagicMock(return_value=(False)))
+    @mock.patch('sonic_y_cable.y_cable.get_vendor', mock.MagicMock(return_value=(False)))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value=1))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=0))
+    def test_show_muxcable_cableinfo_incorrect_port_return_value(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["cableinfo"],
+                               ["Ethernet0"], obj=db)
+        assert result.exit_code == 1
+
+    @mock.patch('sonic_y_cable.y_cable.get_part_number', mock.MagicMock(return_value=(False)))
+    @mock.patch('sonic_y_cable.y_cable.get_vendor', mock.MagicMock(return_value=(False)))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value=1))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0, 1]))
+    def test_show_muxcable_cableinfo_incorrect_logical_port_return_value(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["cableinfo"],
+                               ["Ethernet0"], obj=db)
+        assert result.exit_code == 1
+
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "active"}))
+    @mock.patch('show.muxcable.get_hwmode_mux_direction_port', mock.MagicMock(return_value={0: 0,
+                                                                                            1: "active",
+                                                                                            2: "True"}))
+    @mock.patch('show.muxcable.check_port_in_mux_cable_table', mock.MagicMock(return_value=True))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.check_mux_direction', mock.MagicMock(return_value=(1)))
+    @mock.patch('re.match', mock.MagicMock(return_value=(True)))
+    def test_show_muxcable_hwmode_muxdirection_port_active(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["hwmode"].commands["muxdirection"],
+                               ["Ethernet12"], obj=db)
+        assert result.exit_code == 0
+        assert result.output == show_muxcable_hwmode_muxdirection_active_expected_output
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "active"}))
+    @mock.patch('show.muxcable.get_hwmode_mux_direction_port', mock.MagicMock(return_value={0: 0,
+                                                                                            1: "active",
+                                                                                            2: "True"}))
+    @mock.patch('show.muxcable.check_port_in_mux_cable_table', mock.MagicMock(return_value=True))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.check_mux_direction', mock.MagicMock(return_value=(1)))
+    @mock.patch('re.match', mock.MagicMock(return_value=(True)))
+    def test_show_muxcable_hwmode_muxdirection_active_expected_output_alias(self):
+        runner = CliRunner()
+        db = Db()
+        os.environ['SONIC_CLI_IFACE_MODE'] = "alias"
+        result = runner.invoke(show.cli.commands["muxcable"].commands["hwmode"].commands["muxdirection"],
+                               ["etp4"], obj=db)
+        os.environ['SONIC_CLI_IFACE_MODE'] = "default"
+        assert result.exit_code == 0
+        assert result.output == show_muxcable_hwmode_muxdirection_active_expected_output_alias
+
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "standby"}))
+    @mock.patch('show.muxcable.get_hwmode_mux_direction_port', mock.MagicMock(return_value={0: 0,
+                                                                                            1: "standby",
+                                                                                            2: "True"}))
+    @mock.patch('show.muxcable.check_port_in_mux_cable_table', mock.MagicMock(return_value=True))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.check_mux_direction', mock.MagicMock(return_value=(1)))
+    @mock.patch('re.match', mock.MagicMock(return_value=(True)))
+    def test_show_muxcable_hwmode_muxdirection_active(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["hwmode"].commands["muxdirection"], obj=db)
+        assert result.exit_code == 0
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "standby"}))
+    @mock.patch('show.muxcable.get_hwmode_mux_direction_port', mock.MagicMock(return_value={0: 0,
+                                                                                            1: "standby",
+                                                                                            2: "True"}))
+    @mock.patch('show.muxcable.check_port_in_mux_cable_table', mock.MagicMock(return_value=True))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.check_mux_direction', mock.MagicMock(return_value=(2)))
+    @mock.patch('re.match', mock.MagicMock(return_value=(True)))
+    def test_show_muxcable_hwmode_muxdirection_port_standby(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["hwmode"].commands["muxdirection"],
+                               ["Ethernet12"], obj=db)
+        assert result.exit_code == 0
+        assert result.output == show_muxcable_hwmode_muxdirection_standby_expected_output
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "standby"}))
+    @mock.patch('show.muxcable.get_hwmode_mux_direction_port', mock.MagicMock(return_value={0: 0,
+                                                                                            1: "standby",
+                                                                                            2: "True"}))
+    @mock.patch('show.muxcable.check_port_in_mux_cable_table', mock.MagicMock(return_value=True))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    @mock.patch('sonic_y_cable.y_cable.check_read_side', mock.MagicMock(return_value=(1)))
+    @mock.patch('sonic_y_cable.y_cable.check_mux_direction', mock.MagicMock(return_value=(2)))
+    @mock.patch('re.match', mock.MagicMock(return_value=(True)))
+    def test_show_muxcable_hwmode_muxdirection_port_standby_alias(self):
+        runner = CliRunner()
+        db = Db()
+
+        os.environ['SONIC_CLI_IFACE_MODE'] = "alias"
+        result = runner.invoke(show.cli.commands["muxcable"].commands["hwmode"].commands["muxdirection"],
+                               ["etp4"], obj=db)
+        os.environ['SONIC_CLI_IFACE_MODE'] = "default"
+        assert result.exit_code == 0
+        assert result.output == show_muxcable_hwmode_muxdirection_standby_expected_output_alias
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "sucess"}))
+    @mock.patch('show.muxcable.get_hwmode_mux_direction_port', mock.MagicMock(return_value={0: 0,
+                                                                                            1: "sucess",
+                                                                                            2: "True"}))
+    @mock.patch('show.muxcable.check_port_in_mux_cable_table', mock.MagicMock(return_value=True))
     @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
     @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))


### PR DESCRIPTION
Creating this PR because there was a conflict in #1961 and cherry-pick did not work

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This PR supports for muxcable status command to support HWSTATUS as well.
the HWSTATUS could be either of these values
consistent/inconsistent/absent/Not-Y-Cable-Port/unknown

#### How I did it
Made the changes in both sonic-platform-daemons as well as sonic-utilities. 
This PR is dependent on https://github.com/Azure/sonic-platform-daemons/pull/219

#### How to verify it
Ran the changes on Arista7260cx3 platform as well as unit-tests
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)


```
admin@sonic:~$ show mux status
PORT         STATUS    HEALTH     HWSTATUS    LAST_SWITCHOVER_TIME
-----------  --------  ---------  ----------  ---------------------------
Ethernet0    active    unhealthy  consistent  2022-Mar-14 19:40:06.851394
Ethernet4    active    unhealthy  consistent  2022-Mar-14 19:40:06.863977
Ethernet8    active    unhealthy  consistent  2022-Mar-14 19:40:06.867504
Ethernet12   active    unhealthy  consistent  2022-Mar-14 19:40:07.149011
Ethernet16   active    unhealthy  consistent  2022-Mar-14 19:40:07.179085
Ethernet20   active    unhealthy  consistent  2022-Mar-14 19:40:07.174677
Ethernet40   active    healthy    consistent  2022-Mar-14 19:40:07.264452
Ethernet44   active    healthy    consistent  2022-Mar-14 19:40:07.452626
Ethernet48   active    unhealthy  consistent  2022-Mar-14 19:40:07.511005
Ethernet52   active    unhealthy  consistent  2022-Mar-14 19:40:07.644608
Ethernet56   active    unhealthy  consistent  2022-Mar-14 19:40:07.630628
Ethernet60   active    unhealthy  consistent  2022-Mar-14 19:40:07.739968
Ethernet64   active    unhealthy  consistent  2022-Mar-14 19:40:07.784666
Ethernet68   active    healthy    consistent  2022-Mar-14 19:40:07.728138
Ethernet72   active    healthy    consistent  2022-Mar-14 19:40:07.901363
Ethernet76   active    healthy    consistent  2022-Mar-14 19:40:07.957279
Ethernet80   active    healthy    consistent  2022-Mar-14 19:40:08.011392
Ethernet84   active    healthy    consistent  2022-Mar-14 19:40:08.149346
Ethernet104  active    healthy    consistent  2022-Mar-14 19:40:09.312243
Ethernet108  active    healthy    consistent  2022-Mar-14 19:40:09.312293
Ethernet112  active    healthy    consistent  2022-Mar-14 19:40:09.313652
Ethernet116  active    healthy    consistent  2022-Mar-14 19:40:09.313820
Ethernet120  active    healthy    consistent  2022-Mar-14 19:40:09.318580
Ethernet124  standby   unhealthy  consistent  2022-Mar-14 19:43:57.893061
```

