### PR TITLE
[202012] Fix migration of `pfcwd_sw_enable`

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -417,7 +417,8 @@ class DBMigrator():
         """
         qos_maps = self.configDB.get_table('PORT_QOS_MAP')
         for k, v in qos_maps.items():
-            if 'pfc_enable' in v:
+            # Skip migration if the key already presents
+            if ('pfcwd_sw_enable' not in v) and ('pfc_enable' in v):
                 v['pfcwd_sw_enable'] = v['pfc_enable']
                 self.configDB.set_entry('PORT_QOS_MAP', k, v)
 


### PR DESCRIPTION
Signed-off-by: bingwang <wang.bing@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This PR is to fix a bug in `migrate_pfcwd_sw_enable_table`.
As `migrate_pfcwd_sw_enable_table` is a step of `common_migration_ops`, it's always called in any version. 
Even if the key `pfcwd_sw_enable` is present, the script still overwrite it. This is unexpected.

This PR addressed the issue by checking the existence of `pfcwd_sw_enable` before adding it. 

#### How I did it
Check the existence of `pfcwd_sw_enable` before adding it. 

#### How to verify it
Verified by vstest.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

