### PR TITLE
[generic-config-updater] Add NTP validator 

### DIFF
--- a/generic_config_updater/generic_config_updater.conf.json
+++ b/generic_config_updater/generic_config_updater.conf.json
@@ -47,7 +47,7 @@
             "services_to_validate": [ "caclmgrd-service" ]
         },
         "NTP_SERVER": {
-            "services_to_validate": [ "ntp" ]
+            "services_to_validate": [ "ntp-service" ]
         }
     },
     "services": {
@@ -69,7 +69,7 @@
         "caclmgrd-service": {
             "validate_commands": [ "generic_config_updater.services_validator.caclmgrd_validator" ]
         },
-        "ntp": {
+        "ntp-service": {
             "validate_commands": [ "generic_config_updater.services_validator.ntp_validator" ]
         }
     }

--- a/generic_config_updater/generic_config_updater.conf.json
+++ b/generic_config_updater/generic_config_updater.conf.json
@@ -45,6 +45,9 @@
         },
         "ACL_RULE": {
             "services_to_validate": [ "caclmgrd-service" ]
+        },
+        "NTP_SERVER": {
+            "services_to_validate": [ "ntp" ]
         }
     },
     "services": {
@@ -65,6 +68,9 @@
         },
         "caclmgrd-service": {
             "validate_commands": [ "generic_config_updater.services_validator.caclmgrd_validator" ]
+        },
+        "ntp": {
+            "validate_commands": [ "generic_config_updater.services_validator.ntp_validator" ]
         }
     }
 }

--- a/generic_config_updater/services_validator.py
+++ b/generic_config_updater/services_validator.py
@@ -101,4 +101,3 @@ def caclmgrd_validator(old_config, upd_config, keys):
 
 def ntp_validator(old_config, upd_config, keys):
     return _service_restart("ntp-config")
-

--- a/generic_config_updater/services_validator.py
+++ b/generic_config_updater/services_validator.py
@@ -98,3 +98,7 @@ def caclmgrd_validator(old_config, upd_config, keys):
     # No update to ACL_RULE.
     return True
 
+
+def ntp_validator(old_config, upd_config, keys):
+    return _service_restart("ntp-config")
+


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
When GCU config NTP_SERVER table, its change is not actually taken info effect. Because NTP service is not restarted. So I add NTP service validator and restart service when NTP_SERVER is changed.
#### How I did it
When NTP_SERVER table being configured through GCU, the ntp service will restart.
#### How to verify it
Run GCU E2E test for NTP_SERVER table.
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

