### PR TITLE
[config][muxcable] Add support for displaying soc_ipv4 and cable_type in config/show muxcable commands

### DIFF
--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -244,6 +244,8 @@ def lookup_statedb_and_update_configdb(db, per_npu_statedb, config_db, port, sta
     configdb_state = get_value_for_key_in_config_tbl(config_db, port, "state", "MUX_CABLE")
     ipv4_value = get_value_for_key_in_config_tbl(config_db, port, "server_ipv4", "MUX_CABLE")
     ipv6_value = get_value_for_key_in_config_tbl(config_db, port, "server_ipv6", "MUX_CABLE")
+    soc_ipv4_value = get_value_for_key_in_config_tbl(config_db, port, "soc_ipv4", "MUX_CABLE")
+    cable_type = get_value_for_key_in_config_tbl(config_db, port, "cable_type", "MUX_CABLE")
 
     state = get_value_for_key_in_dict(muxcable_statedb_dict, port, "state", "MUX_CABLE_TABLE")
 
@@ -253,7 +255,10 @@ def lookup_statedb_and_update_configdb(db, per_npu_statedb, config_db, port, sta
         port_status_dict[port_name] = 'OK'
     else:
         config_db.set_entry("MUX_CABLE", port, {"state": state_cfg_val,
-                                                "server_ipv4": ipv4_value, "server_ipv6": ipv6_value})
+                                                "server_ipv4": ipv4_value,
+                                                "server_ipv6": ipv6_value, 
+                                                "soc_ipv4":soc_ipv4_value, 
+                                                "cable_type": cable_type})
         if (str(state_cfg_val) == 'active' and str(state) != 'active') or (str(state_cfg_val) == 'standby' and str(state) != 'standby'):
             port_status_dict[port_name] = 'INPROGRESS'
         else:

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -11,6 +11,7 @@ from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
 from swsscommon import swsscommon
 from tabulate import tabulate
 from utilities_common import platform_sfputil_helper
+from utilities_common.general import get_optional_value_for_key_in_config_tbl 
 
 platform_sfputil = None
 
@@ -203,7 +204,6 @@ def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_
 
     return res_dict
 
-
 def get_value_for_key_in_config_tbl(config_db, port, key, table):
     info_dict = {}
     info_dict = config_db.get_entry(table, port)
