### PR TITLE
Ordering fix for sfpshow eeprom

### DIFF
--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 """
     Script to show SFP EEPROM and presence status.
@@ -10,6 +10,7 @@ import ast
 import os
 import re
 import sys
+from typing import Dict
 
 import click
 from natsort import natsorted
@@ -235,7 +236,7 @@ class SFPShow(object):
         self.intf_name = intf_name
         self.dump_dom = dump_dom
         self.table = []
-        self.output = ''
+        self.intf_eeprom_stdout: Dict[str, str] = {}
         self.multi_asic = multi_asic_util.MultiAsic(namespace_option=namespace_option)
 
     # Convert dict values to cli output string
@@ -408,24 +409,23 @@ class SFPShow(object):
         if self.intf_name is not None:
             presence = self.db.exists(self.db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(self.intf_name))
             if presence:
-                self.output = self.convert_interface_sfp_info_to_cli_output_string(
+                self.intf_eeprom_stdout[self.intf_name] = self.convert_interface_sfp_info_to_cli_output_string(
                     self.db, self.intf_name, self.dump_dom)
             else:
-                self.output += (self.intf_name + ': ' + 'SFP EEPROM Not detected' + '\n')
+                self.intf_eeprom_stdout[self.intf_name] = f"{self.intf_name}: SFP EEPROM Not detected\n"
         else:
             port_table_keys = self.db.keys(self.db.APPL_DB, "PORT_TABLE:*")
             sorted_table_keys = natsorted(port_table_keys)
             for i in sorted_table_keys:
                 interface = re.split(':', i, maxsplit=1)[-1].strip()
-                if interface and interface.startswith(front_panel_prefix()) and not interface.startswith((backplane_prefix(), inband_prefix(), recirc_prefix())):
+                if interface and interface.startswith(front_panel_prefix()) and not interface.startswith(backplane_prefix()) and not interface.startswith(inband_prefix()):
                     presence = self.db.exists(self.db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(interface))
                     if presence:
-                        self.output += self.convert_interface_sfp_info_to_cli_output_string(
+                        self.intf_eeprom_stdout[interface] = self.convert_interface_sfp_info_to_cli_output_string(
                             self.db, interface, self.dump_dom)
                     else:
-                        self.output += (interface + ': ' + 'SFP EEPROM Not detected' + '\n')
+                        self.intf_eeprom_stdout[interface] = f"{interface}: SFP EEPROM Not detected\n"
 
-                    self.output += '\n'
 
     @multi_asic_util.run_on_multi_asic
     def get_presence(self):
@@ -451,7 +451,7 @@ class SFPShow(object):
         self.table += port_table
 
     def display_eeprom(self):
-        click.echo(self.output)
+        click.echo("\n".join([self.intf_eeprom_stdout[k] for k in natsorted(self.intf_eeprom_stdout.keys())]))
 
     def display_presence(self):
         header = ['Port', 'Presence']

--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -415,8 +415,7 @@ class SFPShow(object):
                 self.intf_eeprom[self.intf_name] = "SFP EEPROM Not detected\n"
         else:
             port_table_keys = self.db.keys(self.db.APPL_DB, "PORT_TABLE:*")
-            sorted_table_keys = natsorted(port_table_keys)
-            for i in sorted_table_keys:
+            for i in port_table_keys:
                 interface = re.split(':', i, maxsplit=1)[-1].strip()
                 if interface and interface.startswith(front_panel_prefix()) and not interface.startswith((backplane_prefix(), inband_prefix(), recirc_prefix())):
                     presence = self.db.exists(self.db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(interface))

--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -236,7 +236,7 @@ class SFPShow(object):
         self.intf_name = intf_name
         self.dump_dom = dump_dom
         self.table = []
-        self.intf_eeprom_stdout: Dict[str, str] = {}
+        self.intf_eeprom: Dict[str, str] = {}
         self.multi_asic = multi_asic_util.MultiAsic(namespace_option=namespace_option)
 
     # Convert dict values to cli output string
@@ -392,7 +392,7 @@ class SFPShow(object):
         output = ''
 
         sfp_info_dict = state_db.get_all(state_db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(interface_name))
-        output = interface_name + ': ' + 'SFP EEPROM detected' + '\n'
+        output = 'SFP EEPROM detected' + '\n'
         sfp_info_output = self.convert_sfp_info_to_output_string(sfp_info_dict)
         output += sfp_info_output
 
@@ -409,10 +409,10 @@ class SFPShow(object):
         if self.intf_name is not None:
             presence = self.db.exists(self.db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(self.intf_name))
             if presence:
-                self.intf_eeprom_stdout[self.intf_name] = self.convert_interface_sfp_info_to_cli_output_string(
+                self.intf_eeprom[self.intf_name] = self.convert_interface_sfp_info_to_cli_output_string(
                     self.db, self.intf_name, self.dump_dom)
             else:
-                self.intf_eeprom_stdout[self.intf_name] = f"{self.intf_name}: SFP EEPROM Not detected\n"
+                self.intf_eeprom[self.intf_name] = "SFP EEPROM Not detected\n"
         else:
             port_table_keys = self.db.keys(self.db.APPL_DB, "PORT_TABLE:*")
             sorted_table_keys = natsorted(port_table_keys)
@@ -421,10 +421,10 @@ class SFPShow(object):
                 if interface and interface.startswith(front_panel_prefix()) and not interface.startswith((backplane_prefix(), inband_prefix(), recirc_prefix())):
                     presence = self.db.exists(self.db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(interface))
                     if presence:
-                        self.intf_eeprom_stdout[interface] = self.convert_interface_sfp_info_to_cli_output_string(
+                        self.intf_eeprom[interface] = self.convert_interface_sfp_info_to_cli_output_string(
                             self.db, interface, self.dump_dom)
                     else:
-                        self.intf_eeprom_stdout[interface] = f"{interface}: SFP EEPROM Not detected\n"
+                        self.intf_eeprom[interface] = "SFP EEPROM Not detected\n"
 
 
     @multi_asic_util.run_on_multi_asic
@@ -451,7 +451,7 @@ class SFPShow(object):
         self.table += port_table
 
     def display_eeprom(self):
-        click.echo("\n".join([self.intf_eeprom_stdout[k] for k in natsorted(self.intf_eeprom_stdout.keys())]))
+        click.echo("\n".join([f"{k}: {v}" for k, v in natsorted(self.intf_eeprom.items())]))
 
     def display_presence(self):
         header = ['Port', 'Presence']

--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -418,7 +418,7 @@ class SFPShow(object):
             sorted_table_keys = natsorted(port_table_keys)
             for i in sorted_table_keys:
                 interface = re.split(':', i, maxsplit=1)[-1].strip()
-                if interface and interface.startswith(front_panel_prefix()) and not interface.startswith(backplane_prefix()) and not interface.startswith(inband_prefix()):
+                if interface and interface.startswith(front_panel_prefix()) and not interface.startswith((backplane_prefix(), inband_prefix(), recirc_prefix())):
                     presence = self.db.exists(self.db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(interface))
                     if presence:
                         self.intf_eeprom_stdout[interface] = self.convert_interface_sfp_info_to_cli_output_string(

--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -392,7 +392,7 @@ class SFPShow(object):
         output = ''
 
         sfp_info_dict = state_db.get_all(state_db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(interface_name))
-        output = 'SFP EEPROM detected' + '\n'
+        output = 'SFP EEPROM detected\n'
         sfp_info_output = self.convert_sfp_info_to_output_string(sfp_info_dict)
         output += sfp_info_output
 

--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 """
     Script to show SFP EEPROM and presence status.


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Due to `sfpshow eeprom` being a multi-ASIC function, ports on the same ASIC would be ordered and printed by each ASIC. I have fixed it so that the ports are printed in order, even if in multi-ASIC mode.

