### PR TITLE
[20212][port2alias]: Fix to get right number of return values

### DIFF
--- a/scripts/port2alias
+++ b/scripts/port2alias
@@ -1,11 +1,25 @@
 #!/usr/bin/env python3
 
 import sys
+import os
 from io import StringIO
 
 from portconfig import get_port_config
 from sonic_py_common import device_info
+from sonic_py_common import multi_asic
 
+# mock the redis for unit test purposes #
+try:
+    if os.environ["UTILITIES_UNIT_TESTING"] == "2":
+        modules_path = os.path.join(os.path.dirname(__file__), "..")
+        test_path = os.path.join(modules_path, "tests")
+        sys.path.insert(0, modules_path)
+        sys.path.insert(0, test_path)
+        import mock_tables.dbconnector
+        import mock_tables.mock_multi_asic
+        mock_tables.dbconnector.load_namespace_config()
+except KeyError:
+    pass
 
 def translate_line(line, ports):
     allowed_symbols = ['-', '_']
@@ -35,7 +49,10 @@ def translate_line(line, ports):
 
 def main():
     (platform, hwsku) = device_info.get_platform_and_hwsku()
-    (ports, _) = get_port_config(hwsku, platform)
+    ports = {}
+    for ns in multi_asic.get_namespace_list():
+        (ports_ns, _, _) = get_port_config(hwsku=hwsku, platform=platform, asic_name=ns)
+        ports.update(ports_ns)
     for line in sys.stdin:
         sys.stdout.write(translate_line(line, ports))
 

--- a/scripts/port2alias
+++ b/scripts/port2alias
@@ -51,11 +51,7 @@ def main():
     (platform, hwsku) = device_info.get_platform_and_hwsku()
     ports = {}
     for ns in multi_asic.get_namespace_list():
-        if ns:
-            asic_id = multi_asic.get_asic_id_from_name(ns)
-        else:
-            asic_id = None
-        (ports_ns, _, _) = get_port_config(hwsku=hwsku, platform=platform, asic=asic_id)
+        (ports_ns, _, _) = get_port_config(hwsku=hwsku, platform=platform, asic_name=ns)
         ports.update(ports_ns)
     for line in sys.stdin:
         sys.stdout.write(translate_line(line, ports))

--- a/scripts/port2alias
+++ b/scripts/port2alias
@@ -29,7 +29,7 @@ def translate_line(line, ports):
     while end < len(line):
         if line[end].isalnum() or line[end] in allowed_symbols:
             pass
-        else: 
+        else:
             # End of a word
             word = line[start:end]
             if word in ports:
@@ -51,7 +51,11 @@ def main():
     (platform, hwsku) = device_info.get_platform_and_hwsku()
     ports = {}
     for ns in multi_asic.get_namespace_list():
-        (ports_ns, _, _) = get_port_config(hwsku=hwsku, platform=platform, asic_name=ns)
+        if ns:
+            asic_id = multi_asic.get_asic_id_from_name(ns)
+        else:
+            asic_id = None
+        (ports_ns, _, _) = get_port_config(hwsku=hwsku, platform=platform, asic=asic_id)
         ports.update(ports_ns)
     for line in sys.stdin:
         sys.stdout.write(translate_line(line, ports))

