### PR TITLE
Revert "[scripts/fast-reboot] Shutdown remaining containers through systemd (#2133)"

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -738,6 +738,26 @@ for service in ${SERVICES_TO_STOP}; do
     fi
 done
 
+# Kill other containers to make the reboot faster
+# We call `docker kill ...` to ensure the container stops as quickly as possible,
+# then immediately call `systemctl stop ...` to prevent the service from
+# restarting the container automatically.
+debug "Stopping all remaining containers ..."
+if test -f /usr/local/bin/ctrmgr_tools.py
+then
+    /usr/local/bin/ctrmgr_tools.py kill-all
+else
+    for CONTAINER_NAME in $(docker ps --format '{{.Names}}'); do
+        CONTAINER_STOP_RC=0
+        docker kill $CONTAINER_NAME &> /dev/null || CONTAINER_STOP_RC=$?
+        systemctl stop $CONTAINER_NAME || debug "Ignore stopping $CONTAINER_NAME error $?"
+        if [[ CONTAINER_STOP_RC -ne 0 ]]; then
+            debug "Failed killing container $CONTAINER_NAME RC $CONTAINER_STOP_RC ."
+        fi
+    done
+fi
+debug "Stopped all remaining containers ..."
+
 # Stop the docker container engine. Otherwise we will have a broken docker storage
 systemctl stop docker.service || debug "Ignore stopping docker service error $?"
 


### PR DESCRIPTION
This reverts commit 23e939846d4ea3507fba0fc51c0b3c4e34c6d6bd.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Revert "[scripts/fast-reboot] Shutdown remaining containers through systemd (#2133)"

This reverted PR is part of a story that refactors warm/fast shutdown sequence to gracefully stop services instead of killing them without any ordering and dependency requirements which creates several issues and is error prone for the future.
 
This PR must come together with https://github.com/Azure/sonic-buildimage/pull/10510.
However, #10510 is blocked due to an issue in swss-common https://github.com/Azure/sonic-swss-common/issues/603
And a fix by MSFT is in review https://github.com/Azure/sonic-swss-common/pull/606

I am reverting it because its dependency is still blocked and we cannot update submodule pointer. Once the dependency of the reverted PR is resolved, it shall be re-commited.

#### How I did it

Revert it

#### How to verify it

Run build

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
