### PR TITLE
Fix test for pfcwd_sw_enable in db_migrator_test

### DIFF
--- a/tests/db_migrator_input/config_db/qos_map_table_expected.json
+++ b/tests/db_migrator_input/config_db/qos_map_table_expected.json
@@ -2,35 +2,33 @@
     "VERSIONS|DATABASE": {
         "VERSION": "version_2_0_5"
     },
-    "PORT_QOS_MAP": {
-        "Ethernet0": {
-            "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
-            "pfc_enable": "3,4",
-            "pfcwd_sw_enable": "3,4",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
-            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
-        },
-        "Ethernet100": {
-            "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
-            "pfc_enable": "3,4",
-            "pfcwd_sw_enable": "3,4",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
-            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
-        },
-        "Ethernet92": {
-            "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
-            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
-        },
-        "Ethernet96": {
-            "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
-            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
-        }
+    "PORT_QOS_MAP|Ethernet0": {
+        "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
+        "pfc_enable": "3,4",
+        "pfcwd_sw_enable": "3,4",
+        "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+        "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+        "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
+    },
+    "PORT_QOS_MAP|Ethernet100": {
+        "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
+        "pfc_enable": "3,4",
+        "pfcwd_sw_enable": "3,4",
+        "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+        "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+        "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
+    },
+    "PORT_QOS_MAP|Ethernet92": {
+        "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
+        "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+        "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+        "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
+    },
+    "PORT_QOS_MAP|Ethernet96": {
+        "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
+        "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+        "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+        "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
     }
 }
 

--- a/tests/db_migrator_input/config_db/qos_map_table_input.json
+++ b/tests/db_migrator_input/config_db/qos_map_table_input.json
@@ -2,33 +2,30 @@
     "VERSIONS|DATABASE": {
         "VERSION": "version_2_0_4"
     },
-    "PORT_QOS_MAP": {
-        "Ethernet0": {
-            "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
-            "pfc_enable": "3,4",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
-            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
-        },
-        "Ethernet100": {
-            "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
-            "pfc_enable": "3,4",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
-            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
-        },
-        "Ethernet92": {
-            "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
-            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
-        },
-        "Ethernet96": {
-            "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
-            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
-        }
+    "PORT_QOS_MAP|Ethernet0": {
+        "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
+        "pfc_enable": "3,4",
+        "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+        "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+        "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
+    },
+    "PORT_QOS_MAP|Ethernet100": {
+        "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
+        "pfc_enable": "3,4",
+        "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+        "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+        "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
+    },
+    "PORT_QOS_MAP|Ethernet92": {
+        "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
+        "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+        "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+        "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
+    },
+    "PORT_QOS_MAP|Ethernet96": {
+        "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
+        "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+        "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+        "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
     }
 }
-


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This PR is to fix the input and output for testing the migration of `pfcwd_sw_enable`.
Before this change, 
```
resulting_table = dbmgtr.configDB.get_table('PORT_QOS_MAP')
expected_table = expected_db.cfgdb.get_table('PORT_QOS_MAP')
```
`resulting_table` and `expected_table` are always empty `{}`. So the test case can always pass.

#### How I did it
Fix the input and output for testing the migration of `pfcwd_sw_enable`.

#### How to verify it
Run UT for `db_migrator` after update.
```
collected 75 items                                                                                                                                                                                    

tests/db_migrator_test.py ...........................................................................                                                                                           [100%]

===================================================================================== 75 passed in 17.14 seconds ======================================================================================
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

