### PR TITLE
[show] add new CLI to show tunnel route objects

### DIFF
--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -517,8 +517,6 @@ def get_tunnel_route_per_port(db, port_tunnel_route, per_npu_configdb, per_npu_a
                 per_npu_asic_db[asic_id].ASIC_DB, 'ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:*{}*'.format(dest_address))
             
             if route_keys is not None and len(route_keys):
-                route_dict = per_npu_asic_db[asic_id].get_all(
-                    per_npu_asic_db[asic_id].ASIC_DB, str(route_keys[0]))
 
                 port_tunnel_route["TUNNEL_ROUTE"][port] = port_tunnel_route["TUNNEL_ROUTE"].get(port, {})
                 port_tunnel_route["TUNNEL_ROUTE"][port][name] = {}

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -503,7 +503,7 @@ def create_json_dump_per_port_config(db, port_status_dict, per_npu_configdb, asi
     if soc_ipv4_value is not None:
         port_status_dict["MUX_CABLE"]["PORTS"][port_name]["SERVER"]["soc_ipv4"] = soc_ipv4_value
 
-def get_tunnel_route_per_port(db, port_tunnel_route, per_npu_configdb, per_npu_asic_db, asic_id, port):
+def get_tunnel_route_per_port(db, port_tunnel_route, per_npu_configdb, per_npu_appl_db, asic_id, port):
 
     mux_cfg_dict = per_npu_configdb[asic_id].get_all(
     per_npu_configdb[asic_id].CONFIG_DB, 'MUX_CABLE|{}'.format(port))
@@ -513,8 +513,8 @@ def get_tunnel_route_per_port(db, port_tunnel_route, per_npu_configdb, per_npu_a
         dest_address = mux_cfg_dict.get(name, None)
 
         if dest_address is not None:
-            route_keys = per_npu_asic_db[asic_id].keys(
-                per_npu_asic_db[asic_id].ASIC_DB, 'ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:*{}*'.format(dest_address))
+            route_keys = per_npu_appl_db[asic_id].keys(
+                per_npu_appl_db[asic_id].APPL_DB, 'TUNNEL_ROUTE_TABLE:*{}'.format(dest_address))
             
             if route_keys is not None and len(route_keys):
 
@@ -522,15 +522,15 @@ def get_tunnel_route_per_port(db, port_tunnel_route, per_npu_configdb, per_npu_a
                 port_tunnel_route["TUNNEL_ROUTE"][port][name] = {}
                 port_tunnel_route["TUNNEL_ROUTE"][port][name]['DEST'] = dest_address
 
-def create_json_dump_per_port_tunnel_route(db, port_tunnel_route, per_npu_configdb, per_npu_asic_db, asic_id, port):
+def create_json_dump_per_port_tunnel_route(db, port_tunnel_route, per_npu_configdb, per_npu_appl_db, asic_id, port):
 
-    get_tunnel_route_per_port(db, port_tunnel_route, per_npu_configdb, per_npu_asic_db,  asic_id, port)
+    get_tunnel_route_per_port(db, port_tunnel_route, per_npu_configdb, per_npu_appl_db,  asic_id, port)
 
-def create_table_dump_per_port_tunnel_route(db, print_data, per_npu_configdb, per_npu_asic_db, asic_id, port):
+def create_table_dump_per_port_tunnel_route(db, print_data, per_npu_configdb, per_npu_appl_db, asic_id, port):
 
     port_tunnel_route = {}
     port_tunnel_route["TUNNEL_ROUTE"] = {}
-    get_tunnel_route_per_port(db, port_tunnel_route, per_npu_configdb, per_npu_asic_db,  asic_id, port)
+    get_tunnel_route_per_port(db, port_tunnel_route, per_npu_configdb, per_npu_appl_db,  asic_id, port)
 
     for port, route in port_tunnel_route["TUNNEL_ROUTE"].items():
         for dest_name, values in route.items():
@@ -1797,7 +1797,7 @@ def tunnel_route(db, port, json_output):
 
     port = platform_sfputil_helper.get_interface_name(port, db)
 
-    per_npu_asic_db = {}
+    per_npu_appl_db = {}
     per_npu_configdb = {}
     mux_tbl_keys = {}
 
@@ -1805,8 +1805,8 @@ def tunnel_route(db, port, json_output):
     for namespace in namespaces:
         asic_id = multi_asic.get_asic_index_from_namespace(namespace)
 
-        per_npu_asic_db[asic_id] = swsscommon.SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
-        per_npu_asic_db[asic_id].connect(per_npu_asic_db[asic_id].ASIC_DB)
+        per_npu_appl_db[asic_id] = swsscommon.SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
+        per_npu_appl_db[asic_id].connect(per_npu_appl_db[asic_id].APPL_DB)
 
         per_npu_configdb[asic_id] = swsscommon.SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
         per_npu_configdb[asic_id].connect(per_npu_configdb[asic_id].CONFIG_DB) 
@@ -1841,14 +1841,14 @@ def tunnel_route(db, port, json_output):
                 port_tunnel_route = {}
                 port_tunnel_route["TUNNEL_ROUTE"] = {}
 
-                create_json_dump_per_port_tunnel_route(db, port_tunnel_route, per_npu_configdb, per_npu_asic_db, asic_index, port)
+                create_json_dump_per_port_tunnel_route(db, port_tunnel_route, per_npu_configdb, per_npu_appl_db, asic_index, port)
 
                 click.echo("{}".format(json.dumps(port_tunnel_route, indent=4)))
 
             else:
                 print_data = []
 
-                create_table_dump_per_port_tunnel_route(db, print_data, per_npu_configdb, per_npu_asic_db, asic_index, port)
+                create_table_dump_per_port_tunnel_route(db, print_data, per_npu_configdb, per_npu_appl_db, asic_index, port)
 
                 headers = ['PORT', 'DEST_TYPE', 'DEST_ADDRESS']
 
@@ -1866,7 +1866,7 @@ def tunnel_route(db, port, json_output):
                 for key in natsorted(mux_tbl_keys[asic_id]):
                     port = key.split("|")[1]
 
-                    create_json_dump_per_port_tunnel_route(db, port_tunnel_route, per_npu_configdb, per_npu_asic_db, asic_id, port)
+                    create_json_dump_per_port_tunnel_route(db, port_tunnel_route, per_npu_configdb, per_npu_appl_db, asic_id, port)
             
             click.echo("{}".format(json.dumps(port_tunnel_route, indent=4)))
         else:
@@ -1877,7 +1877,7 @@ def tunnel_route(db, port, json_output):
                 for key in natsorted(mux_tbl_keys[asic_id]):
                     port = key.split("|")[1]
             
-                    create_table_dump_per_port_tunnel_route(db, print_data, per_npu_configdb, per_npu_asic_db, asic_id, port)
+                    create_table_dump_per_port_tunnel_route(db, print_data, per_npu_configdb, per_npu_appl_db, asic_id, port)
 
             headers = ['PORT', 'DEST_TYPE', 'DEST_ADDRESS']
 

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -598,8 +598,8 @@ def status(db, port, json_output):
                 click.echo("Got invalid asic index for port {}, cant retreive mux status".format(port_name))
                 sys.exit(STATUS_FAIL)
 
-        muxcable_info_dict[asic_index] = per_npu_appl_db[asic_id].get_all(
-            per_npu_appl_db[asic_id].APPL_DB, 'MUX_CABLE_TABLE:{}'.format(port))
+        muxcable_info_dict[asic_index] = per_npu_appl_db[asic_index].get_all(
+            per_npu_appl_db[asic_index].APPL_DB, 'MUX_CABLE_TABLE:{}'.format(port))
         muxcable_grpc_dict[asic_index] = per_npu_statedb[asic_index].get_all(
             per_npu_statedb[asic_index].STATE_DB, 'MUX_CABLE_TABLE|{}'.format(port))
         muxcable_health_dict[asic_index] = per_npu_statedb[asic_index].get_all(

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -523,7 +523,6 @@ def get_tunnel_route_per_port(db, port_tunnel_route, per_npu_configdb, per_npu_a
                 port_tunnel_route["TUNNEL_ROUTE"][port] = port_tunnel_route["TUNNEL_ROUTE"].get(port, {})
                 port_tunnel_route["TUNNEL_ROUTE"][port][name] = {}
                 port_tunnel_route["TUNNEL_ROUTE"][port][name]['DEST'] = dest_address
-                port_tunnel_route["TUNNEL_ROUTE"][port][name]['NEXT_HOP_ID'] = route_dict.get("SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", None)
 
 def create_json_dump_per_port_tunnel_route(db, port_tunnel_route, per_npu_configdb, per_npu_asic_db, asic_id, port):
 
@@ -541,7 +540,6 @@ def create_table_dump_per_port_tunnel_route(db, print_data, per_npu_configdb, pe
             print_line.append(port)
             print_line.append(dest_name)
             print_line.append(values['DEST'])
-            print_line.append(values['NEXT_HOP_ID'])
             print_data.append(print_line)
 
 @muxcable.command()
@@ -1829,7 +1827,7 @@ def tunnel_route(db, port, json_output):
 
         asic_index = None
         if platform_sfputil is not None:
-            asic_index = platform_sfputil.get_asic_id_for_logical_port(port)
+            asic_index = platform_sfputil_helper.get_asic_id_for_logical_port(port)
         if asic_index is None:
             # TODO this import is only for unit test purposes, and should be removed once sonic_platform_base
             # is fully mocked
@@ -1837,7 +1835,7 @@ def tunnel_route(db, port, json_output):
             asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
             if asic_index is None:
                 port_name = platform_sfputil_helper.get_interface_alias(port, db)
-                click.echo("Got invalid asic index for port {}, cant retreive tunnel route status".format(port_name))
+                click.echo("Got invalid asic index for port {}, cant retreive tunnel route info".format(port_name))
                 sys.exit(STATUS_FAIL)
         
         if mux_tbl_keys[asic_index] is not None and "MUX_CABLE|{}".format(port) in mux_tbl_keys[asic_index]:
@@ -1854,7 +1852,7 @@ def tunnel_route(db, port, json_output):
 
                 create_table_dump_per_port_tunnel_route(db, print_data, per_npu_configdb, per_npu_asic_db, asic_index, port)
 
-                headers = ['PORT', 'DEST_TYPE', 'DEST_ADDRESS', 'NEXT_HOP_ID']
+                headers = ['PORT', 'DEST_TYPE', 'DEST_ADDRESS']
 
                 click.echo(tabulate(print_data, headers=headers))
         else:
@@ -1883,7 +1881,7 @@ def tunnel_route(db, port, json_output):
             
                     create_table_dump_per_port_tunnel_route(db, print_data, per_npu_configdb, per_npu_asic_db, asic_id, port)
 
-            headers = ['PORT', 'DEST_TYPE', 'DEST_ADDRESS', 'NEXT_HOP_ID']
+            headers = ['PORT', 'DEST_TYPE', 'DEST_ADDRESS']
 
             click.echo(tabulate(print_data, headers=headers))
 

--- a/tests/mock_tables/appl_db.json
+++ b/tests/mock_tables/appl_db.json
@@ -281,5 +281,11 @@
     },
     "MUX_CABLE_TABLE:Ethernet12": {
         "state": "active"
+    },
+    "TUNNEL_ROUTE_TABLE:10.2.1.1": {
+        "alias": "Vlan1000"
+    },
+    "TUNNEL_ROUTE_TABLE:10.3.1.1": {
+        "alias": "Vlan1000"
     }
 }

--- a/tests/mock_tables/asic_db.json
+++ b/tests/mock_tables/asic_db.json
@@ -19,9 +19,5 @@
      "VIDTORID":{
      		"oid:0xd00000000056d": "oid:0xd",
 		"oid:0x10000000004a4": "oid:0x1690000000001"
-     },
-     "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.2.1.1\",\"switch_id\":\"oid:0x21000000000000\",\"vr\":\"oid:0x300000000007c\"}": {
-        "SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION": "SAI_PACKET_ACTION_FORWARD",
-        "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID": "oid:0x40000000015d8"
-    }
+     }
 }

--- a/tests/mock_tables/asic_db.json
+++ b/tests/mock_tables/asic_db.json
@@ -19,5 +19,9 @@
      "VIDTORID":{
      		"oid:0xd00000000056d": "oid:0xd",
 		"oid:0x10000000004a4": "oid:0x1690000000001"
-     }
+     },
+     "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.3.1.1\",\"switch_id\":\"oid:0x21000000000000\",\"vr\":\"oid:0x300000000007c\"}": {
+        "SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION": "SAI_PACKET_ACTION_FORWARD",
+        "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID": "oid:0x40000000015d8"
+    }
 }

