### PR TITLE
Fix speed parsing when speed is NOT fetched from APPL_DB

### DIFF
--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -132,9 +132,9 @@ def appl_db_sub_intf_keys_get(appl_db, sub_intf_list, sub_intf_name):
     return appl_db_sub_intf_keys
 
 
-def appl_db_port_speed_parse(in_speed, optics_type):
+def port_speed_parse(in_speed, optics_type):
     """
-    Parse the speed received from application DB
+    Parse the speed received from DB
     """
     # fetched speed is in megabits per second
     speed = int(in_speed)
@@ -155,13 +155,13 @@ def appl_db_port_status_get(appl_db, intf_name, status_type):
         return "N/A"
     if status_type == PORT_SPEED and status != "N/A":
         optics_type = state_db_port_optics_get(appl_db, intf_name, PORT_OPTICS_TYPE)
-        status = appl_db_port_speed_parse(status, optics_type)
+        status = port_speed_parse(status, optics_type)
     elif status_type == PORT_ADV_SPEEDS and status != "N/A" and status != "all":
         optics_type = state_db_port_optics_get(appl_db, intf_name, PORT_OPTICS_TYPE)
         speed_list = status.split(',')
         new_speed_list = []
         for s in natsorted(speed_list):
-            new_speed_list.append(appl_db_port_speed_parse(s, optics_type))
+            new_speed_list.append(port_speed_parse(s, optics_type))
         status = ','.join(new_speed_list)
     return status
 
@@ -173,8 +173,9 @@ def port_oper_speed_get(db, intf_name):
     oper_status = db.get(db.APPL_DB, PORT_STATUS_TABLE_PREFIX + intf_name, PORT_OPER_STATUS)
     if oper_speed is None or oper_speed == "N/A" or oper_status != "up":
         return appl_db_port_status_get(db, intf_name, PORT_SPEED)
-
-    return '{}G'.format(oper_speed[:-3])
+    else:
+        optics_type = state_db_port_optics_get(db, intf_name, PORT_OPTICS_TYPE)
+        return port_speed_parse(oper_speed, optics_type)
 
 def port_oper_speed_get_raw(db, intf_name):
     """
@@ -301,7 +302,7 @@ def po_speed_dict(po_int_dict, appl_db):
                     po_list.append(None)
                 else:
                     optics_type = state_db_port_optics_get(appl_db, value[0], PORT_OPTICS_TYPE)
-                    interface_speed = appl_db_port_speed_parse(interface_speed, optics_type)
+                    interface_speed = port_speed_parse(interface_speed, optics_type)
                     po_list.append(interface_speed)
             elif len(value) > 1:
                 for intf in value:
@@ -311,7 +312,7 @@ def po_speed_dict(po_int_dict, appl_db):
                     agg_speed_list.append(temp_speed)
                     interface_speed = sum(agg_speed_list)
                     interface_speed = str(interface_speed)
-                    interface_speed = appl_db_port_speed_parse(interface_speed, optics_type)
+                    interface_speed = port_speed_parse(interface_speed, optics_type)
                 po_list.append(interface_speed)
             po_speed_dict = dict(po_list[i:i+2] for i in range(0, len(po_list), 2))
         return po_speed_dict

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -801,5 +801,26 @@
         "pck_expected_count": "840",
         "link_prober_unknown_start": "2022-Jan-26 03:13:05.366900",
         "link_prober_unknown_end": "2022-Jan-26 03:17:35.446580"
+    },
+    "PORT_TABLE|Ethernet16": {
+        "state": "ok",
+        "netdev_oper_status": "up",
+        "admin_status": "up",
+        "mtu":  "9100",
+        "speed": "100"
+    },
+    "PORT_TABLE|Ethernet36": {
+        "state": "ok",
+        "netdev_oper_status": "up",
+        "admin_status": "up",
+        "mtu":  "9100",
+        "speed": "10"
+    },
+    "PORT_TABLE|Ethernet24": {
+        "state": "ok",
+        "netdev_oper_status": "up",
+        "admin_status": "up",
+        "mtu":  "9100",
+        "speed": "1000"
     }
 }


### PR DESCRIPTION
Signed-off-by: Kebo Liu <kebol@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
In PR https://github.com/Azure/sonic-utilities/pull/2110 introduced an enhancement to support display port speed with different unit when it is RJ45 ports, however, it only covered the case that the speed was fetched from APPL_DB. 
Recently there is a change to fetch the speed from STATE_DB in some cases, the same logic also needs to be applied in this case.

#### How I did it
1. rename `appl_db_port_speed_parse`  to a more generic name `port_speed_parse`.
2. call `port_speed_parse` when speed is fetched from STATE_DB.
3. In UT test, add port status entires to mocked STATE_DB to cover the logic that get port speed from STATE_DB.

#### How to verify it
UT and test it on platform support RJ45 ports

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