--- a/tests/port2alias_test.py
+++ b/tests/port2alias_test.py
@@ -12,6 +12,14 @@ import imp
 port2alias = imp.load_source('port2alias', os.path.join(os.path.dirname(__file__), '..', 'scripts', 'port2alias'))
 
 class TestPort2Alias(TestCase):
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        from .mock_tables import dbconnector
+        from .mock_tables import mock_single_asic
+        importlib.reload(mock_single_asic)
+        dbconnector.load_namespace_config()
+
     def setUp(self):
         self.ports = {
                 "Ethernet1": {"alias" : "fortyG0/1"},

--- a/tests/port2alias_test.py
+++ b/tests/port2alias_test.py
@@ -1,6 +1,11 @@
 import sys
 import os
 from unittest import TestCase
+from unittest import mock
+from mock import patch
+from io import StringIO 
+import tests.mock_tables.dbconnector
+import importlib
 
 import imp
 
@@ -8,12 +13,19 @@ port2alias = imp.load_source('port2alias', os.path.join(os.path.dirname(__file__
 
 class TestPort2Alias(TestCase):
     def setUp(self):
+        port2alias = load_module_from_source('port2alias', port2alias_path)
         self.ports = {
                 "Ethernet1": {"alias" : "fortyG0/1"},
                 "Ethernet2": {"alias" : "fortyG0/2"},
                 "Ethernet10": {"alias" : "fortyG0/10"},
                 "Ethernet_11": {"alias" : "fortyG0/11"},
                 }
+
+    @mock.patch('sys.stdout.write')
+    def test_main(self, mock_stdout):
+        with patch('sys.stdin', StringIO("Ethernet0")):
+            port2alias.main()
+            mock_stdout.assert_called_with("etp1")
 
     def test_translate_line_single_word(self):
         self.assertEqual(port2alias.translate_line("1", self.ports),"1")
@@ -39,3 +51,30 @@ class TestPort2Alias(TestCase):
     def test_translate_line_empty_ports(self):
         self.assertEqual(port2alias.translate_line("Ethernet1\n", {}),"Ethernet1\n")
 
+class TestPort2AliasNamespace(TestCase):
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "2"
+        from .mock_tables import dbconnector
+        from .mock_tables import mock_multi_asic
+        importlib.reload(mock_multi_asic)
+        dbconnector.load_namespace_config()
+
+    def setUp(self):
+        port2alias = load_module_from_source('port2alias', port2alias_path)
+
+    @mock.patch('sys.stdout.write')
+    def test_main(self, mock_stdout):
+        with patch('sys.stdin', StringIO("Ethernet0")):
+            port2alias.main()
+            mock_stdout.assert_called_with("Ethernet1/1")
+
+    @classmethod
+    def teardown_class(cls):
+        print("TEARDOWN")
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        # change back to single asic config
+        from .mock_tables import dbconnector
+        from .mock_tables import mock_single_asic
+        importlib.reload(mock_single_asic)
+        dbconnector.load_namespace_config()

--- a/tests/port2alias_test.py
+++ b/tests/port2alias_test.py
@@ -13,7 +13,6 @@ port2alias = imp.load_source('port2alias', os.path.join(os.path.dirname(__file__
 
 class TestPort2Alias(TestCase):
     def setUp(self):
-        port2alias = load_module_from_source('port2alias', port2alias_path)
         self.ports = {
                 "Ethernet1": {"alias" : "fortyG0/1"},
                 "Ethernet2": {"alias" : "fortyG0/2"},
@@ -59,9 +58,6 @@ class TestPort2AliasNamespace(TestCase):
         from .mock_tables import mock_multi_asic
         importlib.reload(mock_multi_asic)
         dbconnector.load_namespace_config()
-
-    def setUp(self):
-        port2alias = load_module_from_source('port2alias', port2alias_path)
 
     @mock.patch('sys.stdout.write')
     def test_main(self, mock_stdout):


### PR DESCRIPTION
(cherry picked from commit 3714f63bfbaac377cb7638ddf73a3299d5d45a1f)
Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Cherry-pick of https://github.com/Azure/sonic-utilities/pull/1906 to 202012 branch
Fix conflict also few changes done to cherry-pick:
- get_port_config function takes asic id as argument in 2019/202012 branches
- Keep load_source of port2alias as module, as is used in unit-test in 202012 branch

get_port_config was modified to return different set number of arguments in PR: https://github.com/Azure/sonic-buildimage/pull/4222. Changes in this PR is:
1. To address the different set of return values
2.  To get the ports from all namespaces
3. To add unit-test

Additional change done over the cherry-pick:
added setup_class method in test case to load single asic mock db, this was done in pfcwd_test teardown method in 201911 and master branches. It is not done in 202012 branch, hence added setup_class method.
#### How I did it
Modify port2alias to read ports from all namespaces and also add unit-test
#### How to verify it
Verified on single and multi-asic DUTs with 202012 image.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

