### PR TITLE
[show][vrf]Fixing show vrf to include vlan subinterface

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -5281,8 +5281,11 @@ If vrf-name is also provided as part of the command, if the vrf is created it wi
      default    Vlan20
      Vrf-red    Vlan100
                 Loopback11
+                Eth0.100
      Vrf-blue   Loopback100
                 Loopback102
+                Ethernet0.10
+                PortChannel101
   ````  
 
 ### VRF config commands

--- a/show/main.py
+++ b/show/main.py
@@ -207,7 +207,7 @@ if is_gearbox_configured():
 def get_interface_bind_to_vrf(config_db, vrf_name):
     """Get interfaces belong to vrf
     """
-    tables = ['INTERFACE', 'PORTCHANNEL_INTERFACE', 'VLAN_INTERFACE', 'LOOPBACK_INTERFACE']
+    tables = ['INTERFACE', 'PORTCHANNEL_INTERFACE', 'VLAN_INTERFACE', 'LOOPBACK_INTERFACE', 'VLAN_SUB_INTERFACE']
     data = []
     for table_name in tables:
         interface_dict = config_db.get_table(table_name)

--- a/tests/show_vrf_test.py
+++ b/tests/show_vrf_test.py
@@ -1,0 +1,39 @@
+import os
+import sys
+from click.testing import CliRunner
+from swsscommon.swsscommon import SonicV2Connector
+from utilities_common.db import Db
+
+import show.main as show
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+mock_db_path = os.path.join(test_path, "vrf_input")
+
+class TestShowVrf(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        os.environ["UTILITIES_UNIT_TESTING"] = "1"
+
+    def test_vrf_show(self):
+        from .mock_tables import dbconnector
+        jsonfile_config = os.path.join(mock_db_path, "config_db")
+        dbconnector.dedicated_dbs['CONFIG_DB'] = jsonfile_config
+        runner = CliRunner()
+        db = Db()
+        expected_output = """\
+VRF     Interfaces
+------  ---------------
+Vrf1
+Vrf101  Ethernet0.10
+Vrf102  PortChannel0002
+        Vlan40
+        Eth32.10
+Vrf103  Ethernet4
+        Loopback0
+"""
+       
+        result = runner.invoke(show.cli.commands['vrf'], [], obj=db)
+        dbconnector.dedicated_dbs = {}
+        assert result.exit_code == 0
+        assert result.output == expected_output

--- a/tests/vrf_input/config_db.json
+++ b/tests/vrf_input/config_db.json
@@ -1,0 +1,35 @@
+{
+    "VLAN_SUB_INTERFACE|Ethernet0.10": {
+        "vrf_name": "Vrf101",
+        "admin_status": "up"
+    },
+    "VLAN_SUB_INTERFACE|Eth32.10": {
+        "vrf_name": "Vrf102",
+        "admin_status": "up",
+        "vlan": "100"
+    },
+    "VLAN_INTERFACE|Vlan40": {
+        "vrf_name": "Vrf102"
+    },
+    "PORTCHANNEL_INTERFACE|PortChannel0002": {
+        "vrf_name": "Vrf102"
+    },
+    "INTERFACE|Ethernet4": {
+        "vrf_name": "Vrf103"
+    },
+    "LOOPBACK_INTERFACE|Loopback0": {
+        "vrf_name": "Vrf103"
+    },
+    "VRF|Vrf1": {
+         "fallback": "false"
+    },
+    "VRF|Vrf101": {
+         "NULL": "NULL"
+    },
+    "VRF|Vrf102": {
+         "NULL": "NULL"
+    },
+    "VRF|Vrf103": {
+         "NULL": "NULL"
+    }
+}


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixed show vrf command to include vlan subinterfaces. Vlan subinterfaces are not displayed under show vrf.


#### How I did it
Added VLAN_SUB_INTERFACE table to the list of tables to look in show vrf command.


#### How to verify it
Added UT to verify.


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

