### PR TITLE
[autoneg] add support for remote speed advertisement

### DIFF
--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -180,7 +180,7 @@ def state_db_port_status_get(db, intf_name, field):
             status = '{}G'.format(int(speed / 1000))
         else:
             status = '{}M'.format(speed)
-    elif field in [PORT_ADV_SPEEDS, PORT_RMT_ADV_SPEEDS] and status not in ["N/A", "all"]:
+    elif field in [PORT_RMT_ADV_SPEEDS] and status not in ["N/A", "all"]:
         speed_list = status.split(',')
         new_speed_list = []
         for s in natsorted(speed_list):

--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -166,21 +166,29 @@ def appl_db_port_status_get(appl_db, intf_name, status_type):
         status = ','.join(new_speed_list)
     return status
 
-def state_db_port_status_get(db, intf_name, type):
+def state_db_port_status_get(db, intf_name, field):
     """
     Get the port status
     """
     full_table_id = PORT_STATE_TABLE_PREFIX + intf_name
-    status = db.get(db.STATE_DB, full_table_id, type)
-    if status in [None, ""]:
+    status = db.get(db.STATE_DB, full_table_id, field)
+    if not status:
         return "N/A"
-    if type == PORT_SPEED and status != "N/A":
-        status = '{}G'.format(status[:-3])
-    elif type in [PORT_ADV_SPEEDS, PORT_RMT_ADV_SPEEDS] and status not in ["N/A", "all"]:
+    if field == PORT_SPEED and status != "N/A":
+        speed = int(status)
+        if speed >= 1000:
+            status = '{}G'.format(int(speed / 1000))
+        else:
+            status = '{}M'.format(speed)
+    elif field in [PORT_ADV_SPEEDS, PORT_RMT_ADV_SPEEDS] and status not in ["N/A", "all"]:
         speed_list = status.split(',')
         new_speed_list = []
         for s in natsorted(speed_list):
-            new_speed_list.append('{}G'.format(s[:-3]))
+            speed = int(s)
+            if speed >= 1000:
+                new_speed_list.append('{}G'.format(int(speed / 1000)))
+            else:
+                new_speed_list.append('{}M'.format(speed))
         status = ','.join(new_speed_list)
     return status
 

--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -141,8 +141,12 @@ def port_speed_parse(in_speed, optics_type):
     speed = int(in_speed)
     if optics_type == OPTICS_TYPE_RJ45 and speed <= 1000:
         out_speed = '{}M'.format(speed)
+    elif speed < 1000:
+        out_speed = '{}M'.format(speed)
+    elif speed % 1000 >= 100:
+        out_speed = '{:.1f}G'.format(speed / 1000)
     else:
-        out_speed = '{}G'.format(int(speed/1000))
+        out_speed = '{:.0f}G'.format(speed / 1000)
 
     return out_speed
 
@@ -174,21 +178,12 @@ def state_db_port_status_get(db, intf_name, field):
     status = db.get(db.STATE_DB, full_table_id, field)
     if not status:
         return "N/A"
-    if field == PORT_SPEED and status != "N/A":
-        speed = int(status)
-        if speed >= 1000:
-            status = '{}G'.format(int(speed / 1000))
-        else:
-            status = '{}M'.format(speed)
-    elif field in [PORT_RMT_ADV_SPEEDS] and status not in ["N/A", "all"]:
+    if field in [PORT_RMT_ADV_SPEEDS] and status not in ["N/A", "all"]:
+        optics_type = state_db_port_optics_get(db, intf_name, PORT_OPTICS_TYPE)
         speed_list = status.split(',')
         new_speed_list = []
         for s in natsorted(speed_list):
-            speed = int(s)
-            if speed >= 1000:
-                new_speed_list.append('{}G'.format(int(speed / 1000)))
-            else:
-                new_speed_list.append('{}M'.format(speed))
+            new_speed_list.append(port_speed_parse(s, optics_type))
         status = ','.join(new_speed_list)
     return status
 

