### PR TITLE
Revert "Revert "[scripts/fast-reboot] Shutdown remaining containers through systemd (#2133)""

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -748,26 +748,6 @@ for service in ${SERVICES_TO_STOP}; do
     fi
 done
 
-# Kill other containers to make the reboot faster
-# We call `docker kill ...` to ensure the container stops as quickly as possible,
-# then immediately call `systemctl stop ...` to prevent the service from
-# restarting the container automatically.
-debug "Stopping all remaining containers ..."
-if test -f /usr/local/bin/ctrmgr_tools.py
-then
-    /usr/local/bin/ctrmgr_tools.py kill-all
-else
-    for CONTAINER_NAME in $(docker ps --format '{{.Names}}'); do
-        CONTAINER_STOP_RC=0
-        docker kill $CONTAINER_NAME &> /dev/null || CONTAINER_STOP_RC=$?
-        systemctl stop $CONTAINER_NAME || debug "Ignore stopping $CONTAINER_NAME error $?"
-        if [[ CONTAINER_STOP_RC -ne 0 ]]; then
-            debug "Failed killing container $CONTAINER_NAME RC $CONTAINER_STOP_RC ."
-        fi
-    done
-fi
-debug "Stopped all remaining containers ..."
-
 # Stop the docker container engine. Otherwise we will have a broken docker storage
 systemctl stop docker.service || debug "Ignore stopping docker service error $?"
 


### PR DESCRIPTION
Reverts Azure/sonic-utilities#2161

**What I did**

Revert a revert. This must be merged togather with https://github.com/Azure/sonic-buildimage/pull/10510

How I did it
Revert it

How to verify it
Run build

Previous command output (if the output of a command-line utility has changed)
New command output (if the output of a command-line utility has changed)