### PR TITLE
[cherry-pick][202012] Update db_migrator to support pfcwd_sw_enable

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -45,7 +45,7 @@ class DBMigrator():
                      none-zero values.
               build: sequentially increase within a minor version domain.
         """
-        self.CURRENT_VERSION = 'version_2_0_5'
+        self.CURRENT_VERSION = 'version_2_0_0'
 
         self.TABLE_NAME      = 'VERSIONS'
         self.TABLE_KEY       = 'DATABASE'
@@ -409,6 +409,18 @@ class DBMigrator():
 
         return True
 
+    def migrate_pfcwd_sw_enable_table(self):
+        """ 
+        Migrate "pfc_enable" to "pfc_enable" and "pfcwd_sw_enable"
+        1. pfc_enable means enable pfc on certain queues
+        2. pfcwd_sw_enable means enable PFC software watchdog on certain queues
+        """
+        qos_maps = self.configDB.get_table('PORT_QOS_MAP')
+        for k, v in qos_maps.items():
+            if 'pfc_enable' in v:
+                v['pfcwd_sw_enable'] = v['pfc_enable']
+                self.configDB.set_entry('PORT_QOS_MAP', k, v)
+
     def version_unknown(self):
         """
         version_unknown tracks all SONiC versions that doesn't have a version
@@ -545,63 +557,9 @@ class DBMigrator():
 
     def version_2_0_0(self):
         """
-        Version 2_0_0 (A dummy migrator).
-        """
-        log.log_info('Handling version_2_0_0')
-
-        self.set_version('version_2_0_1')
-        return 'version_2_0_1'
-
-    def version_2_0_1(self):
-        """
-        Version 2_0_1 (A dummy migrator).
-        """
-        log.log_info('Handling version_2_0_1')
-        
-        self.set_version('version_2_0_2')
-        return 'version_2_0_2'
-
-    def version_2_0_2(self):
-        """
-        Version 2_0_2 (A dummy migrator).
-        """
-        log.log_info('Handling version_2_0_2')
-
-        self.set_version('version_2_0_3')
-        return 'version_2_0_3'
-
-    def version_2_0_3(self):
-        """
-        Version 2_0_3 (A dummy migrator).
-        """
-        log.log_info('Handling version_2_0_3')
-        
-        self.set_version('version_2_0_4')
-        return 'version_2_0_4'
-
-    def version_2_0_4(self):
-        """
-        Version 2_0_4
-        """
-        log.log_info('Handling version_2_0_4')
-        # Migrate "pfc_enable" to "pfc_enable" and "pfcwd_sw_enable"
-        # 1. pfc_enable means enable pfc on certain queues
-        # 2. pfcwd_sw_enable means enable PFC software watchdog on certain queues
-        # By default, PFC software watchdog is enabled on all pfc enabled queues.
-        qos_maps = self.configDB.get_table('PORT_QOS_MAP')
-        for k, v in qos_maps.items():
-            if 'pfc_enable' in v:
-                v['pfcwd_sw_enable'] = v['pfc_enable']
-                self.configDB.set_entry('PORT_QOS_MAP', k, v)
-        self.set_version('version_2_0_5')
-
-        return 'version_2_0_5'
-
-    def version_2_0_5(self):
-        """
         Current latest version. Nothing to do here.
         """
-        log.log_info('Handling version_2_0_5')
+        log.log_info('Handling version_2_0_0')
         return None
 
     def get_version(self):
@@ -652,6 +610,9 @@ class DBMigrator():
         #    version 2_0_1 has been occupied by 202106
         if self.asic_type == "mellanox":
             self.mellanox_buffer_migrator.mlnx_reclaiming_unused_buffer()
+        
+        # Migrate pfcwd_sw_enable table  
+        self.migrate_pfcwd_sw_enable_table()
 
     def migrate(self):
         version = self.get_version()

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -45,7 +45,7 @@ class DBMigrator():
                      none-zero values.
               build: sequentially increase within a minor version domain.
         """
-        self.CURRENT_VERSION = 'version_2_0_0'
+        self.CURRENT_VERSION = 'version_2_0_5'
 
         self.TABLE_NAME      = 'VERSIONS'
         self.TABLE_KEY       = 'DATABASE'
@@ -545,9 +545,63 @@ class DBMigrator():
 
     def version_2_0_0(self):
         """
