### PR TITLE
[portconfig]Support new interface types CR8/SR8/KR8/LR8

### DIFF
--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -60,8 +60,8 @@ PORT_STATE_TABLE_NAME = "PORT_TABLE"
 PORT_STATE_SUPPORTED_SPEEDS = "supported_speeds"
 
 
-VALID_INTERFACE_TYPE_SET = set(['CR','CR2','CR4','SR','SR2','SR4',
-                                'LR','LR4','KR','KR4','CAUI','GMII',
+VALID_INTERFACE_TYPE_SET = set(['CR','CR2','CR4','CR8','SR','SR2','SR4','SR8',
+                                'LR','LR4','LR8','KR','KR4','KR8','CAUI','GMII',
                                 'SFI','XLAUI','KR2','CAUI4','XAUI',
                                 'XFI','XGMII', 'none'])
 


### PR DESCRIPTION
Signed-off-by: Kebo Liu <kebol@nvidia.com>

relevant SWSS and Yang PRs:
https://github.com/Azure/sonic-swss/pull/2268
https://github.com/Azure/sonic-buildimage/pull/10826

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

With SAI V.1.10.2, new interface types CR8/SR8/KR8/LR8 have been introduced, we should also support them from the CLI configuration.

#### How I did it

Add new interface types to `VALID_INTERFACE_TYPE_SET`

#### How to verify it

Run CLI command "config interface types", new types can be accepted by the CLI.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