--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -45,6 +45,7 @@ PORT_OPTICS_TYPE = "type"
 PORT_PFC_ASYM_STATUS = "pfc_asym"
 PORT_AUTONEG = 'autoneg'
 PORT_ADV_SPEEDS = 'adv_speeds'
+PORT_RMT_ADV_SPEEDS = 'rmt_adv_speeds'
 PORT_INTERFACE_TYPE = 'interface_type'
 PORT_ADV_INTERFACE_TYPES = 'adv_interface_types'
 PORT_TPID = "tpid"
@@ -162,6 +163,24 @@ def appl_db_port_status_get(appl_db, intf_name, status_type):
         new_speed_list = []
         for s in natsorted(speed_list):
             new_speed_list.append(port_speed_parse(s, optics_type))
+        status = ','.join(new_speed_list)
+    return status
+
+def state_db_port_status_get(db, intf_name, type):
+    """
+    Get the port status
+    """
+    full_table_id = PORT_STATE_TABLE_PREFIX + intf_name
+    status = db.get(db.STATE_DB, full_table_id, type)
+    if status in [None, ""]:
+        return "N/A"
+    if type == PORT_SPEED and status != "N/A":
+        status = '{}G'.format(status[:-3])
+    elif type in [PORT_ADV_SPEEDS, PORT_RMT_ADV_SPEEDS] and status not in ["N/A", "all"]:
+        speed_list = status.split(',')
+        new_speed_list = []
+        for s in natsorted(speed_list):
+            new_speed_list.append('{}G'.format(s[:-3]))
         status = ','.join(new_speed_list)
     return status
 
@@ -566,7 +585,7 @@ class IntfDescription(object):
 
 
 # ========================== interface-autoneg logic ==========================
-header_autoneg = ['Interface', 'Auto-Neg Mode', 'Speed', 'Adv Speeds', 'Type', 'Adv Types', 'Oper', 'Admin']
+header_autoneg = ['Interface', 'Auto-Neg Mode', 'Speed', 'Adv Speeds', 'Rmt Adv Speeds', 'Type', 'Adv Types', 'Oper', 'Admin']
 
 
 class IntfAutoNegStatus(object):
@@ -616,6 +635,7 @@ class IntfAutoNegStatus(object):
                               autoneg_mode,
                               port_oper_speed_get(self.db, key),
                               appl_db_port_status_get(self.db, key, PORT_ADV_SPEEDS),
+                              state_db_port_status_get(self.db, key, PORT_RMT_ADV_SPEEDS),
                               appl_db_port_status_get(self.db, key, PORT_INTERFACE_TYPE),
                               appl_db_port_status_get(self.db, key, PORT_ADV_INTERFACE_TYPES),
                               appl_db_port_status_get(self.db, key, PORT_OPER_STATUS),

