### PR TITLE
Modify override testcase to cover PORT admin_status

### DIFF
--- a/tests/config_override_input/full_config_override.json
+++ b/tests/config_override_input/full_config_override.json
@@ -30,7 +30,6 @@
         },
         "PORT": {
             "Ethernet4": {
-                "admin_status": "up",
                 "alias": "fortyGigE0/4",
                 "description": "Servers0:eth0",
                 "index": "1",
@@ -41,7 +40,6 @@
                 "tpid": "0x8100"
             },
             "Ethernet8": {
-                "admin_status": "up",
                 "alias": "fortyGigE0/8",
                 "description": "Servers1:eth0",
                 "index": "2",
@@ -73,6 +71,28 @@
             }
         },
         "PORT": {
+            "Ethernet4": {
+                "admin_status": "up",
+                "alias": "fortyGigE0/4",
+                "description": "Servers0:eth0",
+                "index": "1",
+                "lanes": "29,30,31,32",
+                "mtu": "9100",
+                "pfc_asym": "off",
+                "speed": "40000",
+                "tpid": "0x8100"
+            },
+            "Ethernet8": {
+                "admin_status": "down",
+                "alias": "fortyGigE0/8",
+                "description": "Servers1:eth0",
+                "index": "2",
+                "lanes": "33,34,35,36",
+                "mtu": "9100",
+                "pfc_asym": "off",
+                "speed": "40000",
+                "tpid": "0x8100"
+            },
             "Ethernet12": {
                 "admin_status": "up",
                 "alias": "fortyGigE0/12",
@@ -106,6 +126,28 @@
             }
         },
         "PORT": {
+            "Ethernet4": {
+                "admin_status": "up",
+                "alias": "fortyGigE0/4",
+                "description": "Servers0:eth0",
+                "index": "1",
+                "lanes": "29,30,31,32",
+                "mtu": "9100",
+                "pfc_asym": "off",
+                "speed": "40000",
+                "tpid": "0x8100"
+            },
+            "Ethernet8": {
+                "admin_status": "down",
+                "alias": "fortyGigE0/8",
+                "description": "Servers1:eth0",
+                "index": "2",
+                "lanes": "33,34,35,36",
+                "mtu": "9100",
+                "pfc_asym": "off",
+                "speed": "40000",
+                "tpid": "0x8100"
+            },
             "Ethernet12": {
                 "admin_status": "up",
                 "alias": "fortyGigE0/12",

--- a/tests/config_override_input/full_config_override.json
+++ b/tests/config_override_input/full_config_override.json
@@ -30,6 +30,7 @@
         },
         "PORT": {
             "Ethernet4": {
+                "admin_status": "up",
                 "alias": "fortyGigE0/4",
                 "description": "Servers0:eth0",
                 "index": "1",
@@ -40,6 +41,7 @@
                 "tpid": "0x8100"
             },
             "Ethernet8": {
+                "admin_status": "up",
                 "alias": "fortyGigE0/8",
                 "description": "Servers1:eth0",
                 "index": "2",
@@ -71,28 +73,6 @@
             }
         },
         "PORT": {
-            "Ethernet4": {
-                "admin_status": "up",
-                "alias": "fortyGigE0/4",
-                "description": "Servers0:eth0",
-                "index": "1",
-                "lanes": "29,30,31,32",
-                "mtu": "9100",
-                "pfc_asym": "off",
-                "speed": "40000",
-                "tpid": "0x8100"
-            },
-            "Ethernet8": {
-                "admin_status": "down",
-                "alias": "fortyGigE0/8",
-                "description": "Servers1:eth0",
-                "index": "2",
-                "lanes": "33,34,35,36",
-                "mtu": "9100",
-                "pfc_asym": "off",
-                "speed": "40000",
-                "tpid": "0x8100"
-            },
             "Ethernet12": {
                 "admin_status": "up",
                 "alias": "fortyGigE0/12",
@@ -126,28 +106,6 @@
             }
         },
         "PORT": {
-            "Ethernet4": {
-                "admin_status": "up",
-                "alias": "fortyGigE0/4",
-                "description": "Servers0:eth0",
-                "index": "1",
-                "lanes": "29,30,31,32",
-                "mtu": "9100",
-                "pfc_asym": "off",
-                "speed": "40000",
-                "tpid": "0x8100"
-            },
-            "Ethernet8": {
-                "admin_status": "down",
-                "alias": "fortyGigE0/8",
-                "description": "Servers1:eth0",
-                "index": "2",
-                "lanes": "33,34,35,36",
-                "mtu": "9100",
-                "pfc_asym": "off",
-                "speed": "40000",
-                "tpid": "0x8100"
-            },
             "Ethernet12": {
                 "admin_status": "up",
                 "alias": "fortyGigE0/12",

--- a/tests/config_override_input/port_config_override.json
+++ b/tests/config_override_input/port_config_override.json
@@ -1,0 +1,134 @@
+{
+    "running_config": {
+        "ACL_TABLE": {
+            "DATAACL": {
+                "policy_desc": "DATAACL",
+                "ports": [
+                    "Ethernet4"
+                ],
+                "stage": "ingress",
+                "type": "L3"
+            },
+            "NTP_ACL": {
+                "policy_desc": "NTP_ACL",
+                "services": [
+                    "NTP"
+                ],
+                "stage": "ingress",
+                "type": "CTRLPLANE"
+            }
+        },
+        "AUTO_TECHSUPPORT_FEATURE": {
+            "bgp": {
+                "rate_limit_interval": "600",
+                "state": "enabled"
+            },
+            "database": {
+                "rate_limit_interval": "600",
+                "state": "enabled"
+            }
+        },
+        "PORT": {
+            "Ethernet4": {
+                "alias": "fortyGigE0/4",
+                "description": "Servers0:eth0",
+                "index": "1",
+                "lanes": "29,30,31,32",
+                "mtu": "9100",
+                "pfc_asym": "off",
+                "speed": "40000",
+                "tpid": "0x8100"
+            },
+            "Ethernet8": {
+                "alias": "fortyGigE0/8",
+                "description": "Servers1:eth0",
+                "index": "2",
+                "lanes": "33,34,35,36",
+                "mtu": "9100",
+                "pfc_asym": "off",
+                "speed": "40000",
+                "tpid": "0x8100"
+            }
+        }
+    },
+    "golden_config": {
+        "PORT": {
+            "Ethernet4": {
+                "admin_status": "up",
+                "alias": "fortyGigE0/4",
+                "description": "Servers0:eth0",
+                "index": "1",
+                "lanes": "29,30,31,32",
+                "mtu": "9100",
+                "pfc_asym": "off",
+                "speed": "40000",
+                "tpid": "0x8100"
+            },
+            "Ethernet8": {
+                "admin_status": "down",
+                "alias": "fortyGigE0/8",
+                "description": "Servers1:eth0",
+                "index": "2",
+                "lanes": "33,34,35,36",
+                "mtu": "9100",
+                "pfc_asym": "off",
+                "speed": "40000",
+                "tpid": "0x8100"
+            }
+        }
+    },
+    "expected_config": {
+        "ACL_TABLE": {
+            "DATAACL": {
+                "policy_desc": "DATAACL",
+                "ports": [
+                    "Ethernet4"
+                ],
+                "stage": "ingress",
+                "type": "L3"
+            },
+            "NTP_ACL": {
+                "policy_desc": "NTP_ACL",
+                "services": [
+                    "NTP"
+                ],
+                "stage": "ingress",
+                "type": "CTRLPLANE"
+            }
+        },
+        "AUTO_TECHSUPPORT_FEATURE": {
+            "bgp": {
+                "rate_limit_interval": "600",
+                "state": "enabled"
+            },
+            "database": {
+                "rate_limit_interval": "600",
+                "state": "enabled"
+            }
+        },
+        "PORT": {
+            "Ethernet4": {
+                "admin_status": "up",
+                "alias": "fortyGigE0/4",
+                "description": "Servers0:eth0",
+                "index": "1",
+                "lanes": "29,30,31,32",
+                "mtu": "9100",
+                "pfc_asym": "off",
+                "speed": "40000",
+                "tpid": "0x8100"
+            },
+            "Ethernet8": {
+                "admin_status": "down",
+                "alias": "fortyGigE0/8",
+                "description": "Servers1:eth0",
+                "index": "2",
+                "lanes": "33,34,35,36",
+                "mtu": "9100",
+                "pfc_asym": "off",
+                "speed": "40000",
+                "tpid": "0x8100"
+            }
+        }
+    }
+}

--- a/tests/config_override_test.py
+++ b/tests/config_override_test.py
@@ -15,6 +15,7 @@ EMPTY_INPUT = os.path.join(DATA_DIR, "empty_input.json")
 PARTIAL_CONFIG_OVERRIDE = os.path.join(DATA_DIR, "partial_config_override.json")
 NEW_FEATURE_CONFIG = os.path.join(DATA_DIR, "new_feature_config.json")
 FULL_CONFIG_OVERRIDE = os.path.join(DATA_DIR, "full_config_override.json")
+PORT_CONFIG_OVERRIDE = os.path.join(DATA_DIR, "port_config_override.json")
 
 # Load sonic-cfggen from source since /usr/local/bin/sonic-cfggen does not have .py extension.
 sonic_cfggen = load_module_from_source('sonic_cfggen', '/usr/local/bin/sonic-cfggen')
@@ -122,6 +123,15 @@ class TestConfigOverride(object):
         """Golden Config makes change to every table in configDB"""
         db = Db()
         with open(FULL_CONFIG_OVERRIDE, "r") as f:
+            read_data = json.load(f)
+        self.check_override_config_table(
+            db, config, read_data['running_config'], read_data['golden_config'],
+            read_data['expected_config'])
+
+    def test_golden_config_db_port_config(self):
+        """Golden Config makes change to PORT admin_status"""
+        db = Db()
+        with open(PORT_CONFIG_OVERRIDE, "r") as f:
             read_data = json.load(f)
         self.check_override_config_table(
             db, config, read_data['running_config'], read_data['golden_config'],


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Modify the override-config-table testcase to cover PORT admin_status scenario.
#### How I did it
Change the testcase to cover PORT admin_status change.
#### How to verify it
Run unit test.
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

