### PR TITLE
show linkmgrd status in `show mux status`

### DIFF
--- a/tests/mock_tables/appl_db.json
+++ b/tests/mock_tables/appl_db.json
@@ -263,5 +263,23 @@
     },
     "VXLAN_REMOTE_VNI_TABLE:Vlan200:25.25.25.27": {
         "vni": "200"
+    },
+    "MUX_CABLE_TABLE:Ethernet32": {
+        "state": "active"
+    },
+    "MUX_CABLE_TABLE:Ethernet0": {
+        "state": "active"
+    },
+    "MUX_CABLE_TABLE:Ethernet4": {
+        "state": "standby"
+    },
+    "MUX_CABLE_TABLE:Ethernet8": {
+        "state": "standby"
+    },
+    "MUX_CABLE_TABLE:Ethernet16": {
+        "state": "standby"
+    },
+    "MUX_CABLE_TABLE:Ethernet12": {
+        "state": "active"
     }
 }

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -25,25 +25,25 @@ import show.main as show
 
 
 tabular_data_status_output_expected = """\
-PORT        STATUS    HEALTH     HWSTATUS      LAST_SWITCHOVER_TIME
-----------  --------  ---------  ------------  ---------------------------
-Ethernet0   active    healthy    inconsistent  2021-May-13 10:01:15.696728
-Ethernet4   standby   healthy    consistent
-Ethernet8   standby   unhealthy  consistent
-Ethernet12  active    unhealthy  inconsistent
-Ethernet16  standby   healthy    consistent
-Ethernet32  active    healthy    inconsistent
+PORT        STATUS    SERVER_STATUS    HEALTH     HWSTATUS      LAST_SWITCHOVER_TIME
+----------  --------  ---------------  ---------  ------------  ---------------------------
+Ethernet0   active    active           healthy    inconsistent  2021-May-13 10:01:15.696728
+Ethernet4   standby   standby          healthy    consistent
+Ethernet8   standby   standby          unhealthy  consistent
+Ethernet12  active    unknown          unhealthy  inconsistent
+Ethernet16  standby   standby          healthy    consistent
+Ethernet32  active    active           healthy    inconsistent
 """
 
 tabular_data_status_output_expected_alias = """\
-PORT    STATUS    HEALTH     HWSTATUS      LAST_SWITCHOVER_TIME
-------  --------  ---------  ------------  ---------------------------
-etp1    active    healthy    inconsistent  2021-May-13 10:01:15.696728
-etp2    standby   healthy    consistent
-etp3    standby   unhealthy  consistent
-etp4    active    unhealthy  inconsistent
-etp5    standby   healthy    consistent
-etp9    active    healthy    inconsistent
+PORT    STATUS    SERVER_STATUS    HEALTH     HWSTATUS      LAST_SWITCHOVER_TIME
+------  --------  ---------------  ---------  ------------  ---------------------------
+etp1        active    active           healthy    inconsistent  2021-May-13 10:01:15.696728
+etp2        standby   standby          healthy    consistent
+etp3        standby   standby          unhealthy  consistent
+etp4        active    unknown          unhealthy  inconsistent
+etp5        standby   standby          healthy    consistent
+etp9        active    active           healthy    inconsistent
 """
 
 