--- a/tests/dump_tests/dump_state_test.py
+++ b/tests/dump_tests/dump_state_test.py
@@ -34,6 +34,7 @@ table_display_output = '''\
 |             |           | | PORT_TABLE|Ethernet0 | +------------------+--------------------------+ | |
 |             |           | |                      | | field            | value                    | | |
 |             |           | |                      | |------------------+--------------------------| | |
+|             |           | |                      | | rmt_adv_speeds   | 40000                    | | |
 |             |           | |                      | | speed            | 100000                   | | |
 |             |           | |                      | | supported_speeds | 10000,25000,40000,100000 | | |
 |             |           | |                      | +------------------+--------------------------+ | |
@@ -120,7 +121,7 @@ class TestDumpState(object):
         expected = {'Ethernet0': {'CONFIG_DB': {'keys': [{'PORT|Ethernet0': {'alias': 'etp1', 'description': 'etp1', 'index': '0', 'lanes': '25,26,27,28', 'mtu': '9100', 'pfc_asym': 'off', 'speed': '40000'}}], 'tables_not_found': []},
                                   'APPL_DB': {'keys': [{'PORT_TABLE:Ethernet0': {'index': '0', 'lanes': '0', 'alias': 'Ethernet0', 'description': 'ARISTA01T2:Ethernet1', 'speed': '25000', 'oper_status': 'down', 'pfc_asym': 'off', 'mtu': '9100', 'fec': 'rs', 'admin_status': 'up'}}], 'tables_not_found': []},
                                   'ASIC_DB': {'keys': [{'ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF:oid:0xd00000000056d': {'SAI_HOSTIF_ATTR_NAME': 'Ethernet0', 'SAI_HOSTIF_ATTR_OBJ_ID': 'oid:0x10000000004a4', 'SAI_HOSTIF_ATTR_OPER_STATUS': 'true', 'SAI_HOSTIF_ATTR_TYPE': 'SAI_HOSTIF_TYPE_NETDEV', 'SAI_HOSTIF_ATTR_VLAN_TAG': 'SAI_HOSTIF_VLAN_TAG_STRIP'}}, {'ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x10000000004a4': {'NULL': 'NULL', 'SAI_PORT_ATTR_ADMIN_STATE': 'true', 'SAI_PORT_ATTR_MTU': '9122', 'SAI_PORT_ATTR_SPEED': '100000'}}], 'tables_not_found': [], 'vidtorid': {'oid:0xd00000000056d': 'oid:0xd', 'oid:0x10000000004a4': 'oid:0x1690000000001'}},
-                                  'STATE_DB': {'keys': [{'PORT_TABLE|Ethernet0': {'speed': '100000', 'supported_speeds': '10000,25000,40000,100000'}}], 'tables_not_found': []}}}
+                                  'STATE_DB': {'keys': [{'PORT_TABLE|Ethernet0': {'rmt_adv_speeds': '40000', 'speed': '100000', 'supported_speeds': '10000,25000,40000,100000'}}], 'tables_not_found': []}}}
 
         assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
         # Cause other tests depend and change these paths in the mock_db, this test would fail everytime when a field or a value in changed in this path, creating noise
@@ -137,7 +138,7 @@ class TestDumpState(object):
                     {"CONFIG_DB": {"keys": [{"PORT|Ethernet0": {"alias": "etp1", "description": "etp1", "index": "0", "lanes": "25,26,27,28", "mtu": "9100", "pfc_asym": "off", "speed": "40000"}}], "tables_not_found": []},
                      "APPL_DB": {"keys": [{"PORT_TABLE:Ethernet0": {"index": "0", "lanes": "0", "alias": "Ethernet0", "description": "ARISTA01T2:Ethernet1", "speed": "25000", "oper_status": "down", "pfc_asym": "off", "mtu": "9100", "fec": "rs", "admin_status": "up"}}], "tables_not_found": []},
                      "ASIC_DB": {"keys": [{"ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF:oid:0xd00000000056d": {"SAI_HOSTIF_ATTR_NAME": "Ethernet0", "SAI_HOSTIF_ATTR_OBJ_ID": "oid:0x10000000004a4", "SAI_HOSTIF_ATTR_OPER_STATUS": "true", "SAI_HOSTIF_ATTR_TYPE": "SAI_HOSTIF_TYPE_NETDEV", "SAI_HOSTIF_ATTR_VLAN_TAG": "SAI_HOSTIF_VLAN_TAG_STRIP"}}, {"ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x10000000004a4": {"NULL": "NULL", "SAI_PORT_ATTR_ADMIN_STATE": "true", "SAI_PORT_ATTR_MTU": "9122", "SAI_PORT_ATTR_SPEED": "100000"}}], "tables_not_found": [], "vidtorid": {"oid:0xd00000000056d": "oid:0xd", "oid:0x10000000004a4": "oid:0x1690000000001"}},
-                     "STATE_DB": {"keys": [{"PORT_TABLE|Ethernet0": {"speed": "100000", "supported_speeds": "10000,25000,40000,100000"}}], "tables_not_found": []}},
+                     "STATE_DB": {"keys": [{"PORT_TABLE|Ethernet0": {"rmt_adv_speeds": "40000", "speed": "100000", "supported_speeds": "10000,25000,40000,100000"}}], "tables_not_found": []}},
                     "Ethernet4":
                     {"CONFIG_DB": {"keys": [{"PORT|Ethernet4": {"admin_status": "up", "alias": "etp2", "description": "Servers0:eth0", "index": "1", "lanes": "29,30,31,32", "mtu": "9100", "pfc_asym": "off", "speed": "40000"}}], "tables_not_found": []},
                         "APPL_DB": {"keys": [], "tables_not_found": ["PORT_TABLE"]},
@@ -166,7 +167,7 @@ class TestDumpState(object):
         result = runner.invoke(dump.state, ["port", "Ethernet0", "--db", "ASIC_DB", "--db", "STATE_DB"])
         print(result.output)
         expected = {"Ethernet0": {"ASIC_DB": {"keys": [{"ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF:oid:0xd00000000056d": {"SAI_HOSTIF_ATTR_NAME": "Ethernet0", "SAI_HOSTIF_ATTR_OBJ_ID": "oid:0x10000000004a4", "SAI_HOSTIF_ATTR_OPER_STATUS": "true", "SAI_HOSTIF_ATTR_TYPE": "SAI_HOSTIF_TYPE_NETDEV", "SAI_HOSTIF_ATTR_VLAN_TAG": "SAI_HOSTIF_VLAN_TAG_STRIP"}}, {"ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x10000000004a4": {"NULL": "NULL", "SAI_PORT_ATTR_ADMIN_STATE": "true", "SAI_PORT_ATTR_MTU": "9122", "SAI_PORT_ATTR_SPEED": "100000"}}], "tables_not_found": [], "vidtorid": {"oid:0xd00000000056d": "oid:0xd", "oid:0x10000000004a4": "oid:0x1690000000001"}},
-                                  "STATE_DB": {"keys": [{"PORT_TABLE|Ethernet0": {"speed": "100000", "supported_speeds": "10000,25000,40000,100000"}}], "tables_not_found": []}}}
+                                  "STATE_DB": {"keys": [{"PORT_TABLE|Ethernet0": {"rmt_adv_speeds": "40000", "speed": "100000", "supported_speeds": "10000,25000,40000,100000"}}], "tables_not_found": []}}}
         assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
         ddiff = compare_json_output(expected, result.output)
         assert not ddiff, ddiff

--- a/tests/dump_tests/dump_state_test.py
+++ b/tests/dump_tests/dump_state_test.py
@@ -34,7 +34,7 @@ table_display_output = '''\
 |             |           | | PORT_TABLE|Ethernet0 | +------------------+--------------------------+ | |
 |             |           | |                      | | field            | value                    | | |
 |             |           | |                      | |------------------+--------------------------| | |
