### PR TITLE
[yang] remove mistakenly added parameter for 'get_module_name'

### DIFF
--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -281,7 +281,7 @@ class ConfigMgmt():
         """
 
         # Instantiate new context since parse_module_mem() loads the module into context.
-        sy = sonic_yang.SonicYang(YANG_DIR, sonic_yang_options=self.sonicYangOptions)
+        sy = sonic_yang.SonicYang(YANG_DIR)
         module = sy.ctx.parse_module_mem(yang_module_str, ly.LYS_IN_YANG)
         return module.name()
 

--- a/tests/config_mgmt_test.py
+++ b/tests/config_mgmt_test.py
@@ -11,6 +11,7 @@ from utilities_common.general import load_module_from_source
 config_mgmt_py_path = os.path.join(os.path.dirname(__file__), '..', 'config', 'config_mgmt.py')
 config_mgmt = load_module_from_source('config_mgmt', config_mgmt_py_path)
 
+model = "module test_name {namespace urn:test_urn; prefix test_prefix;}"
 
 class TestConfigMgmt(TestCase):
     '''
@@ -20,6 +21,13 @@ class TestConfigMgmt(TestCase):
     def setUp(self):
         config_mgmt.CONFIG_DB_JSON_FILE = "startConfigDb.json"
         config_mgmt.DEFAULT_CONFIG_DB_JSON_FILE = "portBreakOutConfigDb.json"
+        return
+
+    def test_config_get_module_check(self):
+        curConfig = deepcopy(configDbJson)
+        self.writeJson(curConfig, config_mgmt.CONFIG_DB_JSON_FILE)
+        cm = config_mgmt.ConfigMgmt(source=config_mgmt.CONFIG_DB_JSON_FILE)
+        assert cm.get_module_name(model) == "test_name"
         return
 
     def test_config_validation(self):


### PR DESCRIPTION
Signed-off-by: Andriy Yurkiv <ayurkiv@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Revert parameter from function that was mistakenly added in https://github.com/Azure/sonic-utilities/pull/2118

We don't need to pass 'sonic_yang_options' to static function get_module_name()

#### How I did it
remove 'sonic_yang_options' from SonicYang object creation in get_module_name()

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

