### PR TITLE
202012: Cisco-8000 show platform flexibility

### DIFF
--- a/show/platform.py
+++ b/show/platform.py
@@ -37,7 +37,10 @@ version_info = device_info.get_sonic_version_info()
 if (version_info and version_info.get('asic_type') == 'mellanox'):
     from . import mlnx
     platform.add_command(mlnx.mlnx)
-
+elif version_info and version_info.get("asic_type") == "cisco-8000":
+    from sonic_platform.cli import PLATFORM_CLIS
+    for command in PLATFORM_CLIS:
+        platform.add_command(command)
 
 # 'summary' subcommand ("show platform summary")
 @platform.command()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

> Equivalent PR for `master`: https://github.com/Azure/sonic-utilities/pull/2213


#### What I did
Gave cisco-8000 the ability to add sub-commands under `show platform <>` in our downstream repo. Currently every time we want to add/remove/update a cli, we must raise a PR upstream. 

#### How I did it
I have the cisco-8000.py module import a list of `click` commands that are written in a module that is located in our platform code.

#### How to verify it
Run `show platform -h` to see all commands. We will be able to see `show platform inventory`. This is only available on cisco devices.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