-|             |           | |                      | | rmt_adv_speeds   | 40000                    | | |
+|             |           | |                      | | rmt_adv_speeds   | 10,100,1000              | | |
 |             |           | |                      | | speed            | 100000                   | | |
 |             |           | |                      | | supported_speeds | 10000,25000,40000,100000 | | |
 |             |           | |                      | +------------------+--------------------------+ | |
@@ -121,7 +121,7 @@ class TestDumpState(object):
         expected = {'Ethernet0': {'CONFIG_DB': {'keys': [{'PORT|Ethernet0': {'alias': 'etp1', 'description': 'etp1', 'index': '0', 'lanes': '25,26,27,28', 'mtu': '9100', 'pfc_asym': 'off', 'speed': '40000'}}], 'tables_not_found': []},
                                   'APPL_DB': {'keys': [{'PORT_TABLE:Ethernet0': {'index': '0', 'lanes': '0', 'alias': 'Ethernet0', 'description': 'ARISTA01T2:Ethernet1', 'speed': '25000', 'oper_status': 'down', 'pfc_asym': 'off', 'mtu': '9100', 'fec': 'rs', 'admin_status': 'up'}}], 'tables_not_found': []},
                                   'ASIC_DB': {'keys': [{'ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF:oid:0xd00000000056d': {'SAI_HOSTIF_ATTR_NAME': 'Ethernet0', 'SAI_HOSTIF_ATTR_OBJ_ID': 'oid:0x10000000004a4', 'SAI_HOSTIF_ATTR_OPER_STATUS': 'true', 'SAI_HOSTIF_ATTR_TYPE': 'SAI_HOSTIF_TYPE_NETDEV', 'SAI_HOSTIF_ATTR_VLAN_TAG': 'SAI_HOSTIF_VLAN_TAG_STRIP'}}, {'ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x10000000004a4': {'NULL': 'NULL', 'SAI_PORT_ATTR_ADMIN_STATE': 'true', 'SAI_PORT_ATTR_MTU': '9122', 'SAI_PORT_ATTR_SPEED': '100000'}}], 'tables_not_found': [], 'vidtorid': {'oid:0xd00000000056d': 'oid:0xd', 'oid:0x10000000004a4': 'oid:0x1690000000001'}},
-                                  'STATE_DB': {'keys': [{'PORT_TABLE|Ethernet0': {'rmt_adv_speeds': '40000', 'speed': '100000', 'supported_speeds': '10000,25000,40000,100000'}}], 'tables_not_found': []}}}
+                                  'STATE_DB': {'keys': [{'PORT_TABLE|Ethernet0': {'rmt_adv_speeds': '10,100,1000', 'speed': '100000', 'supported_speeds': '10000,25000,40000,100000'}}], 'tables_not_found': []}}}
 
         assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
         # Cause other tests depend and change these paths in the mock_db, this test would fail everytime when a field or a value in changed in this path, creating noise
