### PR TITLE
[202012][dualtor] Fix config_db.json path for config-reload

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -937,7 +937,7 @@ def cache_arp_entries():
     if not cache_err:
         fdb_cache_file = os.path.join(cache_dir, 'fdb.json')
         arp_cache_file = os.path.join(cache_dir, 'arp.json')
-        fdb_filter_cmd = '/usr/local/bin/filter_fdb_entries -f {} -a {} -c /etc/sonic/configdb.json'.format(fdb_cache_file, arp_cache_file)
+        fdb_filter_cmd = '/usr/local/bin/filter_fdb_entries -f {} -a {} -c /etc/sonic/config_db.json'.format(fdb_cache_file, arp_cache_file)
         filter_proc = subprocess.Popen(fdb_filter_cmd, shell=True, text=True, stdout=subprocess.PIPE)
         _, filter_err = filter_proc.communicate()
         if filter_err:


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix the path to `config_db.json` in config-reload for dual-tor device.

Related PR: https://github.com/Azure/sonic-utilities/pull/1465

Presently, there exists a typo in `config_db.json` filename that is sent as an argument to `filter_fdb_entries`. This causes failure during config reload:
```
Apr 27 01:35:26.990670 str2-7050cx3-acs-10 ERR filter_fdb_entries:
	Got an exception file '/etc/sonic/configdb.json' does not exist:
	Traceback: Traceback (most recent call last):
	#012  File "/usr/local/lib/python3.7/dist-packages/fdbutil/filter_fdb_entries.py", line 146, in main
	#012  file_exists_or_raise(config_db_filename)
	#012  File "/usr/local/lib/python3.7/dist-packages/fdbutil/filter_fdb_entries.py", line 126, in file_exists_or_raise
	#012  raise Exception("file '{0}' does not exist".format(filename))
	#012  Exception: file '/etc/sonic/configdb.json' does not exist
```

#### How I did it
Fix the typo.

#### How to verify it
Config reload does not throw errors any more in the syslog.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

