### PR TITLE
Added support for Sonic cross-compilation build.

### DIFF
--- a/utilities_common/auto_techsupport_helper.py
+++ b/utilities_common/auto_techsupport_helper.py
@@ -72,8 +72,10 @@ TS_GLOBAL_TIMEOUT = "60"
 
 # Explicity Pass this to the subprocess invoking techsupport
 ENV_VAR = os.environ
-PATH_PREV = ENV_VAR["PATH"] if "PATH" in ENV_VAR else ""
-ENV_VAR["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:" + PATH_PREV
+if ('CROSS_BUILD_ENVIRON' not in ENV_VAR) or (ENV_VAR['CROSS_BUILD_ENVIRON'] != 'y'):
+	# Add native system directories to PATH variable only if it is not cross-compilation build 
+	PATH_PREV = ENV_VAR["PATH"] if "PATH" in ENV_VAR else ""
+	ENV_VAR["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:" + PATH_PREV
 
 # Techsupport Exit Codes
 EXT_LOCKFAIL = 2


### PR DESCRIPTION
Signed-off-by: marvell <marvell@cpss-build3.marvell.com>

#### What I did
Added support for Sonic cross-compiling build. Specifically building Sonic armhf on amd64 host.

#### How I did it
Removed addition of "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" to PATH variable when Sonic is built using cross-compilation (CROSS_BUILD_ENVIRON variable should be set to 'y' then).
#### How to verify it
Run Sonic armhf build using cross-compilation for marvell platform. Specifically run (when Sonic cross-compilation PR https://github.com/Azure/sonic-buildimage/pull/8035 is merged with the upstream):
NOJESSIE=1 NOSTRETCH=1 CROSS_BLDENV=1 make target/sonic-marvell-armhf.bin 

