### PR TITLE
[counters] skip showing counters that are not enabled

### DIFF
--- a/scripts/watermarkstat
+++ b/scripts/watermarkstat
@@ -226,6 +226,9 @@ class Watermarkstat(object):
 
         # header list contains the port name followed by the queues/pgs. fields is used to populate the queue/pg values
         fields = ["0"]* (len(self.header_list) - 1)
+        if not fields:
+            # counters are not enabled.
+            return fields
 
         for name, obj_id in port_obj.items():
             full_table_id = table_prefix + obj_id


### PR DESCRIPTION
#### What I did
Skip counters that are not enabled.

#### How to verify it
With change https://github.com/Azure/sonic-swss/pull/2143, following commands will cause exception:

admin@vlab-01:~$ show priority-group persistent-watermark headroom         
Traceback (most recent call last):
  File "/usr/local/bin/watermarkstat", line 315, in <module>
    main()
  File "/usr/local/bin/watermarkstat", line 310, in main
    watermarkstat.print_all_stat(table_prefix, args.type)
  File "/usr/local/bin/watermarkstat", line 261, in print_all_stat
    data = self.get_counters(table_prefix,
  File "/usr/local/bin/watermarkstat", line 237, in get_counters
    elif fields[pos] != STATUS_NA:
IndexError: list index out of range

With the change:

admin@vlab-01:~$ show priority-group persistent-watermark headroom         
Ingress headroom per PG:
       Port
-----------
  Ethernet0
  Ethernet4
  Ethernet8
 Ethernet12
 Ethernet16
... ...

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

