### PR TITLE
Add support for IP interface loopback action

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -4034,7 +4034,7 @@ def fec(ctx, interface_name, interface_fec, verbose):
 @interface.group(cls=clicommon.AbbreviationGroup)
 @click.pass_context
 def ip(ctx):
-    """Add or remove IP address"""
+    """Set IP interface attributes"""
     pass
 
 #
@@ -4164,6 +4164,32 @@ def remove(ctx, interface_name, ip_addr):
         command = "ip neigh flush dev {} {}".format(interface_name, str(ip_address))
     clicommon.run_command(command)
 
+#
+# 'loopback-action' subcommand
+#
+
+@ip.command()
+@click.argument('interface_name', metavar='<interface_name>', required=True)
+@click.argument('action', metavar='<action>', required=True)
+@click.pass_context
+def loopback_action(ctx, interface_name, action):
+    """Set IP interface loopback action"""
+    config_db = ctx.obj['config_db']
+
+    if clicommon.get_interface_naming_mode() == "alias":
+        interface_name = interface_alias_to_name(config_db, interface_name)
+        if interface_name is None:
+            ctx.fail('Interface {} is invalid'.format(interface_name))
+
+    if not clicommon.is_interface_in_config_db(config_db, interface_name):
+        ctx.fail('Interface {} is not an IP interface'.format(interface_name))
+
+    allowed_actions = ['drop', 'forward']
+    if action not in allowed_actions:
+        ctx.fail('Invalid action')
+
+    table_name = get_interface_table_name(interface_name)
+    config_db.mod_entry(table_name, interface_name, {"loopback_action": action})
 
 #
 # buffer commands and utilities
@@ -4684,33 +4710,6 @@ def unbind(ctx, interface_name):
     for ipaddress in interface_ipaddresses:
         remove_router_interface_ip_address(config_db, interface_name, ipaddress)
     config_db.set_entry(table_name, interface_name, None)
-
-#
-# 'config interface loopback-action <interface-name> <action>'
-#
-
-@interface.command()
-@click.argument('interface_name', metavar='<interface_name>', required=True)
-@click.argument('action', metavar='<action>', required=True)
-@click.pass_context
-def loopback_action(ctx, interface_name, action):
-    """Set IP interface loopback action"""
-    config_db = ctx.obj['config_db']
-
-    if clicommon.get_interface_naming_mode() == "alias":
-        interface_name = interface_alias_to_name(config_db, interface_name)
-        if interface_name is None:
-            ctx.fail('Interface {} is invalid'.format(interface_name))
-
-    if not clicommon.is_interface_in_config_db(config_db, interface_name):
-        ctx.fail('Interface {} is not an IP interface'.format(interface_name))
-
-    allowed_actions = ['drop', 'forward']
-    if action not in allowed_actions:
-        ctx.fail('Invalid action')
-
-    table_name = get_interface_table_name(interface_name)
-    config_db.mod_entry(table_name, interface_name, {"loopback_action": action})
 
 #
 # 'ipv6' subgroup ('config interface ipv6 ...')

--- a/config/main.py
+++ b/config/main.py
@@ -4685,6 +4685,34 @@ def unbind(ctx, interface_name):
         remove_router_interface_ip_address(config_db, interface_name, ipaddress)
     config_db.set_entry(table_name, interface_name, None)
 
+#
+# 'config interface loopback-action <interface-name> <action>'
+#
+
+@interface.command()
+@click.argument('interface_name', metavar='<interface_name>', required=True)
+@click.argument('action', metavar='<action>', required=True)
+@click.pass_context
+def loopback_action(ctx, interface_name, action):
+    """Set IP interface loopback action"""
+    config_db = ctx.obj['config_db']
+
+    if clicommon.get_interface_naming_mode() == "alias":
+        interface_name = interface_alias_to_name(config_db, interface_name)
+        if interface_name is None:
+            ctx.fail('Interface {} is invalid'.format(interface_name))
+
+    if not clicommon.is_interface_in_config_db(config_db, interface_name):
+        ctx.fail('Interface {} is not an IP interface'.format(interface_name))
+
+    allowed_actions = ['drop', 'forward']
+    if action not in allowed_actions:
+        ctx.fail('Invalid action')
+
+    table_name = get_interface_table_name(interface_name)
+    if not table_name:
+        ctx.fail('Interface {} is invalid'.format(interface_name))
+    config_db.set_entry(table_name, interface_name, {"loopback_action": action})
 
 #
 # 'ipv6' subgroup ('config interface ipv6 ...')

--- a/config/main.py
+++ b/config/main.py
@@ -4712,7 +4712,7 @@ def loopback_action(ctx, interface_name, action):
     table_name = get_interface_table_name(interface_name)
     if not table_name:
         ctx.fail('Interface {} is invalid'.format(interface_name))
