### PR TITLE
[scripts/fast-reboot] stop timers in advance

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -670,6 +670,13 @@ if [ -x ${LOG_SSD_HEALTH} ]; then
     ${LOG_SSD_HEALTH}
 fi
 
+# Stop any timers to prevent any containers starting in the middle of the process.
+TIMERS=$(systemctl list-dependencies --plain sonic-delayed.target | sed 1d)
+for timer in ${TIMERS}; do
+    debug "Stopping ${timer} ..."
+    systemctl stop ${timer}
+    debug "Stopped ${timer} ..."
+done
 
 if [[ -f ${SHUTDOWN_ORDER_FILE} ]]; then
     SERVICES_TO_STOP="$(cat ${SHUTDOWN_ORDER_FILE})"


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Service timers may trigger service start in the middle of warm-reboot. Stopping them in advance prevents this issue.

#### How I did it

Stopped all service timers that are part of sonic-delayed.target

#### How to verify it

Run warm-reboot.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)


*Requested for*: 202111, 202012