@@ -138,7 +138,7 @@ class TestDumpState(object):
                     {"CONFIG_DB": {"keys": [{"PORT|Ethernet0": {"alias": "etp1", "description": "etp1", "index": "0", "lanes": "25,26,27,28", "mtu": "9100", "pfc_asym": "off", "speed": "40000"}}], "tables_not_found": []},
                      "APPL_DB": {"keys": [{"PORT_TABLE:Ethernet0": {"index": "0", "lanes": "0", "alias": "Ethernet0", "description": "ARISTA01T2:Ethernet1", "speed": "25000", "oper_status": "down", "pfc_asym": "off", "mtu": "9100", "fec": "rs", "admin_status": "up"}}], "tables_not_found": []},
                      "ASIC_DB": {"keys": [{"ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF:oid:0xd00000000056d": {"SAI_HOSTIF_ATTR_NAME": "Ethernet0", "SAI_HOSTIF_ATTR_OBJ_ID": "oid:0x10000000004a4", "SAI_HOSTIF_ATTR_OPER_STATUS": "true", "SAI_HOSTIF_ATTR_TYPE": "SAI_HOSTIF_TYPE_NETDEV", "SAI_HOSTIF_ATTR_VLAN_TAG": "SAI_HOSTIF_VLAN_TAG_STRIP"}}, {"ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x10000000004a4": {"NULL": "NULL", "SAI_PORT_ATTR_ADMIN_STATE": "true", "SAI_PORT_ATTR_MTU": "9122", "SAI_PORT_ATTR_SPEED": "100000"}}], "tables_not_found": [], "vidtorid": {"oid:0xd00000000056d": "oid:0xd", "oid:0x10000000004a4": "oid:0x1690000000001"}},
-                     "STATE_DB": {"keys": [{"PORT_TABLE|Ethernet0": {"rmt_adv_speeds": "40000", "speed": "100000", "supported_speeds": "10000,25000,40000,100000"}}], "tables_not_found": []}},
+                     "STATE_DB": {"keys": [{"PORT_TABLE|Ethernet0": {"rmt_adv_speeds": "10,100,1000", "speed": "100000", "supported_speeds": "10000,25000,40000,100000"}}], "tables_not_found": []}},
                     "Ethernet4":
                     {"CONFIG_DB": {"keys": [{"PORT|Ethernet4": {"admin_status": "up", "alias": "etp2", "description": "Servers0:eth0", "index": "1", "lanes": "29,30,31,32", "mtu": "9100", "pfc_asym": "off", "speed": "40000"}}], "tables_not_found": []},
                         "APPL_DB": {"keys": [], "tables_not_found": ["PORT_TABLE"]},
@@ -167,7 +167,7 @@ class TestDumpState(object):
         result = runner.invoke(dump.state, ["port", "Ethernet0", "--db", "ASIC_DB", "--db", "STATE_DB"])
         print(result.output)
         expected = {"Ethernet0": {"ASIC_DB": {"keys": [{"ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF:oid:0xd00000000056d": {"SAI_HOSTIF_ATTR_NAME": "Ethernet0", "SAI_HOSTIF_ATTR_OBJ_ID": "oid:0x10000000004a4", "SAI_HOSTIF_ATTR_OPER_STATUS": "true", "SAI_HOSTIF_ATTR_TYPE": "SAI_HOSTIF_TYPE_NETDEV", "SAI_HOSTIF_ATTR_VLAN_TAG": "SAI_HOSTIF_VLAN_TAG_STRIP"}}, {"ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x10000000004a4": {"NULL": "NULL", "SAI_PORT_ATTR_ADMIN_STATE": "true", "SAI_PORT_ATTR_MTU": "9122", "SAI_PORT_ATTR_SPEED": "100000"}}], "tables_not_found": [], "vidtorid": {"oid:0xd00000000056d": "oid:0xd", "oid:0x10000000004a4": "oid:0x1690000000001"}},
-                                  "STATE_DB": {"keys": [{"PORT_TABLE|Ethernet0": {"rmt_adv_speeds": "40000", "speed": "100000", "supported_speeds": "10000,25000,40000,100000"}}], "tables_not_found": []}}}
+                                  "STATE_DB": {"keys": [{"PORT_TABLE|Ethernet0": {"rmt_adv_speeds": "10,100,1000", "speed": "100000", "supported_speeds": "10000,25000,40000,100000"}}], "tables_not_found": []}}}
         assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
         ddiff = compare_json_output(expected, result.output)
         assert not ddiff, ddiff

