### PR TITLE
Warm/Fast reboot: Remove duplicate kernel options

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -365,6 +365,9 @@ function setup_reboot_variables()
         local fstype=$(blkid -o value -s TYPE ${sonic_dev})
         BOOT_OPTIONS="${BOOT_OPTIONS} ssd-upgrader-part=${sonic_dev},${fstype}"
     fi
+    BOOT_OPTIONS_ORIG=(${BOOT_OPTIONS})
+    BOOT_OPTIONS_UNIQ=($(printf "%s\n" "${BOOT_OPTIONS_ORIG[@]}" | awk '!seen[$0]++'))
+    BOOT_OPTIONS="${BOOT_OPTIONS_UNIQ[*]}"
 }
 
 function check_docker_exec()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Continuous warm upgrades fail at one point on Arista platforms.

The failure is seen during the step "Load kernel into the memory", where below error is seen:

```
May 19 10:16:33.530520 str-7260cx3-acs-2 NOTICE admin: warm-reboot failure (255) cleanup ...
May 19 10:16:33.745967 str-7260cx3-acs-2 NOTICE admin: Cancel warm-reboot: code (0)
'Cannot load /host/image-20201231.66/boot/vmlinuz-4.19.0-12-2-amd64\\n'
```

Failure is because due to continuous upgrades (cleanup prev image included after every boot), `kernel-params-base` file keeps growing. This is because this file is stored at /host/ and is retained after every boot up. Subsequent sonic-installer adds to the list without checking the already existing options.


#### How I did it

In the warmboot path, make sure that the `BOOT_OPTIONS` used for kernel load are unique and hence remove duplicate options, if present.

There should also be a corresponding fix in sonic-installer or Arista platform scripts which generate these duplicate options into `kernel-params-base` file.
#### How to verify it
Tested on physical testbed. Continuous warm upgrades don't fail with this error anymore.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

