### PR TITLE
[202205][config reload] Fixing config reload when timer based services are disabled

### DIFF
--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -73,6 +73,18 @@ reload_config_with_sys_info_command_output="""\
 Running command: rm -rf /tmp/dropstat-*
 Running command: /usr/local/bin/sonic-cfggen -H -k Seastone-DX010-25-50 --write-to-db"""
 
+reload_config_with_disabled_service_output="""\
+Running command: rm -rf /tmp/dropstat-*
+Stopping SONiC target ...
+Running command: /usr/local/bin/sonic-cfggen  -j /tmp/config.json  --write-to-db
+Restarting SONiC target ...
+Reloading Monit configuration ...
+"""
+
+reload_config_with_untriggered_timer_output="""\
+Relevant services are not up. Retry later or use -f to avoid system checks
+"""
+
 def mock_run_command_side_effect(*args, **kwargs):
     command = args[0]
 
@@ -89,12 +101,51 @@ def mock_run_command_side_effect(*args, **kwargs):
         else:
             return ''
 
+def mock_run_command_side_effect_disabled_timer(*args, **kwargs):
+    command = args[0]
+
+    if kwargs.get('display_cmd'):
+        click.echo(click.style("Running command: ", fg='cyan') + click.style(command, fg='green'))
+
+    if kwargs.get('return_cmd'):
+        if command == "systemctl list-dependencies --plain sonic-delayed.target | sed '1d'":
+            return 'snmp.timer'
+        elif command == "systemctl list-dependencies --plain sonic.target | sed '1d'":
+            return 'swss'
+        elif command == "systemctl is-enabled snmp.timer":
+            return 'masked'
+        elif command == "systemctl show swss.service --property ActiveState --value":
+            return 'active'
+        elif command == "systemctl show swss.service --property ActiveEnterTimestampMonotonic --value":
+            return '0'
+        else:
+            return ''
+
+def mock_run_command_side_effect_untriggered_timer(*args, **kwargs):
+    command = args[0]
+
+    if kwargs.get('display_cmd'):
+        click.echo(click.style("Running command: ", fg='cyan') + click.style(command, fg='green'))
+
+    if kwargs.get('return_cmd'):
+        if command == "systemctl list-dependencies --plain sonic-delayed.target | sed '1d'":
+            return 'snmp.timer'
+        elif command == "systemctl list-dependencies --plain sonic.target | sed '1d'":
+            return 'swss'
+        elif command == "systemctl is-enabled snmp.timer":
+            return 'enabled'
+        elif command == "systemctl show snmp.timer --property=LastTriggerUSecMonotonic --value":
+            return '0'
+        else:
+            return ''
 
 # Load sonic-cfggen from source since /usr/local/bin/sonic-cfggen does not have .py extension.
 sonic_cfggen = load_module_from_source('sonic_cfggen', '/usr/local/bin/sonic-cfggen')
 
 
 class TestConfigReload(object):
+    dummy_cfg_file = os.path.join(os.sep, "tmp", "config.json")
+
     @classmethod
     def setup_class(cls):
         os.environ['UTILITIES_UNIT_TESTING'] = "1"
@@ -105,6 +156,7 @@ class TestConfigReload(object):
 
         import config.main
         importlib.reload(config.main)
+        open(cls.dummy_cfg_file, 'w').close()
 
     def test_config_reload(self, get_cmd_module, setup_single_broadcom_asic):
         with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command:
@@ -131,6 +183,32 @@ class TestConfigReload(object):
             assert result.exit_code == 0
 
             assert "\n".join([l.rstrip() for l in result.output.split('\n')][:2]) == reload_config_with_sys_info_command_output
+
+    def test_config_reload_untriggered_timer(self, get_cmd_module, setup_single_broadcom_asic):
+        with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect_untriggered_timer)) as mock_run_command:
+            (config, show) = get_cmd_module
+
+            jsonfile_config = os.path.join(mock_db_path, "config_db.json")
+            jsonfile_init_cfg = os.path.join(mock_db_path, "init_cfg.json")
+
+            # create object
+            config.INIT_CFG_FILE = jsonfile_init_cfg
+            config.DEFAULT_CONFIG_DB_FILE =  jsonfile_config
+
+            db = Db()
+            runner = CliRunner()
+            obj = {'config_db': db.cfgdb}
+
+            # simulate 'config reload' to provoke load_sys_info option
+            result = runner.invoke(config.config.commands["reload"], ["-l", "-y"], obj=obj)
+
+            print(result.exit_code)
+            print(result.output)
+            traceback.print_tb(result.exc_info[2])
+
+            assert result.exit_code == 1
+
+            assert "\n".join([l.rstrip() for l in result.output.split('\n')][:2]) == reload_config_with_untriggered_timer_output
 
     @classmethod
     def teardown_class(cls):
@@ -279,6 +357,25 @@ class TestReloadConfig(object):
             assert result.exit_code == 0
             assert "\n".join([l.rstrip() for l in result.output.split('\n')]) \
                 == RELOAD_CONFIG_DB_OUTPUT
+
+    def test_config_reload_disabled_service(self, get_cmd_module, setup_single_broadcom_asic):
+        with mock.patch(
+               "utilities_common.cli.run_command",
+               mock.MagicMock(side_effect=mock_run_command_side_effect_disabled_timer)
+        ) as mock_run_command:
+            (config, show) = get_cmd_module
+
+            runner = CliRunner()
+            result = runner.invoke(config.config.commands["reload"], [self.dummy_cfg_file, "-y"])
+
+            print(result.exit_code)
+            print(result.output)
+            print(reload_config_with_disabled_service_output)
+            traceback.print_tb(result.exc_info[2])
+
+            assert result.exit_code == 0
+
+            assert "\n".join([l.rstrip() for l in result.output.split('\n')]) == reload_config_with_disabled_service_output
 
     def test_reload_config_masic(self, get_cmd_module, setup_multi_broadcom_masic):
         with mock.patch(


### PR DESCRIPTION
Porting of changes https://github.com/Azure/sonic-utilities/pull/2200
- What I did
Fixed config reload when timer based delayed services are disabled. When they are disabled, the property property=LastTriggerUSecMonotonic returns "0". This will cause config reload to fail even though all enabled services are up.

- How I did it
Fixed the delayed services logic to check if the services are enabled before getting the property LastTriggerUSecMonotonic . Additionally fixed the return codes when config reload fails due to system checks

- How to verify it
Added UT to verify it. Modified sonic-mgmt tests to verify it additionally.

Signed-off-by: Sudharsan Dhamal Gopalarathnam <sudharsand@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

