### PR TITLE
[GCU] Validate peer_group_range ip_range are correct

### DIFF
--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -119,7 +119,7 @@ class ConfigWrapper:
 
             sy.validate_data_tree()
 
-            # TODO: modularize custom validations better
+            # TODO: modularize custom validations better or move directly to sonic-yang module
             return self.validate_bgp_peer_group(config_db_as_json)
         except sonic_yang.SonicYangException as ex:
             return False, ex

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -124,7 +124,6 @@ class ConfigWrapper:
         except sonic_yang.SonicYangException as ex:
             return False, ex
 
-    # TODO: unit-test
     def validate_bgp_peer_group(self, config_db):
         if "BGP_PEER_RANGE" not in config_db:
             return True, None
@@ -136,15 +135,15 @@ class ConfigWrapper:
             if "ip_range" not in peer_group:
                 continue
 
-            # TODO: convert string IpAddress object for better handling of IPs
-            # TODO: does validation only fails if exact match of IP, or if there is an intersection?
+            # TODO: convert string to IpAddress object for better handling of IPs
+            # TODO: validate range intersection
             ip_range = peer_group["ip_range"]
             for ip in ip_range:
                 if ip in visited:
                     return False, f"{ip} is duplicated in BGP_PEER_RANGE: {set([peer_group_name, visited[ip]])}"
                 visited[ip] = peer_group_name
 
-        return True #, None
+        return True, None
 
     def crop_tables_without_yang(self, config_db_as_json):
         sy = self.create_sonic_yang_with_loaded_models()


### PR DESCRIPTION
#### What I did

Fixes #2119

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)
Sorting output:
```
Patch Applier: Applying 4 changes in order:
Patch Applier:   * [{"op": "remove", "path": "/BGP_PEER_RANGE/BGPSLBPassiveV6"}]
Patch Applier:   * [{"op": "add", "path": "/BGP_PEER_RANGE/BGPVac", "value": {"ip_range": ["192.168.0.0/21"], "name": "BGPVac", "src_address": "10.1.0.32"}}]
Patch Applier:   * [{"op": "remove", "path": "/BGP_PEER_RANGE/BGPSLBPassive"}]
Patch Applier:   * [{"op": "add", "path": "/BGP_PEER_RANGE/BGPSLBPassive", "value": {"ip_range": ["10.255.0.0/25"], "name": "BGPSLBPassive", "src_address": "10.1.0.32"}}]

```
#### New command output (if the output of a command-line utility has changed)

Sorting output:
```
Patch Applier: Applying 4 changes in order:
Patch Applier:   * [{"op": "remove", "path": "/BGP_PEER_RANGE/BGPSLBPassiveV6"}]
Patch Applier:   * [{"op": "remove", "path": "/BGP_PEER_RANGE"}]
Patch Applier:   * [{"op": "add", "path": "/BGP_PEER_RANGE", "value": {"BGPSLBPassive": {"ip_range": ["10.255.0.0/25"], "name": "BGPSLBPassive", "src_address": "10.1.0.32"}}}]
Patch Applier:   * [{"op": "add", "path": "/BGP_PEER_RANGE/BGPVac", "value": {"ip_range": ["192.168.0.0/21"], "name": "BGPVac", "src_address": "10.1.0.32"}}]
```

