### PR TITLE
Added cisco config platform commands

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -990,6 +990,10 @@ def config(ctx):
     if asic_type == 'mellanox':
         platform.add_command(mlnx.mlnx)
 
+    if asic_type == 'cisco-8000':
+        from sonic_platform.cli.cisco import cisco
+        platform.add_command(cisco)
+
     # Load the global config file database_global.json once.
     SonicDBConfig.load_sonic_global_db_config()
 


### PR DESCRIPTION
Signed-off-by: Yucai Gu <yucgu@cisco.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add cisco sub-command option under 'config platform' command

#### How I did it
In config/main.py, check the platform type and import the cisco.py file under cisco platform code when it's cisco-8000.

#### How to verify it
Run config platform -h to see all commands. We will be able to see config platform cisco. This is only available on cisco devices.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