--- a/tests/mock_tables/asic_db.json
+++ b/tests/mock_tables/asic_db.json
@@ -20,7 +20,7 @@
      		"oid:0xd00000000056d": "oid:0xd",
 		"oid:0x10000000004a4": "oid:0x1690000000001"
      },
-     "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.3.1.1\",\"switch_id\":\"oid:0x21000000000000\",\"vr\":\"oid:0x300000000007c\"}": {
+     "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.2.1.1\",\"switch_id\":\"oid:0x21000000000000\",\"vr\":\"oid:0x300000000007c\"}": {
         "SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION": "SAI_PACKET_ACTION_FORWARD",
         "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID": "oid:0x40000000015d8"
     }

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -477,6 +477,25 @@ show_muxcable_packetloss_expected_output_json="""\
 }
 """
 
+show_muxcable_tunnel_route_expected_output_json="""\
+{
+    "TUNNEL_ROUTE": {
+        "Ethernet4": {
+            "server_ipv4": {
+                "DEST": "10.3.1.1",
+                "NEXT_HOP_ID": "oid:0x40000000015d8"
+            }
+        }
+    }
+}
+"""
+
+show_muxcable_tunnel_route_expected_output="""\
+PORT       DEST_TYPE    DEST_ADDRESS    NEXT_HOP_ID
+---------  -----------  --------------  -------------------
+Ethernet4  server_ipv4  10.3.1.1        oid:0x40000000015d8
+"""
+
 class TestMuxcable(object):
     @classmethod
     def setup_class(cls):
@@ -2112,6 +2131,32 @@ class TestMuxcable(object):
                                ["Ethernet0", "--json"], obj=db)
         assert result.exit_code == 0
         assert result.output == show_muxcable_packetloss_expected_output_json
