### PR TITLE
[config][muxcable] fix minor config DB logic issue

### DIFF
--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -254,7 +254,7 @@ def lookup_statedb_and_update_configdb(db, per_npu_statedb, config_db, port, sta
     if str(state_cfg_val) == str(configdb_state):
         port_status_dict[port_name] = 'OK'
     else:
-        if cable_type is not None and soc_ipv4_value is not None:
+        if cable_type is not None or soc_ipv4_value is not None:
             config_db.set_entry("MUX_CABLE", port, {"state": state_cfg_val,
                                                     "server_ipv4": ipv4_value,
                                                     "server_ipv6": ipv6_value, 


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>
For active-standby type cable there will not be any soc_ipv4 entry in the "MUX_CABLE" table, hence when updating the config DB entry with update 
for 
```sudo config mux mode <state> <port>```
we should just check the cable_type and update the table entry
if no soc_ipv4 the value written in none in that case
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it
Unit-tests cover the change
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

