### PR TITLE
[scripts/fast-reboot] cleanup

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -674,15 +674,8 @@ fi
 if [[ -f ${SHUTDOWN_ORDER_FILE} ]]; then
     SERVICES_TO_STOP="$(cat ${SHUTDOWN_ORDER_FILE})"
 else
-    # TODO: to be removed once sonic-buildimage change is in
-    if [[ "${REBOOT_TYPE}" == "fast-reboot" ]]; then
-        SERVICES_TO_STOP="nat radv bgp sflow lldp swss teamd syncd"
-    elif [[ "${REBOOT_TYPE}" == "fastfast-reboot" || "${REBOOT_TYPE}" == "warm-reboot" ]]; then
-        SERVICES_TO_STOP="nat radv bgp sflow lldp teamd swss syncd"
-    else
-        error "Unexpected reboot type ${REBOOT_TYPE}"
-        exit $EXIT_FAILURE
-    fi
+    error "No shutdown sequence file found: ${SHUTDOWN_ORDER_FILE}"
+    exit "${EXIT_FAILURE}"
 fi
 
 for service in ${SERVICES_TO_STOP}; do


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Remove obsolete code.

#### How I did it

Removed obsolete code.

#### How to verify it

Run warm-reboot.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

*Requested for*: 202111