@@ -244,8 +244,8 @@ def lookup_statedb_and_update_configdb(db, per_npu_statedb, config_db, port, sta
     configdb_state = get_value_for_key_in_config_tbl(config_db, port, "state", "MUX_CABLE")
     ipv4_value = get_value_for_key_in_config_tbl(config_db, port, "server_ipv4", "MUX_CABLE")
     ipv6_value = get_value_for_key_in_config_tbl(config_db, port, "server_ipv6", "MUX_CABLE")
-    soc_ipv4_value = get_value_for_key_in_config_tbl(config_db, port, "soc_ipv4", "MUX_CABLE")
-    cable_type = get_value_for_key_in_config_tbl(config_db, port, "cable_type", "MUX_CABLE")
+    soc_ipv4_value = get_optional_value_for_key_in_config_tbl(config_db, port, "soc_ipv4", "MUX_CABLE")
+    cable_type = get_optional_value_for_key_in_config_tbl(config_db, port, "cable_type", "MUX_CABLE")
 
     state = get_value_for_key_in_dict(muxcable_statedb_dict, port, "state", "MUX_CABLE_TABLE")
 
@@ -254,11 +254,16 @@ def lookup_statedb_and_update_configdb(db, per_npu_statedb, config_db, port, sta
     if str(state_cfg_val) == str(configdb_state):
         port_status_dict[port_name] = 'OK'
     else:
-        config_db.set_entry("MUX_CABLE", port, {"state": state_cfg_val,
-                                                "server_ipv4": ipv4_value,
-                                                "server_ipv6": ipv6_value, 
-                                                "soc_ipv4":soc_ipv4_value, 
-                                                "cable_type": cable_type})
+        if cable_type is not None and soc_ipv4_value is not None:
+            config_db.set_entry("MUX_CABLE", port, {"state": state_cfg_val,
+                                                    "server_ipv4": ipv4_value,
+                                                    "server_ipv6": ipv6_value, 
+                                                    "soc_ipv4":soc_ipv4_value, 
+                                                    "cable_type": cable_type})
+        else:
+            config_db.set_entry("MUX_CABLE", port, {"state": state_cfg_val,
+                                                    "server_ipv4": ipv4_value,
+                                                    "server_ipv6": ipv6_value}) 
         if (str(state_cfg_val) == 'active' and str(state) != 'active') or (str(state_cfg_val) == 'standby' and str(state) != 'standby'):
             port_status_dict[port_name] = 'INPROGRESS'
         else:

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -13,6 +13,7 @@ from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
 from swsscommon import swsscommon
 from tabulate import tabulate
 from utilities_common import platform_sfputil_helper
+from utilities_common.general import get_optional_value_for_key_in_config_tbl 
 
 platform_sfputil = None
 
@@ -460,7 +461,7 @@ def create_table_dump_per_port_status(db, print_data, muxcable_info_dict, muxcab
     print_data.append(print_port_data)
 
 
-def create_table_dump_per_port_config(db ,print_data, per_npu_configdb, asic_id, port):
+def create_table_dump_per_port_config(db ,print_data, per_npu_configdb, asic_id, port, is_dualtor_active_active):
 
     port_list = []
     port_name = platform_sfputil_helper.get_interface_alias(port, db)
@@ -471,6 +472,13 @@ def create_table_dump_per_port_config(db ,print_data, per_npu_configdb, asic_id,
     port_list.append(ipv4_value)
     ipv6_value = get_value_for_key_in_config_tbl(per_npu_configdb[asic_id], port, "server_ipv6", "MUX_CABLE")
     port_list.append(ipv6_value)
+    soc_ipv4_value = get_optional_value_for_key_in_config_tbl(per_npu_configdb[asic_id], port, "soc_ipv4", "MUX_CABLE")
+    if soc_ipv4_value is not None:
+        port_list.append(soc_ipv4_value)
+        is_dualtor_active_active[0] = True
+    cable_type = get_optional_value_for_key_in_config_tbl(per_npu_configdb[asic_id], port, "cable_type", "MUX_CABLE")
+    if cable_type is not None:
+        port_list.append(cable_type)
     print_data.append(port_list)
 
 
@@ -484,6 +492,12 @@ def create_json_dump_per_port_config(db, port_status_dict, per_npu_configdb, asi
     port_status_dict["MUX_CABLE"]["PORTS"][port_name]["SERVER"]["IPv4"] = ipv4_value
     ipv6_value = get_value_for_key_in_config_tbl(per_npu_configdb[asic_id], port, "server_ipv6", "MUX_CABLE")
     port_status_dict["MUX_CABLE"]["PORTS"][port_name]["SERVER"]["IPv6"] = ipv6_value
+    soc_ipv4_value = get_optional_value_for_key_in_config_tbl(per_npu_configdb[asic_id], port, "soc_ipv4", "MUX_CABLE")
+    if soc_ipv4_value is not None:
+        port_status_dict["MUX_CABLE"]["PORTS"][port_name]["SERVER"]["soc_ipv4"] = soc_ipv4_value
+    cable_type = get_optional_value_for_key_in_config_tbl(per_npu_configdb[asic_id], port, "cable_type", "MUX_CABLE")
+    if cable_type is not None:
+        port_status_dict["MUX_CABLE"]["PORTS"][port_name]["SERVER"]["cable_type"] = cable_type
 
 
 @muxcable.command()
@@ -688,8 +702,10 @@ def config(db, port, json_output):
                 else:
                     print_data = []
                     print_peer_tor = []
+                    is_dualtor_active_active = [False]
 
-                    create_table_dump_per_port_config(db, print_data, per_npu_configdb, asic_id, port)
+
+                    create_table_dump_per_port_config(db, print_data, per_npu_configdb, asic_id, port, is_dualtor_active_active)
 
                     headers = ['SWITCH_NAME', 'PEER_TOR']
                     peer_tor_data = []
@@ -697,7 +713,10 @@ def config(db, port, json_output):
                     peer_tor_data.append(peer_switch_value)
                     print_peer_tor.append(peer_tor_data)
                     click.echo(tabulate(print_peer_tor, headers=headers))
-                    headers = ['port', 'state', 'ipv4', 'ipv6']
+                    if is_dualtor_active_active[0]:
+                        headers = ['port', 'state', 'ipv4', 'ipv6', 'soc_ipv4', 'cable_type']
+                    else:
+                        headers = ['port', 'state', 'ipv4', 'ipv6']
                     click.echo(tabulate(print_data, headers=headers))
 
                     sys.exit(CONFIG_SUCCESSFUL)
@@ -733,10 +752,12 @@ def config(db, port, json_output):
         else:
             print_data = []
             print_peer_tor = []
+            is_dualtor_active_active = [False]
+
             for namespace in namespaces:
                 asic_id = multi_asic.get_asic_index_from_namespace(namespace)
                 for port in natsorted(port_mux_tbl_keys[asic_id]):
-                    create_table_dump_per_port_config(db, print_data, per_npu_configdb, asic_id, port)
+                    create_table_dump_per_port_config(db, print_data, per_npu_configdb, asic_id, port, is_dualtor_active_active)
 
             headers = ['SWITCH_NAME', 'PEER_TOR']
             peer_tor_data = []
@@ -744,7 +765,10 @@ def config(db, port, json_output):
             peer_tor_data.append(peer_switch_value)
             print_peer_tor.append(peer_tor_data)
             click.echo(tabulate(print_peer_tor, headers=headers))
-            headers = ['port', 'state', 'ipv4', 'ipv6']
+            if is_dualtor_active_active[0]:
+                headers = ['port', 'state', 'ipv4', 'ipv6', 'soc_ipv4', 'cable_type']
+            else:
+                headers = ['port', 'state', 'ipv4', 'ipv6']
             click.echo(tabulate(print_data, headers=headers))
 
         sys.exit(CONFIG_SUCCESSFUL)

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -472,13 +472,13 @@ def create_table_dump_per_port_config(db ,print_data, per_npu_configdb, asic_id,
     port_list.append(ipv4_value)
     ipv6_value = get_value_for_key_in_config_tbl(per_npu_configdb[asic_id], port, "server_ipv6", "MUX_CABLE")
     port_list.append(ipv6_value)
+    cable_type = get_optional_value_for_key_in_config_tbl(per_npu_configdb[asic_id], port, "cable_type", "MUX_CABLE")
+    if cable_type is not None:
+        port_list.append(cable_type)
     soc_ipv4_value = get_optional_value_for_key_in_config_tbl(per_npu_configdb[asic_id], port, "soc_ipv4", "MUX_CABLE")
     if soc_ipv4_value is not None:
         port_list.append(soc_ipv4_value)
         is_dualtor_active_active[0] = True
-    cable_type = get_optional_value_for_key_in_config_tbl(per_npu_configdb[asic_id], port, "cable_type", "MUX_CABLE")
-    if cable_type is not None:
-        port_list.append(cable_type)
     print_data.append(port_list)
 
 
@@ -492,12 +492,12 @@ def create_json_dump_per_port_config(db, port_status_dict, per_npu_configdb, asi
     port_status_dict["MUX_CABLE"]["PORTS"][port_name]["SERVER"]["IPv4"] = ipv4_value
     ipv6_value = get_value_for_key_in_config_tbl(per_npu_configdb[asic_id], port, "server_ipv6", "MUX_CABLE")
     port_status_dict["MUX_CABLE"]["PORTS"][port_name]["SERVER"]["IPv6"] = ipv6_value
-    soc_ipv4_value = get_optional_value_for_key_in_config_tbl(per_npu_configdb[asic_id], port, "soc_ipv4", "MUX_CABLE")
-    if soc_ipv4_value is not None:
-        port_status_dict["MUX_CABLE"]["PORTS"][port_name]["SERVER"]["soc_ipv4"] = soc_ipv4_value
     cable_type = get_optional_value_for_key_in_config_tbl(per_npu_configdb[asic_id], port, "cable_type", "MUX_CABLE")
     if cable_type is not None:
         port_status_dict["MUX_CABLE"]["PORTS"][port_name]["SERVER"]["cable_type"] = cable_type
+    soc_ipv4_value = get_optional_value_for_key_in_config_tbl(per_npu_configdb[asic_id], port, "soc_ipv4", "MUX_CABLE")
+    if soc_ipv4_value is not None:
+        port_status_dict["MUX_CABLE"]["PORTS"][port_name]["SERVER"]["soc_ipv4"] = soc_ipv4_value
 
 
 @muxcable.command()
@@ -714,7 +714,7 @@ def config(db, port, json_output):
                     print_peer_tor.append(peer_tor_data)
                     click.echo(tabulate(print_peer_tor, headers=headers))
                     if is_dualtor_active_active[0]:
-                        headers = ['port', 'state', 'ipv4', 'ipv6', 'soc_ipv4', 'cable_type']
+                        headers = ['port', 'state', 'ipv4', 'ipv6', 'cable_type', 'soc_ipv4']
                     else:
                         headers = ['port', 'state', 'ipv4', 'ipv6']
                     click.echo(tabulate(print_data, headers=headers))
@@ -766,7 +766,7 @@ def config(db, port, json_output):
             print_peer_tor.append(peer_tor_data)
             click.echo(tabulate(print_peer_tor, headers=headers))
             if is_dualtor_active_active[0]:
-                headers = ['port', 'state', 'ipv4', 'ipv6', 'soc_ipv4', 'cable_type']
+                headers = ['port', 'state', 'ipv4', 'ipv6', 'cable_type', 'soc_ipv4']
             else:
                 headers = ['port', 'state', 'ipv4', 'ipv6']
             click.echo(tabulate(print_data, headers=headers))

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -1740,11 +1740,14 @@
     "MUX_CABLE|Ethernet32": {
         "state": "auto",
 	"server_ipv4": "10.1.1.1",
+        "cable_type": "active-active",
+	"soc_ipv4": "10.1.1.2",
 	"server_ipv6": "fc00::75"
     },
     "MUX_CABLE|Ethernet16": {
         "state": "standby",
 	"server_ipv4": "10.1.1.1",
+        "cable_type": "active-standby",
 	"server_ipv6": "fc00::75"
     },
     "MUX_CABLE|Ethernet28": {

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -138,30 +138,30 @@ tabular_data_config_output_expected = """\
 SWITCH_NAME    PEER_TOR
 -------------  ----------
 sonic-switch   10.2.2.2
-port        state    ipv4      ipv6
-----------  -------  --------  --------
+port        state    ipv4      ipv6      cable_type      soc_ipv4
+----------  -------  --------  --------  --------------  ----------
 Ethernet0   active   10.2.1.1  e800::46
 Ethernet4   auto     10.3.1.1  e801::46
 Ethernet8   active   10.4.1.1  e802::46
 Ethernet12  active   10.4.1.1  e802::46
-Ethernet16  standby  10.1.1.1  fc00::75
+Ethernet16  standby  10.1.1.1  fc00::75  active-standby
 Ethernet28  manual   10.1.1.1  fc00::75
-Ethernet32  auto     10.1.1.1  fc00::75
+Ethernet32  auto     10.1.1.1  fc00::75  active-active    10.1.1.2
 """
 
 tabular_data_config_output_expected_alias = """\
 SWITCH_NAME    PEER_TOR
 -------------  ----------
 sonic-switch   10.2.2.2
-port    state    ipv4      ipv6
-------  -------  --------  --------
+port    state    ipv4      ipv6      cable_type      soc_ipv4
+------  -------  --------  --------  --------------  ----------
 etp1    active   10.2.1.1  e800::46
 etp2    auto     10.3.1.1  e801::46
 etp3    active   10.4.1.1  e802::46
 etp4    active   10.4.1.1  e802::46
-etp5    standby  10.1.1.1  fc00::75
+etp5    standby  10.1.1.1  fc00::75  active-standby
 etp8    manual   10.1.1.1  fc00::75
-etp9    auto     10.1.1.1  fc00::75
+etp9    auto     10.1.1.1  fc00::75  active-active   10.1.1.2
 """
 
 json_data_status_config_output_expected = """\
@@ -201,7 +201,8 @@ json_data_status_config_output_expected = """\
                 "STATE": "standby",
                 "SERVER": {
                     "IPv4": "10.1.1.1",
-                    "IPv6": "fc00::75"
+                    "IPv6": "fc00::75",
+                    "cable_type": "active-standby"
                 }
             },
             "Ethernet28": {
@@ -215,7 +216,9 @@ json_data_status_config_output_expected = """\
                 "STATE": "auto",
                 "SERVER": {
                     "IPv4": "10.1.1.1",
-                    "IPv6": "fc00::75"
+                    "IPv6": "fc00::75",
+                    "cable_type": "active-active",
+                    "soc_ipv4": "10.1.1.2"
                 }
             }
         }
@@ -260,7 +263,8 @@ json_data_status_config_output_expected_alias = """\
                 "STATE": "standby",
                 "SERVER": {
                     "IPv4": "10.1.1.1",
-                    "IPv6": "fc00::75"
+                    "IPv6": "fc00::75",
+                    "cable_type": "active-standby"
                 }
             },
             "etp8": {
@@ -274,7 +278,9 @@ json_data_status_config_output_expected_alias = """\
                 "STATE": "auto",
                 "SERVER": {
                     "IPv4": "10.1.1.1",
-                    "IPv6": "fc00::75"
+                    "IPv6": "fc00::75",
+                    "cable_type": "active-active",
+                    "soc_ipv4": "10.1.1.2"
                 }
             }
         }

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -146,7 +146,7 @@ Ethernet8   active   10.4.1.1  e802::46
 Ethernet12  active   10.4.1.1  e802::46
 Ethernet16  standby  10.1.1.1  fc00::75  active-standby
 Ethernet28  manual   10.1.1.1  fc00::75
-Ethernet32  auto     10.1.1.1  fc00::75  active-active    10.1.1.2
+Ethernet32  auto     10.1.1.1  fc00::75  active-active   10.1.1.2
 """
 
 tabular_data_config_output_expected_alias = """\

--- a/utilities_common/general.py
+++ b/utilities_common/general.py
@@ -31,3 +31,14 @@ def load_db_config():
     else:
         if not swsscommon.SonicDBConfig.isInit():
             swsscommon.SonicDBConfig.load_sonic_db_config()
+
+def get_optional_value_for_key_in_config_tbl(config_db, port, key, table):
+    info_dict = {}
+    info_dict = config_db.get_entry(table, port)
+    if info_dict is None:
+        return None
+
+    value = info_dict.get(key, None)
+        
+    return value
+


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>
this PR enhances the show mux status output to include the cable -type and soc_ipv4  and config mux mode is corrected to include soc_ipv4 an cable_type when the mux mode entry is overwritten. 

```
admin@sonic-1:~$ show mux config
SWITCH_NAME        PEER_TOR
-----------------  ----------
svcstr-7050-acs-2  10.1.0.33
port        state    ipv4             ipv6               cable_type      soc_ipv4
----------  -------  ---------------  -----------------  --------------  ---------------
Ethernet4   auto     192.168.0.2/32   fc02:1000::2/128   active-active   192.168.0.3/32
Ethernet8   auto     192.168.0.4/32   fc02:1000::4/128   active-active   192.168.0.5/32
Ethernet12  auto     192.168.0.6/32   fc02:1000::6/128   active-active   192.168.0.7/32
Ethernet16  auto     192.168.0.8/32   fc02:1000::8/128   active-active   192.168.0.9/32
Ethernet20  auto     192.168.0.10/32  fc02:1000::a/128   active-active   192.168.0.11/32
Ethernet24  auto     192.168.0.12/32  fc02:1000::c/128   active-active   192.168.0.13/32
Ethernet28  auto     192.168.0.14/32  fc02:1000::e/128   active-active   192.168.0.15/32
Ethernet32  auto     192.168.0.16/32  fc02:1000::10/128  active-active   192.168.0.17/32
Ethernet36  auto     192.168.0.18/32  fc02:1000::12/128  active-active   192.168.0.19/32
Ethernet40  auto     192.168.0.20/32  fc02:1000::14/128  active-active   192.168.0.21/32
Ethernet44  auto     192.168.0.22/32  fc02:1000::16/128  active-active   192.168.0.23/32
Ethernet48  auto     192.168.0.24/32  fc02:1000::18/128  active-active   192.168.0.25/32
Ethernet52  auto     192.168.0.26/32  fc02:1000::1a/128  active-standby
Ethernet56  auto     192.168.0.28/32  fc02:1000::1c/128  active-standby
Ethernet60  auto     192.168.0.30/32  fc02:1000::1e/128  active-standby
Ethernet64  auto     192.168.0.32/32  fc02:1000::20/128  active-standby
Ethernet68  auto     192.168.0.34/32  fc02:1000::22/128  active-standby
Ethernet72  auto     192.168.0.36/32  fc02:1000::24/128  active-standby
Ethernet76  auto     192.168.0.38/32  fc02:1000::26/128  active-standby
Ethernet80  auto     192.168.0.40/32  fc02:1000::28/128  active-standby
Ethernet84  auto     192.168.0.42/32  fc02:1000::2a/128  active-standby
Ethernet88  auto     192.168.0.44/32  fc02:1000::2c/128  active-standby
Ethernet92  auto     192.168.0.46/32  fc02:1000::2e/128  active-standby
Ethernet96  auto     192.168.0.48/32  fc02:1000::30/128  active-standby
```
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
modify config mux mode logic to be correct;
enhanced show mux config to display cable-type and soc_ipv4 if present 
#### How I did it

#### How to verify it
UT and ran the changes on arista testbed
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

