### PR TITLE
[QoS] Fix issues in clear_qos

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -635,6 +635,8 @@ def _clear_cbf():
 
 def _clear_qos():
     QOS_TABLE_NAMES = [
+            'PORT_QOS_MAP',
+            'QUEUE',
             'TC_TO_PRIORITY_GROUP_MAP',
             'MAP_PFC_PRIORITY_TO_QUEUE',
             'TC_TO_QUEUE_MAP',
@@ -642,14 +644,14 @@ def _clear_qos():
             'MPLS_TC_TO_TC_MAP',
             'SCHEDULER',
             'PFC_PRIORITY_TO_PRIORITY_GROUP_MAP',
-            'PORT_QOS_MAP',
             'WRED_PROFILE',
-            'QUEUE',
             'CABLE_LENGTH',
-            'BUFFER_POOL',
-            'BUFFER_PROFILE',
             'BUFFER_PG',
             'BUFFER_QUEUE',
+            'BUFFER_PORT_INGRESS_PROFILE_LIST',
+            'BUFFER_PORT_EGRESS_PROFILE_LIST',
+            'BUFFER_PROFILE',
+            'BUFFER_POOL',
             'DEFAULT_LOSSLESS_BUFFER_PARAMETER',
             'LOSSLESS_TRAFFIC_PATTERN']
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Fix issues in `clear_qos`

- Remove tables BUFFER_PORT_INGRESS_PROFILE_LIST and BUFFER_PORT_EGRESS_PROFILE_LIST
  When `clear_qos` is executed, all QoS- and buffer-related tables should be removed. Currently, both tables are missed. This is to fix it.
- Adjust the order in which the buffer and QoS tables are removed
  Remove the tables whose entries depend on other tables first and then the tables whose entries are referenced by other tables.
  Any object can be removed from SAI only if there is no object referencing it. There are retrying and dependency-tracking mechanisms to guarantee it in `orchagent`.
  If CLI operates the table in an order where the referencing tables removed first before referenced tables, it is possible to reduce the probability to retry theoretically.
  The order does not guarantee it but adjusting the order is almost zero-cost so we would like to do it.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

