### PR TITLE
[config reload] Fix invalid rstrip.

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -746,7 +746,7 @@ def _get_delayed_sonic_services():
     services = []
     for unit in timer:
         if state[timer.index(unit)] == "enabled":
-            services.append(re.sub('.timer$', '', unit, 1))
+            services.append(re.sub('\.timer$', '', unit, 1))
     return services
 
 

--- a/config/main.py
+++ b/config/main.py
@@ -746,7 +746,7 @@ def _get_delayed_sonic_services():
     services = []
     for unit in timer:
         if state[timer.index(unit)] == "enabled":
-            services.append(unit.rstrip(".timer"))
+            services.append(unit.replace(".timer", ""))
     return services
 
 

--- a/config/main.py
+++ b/config/main.py
@@ -746,7 +746,7 @@ def _get_delayed_sonic_services():
     services = []
     for unit in timer:
         if state[timer.index(unit)] == "enabled":
-            services.append(unit.replace(".timer", ""))
+            services.append(re.sub('.timer$', '', unit, 1))
     return services
 
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -81,6 +81,22 @@ def mock_run_command_side_effect(*args, **kwargs):
 
     if kwargs.get('return_cmd'):
         if command == "systemctl list-dependencies --plain sonic-delayed.target | sed '1d'":
+            return 'snmp.timer'
+        elif command == "systemctl list-dependencies --plain sonic.target | sed '1d'":
+            return 'swss'
+        elif command == "systemctl is-enabled snmp.timer":
+            return 'enabled'
+        else:
+            return ''
+
+def mock_run_command_side_effect_gnmi(*args, **kwargs):
+    command = args[0]
+
+    if kwargs.get('display_cmd'):
+        click.echo(click.style("Running command: ", fg='cyan') + click.style(command, fg='green'))
+
+    if kwargs.get('return_cmd'):
+        if command == "systemctl list-dependencies --plain sonic-delayed.target | sed '1d'":
             return 'gnmi.timer'
         elif command == "systemctl list-dependencies --plain sonic.target | sed '1d'":
             return 'swss'
@@ -165,6 +181,22 @@ class TestLoadMinigraph(object):
             # Verify "systemctl reset-failed" is called for services under sonic.target 
             mock_run_command.assert_any_call('systemctl reset-failed swss')
             # Verify "systemctl reset-failed" is called for services under sonic-delayed.target 
+            mock_run_command.assert_any_call('systemctl reset-failed snmp')
+            assert mock_run_command.call_count == 11
+
+    def test_load_minigraph_with_gnmi_timer(self, get_cmd_module, setup_single_broadcom_asic):
+        with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect_gnmi)) as mock_run_command:
+            (config, show) = get_cmd_module
+            runner = CliRunner()
+            result = runner.invoke(config.config.commands["load_minigraph"], ["-y"])
+            print(result.exit_code)
+            print(result.output)
+            traceback.print_tb(result.exc_info[2])
+            assert result.exit_code == 0
+            assert "\n".join([l.rstrip() for l in result.output.split('\n')]) == load_minigraph_command_output
+            # Verify "systemctl reset-failed" is called for services under sonic.target
+            mock_run_command.assert_any_call('systemctl reset-failed swss')
+            # Verify "systemctl reset-failed" is called for services under sonic-delayed.target
             mock_run_command.assert_any_call('systemctl reset-failed gnmi')
             assert mock_run_command.call_count == 11
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -81,10 +81,10 @@ def mock_run_command_side_effect(*args, **kwargs):
 
     if kwargs.get('return_cmd'):
         if command == "systemctl list-dependencies --plain sonic-delayed.target | sed '1d'":
-            return 'snmp.timer'
+            return 'gnmi.timer'
         elif command == "systemctl list-dependencies --plain sonic.target | sed '1d'":
             return 'swss'
-        elif command == "systemctl is-enabled snmp.timer":
+        elif command == "systemctl is-enabled gnmi.timer":
             return 'enabled'
         else:
             return ''
@@ -165,7 +165,7 @@ class TestLoadMinigraph(object):
             # Verify "systemctl reset-failed" is called for services under sonic.target 
             mock_run_command.assert_any_call('systemctl reset-failed swss')
             # Verify "systemctl reset-failed" is called for services under sonic-delayed.target 
-            mock_run_command.assert_any_call('systemctl reset-failed snmp')
+            mock_run_command.assert_any_call('systemctl reset-failed gnmi')
             assert mock_run_command.call_count == 11
 
     def test_load_minigraph_with_port_config_bad_format(self, get_cmd_module, setup_single_broadcom_asic):


### PR DESCRIPTION
Signed-off-by: Gang Lv ganglv@microsoft.com

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
'rstrip' behavior is wrong, if unit is 'gnmi.timer', the result is 'gn', and 'gnmi' is expected.

#### How I did it
Use 're.sub' to replace 'rstrip'.

#### How to verify it
Run unit test for sonic-utilities.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