-    config_db.set_entry(table_name, interface_name, {"loopback_action": action})
+    config_db.mod_entry(table_name, interface_name, {"loopback_action": action})
 
 #
 # 'ipv6' subgroup ('config interface ipv6 ...')

--- a/config/main.py
+++ b/config/main.py
@@ -4710,8 +4710,6 @@ def loopback_action(ctx, interface_name, action):
         ctx.fail('Invalid action')
 
     table_name = get_interface_table_name(interface_name)
-    if not table_name:
-        ctx.fail('Interface {} is invalid'.format(interface_name))
     config_db.mod_entry(table_name, interface_name, {"loopback_action": action})
 
 #

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -3657,6 +3657,25 @@ This command is used to display the configured MPLS state for the list of config
   Ethernet4    enable
   ```
 
+**show interfaces loopback-action**
+
+This command displays the configured loopback action
+
+- Usage:
+  ```
+  show ip interfaces loopback-action
+  ```
+
+- Example:
+  ```
+  root@sonic:~# show ip interfaces loopback-action
+  Interface     Action
+  ------------  ----------
+  Ethernet232   drop
+  Vlan100       forward
+  ```
+
+
 **show interfaces tpid**
 
 This command displays the key fields of the interfaces such as Operational Status, Administrative Status, Alias and TPID.
@@ -3803,6 +3822,7 @@ This sub-section explains the following list of configuration on the interfaces.
 9) advertised-types - to set interface advertised types
 10) type - to set interface type
 11) mpls - To add or remove MPLS operation for the interface
+12) loopback-action - to set action for packet that ingress and gets routed on the same IP interface
 
 From 201904 release onwards, the “config interface” command syntax is changed and the format is as follows:
 
@@ -4336,6 +4356,29 @@ MPLS operation for either physical, portchannel, or VLAN interface can be config
   admin@sonic:~$ sudo config interface mpls remove Ethernet4
   ```
 
+**config interface ip loopback-action <interface_name> <action> (Versions >= 202205)**
+
+This command is used for setting the action being taken on packets that ingress and get routed on the same IP interface.
+Loopback action can be set on IP interface from type physical, portchannel, VLAN interface and VLAN subinterface.
+Loopback action can be drop or forward.
+
+- Usage:
+  ```
+  config interface ip loopback-action --help
+  Usage: config interface ip loopback-action [OPTIONS] <interface_name> <action>
+
+    Set IP interface loopback action
+
+  Options:
+    -?, -h, --help  Show this message and exit.
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ config interface ip loopback-action Ethernet0 drop
+  admin@sonic:~$ config interface ip loopback-action Ethernet0 forward
+
+  ```
 Go Back To [Beginning of the document](#) or [Beginning of this section](#interfaces)
 
 ## Interface Naming Mode

--- a/tests/loopback_action_test.py
+++ b/tests/loopback_action_test.py
@@ -113,7 +113,7 @@ class TestLoopbackAction(object):
         iface = 'Ethernet0.11'
         ERROR_MSG = "Error: Interface {} is not an IP interface".format(iface)
 
-        result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
+        result = runner.invoke(config.config.commands['interface'].commands["ip"].commands['loopback-action'], [iface, action], obj=obj)
     
         print(result.exit_code, result.output)
         assert result.exit_code != 0
@@ -127,7 +127,7 @@ class TestLoopbackAction(object):
         iface = 'Ethernet0'
         ERROR_MSG = "Error: Invalid action"
 
-        result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
+        result = runner.invoke(config.config.commands['interface'].commands["ip"].commands['loopback-action'], [iface, action], obj=obj)
     
         print(result.exit_code, result.output)
         assert result.exit_code != 0

--- a/tests/loopback_action_test.py
+++ b/tests/loopback_action_test.py
@@ -26,7 +26,7 @@ class TestLoopbackAction(object):
         action = 'drop'
         iface = 'Ethernet0'
 
-        result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
+        result = runner.invoke(config.config.commands['interface'].commands["ip"].commands['loopback-action'], [iface, action], obj=obj)
     
         table = db.cfgdb.get_table('INTERFACE')
         assert(table[iface]['loopback_action'] == action)
@@ -43,7 +43,7 @@ class TestLoopbackAction(object):
         iface_alias = 'etp1'
 
         os.environ['SONIC_CLI_IFACE_MODE'] = "alias"
-        result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface_alias, action], obj=obj)
+        result = runner.invoke(config.config.commands['interface'].commands["ip"].commands['loopback-action'], [iface_alias, action], obj=obj)
         os.environ['SONIC_CLI_IFACE_MODE'] = "default"
 
         table = db.cfgdb.get_table('INTERFACE')
@@ -59,7 +59,7 @@ class TestLoopbackAction(object):
         action = 'forward'
         iface = 'PortChannel0002'
 
