### PR TITLE
[Mellanox] [reboot] [asan] stop asan-enabled containers on reboot

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -25,6 +25,7 @@ REBOOT_USER=$(logname)
 PLATFORM=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
 ASIC_TYPE=$(sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)
 SUBTYPE=$(sonic-cfggen -d -v DEVICE_METADATA.localhost.subtype)
+ASAN=$(sonic-cfggen -y /etc/sonic/sonic_version.yml -v asan)
 VERBOSE=no
 EXIT_NEXT_IMAGE_NOT_EXISTS=4
 EXIT_SONIC_INSTALLER_VERIFY_REBOOT=21
@@ -76,6 +77,17 @@ function stop_sonic_services()
         sleep 3
     fi
     stop_pmon_service
+}
+
+function stop_services_asan()
+{
+    if [[ x"$ASIC_TYPE" == x"mellanox" ]]; then
+        debug "Stopping syncd for ASAN"
+        systemctl stop syncd
+    fi
+
+    debug "Stopping swss for ASAN"
+    systemctl stop swss
 }
 
 function clear_warm_boot()
@@ -186,6 +198,11 @@ tag_images
 
 # Stop SONiC services gracefully.
 stop_sonic_services
+
+# Stop ASAN-enabled services so the report can be generated
+if [[ x"$ASAN" == x"yes" ]]; then
+    stop_services_asan
+fi
 
 clear_warm_boot
 

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -81,11 +81,6 @@ function stop_sonic_services()
 
 function stop_services_asan()
 {
-    if [[ x"$ASIC_TYPE" == x"mellanox" ]]; then
-        debug "Stopping syncd for ASAN"
-        systemctl stop syncd
-    fi
-
     debug "Stopping swss for ASAN"
     systemctl stop swss
 }


### PR DESCRIPTION
During a cold reboot on an image built with ENABLE_ASAN=y, swss and syncd (only on Mellanox platform) are explicitly stopped.
This will make the relevant processes receive SIGTERM and generate the ASAN reports.
The behavior for fast/warm reboots is not affected.
The behavior of regular (ENABLE_ASAN=n) images is not affected.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Modified the reboot script so the asan logs are generated on reboot.
#### How I did it
Added stop_services_asan() to reboot script.
#### How to verify it
Added "asan: 'yes'" to the /etc/sonic/sonic_version.yml
Checked that relevant containers are stopped and logs are generated 
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