+
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet4"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet4"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    def test_show_muxcable_tunnel_route(self):
+        runner = CliRunner()
+        db = Db()
+        
+        result = runner.invoke(show.cli.commands["muxcable"].commands["tunnel-route"],
+                               ["Ethernet4"], obj=db)
+
+        assert result.output == show_muxcable_tunnel_route_expected_output
+    
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet4"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet4"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    def test_show_muxcable_tunnel_route_json(self):
+        runner = CliRunner()
+        db = Db()
+        
+        result = runner.invoke(show.cli.commands["muxcable"].commands["tunnel-route"],
+                               ["Ethernet4", "--json"], obj=db)
+        assert result.exit_code == 0
+        assert result.output == show_muxcable_tunnel_route_expected_output_json
 
     @classmethod
     def teardown_class(cls):

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -484,12 +484,36 @@ show_muxcable_tunnel_route_expected_output_json="""\
             "server_ipv4": {
                 "DEST": "10.2.1.1"
             }
+        },
+        "Ethernet4": {
+            "server_ipv4": {
+                "DEST": "10.3.1.1"
+            }
         }
     }
 }
 """
 
 show_muxcable_tunnel_route_expected_output="""\
+PORT       DEST_TYPE    DEST_ADDRESS
+---------  -----------  --------------
+Ethernet0  server_ipv4  10.2.1.1
+Ethernet4  server_ipv4  10.3.1.1
+"""
+
+show_muxcable_tunnel_route_expected_output_port_json="""\
+{
+    "TUNNEL_ROUTE": {
+        "Ethernet0": {
+            "server_ipv4": {
+                "DEST": "10.2.1.1"
+            }
+        }
+    }
+}
+"""
+
+show_muxcable_tunnel_route_expected_port_output="""\
 PORT       DEST_TYPE    DEST_ADDRESS
 ---------  -----------  --------------
 Ethernet0  server_ipv4  10.2.1.1
@@ -2139,8 +2163,7 @@ class TestMuxcable(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(show.cli.commands["muxcable"].commands["tunnel-route"],
-                               ["Ethernet0"], obj=db)
+        result = runner.invoke(show.cli.commands["muxcable"].commands["tunnel-route"], obj=db)
 
         assert result.exit_code == 0
         assert result.output == show_muxcable_tunnel_route_expected_output
@@ -2154,9 +2177,37 @@ class TestMuxcable(object):
         db = Db()
         
         result = runner.invoke(show.cli.commands["muxcable"].commands["tunnel-route"],
-                               ["Ethernet0", "--json"], obj=db)
+                               ["--json"], obj=db)
+
         assert result.exit_code == 0
         assert result.output == show_muxcable_tunnel_route_expected_output_json
+
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    def test_show_muxcable_tunnel_route_port(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["tunnel-route"],
+                               ["Ethernet0"], obj=db)
+
+        assert result.exit_code == 0
+        assert result.output == show_muxcable_tunnel_route_expected_port_output
+
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    def test_show_muxcable_tunnel_route_json_port(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["tunnel-route"],
+                               ["Ethernet0", "--json"], obj=db)
+        assert result.exit_code == 0
+        assert result.output == show_muxcable_tunnel_route_expected_output_port_json
 
     @classmethod
     def teardown_class(cls):

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -480,10 +480,9 @@ show_muxcable_packetloss_expected_output_json="""\
 show_muxcable_tunnel_route_expected_output_json="""\
 {
     "TUNNEL_ROUTE": {
-        "Ethernet4": {
+        "Ethernet0": {
             "server_ipv4": {
-                "DEST": "10.3.1.1",
-                "NEXT_HOP_ID": "oid:0x40000000015d8"
+                "DEST": "10.2.1.1"
             }
         }
     }
@@ -491,9 +490,9 @@ show_muxcable_tunnel_route_expected_output_json="""\
 """
 
 show_muxcable_tunnel_route_expected_output="""\
