### PR TITLE
[show][muxcable] Decrease the timeout for show mux status/hwmode muxdirection from 1 sec to 100ms

### DIFF
--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -18,6 +18,7 @@ platform_sfputil = None
 
 REDIS_TIMEOUT_MSECS = 0
 SELECT_TIMEOUT = 1000
+HWMODE_MUXDIRECTION_TIMEOUT = 0.1
 
 # The empty namespace refers to linux host namespace.
 EMPTY_NAMESPACE = ''
@@ -1095,7 +1096,7 @@ def get_hwmode_mux_direction_port(db, port):
     if port is not None:
 
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "state", "state", "True", "XCVRD_SHOW_HWMODE_DIR_CMD", "XCVRD_SHOW_HWMODE_DIR_RES", "XCVRD_SHOW_HWMODE_DIR_RSP", port, 1, None, "probe")
+            "state", "state", "True", "XCVRD_SHOW_HWMODE_DIR_CMD", "XCVRD_SHOW_HWMODE_DIR_RES", "XCVRD_SHOW_HWMODE_DIR_RSP", port, HWMODE_MUXDIRECTION_TIMEOUT, None, "probe")
 
         result = get_result(port, res_dict, "muxdirection" , result, "XCVRD_SHOW_HWMODE_DIR_RES")
 


### PR DESCRIPTION

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Currently the response for hwmode muxdirection comes from ycabled. Since ycabled might not be running/exited state or
if the underlying hardware takes a long time to reciprocate the response for muxdirection, we decrease the timeout for the command, so atleast the user can see the output of CLI in 100ms. 
#### How I did it
Added a constant timeout variable inside show/muxcable.py

#### How to verify it
Ran the change on Test DUT and unit-tests
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

