### PR TITLE
[scripts/fast-reboot] Add option to include ssd-upgrader-part boot option with SONiC partition

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -24,6 +24,7 @@ PLATFORM_PLUGIN="${REBOOT_TYPE}_plugin"
 LOG_SSD_HEALTH="/usr/local/bin/log_ssd_health"
 PLATFORM_FWUTIL_AU_REBOOT_HANDLE="platform_fw_au_reboot_handle"
 SSD_FW_UPDATE="ssd-fw-upgrade"
+SSD_FW_UPDATE_BOOT_OPTION=no
 TAG_LATEST=yes
 DETACH=no
 LOG_PATH="/var/log/${REBOOT_TYPE}.txt"
@@ -77,13 +78,14 @@ function showHelpAndExit()
     echo "            - control plane assistant IP list."
     echo "    -t    : Don't tag the current kube images as latest"
     echo "    -D    : detached mode - closing terminal will not cause stopping reboot"
+    echo "    -u    : include ssd-upgrader-part in boot options"
 
     exit "${EXIT_SUCCESS}"
 }
 
 function parseOptions()
 {
-    while getopts "vfidh?rkxc:sD" opt; do #TODO "t" is missing
+    while getopts "vfidh?rkxc:sDu" opt; do #TODO "t" is missing
         case ${opt} in
             h|\? )
                 showHelpAndExit
@@ -120,6 +122,9 @@ function parseOptions()
                 ;;
             D )
                 DETACH=yes
+                ;;
+            u )
+                SSD_FW_UPDATE_BOOT_OPTION=yes
                 ;;
         esac
     done
@@ -354,6 +359,11 @@ function setup_reboot_variables()
     else
         error "Unknown bootloader. ${REBOOT_TYPE} is not supported."
         exit "${EXIT_NOT_SUPPORTED}"
+    fi
+    if [[ x"${SSD_FW_UPDATE_BOOT_OPTION}" == x"yes" ]]; then
+        local sonic_dev=$(blkid -L SONiC-OS)
+        local fstype=$(blkid -o value -s TYPE ${sonic_dev})
+        BOOT_OPTIONS="${BOOT_OPTIONS} ssd-upgrader-part=${sonic_dev},${fstype}"
     fi
 }
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Add new option "-u"  in ‘fast-reboot’ script, to add the “ssd-upgrader-part” boot option with SONiC partition and filesystem type.
Required by: https://github.com/Azure/sonic-buildimage/pull/10748

#### How I did it

- Included a new option "-u" in fast-reboot script.
- If the option '-u' is specified, add "ssd-upgrader-part" with the SONiC partition and filesystem to the boot options to be used with kexec.

#### How to verify it

Execute fast-reboot with "-u" option and verify that the ssd-upgrader-part is specified in /proc/cmdline.
UT logs: [fast_reboot_new_option_logs.txt](https://github.com/Azure/sonic-utilities/files/8630286/fast_reboot_new_option_logs.txt)

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