--- a/tests/intfutil_test.py
+++ b/tests/intfutil_test.py
@@ -73,7 +73,7 @@ show_interface_description_eth9_output="""\
 show_interface_auto_neg_status_output = """\
   Interface    Auto-Neg Mode    Speed    Adv Speeds    Rmt Adv Speeds    Type    Adv Types    Oper    Admin
 -----------  ---------------  -------  ------------  ----------------  ------  -----------  ------  -------
-  Ethernet0          enabled      25G       10G,50G               40G     CR4      CR4,CR2    down       up
+  Ethernet0          enabled      25G       10G,50G       10M,100M,1G     CR4      CR4,CR2    down       up
  Ethernet16              N/A     100M           N/A               N/A     N/A          N/A      up       up
  Ethernet24              N/A       1G           N/A               N/A     N/A          N/A      up       up
  Ethernet28              N/A    1000M           N/A               N/A     N/A          N/A      up       up
@@ -88,7 +88,7 @@ Ethernet124              N/A      40G           N/A               N/A     N/A   
 show_interface_auto_neg_status_Ethernet0_output = """\
   Interface    Auto-Neg Mode    Speed    Adv Speeds    Rmt Adv Speeds    Type    Adv Types    Oper    Admin
 -----------  ---------------  -------  ------------  ----------------  ------  -----------  ------  -------
-  Ethernet0          enabled      25G       10G,50G               40G     CR4      CR4,CR2    down       up
+  Ethernet0          enabled      25G       10G,50G       10M,100M,1G     CR4      CR4,CR2    down       up
 """
 
 show_interface_auto_neg_status_eth9_output = """\
@@ -293,7 +293,7 @@ class TestIntfutil(TestCase):
         assert result.exit_code == 0
         assert result.output == show_interface_auto_neg_status_Ethernet0_output
   
-    def test_show_interfaces_autoneg_status_eth9_in_alias_mode(self):
+    def test_show_interfaces_autoneg_status_etp9_in_alias_mode(self):
         os.environ["SONIC_CLI_IFACE_MODE"] = "alias"
         result = self.runner.invoke(show.cli.commands["interfaces"].commands["autoneg"].commands["status"], ["etp9"])
         os.environ["SONIC_CLI_IFACE_MODE"] = "default"

--- a/tests/intfutil_test.py
+++ b/tests/intfutil_test.py
@@ -71,30 +71,30 @@ show_interface_description_eth9_output="""\
 """
 
 show_interface_auto_neg_status_output = """\
