### PR TITLE
[202205] Add check to not allow deleting PO if its member of vlan

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1851,6 +1851,11 @@ def remove_portchannel(ctx, portchannel_name):
     if is_portchannel_present_in_db(db, portchannel_name) is False:
         ctx.fail("{} is not present.".format(portchannel_name))
 
+    # Dont let to remove port channel if vlan membership exists
+    for k,v in db.get_table('VLAN_MEMBER'):
+        if v == portchannel_name:
+            ctx.fail("{} has vlan {} configured, remove vlan membership to proceed".format(portchannel_name, str(k)))
+
     if len([(k, v) for k, v in db.get_table('PORTCHANNEL_MEMBER') if k == portchannel_name]) != 0:
         click.echo("Error: Portchannel {} contains members. Remove members before deleting Portchannel!".format(portchannel_name))
     else:

--- a/tests/portchannel_test.py
+++ b/tests/portchannel_test.py
@@ -157,6 +157,18 @@ class TestPortChannel(object):
         assert result.exit_code != 0
         assert "Error: Ethernet116 is not a member of portchannel PortChannel1001" in result.output
 
+    def test_delete_portchannel_which_is_member_of_a_vlan(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+
+        # try to delete the portchannel when its member of a vlan
+        result = runner.invoke(config.config.commands["portchannel"].commands["del"], ["PortChannel1001"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "PortChannel1001 has vlan Vlan4000 configured, remove vlan membership to proceed" in result.output
+
     @classmethod
     def teardown_class(cls):
         os.environ['UTILITIES_UNIT_TESTING'] = "0"


### PR DESCRIPTION
What I did
Added check to not allow deleting PortChannel if its member of vlan.

How I did it
Added a check in the command script.

How to verify it
Create a portchannel.
Add the portchannel to a vlan.
Try to delete the portchannel.
It should throw an error message.
Previous command output (if the output of a command-line utility has changed)
New command output (if the output of a command-line utility has changed)
Error: PortChannel1 has vlan Vlan100 configured, remove vlan membership to proceed