@@ -52,36 +52,42 @@ json_data_status_output_expected = """\
     "MUX_CABLE": {
         "Ethernet0": {
             "STATUS": "active",
+            "SERVER_STATUS": "active",
             "HEALTH": "healthy",
             "HWSTATUS": "inconsistent",
             "LAST_SWITCHOVER_TIME": "2021-May-13 10:01:15.696728"
         },
         "Ethernet4": {
             "STATUS": "standby",
+            "SERVER_STATUS": "standby",
             "HEALTH": "healthy",
             "HWSTATUS": "consistent",
             "LAST_SWITCHOVER_TIME": ""
         },
         "Ethernet8": {
             "STATUS": "standby",
+            "SERVER_STATUS": "standby",
             "HEALTH": "unhealthy",
             "HWSTATUS": "consistent",
             "LAST_SWITCHOVER_TIME": ""
         },
         "Ethernet12": {
             "STATUS": "active",
+            "SERVER_STATUS": "unknown",
             "HEALTH": "unhealthy",
             "HWSTATUS": "inconsistent",
             "LAST_SWITCHOVER_TIME": ""
         },
         "Ethernet16": {
             "STATUS": "standby",
+            "SERVER_STATUS": "standby",
             "HEALTH": "healthy",
             "HWSTATUS": "consistent",
             "LAST_SWITCHOVER_TIME": ""
         },
         "Ethernet32": {
             "STATUS": "active",
+            "SERVER_STATUS": "active",
             "HEALTH": "healthy",
             "HWSTATUS": "inconsistent",
             "LAST_SWITCHOVER_TIME": ""
@@ -95,36 +101,42 @@ json_data_status_output_expected_alias = """\
     "MUX_CABLE": {
         "etp1": {
             "STATUS": "active",
+            "SERVER_STATUS": "active",
             "HEALTH": "healthy",
             "HWSTATUS": "inconsistent",
             "LAST_SWITCHOVER_TIME": "2021-May-13 10:01:15.696728"
         },
         "etp2": {
             "STATUS": "standby",
+            "SERVER_STATUS": "standby",
             "HEALTH": "healthy",
             "HWSTATUS": "consistent",
             "LAST_SWITCHOVER_TIME": ""
         },
         "etp3": {
             "STATUS": "standby",
+            "SERVER_STATUS": "standby",
             "HEALTH": "unhealthy",
             "HWSTATUS": "consistent",
             "LAST_SWITCHOVER_TIME": ""
         },
         "etp4": {
             "STATUS": "active",
+            "SERVER_STATUS": "unknown",
             "HEALTH": "unhealthy",
             "HWSTATUS": "inconsistent",
             "LAST_SWITCHOVER_TIME": ""
         },
         "etp5": {
             "STATUS": "standby",
+            "SERVER_STATUS": "standby",
             "HEALTH": "healthy",
             "HWSTATUS": "consistent",
             "LAST_SWITCHOVER_TIME": ""
         },
         "etp9": {
             "STATUS": "active",
+            "SERVER_STATUS": "active",
             "HEALTH": "healthy",
             "HWSTATUS": "inconsistent",
             "LAST_SWITCHOVER_TIME": ""

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -30,7 +30,7 @@ PORT        STATUS    HEALTH     HWSTATUS      LAST_SWITCHOVER_TIME
 Ethernet0   active    healthy    inconsistent  2021-May-13 10:01:15.696728
 Ethernet4   standby   healthy    consistent
 Ethernet8   standby   unhealthy  consistent
-Ethernet12  unknown   unhealthy  inconsistent
+Ethernet12  active    unhealthy  inconsistent
 Ethernet16  standby   healthy    consistent
 Ethernet32  active    healthy    inconsistent
 """
@@ -41,7 +41,7 @@ PORT    STATUS    HEALTH     HWSTATUS      LAST_SWITCHOVER_TIME
 etp1    active    healthy    inconsistent  2021-May-13 10:01:15.696728
 etp2    standby   healthy    consistent
 etp3    standby   unhealthy  consistent
-etp4    unknown   unhealthy  inconsistent
+etp4    active    unhealthy  inconsistent
 etp5    standby   healthy    consistent
 etp9    active    healthy    inconsistent
 """
@@ -69,7 +69,7 @@ json_data_status_output_expected = """\
             "LAST_SWITCHOVER_TIME": ""
         },
         "Ethernet12": {
-            "STATUS": "unknown",
+            "STATUS": "active",
             "HEALTH": "unhealthy",
             "HWSTATUS": "inconsistent",
             "LAST_SWITCHOVER_TIME": ""
@@ -112,7 +112,7 @@ json_data_status_output_expected_alias = """\
             "LAST_SWITCHOVER_TIME": ""
         },
         "etp4": {
-            "STATUS": "unknown",
+            "STATUS": "active",
             "HEALTH": "unhealthy",
             "HWSTATUS": "inconsistent",
             "LAST_SWITCHOVER_TIME": ""

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -38,12 +38,12 @@ Ethernet32  active    active           healthy    inconsistent
 tabular_data_status_output_expected_alias = """\
 PORT    STATUS    SERVER_STATUS    HEALTH     HWSTATUS      LAST_SWITCHOVER_TIME
 ------  --------  ---------------  ---------  ------------  ---------------------------
-etp1        active    active           healthy    inconsistent  2021-May-13 10:01:15.696728
-etp2        standby   standby          healthy    consistent
-etp3        standby   standby          unhealthy  consistent
-etp4        active    unknown          unhealthy  inconsistent
-etp5        standby   standby          healthy    consistent
-etp9        active    active           healthy    inconsistent
+etp1    active    active           healthy    inconsistent  2021-May-13 10:01:15.696728
+etp2    standby   standby          healthy    consistent
+etp3    standby   standby          unhealthy  consistent
+etp4    active    unknown          unhealthy  inconsistent
+etp5    standby   standby          healthy    consistent
+etp9    active    active           healthy    inconsistent
 """
 
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Replace status in `show mux status` with APP DB `MUX_CABLE_TABLE:<port_name>`, which is written by linkmgrd and indicates linkmgrd's state transition. 

This change is required for active-active dualtor setup. In active-active setup, we care more about whether state transition happens **on ToR side**. In tests, we want to see if linkmgrd makes immediate reaction on link state changes. If we continue to use STATE DB entries, when gRPC is not available, we will get `unknow` in `show mux status`, which is not informatic and not the actual value we want to check. 

sign-off: Jing Zhang zhangjing@microsoft.com 

#### How I did it
Use APP DB entries instead of STATE DB. 

Move STATE DB to column `SERVER_STATUS`. 

#### How to verify it
Unit tests with mock DB values. 
Tests on dual testbeds. 

#### Previous command output (if the output of a command-line utility has changed)
```
PORT         STATUS    HEALTH     HWSTATUS    LAST_SWITCHOVER_TIME
-----------  --------  ---------  ----------  ---------------------------
Ethernet0    active    unhealthy  consistent  2022-Jul-05 18:04:14.994631
Ethernet4    active    unhealthy  consistent  2022-Jul-05 18:04:14.762461
Ethernet8    active    unhealthy  consistent  2022-Jul-05 18:04:15.122499
Ethernet12   active    unhealthy  consistent  2022-Jul-05 18:04:15.289365
Ethernet16   active    unhealthy  consistent  2022-Jul-05 18:04:15.329785
Ethernet20   active    unhealthy  consistent  2022-Jul-05 18:04:13.423934
Ethernet24   active    unhealthy  consistent  2022-Jul-05 18:04:13.163920
Ethernet28   active    unhealthy  consistent  2022-Jul-05 18:04:14.146729
...
```

#### New command output (if the output of a command-line utility has changed)
```
PORT         STATUS    SERVER_STATUS    HEALTH     HWSTATUS    LAST_SWITCHOVER_TIME
-----------  --------  ---------------  ---------  ----------  ---------------------------
Ethernet0    standby   standby          unhealthy  consistent  2022-Jul-05 18:01:44.211843
Ethernet4    standby   standby          unhealthy  consistent  2022-Jul-05 18:01:47.041878
Ethernet8    standby   standby          unhealthy  consistent  2022-Jul-05 18:01:47.146947
Ethernet12   standby   standby          unhealthy  consistent  2022-Jul-05 18:01:42.727104
Ethernet16   standby   standby          unhealthy  consistent  2022-Jul-05 18:01:43.583465
Ethernet20   standby   standby          unhealthy  consistent  2022-Jul-05 18:01:45.414725
Ethernet24   standby   standby          unhealthy  consistent  2022-Jul-05 18:01:46.283276
Ethernet28   standby   standby          unhealthy  consistent  2022-Jul-05 18:01:46.883513
```

