### PR TITLE
Add 'traffic_shift_away' option to config load_minigraph

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1641,8 +1641,9 @@ def load_mgmt_config(filename):
 @click.option('-y', '--yes', is_flag=True, callback=_abort_if_false,
                 expose_value=False, prompt='Reload config from minigraph?')
 @click.option('-n', '--no_service_restart', default=False, is_flag=True, help='Do not restart docker services')
+@click.option('-t', '--traffic_shift_away', default=False, is_flag=True, help='Keep device in maintenance with TSA')
 @clicommon.pass_db
-def load_minigraph(db, no_service_restart):
+def load_minigraph(db, no_service_restart, traffic_shift_away):
     """Reconfigure based on minigraph."""
     log.log_info("'load_minigraph' executing...")
 
@@ -1711,6 +1712,10 @@ def load_minigraph(db, no_service_restart):
     # Load golden_config_db.json
     if os.path.isfile(DEFAULT_GOLDEN_CONFIG_DB_FILE):
         override_config_by(DEFAULT_GOLDEN_CONFIG_DB_FILE)
+
+    # Keep device in maintenance with TSA 
+    if traffic_shift_away:
+        clicommon.run_command("TSA", display_cmd=True)
 
     # We first run "systemctl reset-failed" to remove the "failed"
     # status from all services before we attempt to restart them

--- a/config/main.py
+++ b/config/main.py
@@ -1757,13 +1757,16 @@ def load_minigraph(db, no_service_restart, traffic_shift_away):
                 cfggen_namespace_option = " -n {}".format(namespace)
             clicommon.run_command(db_migrator + ' -o set_version' + cfggen_namespace_option)
 
+    # Keep device isolated with TSA 
+    if traffic_shift_away:
+        clicommon.run_command("TSA", display_cmd=True)
+        if os.path.isfile(DEFAULT_GOLDEN_CONFIG_DB_FILE):
+            log.log_warning("Golden configuration may override System Maintenance state. Please execute TSC to check the current System mode")
+            click.secho("[WARNING] Golden configuration may override Traffic-shift-away state. Please execute TSC to check the current System mode")
+
     # Load golden_config_db.json
     if os.path.isfile(DEFAULT_GOLDEN_CONFIG_DB_FILE):
         override_config_by(DEFAULT_GOLDEN_CONFIG_DB_FILE)
-
-    # Keep device in maintenance with TSA 
-    if traffic_shift_away:
-        clicommon.run_command("TSA", display_cmd=True)
 
     # We first run "systemctl reset-failed" to remove the "failed"
     # status from all services before we attempt to restart them

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -5106,9 +5106,11 @@ When user specifies the optional argument "-n" or "--no-service-restart", this c
 running on the device. One use case for this option is during boot time when config-setup service loads minigraph configuration and there is no services
 running on the device.
 
+When user specifies the optional argument "-t" or "--traffic-shift-away", this command executes TSA command at the end to ensure the device remains in maintenance after loading minigraph.
+
 - Usage:
   ```
-  config load_minigraph [-y|--yes] [-n|--no-service-restart]
+  config load_minigraph [-y|--yes] [-n|--no-service-restart] [-t|--traffic-shift-away]
   ```
 
 - Example:

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -446,6 +446,23 @@ class TestLoadMinigraph(object):
             assert result.exit_code == 0
             assert "TSA" in result.output
 
+    def test_load_minigraph_with_traffic_shift_away_with_golden_config(self, get_cmd_module):
+        with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command:
+            def is_file_side_effect(filename):
+                return True if 'golden_config' in filename else False
+            with mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)):
+                (config, show) = get_cmd_module
+                db = Db()
+                golden_config = {}
+                runner = CliRunner()
+                result = runner.invoke(config.config.commands["load_minigraph"], ["-ty"])
+                print(result.exit_code)
+                print(result.output)
+                traceback.print_tb(result.exc_info[2])
+                assert result.exit_code == 0
+                assert "TSA" in result.output
+                assert "[WARNING] Golden configuration may override Traffic-shift-away state" in result.output
+
     @classmethod
     def teardown_class(cls):
         os.environ['UTILITIES_UNIT_TESTING'] = "0"

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -356,6 +356,17 @@ class TestLoadMinigraph(object):
             assert result.exit_code == 0
             assert expected_output in result.output
 
+    def test_load_minigraph_with_traffic_shift_away(self, get_cmd_module):
+        with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command:
+            (config, show) = get_cmd_module
+            runner = CliRunner()
+            result = runner.invoke(config.config.commands["load_minigraph"], ["-ty"])
+            print(result.exit_code)
+            print(result.output)
+            traceback.print_tb(result.exc_info[2])
+            assert result.exit_code == 0
+            assert "TSA" in result.output
+
     @classmethod
     def teardown_class(cls):
         os.environ['UTILITIES_UNIT_TESTING'] = "0"


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add a CLI option to 'config load_minigraph' to keep the device in maintenance

#### How I did it
Added changes to execute TSA after minigraph is loaded to ensure the device is kept in maintenance. 

#### How to verify it
1. Execute 'sudo load_minigraph -t'
2.  After the new config is fully applied, execute 'TSC' to ensure the device mode is "Maintenance"

#### Previous command output (if the output of a command-line utility has changed)
sudo config load_minigraph -h
Usage: config load_minigraph [OPTIONS]

  Reconfigure based on minigraph.

Options:
  -y, --yes
  -n, --no_service_restart  Do not restart docker services
  -?, -h, --help            Show this message and exit.

#### New command output (if the output of a command-line utility has changed)
sudo config load_minigraph -h
Usage: config load_minigraph [OPTIONS]

  Reconfigure based on minigraph.

Options:
  -y, --yes
  -n, --no_service_restart  Do not restart docker services
  **-t, --traffic_shift_away  Keep device in maintenance with TSA**
  -?, -h, --help            Show this message and exit.