#### How I did it
Previously we would keep appending to an output (string) class variable, and print that out after all of the information is gathered. Since this runs first on _asic0_, _asic1_, ... _asicN_, it would append each alphabetically organized list into one, which would then no longer be alphabetized.

Instead, I have the output saved into a dictionary of `EthernetN` -> `<output string>`. After the information is collected for each port, the `output string`s are pulled from the dictionary in the _natsorted_ order of the keys.

#### How to verify it
Run `sfpshow eeprom` and see all of the ports printing in order


#### Previous command output (if the output of a command-line utility has changed)

```
Ethernet1: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: MPOx12
        Encoding: 64B66B
        Extended Identifier: Power Class 4(3.5W max), CLEI present, CDR present in Rx Tx
        Extended RateSelect Compliance: QSFP+ Rate Select Version 1
        Identifier: QSFP28 or later
        Length Cable Assembly(m): 50
        Nominal Bit Rate(100Mbs): 255
        Specification compliance:
        Vendor Date Code(YYYY-MM-DD Lot): 2017-09-27 
        Vendor Name: CISCO-AVAGO
        Vendor OUI: 00-17-6a
        Vendor PN: AFBR-89CDDZ-CS3
        Vendor Rev: 05
        Vendor SN: AVF2138S25L

Ethernet3: SFP EEPROM Not detected

Ethernet4: SFP EEPROM Not detected

Ethernet18: SFP EEPROM Not detected

Ethernet21: SFP EEPROM Not detected

Ethernet23: SFP EEPROM Not detected

Ethernet30: SFP EEPROM Not detected

Ethernet34: SFP EEPROM Not detected

Ethernet35: SFP EEPROM Not detected

Ethernet12: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: Unknown
        Encoding: Unknown
        Extended Identifier: Power Class 2(2.0W max), CLEI present, CDR present in Rx
        Extended RateSelect Compliance: Unknown
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Length Cable Assembly(m): 34
        Nominal Bit Rate(100Mbs): 118
        Specification compliance: {'10/40G Ethernet Compliance Code': '10GBase-LR', 'SONET Compliance codes': 'OC 48 short reach', 'SAS/SATA compliance codes': 'SAS 6.0G', 'Gigabit Ethernet Compliant codes': '1000BASE-CX', 'Fibre Channel link length/Transmitter Technology': 'Intermediate distance (I)', 'Fibre Channel transmission media': 'Miniature Coax (MI)', 'Fibre Channel Speed': '100 Mbytes/Sec'}
        Vendor Date Code(YYYY-MM-DD Lot): 20
        Vendor Name: 2323766-2
        Vendor OUI: 20-31-38
        Vendor PN: 229081        18
        Vendor Rev: 06
        Vendor SN: 

Ethernet13: SFP EEPROM Not detected

Ethernet14: SFP EEPROM Not detected

Ethernet15: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: Unknown
        Encoding: Unknown
        Extended Identifier: Power Class 2(2.0W max), CLEI present, CDR present in Rx
        Extended RateSelect Compliance: Unknown
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Length Cable Assembly(m): 34
        Nominal Bit Rate(100Mbs): 118
        Specification compliance: {'10/40G Ethernet Compliance Code': '10GBase-LR', 'SONET Compliance codes': 'OC 48 short reach', 'SAS/SATA compliance codes': 'SAS 6.0G', 'Gigabit Ethernet Compliant codes': '1000BASE-CX', 'Fibre Channel link length/Transmitter Technology': 'Intermediate distance (I)', 'Fibre Channel transmission media': 'Miniature Coax (MI)', 'Fibre Channel Speed': '100 Mbytes/Sec'}
        Vendor Date Code(YYYY-MM-DD Lot): 20
        Vendor Name: 2323766-2
        Vendor OUI: 20-31-38
        Vendor PN: 229081        18
        Vendor Rev: 06
        Vendor SN: 

Ethernet16: SFP EEPROM Not detected

Ethernet17: SFP EEPROM Not detected

Ethernet19: SFP EEPROM Not detected

Ethernet20: SFP EEPROM Not detected

Ethernet22: SFP EEPROM Not detected

Ethernet0: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: MPOx12
        Encoding: 64B66B
        Extended Identifier: Power Class 4(3.5W max), CLEI present, CDR present in Rx Tx
        Extended RateSelect Compliance: QSFP+ Rate Select Version 1
        Identifier: QSFP28 or later
        Length Cable Assembly(m): 50
        Nominal Bit Rate(100Mbs): 255
        Specification compliance:
        Vendor Date Code(YYYY-MM-DD Lot): 2017-09-27 
        Vendor Name: CISCO-AVAGO
        Vendor OUI: 00-17-6a
        Vendor PN: AFBR-89CDDZ-CS3
        Vendor Rev: 05
        Vendor SN: AVF2138S2YK

Ethernet2: SFP EEPROM Not detected

Ethernet5: SFP EEPROM Not detected

Ethernet6: SFP EEPROM Not detected

Ethernet7: SFP EEPROM Not detected

Ethernet8: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: No separable connector
        Encoding: 64B66B
        Extended Identifier: Power Class 1(1.5W max), CLEI present
        Extended RateSelect Compliance: QSFP+ Rate Select Version 1
        Identifier: QSFP28 or later
        Length Cable Assembly(m): 1
        Nominal Bit Rate(100Mbs): 255
        Specification compliance:
        Vendor Date Code(YYYY-MM-DD Lot): 2017-08-17 
        Vendor Name: CISCO-AMPHENOL
        Vendor OUI: 78-a7-14
        Vendor PN: NDAAFF-C401
        Vendor Rev: A
        Vendor SN: APF21330221-A

Ethernet9: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: No separable connector
        Encoding: 64B66B
        Extended Identifier: Power Class 1(1.5W max), CLEI present
        Extended RateSelect Compliance: QSFP+ Rate Select Version 1
        Identifier: QSFP28 or later
        Length Cable Assembly(m): 1
        Nominal Bit Rate(100Mbs): 255
        Specification compliance:
        Vendor Date Code(YYYY-MM-DD Lot): 2017-08-17 
        Vendor Name: CISCO-AMPHENOL
        Vendor OUI: 78-a7-14
        Vendor PN: NDAAFF-C401
        Vendor Rev: A
        Vendor SN: APF21330221-B

Ethernet10: SFP EEPROM Not detected

Ethernet11: SFP EEPROM Not detected

Ethernet24: SFP EEPROM Not detected

Ethernet25: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: Unknown
        Encoding: Unknown
        Extended Identifier: Power Class 2(2.0W max), CLEI present, CDR present in Rx
        Extended RateSelect Compliance: Unknown
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Length Cable Assembly(m): 34
        Nominal Bit Rate(100Mbs): 118
        Specification compliance: {'10/40G Ethernet Compliance Code': '10GBase-LR', 'SONET Compliance codes': 'OC 48 short reach', 'SAS/SATA compliance codes': 'SAS 6.0G', 'Gigabit Ethernet Compliant codes': '1000BASE-CX', 'Fibre Channel link length/Transmitter Technology': 'Intermediate distance (I)', 'Fibre Channel transmission media': 'Miniature Coax (MI)', 'Fibre Channel Speed': '100 Mbytes/Sec'}
        Vendor Date Code(YYYY-MM-DD Lot): 20
        Vendor Name: 2323766-2
        Vendor OUI: 20-31-38
        Vendor PN: 169164        18
        Vendor Rev: 04
        Vendor SN: 

Ethernet26: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: Unknown
        Encoding: Unknown
        Extended Identifier: Power Class 2(2.0W max), CLEI present, CDR present in Rx
        Extended RateSelect Compliance: Unknown
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Length Cable Assembly(m): 34
        Nominal Bit Rate(100Mbs): 118
        Specification compliance: {'10/40G Ethernet Compliance Code': '10GBase-LR', 'SONET Compliance codes': 'OC 48 short reach', 'SAS/SATA compliance codes': 'SAS 6.0G', 'Gigabit Ethernet Compliant codes': '1000BASE-CX', 'Fibre Channel link length/Transmitter Technology': 'Intermediate distance (I)', 'Fibre Channel transmission media': 'Miniature Coax (MI)', 'Fibre Channel Speed': '100 Mbytes/Sec'}
        Vendor Date Code(YYYY-MM-DD Lot): 20
        Vendor Name: 2323766-2
        Vendor OUI: 20-31-38
        Vendor PN: 169164        18
        Vendor Rev: 04
        Vendor SN: 

Ethernet27: SFP EEPROM Not detected

Ethernet28: SFP EEPROM Not detected

Ethernet29: SFP EEPROM Not detected

Ethernet31: SFP EEPROM Not detected

Ethernet32: SFP EEPROM Not detected

Ethernet33: SFP EEPROM Not detected


```
#### New command output (if the output of a command-line utility has changed)