-  Interface    Auto-Neg Mode    Speed    Adv Speeds    Type    Adv Types    Oper    Admin
------------  ---------------  -------  ------------  ------  -----------  ------  -------
-  Ethernet0          enabled      25G       10G,50G     CR4      CR4,CR2    down       up
- Ethernet16              N/A     100M           N/A     N/A          N/A      up       up
- Ethernet24              N/A       1G           N/A     N/A          N/A      up       up
- Ethernet28              N/A    1000M           N/A     N/A          N/A      up       up
- Ethernet32         disabled      40G           all     N/A          all      up       up
- Ethernet36              N/A      10M           N/A     N/A          N/A      up       up
-Ethernet112              N/A      40G           N/A     N/A          N/A      up       up
-Ethernet116              N/A      40G           N/A     N/A          N/A      up       up
-Ethernet120              N/A      40G           N/A     N/A          N/A      up       up
-Ethernet124              N/A      40G           N/A     N/A          N/A      up       up
+  Interface    Auto-Neg Mode    Speed    Adv Speeds    Rmt Adv Speeds    Type    Adv Types    Oper    Admin
+-----------  ---------------  -------  ------------  ----------------  ------  -----------  ------  -------
+  Ethernet0          enabled      25G       10G,50G               40G     CR4      CR4,CR2    down       up
+ Ethernet16              N/A     100M           N/A               N/A     N/A          N/A      up       up
+ Ethernet24              N/A       1G           N/A               N/A     N/A          N/A      up       up
+ Ethernet28              N/A    1000M           N/A               N/A     N/A          N/A      up       up
+ Ethernet32         disabled      40G           all               N/A     N/A          all      up       up
+ Ethernet36              N/A      10M           N/A               N/A     N/A          N/A      up       up
+Ethernet112              N/A      40G           N/A               N/A     N/A          N/A      up       up
+Ethernet116              N/A      40G           N/A               N/A     N/A          N/A      up       up
+Ethernet120              N/A      40G           N/A               N/A     N/A          N/A      up       up
+Ethernet124              N/A      40G           N/A               N/A     N/A          N/A      up       up
 """
 
 show_interface_auto_neg_status_Ethernet0_output = """\
-  Interface    Auto-Neg Mode    Speed    Adv Speeds    Type    Adv Types    Oper    Admin
------------  ---------------  -------  ------------  ------  -----------  ------  -------
-  Ethernet0          enabled      25G       10G,50G     CR4      CR4,CR2    down       up
+  Interface    Auto-Neg Mode    Speed    Adv Speeds    Rmt Adv Speeds    Type    Adv Types    Oper    Admin
+-----------  ---------------  -------  ------------  ----------------  ------  -----------  ------  -------
+  Ethernet0          enabled      25G       10G,50G               40G     CR4      CR4,CR2    down       up
 """
 
 show_interface_auto_neg_status_eth9_output = """\
