### PR TITLE
Added bf_drivers.log to zipped dump after execution of "show techsupport"

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1023,8 +1023,8 @@ collect_broadcom() {
 ###############################################################################
 collect_barefoot() {
     local bf_logs="/tmp/bf_logs"
-	$( rm -rf ${bf_logs} )
-	$( mkdir  ${bf_logs} )
+    $( rm -rf ${bf_logs} )
+    $( mkdir  ${bf_logs} )
     unset array
     array=( $(docker exec -ti syncd ls -1 | grep bf_drivers.log) )
     for y in "${array[@]}"; do

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1012,6 +1012,16 @@ collect_broadcom() {
     copy_from_masic_docker "syncd" "/var/log/bcm_diag_post" "/var/log/bcm_diag_post"
 }
 
+
+collect_barefoot() {
+	unset array
+	array=( $(docker exec -ti syncd ls -1 | grep bf_drivers.log) )
+    for y in "${array[@]}"; do
+        itstr=`echo ${y} | tr -d "\r\n"`
+	    copy_from_masic_docker "syncd" "/${itstr}" "/var/log/${itstr}"
+    done
+} 
+
 ###############################################################################
 # Save log file
 # Globals:
@@ -1050,6 +1060,11 @@ save_log_files() {
     echo "[ TAR /var/log Files ] : $(($end_t-$start_t)) msec" >> $TECHSUPPORT_TIME_INFO
 
     enable_logrotate
+
+    local asic="$(/usr/local/bin/sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)"
+    if [ "$asic" = "barefoot" ]; then
+    	collect_barefoot
+    fi
 }
 
 ###############################################################################

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1014,8 +1014,8 @@ collect_broadcom() {
 
 
 collect_barefoot() {
-	unset array
-	array=( $(docker exec -ti syncd ls -1 | grep bf_drivers.log) )
+    unset array
+    array=( $(docker exec -ti syncd ls -1 | grep bf_drivers.log) )
     for y in "${array[@]}"; do
         itstr=`echo ${y} | tr -d "\r\n"`
 	    copy_from_masic_docker "syncd" "/${itstr}" "/var/log/${itstr}"

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1012,13 +1012,21 @@ collect_broadcom() {
     copy_from_masic_docker "syncd" "/var/log/bcm_diag_post" "/var/log/bcm_diag_post"
 }
 
-
+###############################################################################
+# Collect Barefoot specific information
+# Globals:
+#  None
+# Arguments:
+#  None
+# Returns:
+#  None
+###############################################################################
 collect_barefoot() {
     unset array
     array=( $(docker exec -ti syncd ls -1 | grep bf_drivers.log) )
     for y in "${array[@]}"; do
         itstr=`echo ${y} | tr -d "\r\n"`
-	    copy_from_masic_docker "syncd" "/${itstr}" "/var/log/${itstr}"
+        copy_from_masic_docker "syncd" "/${itstr}" "/var/log/${itstr}"
     done
 } 
 
@@ -1060,11 +1068,6 @@ save_log_files() {
     echo "[ TAR /var/log Files ] : $(($end_t-$start_t)) msec" >> $TECHSUPPORT_TIME_INFO
 
     enable_logrotate
-
-    local asic="$(/usr/local/bin/sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)"
-    if [ "$asic" = "barefoot" ]; then
-    	collect_barefoot
-    fi
 }
 
 ###############################################################################
@@ -1256,6 +1259,12 @@ main() {
     end_t=$(date +%s%3N)
     echo "[ Capture Proc State ] : $(($end_t-$start_t)) msec" >> $TECHSUPPORT_TIME_INFO
 
+    
+    local asic="$(/usr/local/bin/sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)"
+    if [ "$asic" = "barefoot" ]; then
+    	collect_barefoot
+    fi
+
     # Save logs and cores early
     save_log_files
     save_crash_files
@@ -1267,7 +1276,6 @@ main() {
     # Save reboot cause information
     save_cmd "show reboot-cause" reboot.cause
 
-    local asic="$(/usr/local/bin/sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)"
     # 1st counter snapshot early. Need 2 snapshots to make sense of counters trend.
     save_counter_snapshot $asic 1
 

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1022,17 +1022,17 @@ collect_broadcom() {
 #  None
 ###############################################################################
 collect_barefoot() {
-    local bf_log_folder="/tmp/bf_log_folder"
-	$( rm -rf ${bf_log_folder} )
-	$( mkdir  ${bf_log_folder} )
+    local bf_logs="/tmp/bf_logs"
+	$( rm -rf ${bf_logs} )
+	$( mkdir  ${bf_logs} )
     unset array
     array=( $(docker exec -ti syncd ls -1 | grep bf_drivers.log) )
     for y in "${array[@]}"; do
         itstr=`echo ${y} | tr -d "\r\n"`
-        copy_from_masic_docker "syncd" "/${itstr}" "${bf_log_folder}"
+        copy_from_masic_docker "syncd" "/${itstr}" "${bf_logs}"
     done
 
-    for file in $(find /tmp/bf_log_folder -type f); do
+    for file in $(find /tmp/bf_logs -type f); do
         save_file "${file}" log true true
     done
 } 

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1022,11 +1022,18 @@ collect_broadcom() {
 #  None
 ###############################################################################
 collect_barefoot() {
+    local bf_log_folder="/tmp/bf_log_folder"
+	$( rm -rf ${bf_log_folder} )
+	$( mkdir  ${bf_log_folder} )
     unset array
     array=( $(docker exec -ti syncd ls -1 | grep bf_drivers.log) )
     for y in "${array[@]}"; do
         itstr=`echo ${y} | tr -d "\r\n"`
-        copy_from_masic_docker "syncd" "/${itstr}" "/var/log/${itstr}"
+        copy_from_masic_docker "syncd" "/${itstr}" "${bf_log_folder}"
+    done
+
+    for file in $(find /tmp/bf_log_folder -type f); do
+        save_file "${file}" log true true
     done
 } 
 
@@ -1259,12 +1266,6 @@ main() {
     end_t=$(date +%s%3N)
     echo "[ Capture Proc State ] : $(($end_t-$start_t)) msec" >> $TECHSUPPORT_TIME_INFO
 
-    
-    local asic="$(/usr/local/bin/sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)"
-    if [ "$asic" = "barefoot" ]; then
-    	collect_barefoot
-    fi
-
     # Save logs and cores early
     save_log_files
     save_crash_files
@@ -1276,6 +1277,7 @@ main() {
     # Save reboot cause information
     save_cmd "show reboot-cause" reboot.cause
 
+    local asic="$(/usr/local/bin/sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)"
     # 1st counter snapshot early. Need 2 snapshots to make sense of counters trend.
     save_counter_snapshot $asic 1
 
@@ -1352,6 +1354,10 @@ main() {
     fi
 
     save_saidump
+
+    if [ "$asic" = "barefoot" ]; then
+        collect_barefoot
+    fi
 
     if [[ "$asic" = "mellanox" ]]; then
         collect_mellanox


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
I add all bf_drivers*.log files into log folder of zipped filed created after perform the "show techsupport"

#### How I did it
I gather all bf_drivers*.log files and make copy from syncd container into /var/log folder

#### How to verify it
I verified it on device with performing of "show techsupport"

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