```
Ethernet0: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: MPOx12
        Encoding: 64B66B
        Extended Identifier: Power Class 4(3.5W max), CLEI present, CDR present in Rx Tx
        Extended RateSelect Compliance: QSFP+ Rate Select Version 1
        Identifier: QSFP28 or later
        Length Cable Assembly(m): 50
        Nominal Bit Rate(100Mbs): 255
        Specification compliance:
        Vendor Date Code(YYYY-MM-DD Lot): 2017-09-27 
        Vendor Name: CISCO-AVAGO
        Vendor OUI: 00-17-6a
        Vendor PN: AFBR-89CDDZ-CS3
        Vendor Rev: 05
        Vendor SN: AVF2138S2YK

Ethernet1: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: MPOx12
        Encoding: 64B66B
        Extended Identifier: Power Class 4(3.5W max), CLEI present, CDR present in Rx Tx
        Extended RateSelect Compliance: QSFP+ Rate Select Version 1
        Identifier: QSFP28 or later
        Length Cable Assembly(m): 50
        Nominal Bit Rate(100Mbs): 255
        Specification compliance:
        Vendor Date Code(YYYY-MM-DD Lot): 2017-09-27 
        Vendor Name: CISCO-AVAGO
        Vendor OUI: 00-17-6a
        Vendor PN: AFBR-89CDDZ-CS3
        Vendor Rev: 05
        Vendor SN: AVF2138S25L

Ethernet2: SFP EEPROM Not detected

Ethernet3: SFP EEPROM Not detected

Ethernet4: SFP EEPROM Not detected

Ethernet5: SFP EEPROM Not detected

Ethernet6: SFP EEPROM Not detected

Ethernet7: SFP EEPROM Not detected

Ethernet8: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: No separable connector
        Encoding: 64B66B
        Extended Identifier: Power Class 1(1.5W max), CLEI present
        Extended RateSelect Compliance: QSFP+ Rate Select Version 1
        Identifier: QSFP28 or later
        Length Cable Assembly(m): 1
        Nominal Bit Rate(100Mbs): 255
        Specification compliance:
        Vendor Date Code(YYYY-MM-DD Lot): 2017-08-17 
        Vendor Name: CISCO-AMPHENOL
        Vendor OUI: 78-a7-14
        Vendor PN: NDAAFF-C401
        Vendor Rev: A
        Vendor SN: APF21330221-A

Ethernet9: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: No separable connector
        Encoding: 64B66B
        Extended Identifier: Power Class 1(1.5W max), CLEI present
        Extended RateSelect Compliance: QSFP+ Rate Select Version 1
        Identifier: QSFP28 or later
        Length Cable Assembly(m): 1
        Nominal Bit Rate(100Mbs): 255
        Specification compliance:
        Vendor Date Code(YYYY-MM-DD Lot): 2017-08-17 
        Vendor Name: CISCO-AMPHENOL
        Vendor OUI: 78-a7-14
        Vendor PN: NDAAFF-C401
        Vendor Rev: A
        Vendor SN: APF21330221-B

Ethernet10: SFP EEPROM Not detected

Ethernet11: SFP EEPROM Not detected

Ethernet12: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: Unknown
        Encoding: Unknown
        Extended Identifier: Power Class 2(2.0W max), CLEI present, CDR present in Rx
        Extended RateSelect Compliance: Unknown
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Length Cable Assembly(m): 34
        Nominal Bit Rate(100Mbs): 118
        Specification compliance: {'10/40G Ethernet Compliance Code': '10GBase-LR', 'SONET Compliance codes': 'OC 48 short reach', 'SAS/SATA compliance codes': 'SAS 6.0G', 'Gigabit Ethernet Compliant codes': '1000BASE-CX', 'Fibre Channel link length/Transmitter Technology': 'Intermediate distance (I)', 'Fibre Channel transmission media': 'Miniature Coax (MI)', 'Fibre Channel Speed': '100 Mbytes/Sec'}
        Vendor Date Code(YYYY-MM-DD Lot): 20
        Vendor Name: 2323766-2
        Vendor OUI: 20-31-38
        Vendor PN: 229081        18
        Vendor Rev: 06
        Vendor SN: 

Ethernet13: SFP EEPROM Not detected

Ethernet14: SFP EEPROM Not detected

Ethernet15: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: Unknown
        Encoding: Unknown
        Extended Identifier: Power Class 2(2.0W max), CLEI present, CDR present in Rx
        Extended RateSelect Compliance: Unknown
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Length Cable Assembly(m): 34
        Nominal Bit Rate(100Mbs): 118
        Specification compliance: {'10/40G Ethernet Compliance Code': '10GBase-LR', 'SONET Compliance codes': 'OC 48 short reach', 'SAS/SATA compliance codes': 'SAS 6.0G', 'Gigabit Ethernet Compliant codes': '1000BASE-CX', 'Fibre Channel link length/Transmitter Technology': 'Intermediate distance (I)', 'Fibre Channel transmission media': 'Miniature Coax (MI)', 'Fibre Channel Speed': '100 Mbytes/Sec'}
        Vendor Date Code(YYYY-MM-DD Lot): 20
        Vendor Name: 2323766-2
        Vendor OUI: 20-31-38
        Vendor PN: 229081        18
        Vendor Rev: 06
        Vendor SN: 

Ethernet16: SFP EEPROM Not detected

Ethernet17: SFP EEPROM Not detected

Ethernet18: SFP EEPROM Not detected

Ethernet19: SFP EEPROM Not detected

Ethernet20: SFP EEPROM Not detected

Ethernet21: SFP EEPROM Not detected

Ethernet22: SFP EEPROM Not detected

Ethernet23: SFP EEPROM Not detected

Ethernet24: SFP EEPROM Not detected

Ethernet25: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: Unknown
        Encoding: Unknown
        Extended Identifier: Power Class 2(2.0W max), CLEI present, CDR present in Rx
        Extended RateSelect Compliance: Unknown
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Length Cable Assembly(m): 34
        Nominal Bit Rate(100Mbs): 118
        Specification compliance: {'10/40G Ethernet Compliance Code': '10GBase-LR', 'SONET Compliance codes': 'OC 48 short reach', 'SAS/SATA compliance codes': 'SAS 6.0G', 'Gigabit Ethernet Compliant codes': '1000BASE-CX', 'Fibre Channel link length/Transmitter Technology': 'Intermediate distance (I)', 'Fibre Channel transmission media': 'Miniature Coax (MI)', 'Fibre Channel Speed': '100 Mbytes/Sec'}
        Vendor Date Code(YYYY-MM-DD Lot): 20
        Vendor Name: 2323766-2
        Vendor OUI: 20-31-38
        Vendor PN: 169164        18
        Vendor Rev: 04
        Vendor SN: 

Ethernet26: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: Unknown
        Encoding: Unknown
        Extended Identifier: Power Class 2(2.0W max), CLEI present, CDR present in Rx
        Extended RateSelect Compliance: Unknown
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Length Cable Assembly(m): 34
        Nominal Bit Rate(100Mbs): 118
        Specification compliance: {'10/40G Ethernet Compliance Code': '10GBase-LR', 'SONET Compliance codes': 'OC 48 short reach', 'SAS/SATA compliance codes': 'SAS 6.0G', 'Gigabit Ethernet Compliant codes': '1000BASE-CX', 'Fibre Channel link length/Transmitter Technology': 'Intermediate distance (I)', 'Fibre Channel transmission media': 'Miniature Coax (MI)', 'Fibre Channel Speed': '100 Mbytes/Sec'}
        Vendor Date Code(YYYY-MM-DD Lot): 20
        Vendor Name: 2323766-2
        Vendor OUI: 20-31-38
        Vendor PN: 169164        18
        Vendor Rev: 04
        Vendor SN: 

Ethernet27: SFP EEPROM Not detected

Ethernet28: SFP EEPROM Not detected

Ethernet29: SFP EEPROM Not detected

Ethernet30: SFP EEPROM Not detected

Ethernet31: SFP EEPROM Not detected

Ethernet32: SFP EEPROM Not detected

Ethernet33: SFP EEPROM Not detected

Ethernet34: SFP EEPROM Not detected

Ethernet35: SFP EEPROM Not detected

```

