### PR TITLE
Fix 'show mac' output when FDB entry for default vlan is None instead of 1

### DIFF
--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -130,7 +130,9 @@ class FdbShow(object):
                     except Exception:
                         vlan_id = bvid
                         print("Failed to get Vlan id for bvid {}\n".format(bvid))
-            self.bridge_mac_list.append((int(vlan_id or 1),) + (fdb["mac"],) + (if_name,) + (fdb_type,))
+
+            if vlan_id is not None:
+                self.bridge_mac_list.append((int(vlan_id),) + (fdb["mac"],) + (if_name,) + (fdb_type,))
 
         self.bridge_mac_list.sort(key = lambda x: x[0])
         return

--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -130,7 +130,7 @@ class FdbShow(object):
                     except Exception:
                         vlan_id = bvid
                         print("Failed to get Vlan id for bvid {}\n".format(bvid))
-            self.bridge_mac_list.append((int(vlan_id),) + (fdb["mac"],) + (if_name,) + (fdb_type,))
+            self.bridge_mac_list.append((int(vlan_id or 1),) + (fdb["mac"],) + (if_name,) + (fdb_type,))
 
         self.bridge_mac_list.sort(key = lambda x: x[0])
         return


### PR DESCRIPTION
• Fixes an issue where VLAN ID of None results in "int() argument must be a string, a bytes-like object or a number, not 'NoneType'" error.

Signed-off-by: James Denton <james.denton@outlook.com>

#### What I did

Fixed "show mac" command execution failure when the system has an FDB entry linked to default Vlan 1 that cannot be looked up (returns None).

#### How I did it

If VLAN ID is None, assume it is 1 and allow the entry to be listed.

#### How to verify it

Pass traffic through an unconfigured interface and perform a 'show mac' or 'fdbshow'  command. 

#### Previous command output (if the output of a command-line utility has changed)

admin@sonic:~$ show mac
int() argument must be a string, a bytes-like object or a number, not 'NoneType'

#### New command output (if the output of a command-line utility has changed)

admin@sonic:~$ show mac
  No.    Vlan  MacAddress         Port          Type
-----  ------  -----------------  ------------  -------
    1       1  98:03:9B:BE:E9:68  Ethernet60    Dynamic
    2       1  6C:3B:E5:BD:14:D0  Ethernet21    Dynamic
    3       1  00:0C:29:E6:70:A2  Ethernet2     Dynamic
    4       1  3C:FD:FE:9E:8A:C9  PortChannel2  Dynamic
    5       1  6C:6C:D3:CC:04:41  Ethernet60    Dynamic
    6       6  FA:16:3E:27:E2:C7  Ethernet2     Dynamic
    7       6  6C:6C:D3:CC:04:33  Ethernet60    Dynamic
    8      20  00:16:3E:22:62:4F  Ethernet2     Dynamic
    9      20  00:16:3E:BF:84:84  Ethernet2     Dynamic
   10      20  00:16:3E:50:A3:35  Ethernet2     Dynamic
   11      20  00:16:3E:1A:74:BD  Ethernet2     Dynamic
   12      20  00:16:3E:37:EE:EC  Ethernet2     Dynamic
   13      20  00:16:3E:5A:71:A2  Ethernet2     Dynamic