-  Interface    Auto-Neg Mode    Speed    Adv Speeds    Type    Adv Types    Oper    Admin
------------  ---------------  -------  ------------  ------  -----------  ------  -------
- Ethernet32         disabled      40G           all     N/A          all      up       up
+  Interface    Auto-Neg Mode    Speed    Adv Speeds    Rmt Adv Speeds    Type    Adv Types    Oper    Admin
+-----------  ---------------  -------  ------------  ----------------  ------  -----------  ------  -------
+ Ethernet32         disabled      40G           all               N/A     N/A          all      up       up
 """
 
 
@@ -293,7 +293,7 @@ class TestIntfutil(TestCase):
         assert result.exit_code == 0
         assert result.output == show_interface_auto_neg_status_Ethernet0_output
   
-    def test_show_interfaces_autoneg_status_etp9_in_alias_mode(self):
+    def test_show_interfaces_autoneg_status_eth9_in_alias_mode(self):
         os.environ["SONIC_CLI_IFACE_MODE"] = "alias"
         result = self.runner.invoke(show.cli.commands["interfaces"].commands["autoneg"].commands["status"], ["etp9"])
         os.environ["SONIC_CLI_IFACE_MODE"] = "default"

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -683,6 +683,7 @@
         "access": "False"
     },
     "PORT_TABLE|Ethernet0": {
+        "rmt_adv_speeds" : "40000",
         "speed" : "100000",
         "supported_speeds": "10000,25000,40000,100000"
     },

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -683,7 +683,7 @@
         "access": "False"
     },
     "PORT_TABLE|Ethernet0": {
-        "rmt_adv_speeds" : "40000",
+        "rmt_adv_speeds" : "10,100,1000",
         "speed" : "100000",
         "supported_speeds": "10000,25000,40000,100000"
     },


### PR DESCRIPTION
Add support for remote speed advertisement, such that users could easily
identify the connection issues when autoneg is enabled.

HLD: Azure/SONiC#924

Signed-off-by: Dante Su <dante.su@broadcom.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add support for remote speed advertisement

#### How I did it
Implementation is done according to the AutoNeg HLD

#### How to verify it
1. Built-in unit tests
2. Manual tests

#### Previous command output (if the output of a command-line utility has changed)

```
  Interface    Auto-Neg Mode    Speed    Adv Speeds    Type    Adv Types    Oper    Admin
-----------  ---------------  -------  ------------  ------  -----------  ------  -------
  Ethernet0          enabled      25G       10G,50G     CR4      CR4,CR2    down       up
 Ethernet16              N/A     100M           N/A     N/A          N/A      up       up
 Ethernet24              N/A       1G           N/A     N/A          N/A      up       up
 Ethernet28              N/A    1000M           N/A     N/A          N/A      up       up
 Ethernet32         disabled      40G           all     N/A          all      up       up
 Ethernet36              N/A      10M           N/A     N/A          N/A      up       up

```
#### New command output (if the output of a command-line utility has changed)

```
  Interface    Auto-Neg Mode    Speed    Adv Speeds    Rmt Adv Speeds    Type    Adv Types    Oper    Admin
-----------  ---------------  -------  ------------  ----------------  ------  -----------  ------  -------
  Ethernet0          enabled      25G       10G,50G       10M,100M,1G     CR4      CR4,CR2    down       up
 Ethernet16              N/A     100M           N/A               N/A     N/A          N/A      up       up
 Ethernet24              N/A       1G           N/A               N/A     N/A          N/A      up       up
 Ethernet28              N/A    1000M           N/A               N/A     N/A          N/A      up       up
 Ethernet32         disabled      40G           all               N/A     N/A          all      up       up
 Ethernet36              N/A      10M           N/A               N/A     N/A          N/A      up       up

```