### PR TITLE
Fix incorrect command for portchannel creation

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -6747,7 +6747,7 @@ A port channel can be deleted only if it does not have any members or the member
 
 - Usage:
   ```
-  config portchannel (add | del) <portchannel_name> [min-links <num_min_links>] [fallback (true | false)]
+  config portchannel (add | del) <portchannel_name> [--min-links <num_min_links>] [--fallback (true | false)]
   ```
 
 - Example (Create the portchannel with name "PortChannel0011"):


### PR DESCRIPTION
Signed-off-by: EdenGri <eden7045@gmail.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix command for portchannel creation

#### How I did it
Change the command line guide:
Before:
config portchannel (add | del) [min-links ] [fallback (true | false)]
After:
config portchannel (add | del) [--min-links ] [--fallback (true | false)]
#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