-        result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
+        result = runner.invoke(config.config.commands['interface'].commands["ip"].commands['loopback-action'], [iface, action], obj=obj)
     
         table = db.cfgdb.get_table('PORTCHANNEL_INTERFACE')
         assert(table[iface]['loopback_action'] == action)
@@ -74,7 +74,7 @@ class TestLoopbackAction(object):
         action = 'drop'
         iface = 'Vlan1000'
 
-        result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
+        result = runner.invoke(config.config.commands['interface'].commands["ip"].commands['loopback-action'], [iface, action], obj=obj)
     
         table = db.cfgdb.get_table('VLAN_INTERFACE')
         assert(table[iface]['loopback_action'] == action)
@@ -89,7 +89,7 @@ class TestLoopbackAction(object):
         action = 'forward'
         iface = 'Ethernet0.10'
 
-        result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
+        result = runner.invoke(config.config.commands['interface'].commands["ip"].commands['loopback-action'], [iface, action], obj=obj)
     
         table = db.cfgdb.get_table('VLAN_SUB_INTERFACE')
         assert(table[iface]['loopback_action'] == action)

--- a/tests/loopback_action_test.py
+++ b/tests/loopback_action_test.py
@@ -10,7 +10,7 @@ Interface        Action
 Eth32.10         drop
 Ethernet0        forward
 PortChannel0001  drop
