### PR TITLE
[202205] [generate dump] Move the Core/Log collection to the End of process Execution and removed default timeout 

### DIFF
--- a/scripts/coredump_gen_handler.py
+++ b/scripts/coredump_gen_handler.py
@@ -111,7 +111,7 @@ class CriticalProcCoreDumpHandle():
         return ""
 
     def invoke_ts_cmd(self, since_cfg, num_retry=0):
-        cmd_opts = ["show", "techsupport", "--silent", "--since", since_cfg]
+        cmd_opts = ["show", "techsupport", "--silent", "--since", since_cfg, "--global-timeout", TS_GLOBAL_TIMEOUT]
         cmd  = " ".join(cmd_opts)
         rc, stdout, stderr = subprocess_exec(cmd_opts, env=ENV_VAR)
         new_dump = ""

--- a/scripts/coredump_gen_handler.py
+++ b/scripts/coredump_gen_handler.py
@@ -111,7 +111,7 @@ class CriticalProcCoreDumpHandle():
         return ""
 
     def invoke_ts_cmd(self, since_cfg, num_retry=0):
-        cmd_opts = ["show", "techsupport", "--silent", "--since", since_cfg, "--global-timeout", TS_GLOBAL_TIMEOUT]
+        cmd_opts = ["show", "techsupport", "--silent", "--global-timeout", TS_GLOBAL_TIMEOUT, "--since", since_cfg]
         cmd  = " ".join(cmd_opts)
         rc, stdout, stderr = subprocess_exec(cmd_opts, env=ENV_VAR)
         new_dump = ""

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1287,11 +1287,6 @@ main() {
     end_t=$(date +%s%3N)
     echo "[ Capture Proc State ] : $(($end_t-$start_t)) msec" >> $TECHSUPPORT_TIME_INFO
 
-    # Save logs and cores early
-    save_log_files
-    save_crash_files
-    save_warmboot_files
-
     # Save all the processes within each docker
     save_cmd "show services" services.summary
 
@@ -1425,6 +1420,10 @@ main() {
         && $RM $V -rf $TARDIR
     end_t=$(date +%s%3N)
     echo "[ TAR /etc Files ] : $(($end_t-$start_t)) msec" >> $TECHSUPPORT_TIME_INFO
+
+    save_log_files
+    save_crash_files
+    save_warmboot_files
 
     finalize
 }

--- a/show/main.py
+++ b/show/main.py
@@ -1147,10 +1147,10 @@ def users(verbose):
 @click.option('--redirect-stderr', '-r', is_flag=True, help="Redirect an intermediate errors to STDERR")
 def techsupport(since, global_timeout, cmd_timeout, verbose, allow_process_stop, silent, debug_dump, redirect_stderr):
     """Gather information for troubleshooting"""
-    cmd = "sudo timeout --kill-after={}s -s SIGTERM".format(COMMAND_TIMEOUT)
+    cmd = "sudo"
 
     if global_timeout:
-        cmd += " --foreground {}m".format(global_timeout)
+        cmd += " timeout --kill-after={}s -s SIGTERM --foreground {}m".format(COMMAND_TIMEOUT, global_timeout)
 
     if allow_process_stop:
         cmd += " -a"

--- a/show/main.py
+++ b/show/main.py
@@ -1138,7 +1138,7 @@ def users(verbose):
 
 @cli.command()
 @click.option('--since', required=False, help="Collect logs and core files since given date")
-@click.option('-g', '--global-timeout', default=30, type=int, help="Global timeout in minutes. Default 30 mins")
+@click.option('-g', '--global-timeout', required=False, type=int, help="Global timeout in minutes. WARN: Dump might be incomplete if enforced")
 @click.option('-c', '--cmd-timeout', default=5, type=int, help="Individual command timeout in minutes. Default 5 mins")
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 @click.option('--allow-process-stop', is_flag=True, help="Dump additional data which may require system interruption")
@@ -1147,7 +1147,10 @@ def users(verbose):
 @click.option('--redirect-stderr', '-r', is_flag=True, help="Redirect an intermediate errors to STDERR")
 def techsupport(since, global_timeout, cmd_timeout, verbose, allow_process_stop, silent, debug_dump, redirect_stderr):
     """Gather information for troubleshooting"""
-    cmd = "sudo timeout --kill-after={}s -s SIGTERM --foreground {}m".format(COMMAND_TIMEOUT, global_timeout)
+    cmd = "sudo timeout --kill-after={}s -s SIGTERM".format(COMMAND_TIMEOUT)
+
+    if global_timeout:
+        cmd += " --foreground {}m".format(global_timeout)
 
     if allow_process_stop:
         cmd += " -a"

--- a/tests/coredump_gen_handler_test.py
+++ b/tests/coredump_gen_handler_test.py
@@ -20,6 +20,8 @@ The SAI dump is generated to /tmp/saisdkdump/sai_sdk_dump_11_22_2021_11_07_PM
 /tmp/saisdkdump
 """
 
+TS_DEFAULT_CMD = "show techsupport --silent --since '2 days ago' --global-timeout 60"
+
 def signal_handler(signum, frame):
     raise Exception("Timed out!")
 
@@ -427,4 +429,23 @@ class TestCoreDumpCreationEvent(unittest.TestCase):
                 assert False, "Method should not time out"
             finally:
                 signal.alarm(0)
+    
+    def test_auto_ts_options(self):
+        """
+        Scenario: Check if the techsupport is called as expected
+        """
+        db_wrap = Db()
+        redis_mock = db_wrap.db
+        set_auto_ts_cfg(redis_mock, state="enabled", since_cfg="2 days ago")
+        set_feature_table_cfg(redis_mock, state="enabled")
+        with Patcher() as patcher:
+            def mock_cmd(cmd, env):
+                cmd_str = " ".join(cmd)
+                if "show techsupport" in cmd_str and cmd_str != TS_DEFAULT_CMD:
+                    assert False, "Expected TS_CMD: {}, Recieved: {}".format(TS_DEFAULT_CMD, cmd_str)
+                return 0, AUTO_TS_STDOUT, ""
+            cdump_mod.subprocess_exec = mock_cmd
+            patcher.fs.create_file("/var/core/orchagent.12345.123.core.gz")
+            cls = cdump_mod.CriticalProcCoreDumpHandle("orchagent.12345.123.core.gz", "swss", redis_mock)
+            cls.handle_core_dump_creation_event()
 

--- a/tests/coredump_gen_handler_test.py
+++ b/tests/coredump_gen_handler_test.py
@@ -20,7 +20,7 @@ The SAI dump is generated to /tmp/saisdkdump/sai_sdk_dump_11_22_2021_11_07_PM
 /tmp/saisdkdump
 """
 
-TS_DEFAULT_CMD = "show techsupport --silent --global-timeout 60 --since '2 days ago'"
+TS_DEFAULT_CMD = "show techsupport --silent --global-timeout 60 --since 2 days ago"
 
 def signal_handler(signum, frame):
     raise Exception("Timed out!")

--- a/tests/coredump_gen_handler_test.py
+++ b/tests/coredump_gen_handler_test.py
@@ -20,7 +20,7 @@ The SAI dump is generated to /tmp/saisdkdump/sai_sdk_dump_11_22_2021_11_07_PM
 /tmp/saisdkdump
 """
 
-TS_DEFAULT_CMD = "show techsupport --silent --since '2 days ago' --global-timeout 60"
+TS_DEFAULT_CMD = "show techsupport --silent --global-timeout 60 --since '2 days ago'"
 
 def signal_handler(signum, frame):
     raise Exception("Timed out!")

--- a/tests/techsupport_test.py
+++ b/tests/techsupport_test.py
@@ -3,7 +3,7 @@ import show.main
 from unittest.mock import patch, Mock
 from click.testing import CliRunner
 
-EXPECTED_BASE_COMMAND = 'sudo timeout --kill-after=300s -s SIGTERM '
+EXPECTED_BASE_COMMAND = 'sudo '
 
 @patch("show.main.run_command")
 @pytest.mark.parametrize(
@@ -11,7 +11,7 @@ EXPECTED_BASE_COMMAND = 'sudo timeout --kill-after=300s -s SIGTERM '
         [
             ([], 'generate_dump -v -t 5'),
             (['--since', '2 days ago'], "generate_dump -v -s '2 days ago' -t 5"),
-            (['-g', '50'], '--foreground 50m generate_dump -v -t 5'),
+            (['-g', '50'], 'timeout --kill-after=300s -s SIGTERM --foreground 50m generate_dump -v -t 5'),
             (['--allow-process-stop'], '-a generate_dump -v -t 5'),
             (['--silent'], 'generate_dump -t 5'),
             (['--debug-dump', '--redirect-stderr'], 'generate_dump -v -d -t 5 -r'),

--- a/tests/techsupport_test.py
+++ b/tests/techsupport_test.py
@@ -3,18 +3,18 @@ import show.main
 from unittest.mock import patch, Mock
 from click.testing import CliRunner
 
-EXPECTED_BASE_COMMAND = 'sudo timeout --kill-after=300s -s SIGTERM --foreground '
+EXPECTED_BASE_COMMAND = 'sudo timeout --kill-after=300s -s SIGTERM '
 
 @patch("show.main.run_command")
 @pytest.mark.parametrize(
         "cli_arguments,expected",
         [
-            ([], '30m generate_dump -v -t 5'),
-            (['--since', '2 days ago'], "30m generate_dump -v -s '2 days ago' -t 5"),
-            (['-g', '50'], '50m generate_dump -v -t 5'),
-            (['--allow-process-stop'], '30m -a generate_dump -v -t 5'),
-            (['--silent'], '30m generate_dump -t 5'),
-            (['--debug-dump', '--redirect-stderr'], '30m generate_dump -v -d -t 5 -r'),
+            ([], 'generate_dump -v -t 5'),
+            (['--since', '2 days ago'], "generate_dump -v -s '2 days ago' -t 5"),
+            (['-g', '50'], '--foreground 50m generate_dump -v -t 5'),
+            (['--allow-process-stop'], '-a generate_dump -v -t 5'),
+            (['--silent'], 'generate_dump -t 5'),
+            (['--debug-dump', '--redirect-stderr'], 'generate_dump -v -d -t 5 -r'),
         ]
 )
 def test_techsupport(run_command, cli_arguments, expected):

--- a/utilities_common/auto_techsupport_helper.py
+++ b/utilities_common/auto_techsupport_helper.py
@@ -13,7 +13,7 @@ __all__ = [  # Contants
             "CFG_CORE_USAGE", "CFG_SINCE", "FEATURE", "STATE_DB",
             "TS_MAP", "CORE_DUMP", "TIMESTAMP", "CONTAINER", "TIME_BUF",
             "SINCE_DEFAULT", "TS_PTRN_GLOB", "EXT_LOCKFAIL", "EXT_RETRY",
-            "EXT_SUCCESS", "MAX_RETRY_LIMIT"
+            "EXT_SUCCESS", "MAX_RETRY_LIMIT", "TS_GLOBAL_TIMEOUT"
         ] + [  # Methods
             "verify_recent_file_creation",
             "get_ts_dumps",
@@ -60,6 +60,7 @@ CONTAINER = "container_name"
 
 TIME_BUF = 20
 SINCE_DEFAULT = "2 days ago"
+TS_GLOBAL_TIMEOUT = "60"
 
 # Techsupport Exit Codes
 EXT_LOCKFAIL = 2


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### What I did

Besides, it's better to collect the logs in the end, since we could collect more info and also core files are mostly static and it shouldn't matter much even if we collect them late. 

```
[ save_file:/var/core/bash.1653599272.10047.core.gz] : 10041  | [ save_file:/var/core/python3.1653598683.29.core.gz] : 42 mse
[ save_file:/var/core/bash.1653601099.288.core.gz] : 382 msec | [ save_file:/var/core/python3.1653598325.23.core.gz] : 43 mse
[ save_file:/var/crash/kdump_lock] : 473 msec                 | [ save_file:/var/crash/kdump_lock] : 29 msec
[ Warm-boot Files ] : 832 msec                                | [ Warm-boot Files ] : 39 msec
[ save_cmd:show services ] : 2191 msec                        | [ save_cmd:show services ] : 1738 msec
[ save_cmd:show reboot-cause ] : 817 msec                     | [ save_cmd:show reboot-cause ] : 469 msec
[ save_cmd:echo 26/05/2022 21:38:42:138993 ] : 412 msec       | [ save_cmd:echo 26/05/2022 20:58:13:932428 ] : 35 msec
[ save_cmd:show interface counters ] : 2232 msec              | [ save_cmd:show interface counters ] : 1731 msec
[ save_cmd:show queue counters ] : 1775 msec                  | [ save_cmd:show queue counters ] : 1307 msec
[ save_cmd:sonic-db-dump -n 'COUNTERS_DB' -y ] : 1119 msec    | [ save_cmd:sonic-db-dump -n 'COUNTERS_DB' -y ] : 682 msec
[ save_cmd:netstat -i ] : 399 msec                            | [ save_cmd:netstat -i ] : 34 msec
[ save_cmd:ifconfig -a ] : 419 msec                           | [ save_cmd:ifconfig -a ] : 49 msec
[ save_cmd:systemd-analyze blame ] : 775 msec                 | [ save_cmd:systemd-analyze blame ] : 363 msec
[ save_cmd:systemd-analyze dump ] : 473 msec                  | [ save_cmd:systemd-analyze dump ] : 113 msec
[ save_cmd:systemd-analyze plot ] : 1298 msec                 | [ save_cmd:systemd-analyze plot ] : 1009 msec
[ save_cmd:show platform syseeprom ] : 1065 msec              | [ save_cmd:show platform syseeprom ] : 776 msec
[ save_cmd:show platform psustatus ] : 890 msec               | [ save_cmd:show platform psustatus ] : 578 msec
[ save_cmd:show platform ssdhealth ] : 1231 msec              | [ save_cmd:show platform ssdhealth ] : 797 msec
[ save_cmd:show platform temperature ] : 894 msec             | [ save_cmd:show platform temperature ] : 635 msec
[ save_cmd:show platform fan ] : 901 msec                     | [ save_cmd:show platform fan ] : 542 msec
[ save_cmd:show vlan brief ] : 825 msec                       | [ save_cmd:show vlan brief ] : 490 msec
[ save_cmd:show version ] : 955 msec                          | [ save_cmd:show version ] : 543 msec
[ save_cmd:show platform summary ] : 906 msec                 | [ save_cmd:show platform summary ] : 469 msec
[ save_cmd:cat /host/machine.conf ] : 423 msec                | [ save_cmd:cat /host/machine.conf ] : 31 msec
[ save_cmd:docker stats --no-stream ] : 3134 msec             | [ save_cmd:docker stats --no-stream ] : 2712 msec
[ save_cmd:sensors ] : 2106 msec                              | [ save_cmd:sensors ] : 1712 msec
[ save_cmd:lspci -vvv -xx ] : 446 msec                        | [ save_cmd:lspci -vvv -xx ] : 71 msec
[ save_cmd:lsusb -v ] : 398 msec                              | [ save_cmd:lsusb -v ] : 48 msec
[ save_cmd:sysctl -a ] : 693 msec                             | [ save_cmd:sysctl -a ] : 335 msec
[ save_cmd:ip link ] : 407 msec                               | [ save_cmd:ip link ] : 43 msec
[ save_cmd:ip addr ] : 377 msec                               | [ save_cmd:ip addr ] : 33 msec
[ save_cmd:ip rule ] : 381 msec                               | [ save_cmd:ip rule ] : 31 msec
```

1) Thus moved the core/log collection to the end. 

2) But there is a catch regarding the above change, For eg: system is in a unstable state and most of the individual commands start to timeout, the techsupport dump eventually times out at 30m (because of the global timeout), then the dump is pretty useless, since it might not have any useful information at all
Thus, i've removed the default global timeout, Clients can/should knowingly provide a value using -g option if the execution time has to be capped.

3) A global timeout of 60 mins is used for Global timeout for Auto-techsupport invocation. 

Backport https://github.com/Azure/sonic-utilities/pull/2209 to 2205

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

