### PR TITLE
[202012] [generate_dump] allow to extend dump with plugin scripts

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -32,6 +32,7 @@ DUMPDIR=/var/dump
 TARDIR=$DUMPDIR/$BASE
 TARFILE=$DUMPDIR/$BASE.tar
 LOGDIR=$DUMPDIR/$BASE/dump
+PLUGINS_DIR=/usr/local/bin/debug-dump
 NUM_ASICS=1
 HOME=${HOME:-/root}
 USER=${USER:-root}
@@ -1215,6 +1216,14 @@ main() {
 
     save_cmd "docker ps -a" "docker.ps"
     save_cmd "docker top pmon" "docker.pmon"
+
+    if [[ -d ${PLUGINS_DIR} ]]; then
+        local -r dump_plugins="$(find ${PLUGINS_DIR} -type f -executable)"
+        for plugin in $dump_plugins; do
+            # save stdout output of plugin and gzip it
+            save_cmd "$plugin" "$(basename $plugin)" true
+        done
+    fi
 
     save_saidump
 


### PR DESCRIPTION
Signed-off-by: Noa Or <noaor@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added support for tech support extension scripts,
by cherry-picking of https://github.com/Azure/sonic-utilities/pull/1335 to 202012 branch.

The purpose is to have dumps of extensions in SONiC techsupport, even without App Extension infrastructure.
The new application will write a file that contains the dump command into /usr/bin/debug-dump folder, and it will appear in the output of `show techsupport` command.
#### How I did it
It looks at /usr/bin/debug-dump for scripts, if it finds one it will execute them and save the output to dump/ folder.

#### How to verify it
Write a simple scripts with an output and place it under /usr/bin/debug-dump/

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