-Vlan2000         forward
+Vlan3000         forward
 """
 
 class TestLoopbackAction(object):
@@ -25,6 +25,7 @@ class TestLoopbackAction(object):
         obj = {'config_db':db.cfgdb}
         action = 'drop'
         iface = 'Ethernet0'
+
         result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
     
         table = db.cfgdb.get_table('INTERFACE')
@@ -39,6 +40,7 @@ class TestLoopbackAction(object):
         obj = {'config_db':db.cfgdb}
         action = 'forward'
         iface = 'PortChannel0002'
+
         result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
     
         table = db.cfgdb.get_table('PORTCHANNEL_INTERFACE')
@@ -53,6 +55,7 @@ class TestLoopbackAction(object):
         obj = {'config_db':db.cfgdb}
         action = 'drop'
         iface = 'Vlan1000'
+
         result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
     
         table = db.cfgdb.get_table('VLAN_INTERFACE')
@@ -67,6 +70,7 @@ class TestLoopbackAction(object):
         obj = {'config_db':db.cfgdb}
         action = 'forward'
         iface = 'Ethernet0.10'
+
         result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
     
         table = db.cfgdb.get_table('VLAN_SUB_INTERFACE')
@@ -90,6 +94,7 @@ class TestLoopbackAction(object):
         action = 'forward'
         iface = 'Ethernet0.11'
         ERROR_MSG = "Error: Interface {} is not an IP interface".format(iface)
+
         result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
     
         print(result.exit_code, result.output)
@@ -103,6 +108,7 @@ class TestLoopbackAction(object):
         action = 'xforwardx'
         iface = 'Ethernet0'
         ERROR_MSG = "Error: Invalid action"
+
         result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
     
         print(result.exit_code, result.output)

--- a/tests/loopback_action_test.py
+++ b/tests/loopback_action_test.py
@@ -34,6 +34,24 @@ class TestLoopbackAction(object):
         print(result.exit_code, result.output)
         assert result.exit_code == 0
         
+    def test_config_loopback_action_on_physical_interface_alias(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db':db.cfgdb}
+        action = 'forward'
+        iface = 'Ethernet0'
+        iface_alias = 'etp1'
+
+        os.environ['SONIC_CLI_IFACE_MODE'] = "alias"
+        result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface_alias, action], obj=obj)
+        os.environ['SONIC_CLI_IFACE_MODE'] = "default"
+
+        table = db.cfgdb.get_table('INTERFACE')
+        assert(table[iface]['loopback_action'] == action)
+
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
     def test_config_loopback_action_on_port_channel_interface(self):        
         runner = CliRunner()
         db = Db()

--- a/tests/loopback_action_test.py
+++ b/tests/loopback_action_test.py
@@ -1,0 +1,115 @@
+import os
+from click.testing import CliRunner
+import config.main as config
+import show.main as show
+from utilities_common.db import Db
+
+show_ip_interfaces_loopback_action_output="""\
+Interface        Action
+---------------  --------
+Eth32.10         drop
+Ethernet0        forward
+PortChannel0001  drop
+Vlan2000         forward
+"""
+
+class TestLoopbackAction(object):
+    @classmethod
+    def setup_class(cls):
+        print("\nSETUP")
+        os.environ['UTILITIES_UNIT_TESTING'] = "1"
+
+    def test_config_loopback_action_on_physical_interface(self):        
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db':db.cfgdb}
+        action = 'drop'
+        iface = 'Ethernet0'
+        result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
+    
+        table = db.cfgdb.get_table('INTERFACE')
+        assert(table[iface]['loopback_action'] == action)
+        
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+        
+    def test_config_loopback_action_on_port_channel_interface(self):        
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db':db.cfgdb}
+        action = 'forward'
+        iface = 'PortChannel0002'
+        result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
+    
+        table = db.cfgdb.get_table('PORTCHANNEL_INTERFACE')
+        assert(table[iface]['loopback_action'] == action)
+        
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+        
+    def test_config_loopback_action_on_vlan_interface(self):        
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db':db.cfgdb}
+        action = 'drop'
+        iface = 'Vlan1000'
+        result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
+    
+        table = db.cfgdb.get_table('VLAN_INTERFACE')
+        assert(table[iface]['loopback_action'] == action)
+        
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0  
+            
+    def test_config_loopback_action_on_subinterface(self):        
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db':db.cfgdb}
+        action = 'forward'
+        iface = 'Ethernet0.10'
+        result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
+    
+        table = db.cfgdb.get_table('VLAN_SUB_INTERFACE')
+        assert(table[iface]['loopback_action'] == action)
+        
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+        
+    def test_show_ip_interfaces_loopback_action(self):
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["ip"].commands["interfaces"].commands["loopback-action"], [])
+        
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+        assert result.output == show_ip_interfaces_loopback_action_output
+
+    def test_config_loopback_action_on_non_ip_interface(self):        
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db':db.cfgdb}
+        action = 'forward'
+        iface = 'Ethernet0.11'
+        ERROR_MSG = "Error: Interface {} is not an IP interface".format(iface)
+        result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
+    
+        print(result.exit_code, result.output)
+        assert result.exit_code != 0
+        assert ERROR_MSG in result.output
+        
+    def test_config_loopback_action_invalid_action(self):        
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db':db.cfgdb}
+        action = 'xforwardx'
+        iface = 'Ethernet0'
+        ERROR_MSG = "Error: Invalid action"
+        result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
+    
+        print(result.exit_code, result.output)
+        assert result.exit_code != 0
+        assert ERROR_MSG in result.output
+
+    @classmethod
+    def teardown_class(cls):
+        print("\nTEARDOWN")
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -375,6 +375,7 @@
     },
     "VLAN_SUB_INTERFACE|Eth32.10": {
         "admin_status": "up",
+        "loopback_action": "drop",
         "vlan": "100"
     },
     "ACL_RULE|NULL_ROUTE_V4|DEFAULT_RULE": {
@@ -550,7 +551,8 @@
         "NULL": "NULL"
     },
     "VLAN_INTERFACE|Vlan2000": {
-        "proxy_arp": "enabled"
+        "proxy_arp": "enabled",
+        "loopback_action": "forward"
     },
     "VLAN_INTERFACE|Vlan1000|192.168.0.1/21": {
         "NULL": "NULL"
@@ -636,7 +638,8 @@
         "NULL": "NULL"
     },
     "PORTCHANNEL_INTERFACE|PortChannel0001": {
-        "ipv6_use_link_local_only": "disable"
+        "ipv6_use_link_local_only": "disable",
+        "loopback_action": "drop"
     },
     "PORTCHANNEL_INTERFACE|PortChannel0002": {
         "NULL": "NULL"
@@ -672,7 +675,8 @@
         "NULL": "NULL"
     },
     "INTERFACE|Ethernet0": {
-        "ipv6_use_link_local_only": "disable"
+        "ipv6_use_link_local_only": "disable",
+        "loopback_action": "forward"
     },
     "INTERFACE|Ethernet0|14.14.0.1/24": {
         "NULL": "NULL"

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -551,7 +551,9 @@
         "NULL": "NULL"
     },
     "VLAN_INTERFACE|Vlan2000": {
-        "proxy_arp": "enabled",
+        "proxy_arp": "enabled"
+    },
+    "VLAN_INTERFACE|Vlan3000": {
         "loopback_action": "forward"
     },
     "VLAN_INTERFACE|Vlan1000|192.168.0.1/21": {

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -593,6 +593,7 @@ def is_interface_in_config_db(config_db, interface_name):
     if (not interface_name in config_db.get_keys('VLAN_INTERFACE') and
         not interface_name in config_db.get_keys('INTERFACE') and
         not interface_name in config_db.get_keys('PORTCHANNEL_INTERFACE') and
+        not interface_name in config_db.get_keys('VLAN_SUB_INTERFACE') and
         not interface_name == 'null'):
             return False
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add support for IP interface loopback action.

#### How I did it

#### How to verify it
New CLI unittests were added.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
```
root@sonic:~# config interface ip loopback-action Ethernet0 drop
```
```
root@sonic:~# show ip interfaces loopback-action
Interface     Action      
------------  ----------  
Ethernet232   drop
Vlan100       forward    
```

