### PR TITLE
[show] fix get routing stack routine

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -78,7 +78,7 @@ def get_routing_stack():
     command = "sudo docker ps | grep bgp | awk '{print$2}' | cut -d'-' -f3 | cut -d':' -f1 | head -n 1"
 
     try:
-        stdout = subprocess.check_output(command, shell=True, timeout=COMMAND_TIMEOUT)
+        stdout = subprocess.check_output(command, shell=True, text=True, timeout=COMMAND_TIMEOUT)
         result = stdout.rstrip('\n')
     except Exception as err:
         click.echo('Failed to get routing stack: {}'.format(err), err=True)


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Fixed error message: "Failed to get routing stack: a bytes-like object is required, not 'str'" introduced by https://github.com/Azure/sonic-utilities/pull/2117

#### How I did it
Add missing 'text' paramter

#### How to verify it

Run on switch

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)


Required for 202111