### PR TITLE
Cisco-8000 show platform flexibility

### DIFF
--- a/show/plugins/cisco-8000.py
+++ b/show/plugins/cisco-8000.py
@@ -1,36 +1,25 @@
 #!/usr/bin/env python
 #########################################################
-# Copyright 2021 Cisco Systems, Inc.
+# Copyright 2021-2022 Cisco Systems, Inc.
 # All rights reserved.
 #
 # CLI Extensions for show command
 #########################################################
 
 try:
-    import click
-    import yaml
-    from show import platform
     from sonic_py_common import device_info
     import utilities_common.cli as clicommon
 except ImportError as e:
-    raise ImportError("%s - required module not found" % str(e))
+    raise ImportError("%s - required module not found".format(str(e)))
 
-PLATFORM_PY = '/opt/cisco/bin/platform.py'
+try:
+    from sonic_platform.cli import PLATFORM_CLIS
+except ImportError:
+    PLATFORM_CLIS = []
 
-@click.command()
-def inventory():
-    """Show Platform Inventory"""
-    args = [ PLATFORM_PY, 'inventoryshow' ]
-    clicommon.run_command(args)
-
-@click.command()
-def idprom():
-    """Show Platform Idprom Inventory"""
-    args = [ PLATFORM_PY, 'idprom' ]
-    clicommon.run_command(args)
 
 def register(cli):
-    version_info = device_info.get_sonic_version_info() 
-    if (version_info and version_info.get('asic_type') == 'cisco-8000'):
-        cli.commands['platform'].add_command(inventory)
-        cli.commands['platform'].add_command(idprom)
+    version_info = device_info.get_sonic_version_info()
+    if version_info and version_info.get("asic_type") == "cisco-8000":
+        for c in PLATFORM_CLIS:
+            cli.commands["platform"].add_command(c)


### PR DESCRIPTION


<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Gave cisco-8000 the ability to add sub-commands under `show platform <>` in our downstream repo. Currently every time we want to add/remove/update a cli, we must raise a PR upstream. 

#### How I did it
I have the cisco-8000.py module import a list of `click` commands that are written in a module that is located in our platform code.

#### How to verify it
Run `show platform -h` to see all commands. We will be able to see `show platform inventory`. This is only available on cisco devices.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