-PORT       DEST_TYPE    DEST_ADDRESS    NEXT_HOP_ID
----------  -----------  --------------  -------------------
-Ethernet4  server_ipv4  10.3.1.1        oid:0x40000000015d8
+PORT       DEST_TYPE    DEST_ADDRESS
+---------  -----------  --------------
+Ethernet0  server_ipv4  10.2.1.1
 """
 
 class TestMuxcable(object):
@@ -2132,29 +2131,30 @@ class TestMuxcable(object):
         assert result.exit_code == 0
         assert result.output == show_muxcable_packetloss_expected_output_json
 
-    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet4"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
     @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
-    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet4"]}))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
     @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
     def test_show_muxcable_tunnel_route(self):
         runner = CliRunner()
         db = Db()
-        
-        result = runner.invoke(show.cli.commands["muxcable"].commands["tunnel-route"],
-                               ["Ethernet4"], obj=db)
 
+        result = runner.invoke(show.cli.commands["muxcable"].commands["tunnel-route"],
+                               ["Ethernet0"], obj=db)
+
+        assert result.exit_code == 0
         assert result.output == show_muxcable_tunnel_route_expected_output
     
-    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet4"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
     @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
-    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet4"]}))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
     @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
     def test_show_muxcable_tunnel_route_json(self):
         runner = CliRunner()
         db = Db()
         
         result = runner.invoke(show.cli.commands["muxcable"].commands["tunnel-route"],
-                               ["Ethernet4", "--json"], obj=db)
+                               ["Ethernet0", "--json"], obj=db)
         assert result.exit_code == 0
         assert result.output == show_muxcable_tunnel_route_expected_output_json
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add new CLI support to show tunnel route objects in ASIC DB.

sign-off: Jing Zhang zhangjing@microsoft.com

#### How I did it
* Check if tunnel route object exists for **server_ipv4, server_ipv6, soc_ipv4**. If existing, print it out. 
* If not specifying port name, print all tunnel route objects. 
  
#### How to verify it
* Added unit tests. 
* Tested on dual testbeds: 
  *  show mux tunnel-route Ethernet140
     ```
      PORT         DEST_TYPE    DEST_ADDRESS    
      -----------  -----------  ---------------  
      Ethernet140  server_ipv4  192.168.0.29/32  
     ```
  *  show mux tunnel-route --json Ethernet140
     ```
      {
          "TUNNEL_ROUTE": {
              "Ethernet140": {
                  "server_ipv4": {
                      "DEST": "192.168.0.29/32"
                  }
              }
          }
      }
     ```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