-        Current latest version. Nothing to do here.
+        Version 2_0_0 (A dummy migrator).
         """
         log.log_info('Handling version_2_0_0')
+
+        self.set_version('version_2_0_1')
+        return 'version_2_0_1'
+
+    def version_2_0_1(self):
+        """
+        Version 2_0_1 (A dummy migrator).
+        """
+        log.log_info('Handling version_2_0_1')
+        
+        self.set_version('version_2_0_2')
+        return 'version_2_0_2'
+
+    def version_2_0_2(self):
+        """
+        Version 2_0_2 (A dummy migrator).
+        """
+        log.log_info('Handling version_2_0_2')
+
+        self.set_version('version_2_0_3')
+        return 'version_2_0_3'
+
+    def version_2_0_3(self):
+        """
+        Version 2_0_3 (A dummy migrator).
+        """
+        log.log_info('Handling version_2_0_3')
+        
+        self.set_version('version_2_0_4')
+        return 'version_2_0_4'
+
+    def version_2_0_4(self):
+        """
+        Version 2_0_4
+        """
+        log.log_info('Handling version_2_0_4')
+        # Migrate "pfc_enable" to "pfc_enable" and "pfcwd_sw_enable"
+        # 1. pfc_enable means enable pfc on certain queues
+        # 2. pfcwd_sw_enable means enable PFC software watchdog on certain queues
+        # By default, PFC software watchdog is enabled on all pfc enabled queues.
+        qos_maps = self.configDB.get_table('PORT_QOS_MAP')
+        for k, v in qos_maps.items():
+            if 'pfc_enable' in v:
+                v['pfcwd_sw_enable'] = v['pfc_enable']
+                self.configDB.set_entry('PORT_QOS_MAP', k, v)
+        self.set_version('version_2_0_5')
+
+        return 'version_2_0_5'
+
+    def version_2_0_5(self):
+        """
+        Current latest version. Nothing to do here.
+        """
+        log.log_info('Handling version_2_0_5')
         return None
 
     def get_version(self):

--- a/tests/db_migrator_input/config_db/qos_map_table_expected.json
+++ b/tests/db_migrator_input/config_db/qos_map_table_expected.json
@@ -1,0 +1,36 @@
+{
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_2_0_5"
+    },
+    "PORT_QOS_MAP": {
+        "Ethernet0": {
+            "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
+            "pfc_enable": "3,4",
+            "pfcwd_sw_enable": "3,4",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
+        },
+        "Ethernet100": {
+            "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
+            "pfc_enable": "3,4",
+            "pfcwd_sw_enable": "3,4",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
+        },
+        "Ethernet92": {
+            "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
+        },
+        "Ethernet96": {
+            "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
+        }
+    }
+}
+

--- a/tests/db_migrator_input/config_db/qos_map_table_expected.json
+++ b/tests/db_migrator_input/config_db/qos_map_table_expected.json
@@ -1,6 +1,6 @@
 {
     "VERSIONS|DATABASE": {
-        "VERSION": "version_2_0_5"
+        "VERSION": "version_2_0_0"
     },
     "PORT_QOS_MAP": {
         "Ethernet0": {

--- a/tests/db_migrator_input/config_db/qos_map_table_input.json
+++ b/tests/db_migrator_input/config_db/qos_map_table_input.json
@@ -1,0 +1,34 @@
+{
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_2_0_4"
+    },
+    "PORT_QOS_MAP": {
+        "Ethernet0": {
+            "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
+            "pfc_enable": "3,4",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
+        },
+        "Ethernet100": {
+            "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
+            "pfc_enable": "3,4",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
+        },
+        "Ethernet92": {
+            "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
+        },
+        "Ethernet96": {
+            "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
+        }
+    }
+}
+

--- a/tests/db_migrator_input/config_db/qos_map_table_input.json
+++ b/tests/db_migrator_input/config_db/qos_map_table_input.json
@@ -1,6 +1,6 @@
 {
     "VERSIONS|DATABASE": {
-        "VERSION": "version_2_0_4"
+        "VERSION": "version_2_0_0"
     },
     "PORT_QOS_MAP": {
         "Ethernet0": {

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -249,3 +249,27 @@ class TestInitConfigMigrator(object):
         assert not diff
 
         assert not expected_db.cfgdb.get_table('CONTAINER_FEATURE')
+
+class TestPfcEnableMigrator(object):
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "2"
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        dbconnector.dedicated_dbs['CONFIG_DB'] = None
+
+    def test_pfc_enable_migrator(self):
+        dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', 'qos_map_table_input')
+        import db_migrator
+        dbmgtr = db_migrator.DBMigrator(None)
+        dbmgtr.migrate()
+        dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', 'qos_map_table_expected')
+        expected_db = Db()
+
+        resulting_table = dbmgtr.configDB.get_table('PORT_QOS_MAP')
+        expected_table = expected_db.cfgdb.get_table('PORT_QOS_MAP')
+
+        diff = DeepDiff(resulting_table, expected_table, ignore_order=True)
+        assert not diff


### PR DESCRIPTION
Signed-off-by: bingwang <wang.bing@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This PR is to cherry-pick changes in PR #2087 to `202012` branch after resolving conflicts.
This PR is to update `db_migrator` to support `pfcwd_sw_enable`.
Currently, table `pfc_enable` is to specify on which queue to enable PFC and pfc watchdog. As we are going to add two extra lossless queues on which on watchdog is enable(HLD https://github.com/Azure/SONiC/pull/950), a new table is required to specify on which queue to enable PFC watchdog. That is `pfcwd_sw_enable`.
 

| Table | Description |
| --- |----|
|pfc_enable|Specify on which queues to enable PFC| 
|pfcwd_sw_enable|Specify on which queues to enable software PFC watchdog|

HLD [DSCP remapping](https://github.com/Azure/SONiC/pull/950)

Change in orchagent [Update orchagent to support new field pfcwd_sw_enable](https://github.com/Azure/sonic-swss/pull/2171)
#### How I did it
Update db_migrator.

#### How to verify it
1. Verified by UT
```
python3 setup.py test --addopts tests/db_migrator_test.py 

===================================================================================================================== test session starts ======================================================================================================================
platform linux -- Python 3.7.3, pytest-3.10.1, py-1.7.0, pluggy-0.8.0
rootdir: /sonic/src/sonic-utilities/tests, inifile: pytest.ini
plugins: cov-2.6.0
collected 75 items                                                                                                                                                                                                                                             

tests/db_migrator_test.py ...........................................................................                                                                                                                                                    [100%]

================================================================================================================== 75 passed in 16.75 seconds ==================================================================================================================
```
3. Verified by copying the updated `db_migrator.py` to a SONiC box and run `db_migrator.py -o migrate`

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

