### PR TITLE
[sfpshow][recycle_port]  Command show interfaces transceiver presence/eeprom should not display recycle port.

### DIFF
--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -13,7 +13,7 @@ import sys
 
 import click
 from natsort import natsorted
-from sonic_py_common.interface import front_panel_prefix, backplane_prefix, inband_prefix
+from sonic_py_common.interface import front_panel_prefix, backplane_prefix, inband_prefix, recirc_prefix
 from sonic_py_common import multi_asic
 from tabulate import tabulate
 from utilities_common import multi_asic as multi_asic_util
@@ -417,7 +417,7 @@ class SFPShow(object):
             sorted_table_keys = natsorted(port_table_keys)
             for i in sorted_table_keys:
                 interface = re.split(':', i, maxsplit=1)[-1].strip()
-                if interface and interface.startswith(front_panel_prefix()) and not interface.startswith(backplane_prefix()) and not interface.startswith(inband_prefix()):
+                if interface and interface.startswith(front_panel_prefix()) and not interface.startswith((backplane_prefix(), inband_prefix(), recirc_prefix())):
                     presence = self.db.exists(self.db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(interface))
                     if presence:
                         self.output += self.convert_interface_sfp_info_to_cli_output_string(
@@ -441,7 +441,7 @@ class SFPShow(object):
             port_table_keys = self.db.keys(self.db.APPL_DB, "PORT_TABLE:*")
             for i in port_table_keys:
                 key = re.split(':', i, maxsplit=1)[-1].strip()
-                if key and key.startswith(front_panel_prefix()) and not key.startswith(backplane_prefix()) and not key.startswith(inband_prefix()):
+                if key and key.startswith(front_panel_prefix()) and not key.startswith((backplane_prefix(), inband_prefix(), recirc_prefix())):
                     presence = self.db.exists(self.db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(key))
                     if presence:
                         port_table.append((key, 'Present'))


### PR DESCRIPTION
#### What I did
Command show interfaces transceiver presence/eeprom should not display recycle port.  
Script sfpshow needs to skip the recycle ports since recylce port is internal port without any SFP module.

This change is applicable to the 202111 branch

#### How I did it
Modify the sfpshow script with using a function  recirc_prefix() to check if a port is a recycle port, skip it.
 
#### How to verify it
1. login to the linecard which contains recycle port
2. execute the CLI command:  show interface transceiver eeprom
```
admin@ixre-egl-board3:~$ show interfaces transceiver presence 
Port           Presence
-------------  -----------
Ethernet0      Not present
Ethernet1      Not present
Ethernet2      Not present
Ethernet3      Not present
...
Ethernet30     Not present
Ethernet31     Not present
Ethernet32     Not present
Ethernet33     Not present
Ethernet34     Not present
Ethernet35     Not present
```
3.  Verify the output. It should not contain any recycle port.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

