### PR TITLE
Enhance "config interface type/advertised-type" to be blocked on RJ45 ports 

### DIFF
--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -172,7 +172,7 @@ class portconfig(object):
 
     def set_adv_interface_types(self, port, adv_interface_types):
         if self.is_rj45_port:
-            print("Setting RJ45 ports' advertised type is not supported")
+            print("Setting RJ45 ports' advertised types is not supported")
             exit(1)
         if self.verbose:
             print("Setting adv_interface_types %s on port %s" % (adv_interface_types, port))

--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -75,6 +75,7 @@ class portconfig(object):
         self.is_lag = False
         self.is_lag_mbr = False
         self.parent = port
+        self.is_rj45_port = False
         # Set up db connections
         if namespace is None:
             self.db = ConfigDBConnector()
@@ -90,6 +91,9 @@ class portconfig(object):
         lag_tables = self.db.get_table(PORT_CHANNEL_TABLE_NAME)
         lag_mbr_tables = self.db.get_table(PORT_CHANNEL_MBR_TABLE_NAME)
         if port in port_tables:
+            port_transceiver_info = self.state_db.get_all(self.state_db.STATE_DB, "TRANSCEIVER_INFO|{}".format(port))
+            if port_transceiver_info:
+                self.is_rj45_port = True if port_transceiver_info.get("type") == "RJ45" else False
             for key in lag_mbr_tables:
                 if port == key[1]:
                     self.parent = key[0]
@@ -155,6 +159,9 @@ class portconfig(object):
         self.db.mod_entry(PORT_TABLE_NAME, port, {PORT_ADV_SPEEDS_CONFIG_FIELD_NAME: adv_speeds})
 
     def set_interface_type(self, port, interface_type):
+        if self.is_rj45_port:
+            print("Setting RJ45 ports' type is not supported")
+            exit(1)
         if self.verbose:
             print("Setting interface_type %s on port %s" % (interface_type, port))
         if interface_type not in VALID_INTERFACE_TYPE_SET:
@@ -164,6 +171,9 @@ class portconfig(object):
         self.db.mod_entry(PORT_TABLE_NAME, port, {PORT_INTERFACE_TYPE_CONFIG_FIELD_NAME: interface_type})
 
     def set_adv_interface_types(self, port, adv_interface_types):
+        if self.is_rj45_port:
+            print("Setting RJ45 ports' advertised type is not supported")
+            exit(1)
         if self.verbose:
             print("Setting adv_interface_types %s on port %s" % (adv_interface_types, port))
 

--- a/tests/config_an_test.py
+++ b/tests/config_an_test.py
@@ -62,6 +62,8 @@ class TestConfigInterface(object):
         result = self.basic_check("type", ["Ethernet0", "Invalid"], ctx, operator.ne)
         assert 'Invalid interface type specified' in result.output
         assert 'Valid interface types:' in result.output
+        result = self.basic_check("type", ["Ethernet16", "Invalid"], ctx, operator.ne)
+        assert "Setting RJ45 ports' type is not supported" in result.output
 
     def test_config_adv_types(self, ctx):
         self.basic_check("advertised-types", ["Ethernet0", "CR4,KR4"], ctx)
@@ -74,6 +76,8 @@ class TestConfigInterface(object):
         assert 'Invalid interface type specified' in result.output
         assert 'duplicate' in result.output
         self.basic_check("advertised-types", ["Ethernet0", ""], ctx, operator.ne)
+        result = self.basic_check("advertised-types", ["Ethernet16", "Invalid"], ctx, operator.ne)
+        assert "Setting RJ45 ports' advertised type is not supported" in result.output
 
     def basic_check(self, command_name, para_list, ctx, op=operator.eq, expect_result=0):
         runner = CliRunner()

--- a/tests/config_an_test.py
+++ b/tests/config_an_test.py
@@ -77,7 +77,7 @@ class TestConfigInterface(object):
         assert 'duplicate' in result.output
         self.basic_check("advertised-types", ["Ethernet0", ""], ctx, operator.ne)
         result = self.basic_check("advertised-types", ["Ethernet16", "Invalid"], ctx, operator.ne)
-        assert "Setting RJ45 ports' advertised type is not supported" in result.output
+        assert "Setting RJ45 ports' advertised types is not supported" in result.output
 
     def basic_check(self, command_name, para_list, ctx, op=operator.eq, expect_result=0):
         runner = CliRunner()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Block **"config interface type"** and **"config interface advertised type"** configuration on RJ45 ports

```
admin@sonic:~$ sudo config interface type Ethernet0 XGMII
Setting RJ45 ports' type is not supported

admin@sonic:~$ sudo config interface advertised-type Ethernet0 XGMII
Setting RJ45 ports' advertised types is not supported
```

Mock table depends on PR https://github.com/Azure/sonic-utilities/pull/2110
#### How I did it
Check port type in the command, if RJ45 port then exit with not supported print out.

#### How to verify it

run above command on platforms with RJ45 ports

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

