### PR TITLE
[MultiAsic] sudo reboot command doesn't gracefully stop Asic syncd# on multiasic platform

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -72,8 +72,21 @@ function stop_sonic_services()
     fi
 
     if [[ x"$ASIC_TYPE" != x"mellanox" ]]; then
-        debug "Stopping syncd process..."
-        docker exec -i syncd /usr/bin/syncd_request_shutdown --cold > /dev/null
+        ASIC_CONF=${DEVPATH}/$PLATFORM/asic.conf
+        if [ -f "$ASIC_CONF" ]; then
+            source $ASIC_CONF
+        fi
+        if [[ ($NUM_ASIC -gt 1) ]]; then
+            asic_num=0
+            while [[ ($asic_num -lt $NUM_ASIC) ]]; do
+                debug "Stopping syncd$asic_num process..."
+                docker exec -i syncd$asic_num /usr/bin/syncd_request_shutdown --cold > /dev/null
+                ((asic_num = asic_num + 1))
+            done
+        else
+            debug "Stopping syncd process..."
+            docker exec -i syncd /usr/bin/syncd_request_shutdown --cold > /dev/null
+        fi
         sleep 3
     fi
     stop_pmon_service


### PR DESCRIPTION
#### What I did
Function stop_sonic_service() in /usr/local/bin/reboot script doesn't handle stopping the Asic syncd# on multiasic platform.  Instead, it only stops the syncd on  non-multiasic platform.  When issue command "sudo reboot",   the below message will be shown. 
```
admin@sonic:~$ sudo reboot
Error: No such container: syncd
```
Fixes https://github.com/Azure/sonic-buildimage/issues/11377

#### How I did it
Add code the stop_sonic_services() to check and get NUM_ASIC. If it is multiasic, looping all asics  and call the syncd_request_shutdown for each asic. 

#### How to verify it
Issue the "sudo reboot" on the multiasic platform, the error message "Error: No such container: syncd"  should not be shown.  

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

