### PR TITLE
[202205][counters] Keep counters cache in a single directory

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1439,11 +1439,6 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, disable_arp_cach
     if multi_asic.is_multi_asic() and file_format == 'config_db':
         num_cfg_file += num_asic
 
-    # Remove cached PG drop counters data
-    dropstat_dir_prefix = '/tmp/dropstat'
-    command = "rm -rf {}-*".format(dropstat_dir_prefix)
-    clicommon.run_command(command, display_cmd=True)
-
     # If the user give the filename[s], extract the file names.
     if filename is not None:
         cfg_files = filename.split(',')

--- a/config/plugins/pbh.py
+++ b/config/plugins/pbh.py
@@ -6,13 +6,14 @@ PBH HLD - https://github.com/Azure/SONiC/pull/773
 CLI Auto-generation tool HLD - https://github.com/Azure/SONiC/pull/78
 """
 
+import os
 import click
 import json
 import ipaddress
 import re
 import utilities_common.cli as clicommon
 
-from show.plugins.pbh import deserialize_pbh_counters
+from show.plugins.pbh import deserialize_pbh_counters, PBH_COUNTERS_CACHE_FILENAME
 
 GRE_KEY_RE = r"^(0x){1}[a-fA-F0-9]{1,8}/(0x){1}[a-fA-F0-9]{1,8}$"
 
@@ -78,8 +79,6 @@ PBH_HASH_FIELD_CAPABILITIES_KEY = "hash-field"
 PBH_ADD = "ADD"
 PBH_UPDATE = "UPDATE"
 PBH_REMOVE = "REMOVE"
-
-PBH_COUNTERS_LOCATION = "/tmp/.pbh_counters.txt"
 
 #
 # DB interface --------------------------------------------------------------------------------------------------------
@@ -467,11 +466,14 @@ def serialize_pbh_counters(obj):
             obj: counters dict.
     """
 
+    cache = clicommon.UserCache('pbh')
+    counters_cache_file = os.path.join(cache.get_directory(), PBH_COUNTERS_CACHE_FILENAME)
+
     def remap_keys(obj):
         return [{'key': k, 'value': v} for k, v in obj.items()]
 
     try:
-        with open(PBH_COUNTERS_LOCATION, 'w') as f:
+        with open(counters_cache_file, 'w') as f:
             json.dump(remap_keys(obj), f)
     except IOError as err:
         pass

--- a/scripts/aclshow
+++ b/scripts/aclshow
@@ -20,15 +20,13 @@ optional arguments:
 import argparse
 import json
 import os
-from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
 import sys
+
+from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
+from utilities_common.cli import UserCache
 
 from tabulate import tabulate
 
-### temp file to save counter positions when doing clear counter action.
-### if we could have a SAI command to clear counters will be better, so no need to maintain
-### counters in temp loaction for clear conter action
-COUNTER_POSITION = '/tmp/.counters_acl.p'
 COUNTERS = "COUNTERS"
 ACL_COUNTER_RULE_MAP = "ACL_COUNTER_RULE_MAP"
 
@@ -38,6 +36,9 @@ ACL_HEADER = ["RULE NAME", "TABLE NAME", "PRIO", "PACKETS COUNT", "BYTES COUNT"]
 COUNTER_PACKETS_ATTR = "SAI_ACL_COUNTER_ATTR_PACKETS"
 COUNTER_BYTES_ATTR = "SAI_ACL_COUNTER_ATTR_BYTES"
 
+USER_CACHE = UserCache()
+COUNTERS_CACHE_DIR = USER_CACHE.get_directory()
+COUNTERS_CACHE = os.path.join(COUNTERS_CACHE_DIR, 'aclstat')
 
 class AclStat(object):
     """
@@ -78,9 +79,9 @@ class AclStat(object):
                 res[e['key'][0], e['key'][1]] = e['value']
             return res
 
-        if os.path.isfile(COUNTER_POSITION):
+        if os.path.isfile(COUNTERS_CACHE):
             try:
-                with open(COUNTER_POSITION) as fp:
+                with open(COUNTERS_CACHE) as fp:
                     self.saved_acl_counters = remap_keys(json.load(fp))
             except Exception:
                 pass
@@ -207,7 +208,7 @@ class AclStat(object):
         def remap_keys(dict):
             return [{'key': k, 'value': v} for k, v in dict.items()]
 
-        with open(COUNTER_POSITION, 'w') as fp:
+        with open(COUNTERS_CACHE, 'w') as fp:
             json.dump(remap_keys(self.acl_counters), fp)
 
 def main():

--- a/scripts/dropstat
+++ b/scripts/dropstat
@@ -35,6 +35,7 @@ except KeyError:
     pass
 
 from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
+from utilities_common.cli import UserCache
 
 
 # COUNTERS_DB Tables
@@ -80,8 +81,7 @@ std_switch_description_header = ['DEVICE']
 
 
 def get_dropstat_dir():
-    dropstat_dir_prefix = '/tmp/dropstat'
-    return "{}-{}/".format(dropstat_dir_prefix, os.getuid())
+    return UserCache().get_directory()
 
 
 class DropStat(object):
@@ -411,18 +411,7 @@ Examples:
     group = args.group
     counter_type = args.type
 
-    dropstat_dir = get_dropstat_dir()
-
-    # Create the directory to hold clear results
-    if not os.path.exists(dropstat_dir):
-        try:
-            os.makedirs(dropstat_dir)
-        except IOError as e:
-            print(e)
-            sys.exit(e.errno)
-
     dcstat = DropStat()
-
     if command == 'clear':
         dcstat.clear_drop_counts()
     elif command == 'show':

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -452,21 +452,14 @@ function unload_kernel()
 }
 
 function save_counters_folder() {
-    debug "Saving counters folder before warmboot..."
+    if [[ "$REBOOT_TYPE" = "warm-reboot" ]]; then
+        debug "Saving counters folder before warmboot..."
 
-    counters_folder="/host/counters"
-    if [[ ! -d $counters_folder ]]; then
-        mkdir $counters_folder
-    fi
-    if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" ]]; then
-        modules=("portstat-0" "dropstat" "pfcstat-0" "queuestat-0" "intfstat-0")
-        for module in ${modules[@]}
-        do
-            statfile="/tmp/$module"
-            if [[ -d $statfile ]]; then
-                cp -rf $statfile $counters_folder
-            fi
-        done
+        counters_folder="/host/counters"
+        if [[ ! -d $counters_folder ]]; then
+            mkdir $counters_folder
+        fi
+        cp -rf /tmp/cache $counters_folder
     fi
 }
 

--- a/scripts/flow_counters_stat
+++ b/scripts/flow_counters_stat
@@ -27,6 +27,7 @@ import utilities_common.multi_asic as multi_asic_util
 from flow_counter_util.route import build_route_pattern, extract_route_pattern, exit_if_route_flow_counter_not_support, DEFAULT_VRF, COUNTERS_ROUTE_TO_PATTERN_MAP
 from utilities_common import constants
 from utilities_common.netstat import format_number_with_comma, table_as_json, ns_diff, format_prate
+from utilities_common.cli import UserCache
 
 # Flow counter meta data, new type of flow counters can extend this dictinary to reuse existing logic
 flow_counter_meta = {
@@ -57,9 +58,10 @@ class FlowCounterStats(object):
         meta_data = flow_counter_meta[args.type]
         self.name_map = meta_data['name_map']
         self.headers = meta_data['headers']
-        self.data_file = os.path.join('/tmp/{}-stats-{}'.format(args.type, os.getuid()))
-        if self.args.delete and os.path.exists(self.data_file):
-            os.remove(self.data_file)
+        self.cache = UserCache()
+        self.data_file = os.path.join(self.cache.get_directory(), "flow-counter-stats")
+        if self.args.delete:
+            self.cache.remove()
         self.data = {}
 
     def show(self):

--- a/scripts/intfstat
+++ b/scripts/intfstat
@@ -28,6 +28,7 @@ from collections import namedtuple, OrderedDict
 from natsort import natsorted
 from tabulate import tabulate
 from utilities_common.netstat import ns_diff, table_as_json, STATUS_NA, format_brate, format_prate
+from utilities_common.cli import UserCache
 from swsscommon.swsscommon import SonicV2Connector
 
 nstat_fields = (
@@ -274,63 +275,34 @@ def main():
     delete_saved_stats = args.delete
     delete_all_stats = args.delete_all
     use_json = args.json
-    tag_name = args.tag if args.tag else ""
-    uid = str(os.getuid())
+    tag_name = args.tag
     wait_time_in_seconds = args.period
     interface_name = args.interface if args.interface else ""
 
-    # fancy filename with dashes: uid-tag / uid etc
-    filename_components = [uid, tag_name]
+    cnstat_file = "intfstat"
 
-    cnstat_file = "-".join(filter(None, filename_components))
+    cache = UserCache(tag=tag_name)
 
-    cnstat_dir = "/tmp/intfstat-" + uid
+    cache_general = UserCache()
+    cnstat_dir = cache.get_directory()
+    cnstat_general_dir = cache_general.get_directory()
+
+    cnstat_fqn_general_file = cnstat_general_dir + "/" + cnstat_file
     cnstat_fqn_file = cnstat_dir + "/" + cnstat_file
 
     if delete_all_stats:
-        # There is nothing to delete
-        if not os.path.isdir(cnstat_dir):
-            sys.exit(0)
-
-        for file in os.listdir(cnstat_dir):
-            os.remove(cnstat_dir + "/" + file)
-
-        try:
-            os.rmdir(cnstat_dir)
-            sys.exit(0)
-        except IOError as e:
-            print(e.errno, e)
-            sys.exit(e)
+        cache.remove_all()
 
     if delete_saved_stats:
-        try:
-            os.remove(cnstat_fqn_file)
-        except IOError as e:
-            if e.errno != ENOENT:
-                print(e.errno, e)
-                sys.exit(1)
-        finally:
-            if os.listdir(cnstat_dir) == []:
-                os.rmdir(cnstat_dir)
-            sys.exit(0)
+        cache.remove()
 
     intfstat = Intfstat()
     cnstat_dict, ratestat_dict = intfstat.get_cnstat(rif=interface_name)
 
-    # At this point, either we'll create a file or open an existing one.
-    if not os.path.exists(cnstat_dir):
-        try:
-            os.makedirs(cnstat_dir)
-        except IOError as e:
-            print(e.errno, e)
-            sys.exit(1)
-
     if save_fresh_stats:
         try:
             # Add the information also to the general file - i.e. without the tag name
-            if tag_name != '' and tag_name in cnstat_fqn_file.split('/')[-1]:
-                gen_index = cnstat_fqn_file.rfind('/')
-                cnstat_fqn_general_file = cnstat_fqn_file[:gen_index] + cnstat_fqn_file[gen_index:].split('-')[0]
+            if tag_name is not None:
                 if os.path.isfile(cnstat_fqn_general_file):
                     try:
                         general_data = pickle.load(open(cnstat_fqn_general_file, 'rb'))
@@ -354,9 +326,6 @@ def main():
             sys.exit(0)
 
     if wait_time_in_seconds == 0:
-        gen_index = cnstat_fqn_file.rfind('/')
-        cnstat_fqn_general_file = cnstat_fqn_file[:gen_index] + cnstat_fqn_file[gen_index:].split('-')[0]
-
         if os.path.isfile(cnstat_fqn_file) or (os.path.isfile(cnstat_fqn_general_file)):
             try:
                 cnstat_cached_dict = {}

--- a/scripts/pfcstat
+++ b/scripts/pfcstat
@@ -18,9 +18,6 @@ from natsort import natsorted
 from tabulate import tabulate
 
 from sonic_py_common.multi_asic import get_external_ports
-from utilities_common.netstat import ns_diff, STATUS_NA, format_number_with_comma
-from utilities_common import multi_asic as multi_asic_util
-from utilities_common import constants
 
 # mock the redis for unit test purposes #
 try:
@@ -36,6 +33,12 @@ try:
 
 except KeyError:
     pass
+
+from utilities_common.netstat import ns_diff, STATUS_NA, format_number_with_comma
+from utilities_common import multi_asic as multi_asic_util
+from utilities_common import constants
+from utilities_common.cli import UserCache
+
 
 PStats = namedtuple("PStats", "pfc0, pfc1, pfc2, pfc3, pfc4, pfc5, pfc6, pfc7")
 header_Rx = ['Port Rx', 'PFC0', 'PFC1', 'PFC2', 'PFC3', 'PFC4', 'PFC5', 'PFC6', 'PFC7']
@@ -224,10 +227,10 @@ Examples:
     save_fresh_stats = args.clear
     delete_all_stats = args.delete
 
-    uid = str(os.getuid())
-    cnstat_file = uid
+    cache = UserCache()
+    cnstat_file = 'pfcstat'
 
-    cnstat_dir = os.path.join(os.sep, "tmp", "pfcstat-{}".format(uid))
+    cnstat_dir = cache.get_directory()
     cnstat_fqn_file_rx = os.path.join(cnstat_dir, "{}rx".format(cnstat_file))
     cnstat_fqn_file_tx = os.path.join(cnstat_dir, "{}tx".format(cnstat_file))
 
@@ -239,15 +242,7 @@ Examples:
     pfcstat = Pfcstat(args.namespace, args.show)
 
     if delete_all_stats:
-        for file in os.listdir(cnstat_dir):
-            os.remove(os.path.join(cnstat_dir, file))
-
-        try:
-            os.rmdir(cnstat_dir)
-            sys.exit(0)
-        except IOError as e:
-            print(e.errno, e)
-            sys.exit(e)
+        cache.remove()
 
     """
         Get the counters of pfc rx counter
@@ -258,14 +253,6 @@ Examples:
         Get the counters of pfc tx counter
     """
     cnstat_dict_tx = deepcopy(pfcstat.get_cnstat(False))
-
-    # At this point, either we'll create a file or open an existing one.
-    if not os.path.exists(cnstat_dir):
-        try:
-            os.makedirs(cnstat_dir)
-        except IOError as e:
-            print(e.errno, e)
-            sys.exit(1)
 
     if save_fresh_stats:
         try:

--- a/scripts/pg-drop
+++ b/scripts/pg-drop
@@ -26,6 +26,7 @@ try:
 except KeyError:
     pass
 
+from utilities_common.cli import UserCache
 from swsscommon.swsscommon import ConfigDBConnector, SonicV2Connector
 
 STATUS_NA = 'N/A'
@@ -38,8 +39,7 @@ COUNTERS_PG_PORT_MAP = "COUNTERS_PG_PORT_MAP"
 COUNTERS_PG_INDEX_MAP = "COUNTERS_PG_INDEX_MAP"
 
 def get_dropstat_dir():
-    dropstat_dir_prefix = '/tmp/dropstat'
-    return "{}-{}/".format(dropstat_dir_prefix, os.getuid())
+    return UserCache().get_directory()
 
 class PgDropStat(object):
 

--- a/scripts/portstat
+++ b/scripts/portstat
@@ -38,6 +38,8 @@ from utilities_common.intf_filter import parse_interface_in_filter
 import utilities_common.multi_asic as multi_asic_util
 from utilities_common.netstat import ns_diff, table_as_json, format_brate, format_prate, format_util, format_number_with_comma
 
+from utilities_common.cli import UserCache
+
 """
 The order and count of statistics mentioned below needs to be in sync with the values in portstat script
 So, any fields added/deleted in here should be reflected in portstat script also
@@ -567,7 +569,6 @@ Examples:
     use_json = args.json
     raw_stats = args.raw
     tag_name = args.tag
-    uid = str(os.getuid())
     wait_time_in_seconds = args.period
     print_all = args.all
     intf_fs = args.interface
@@ -575,36 +576,17 @@ Examples:
     display_option = args.show
     detail = args.detail
 
-    if tag_name is not None:
-        cnstat_file = uid + "-" + tag_name
-    else:
-        cnstat_file = uid
+    cache = UserCache(tag=tag_name)
 
-    cnstat_dir = "/tmp/portstat-" + uid
+    cnstat_file = "portstat"
+    cnstat_dir = cache.get_directory()
     cnstat_fqn_file = cnstat_dir + "/" + cnstat_file
 
     if delete_all_stats:
-        for file in os.listdir(cnstat_dir):
-            os.remove(cnstat_dir + "/" + file)
-
-        try:
-            os.rmdir(cnstat_dir)
-            sys.exit(0)
-        except IOError as e:
-            print(e.errno, e)
-            sys.exit(e)
+        cache.remove_all()
 
     if delete_saved_stats:
-        try:
-            os.remove(cnstat_fqn_file)
-        except IOError as e:
-            if e.errno != ENOENT:
-                print(e.errno, e)
-                sys.exit(1)
-        finally:
-            if os.listdir(cnstat_dir) == []:
-                os.rmdir(cnstat_dir)
-            sys.exit(0)
+        cache.remove()
 
     intf_list = parse_interface_in_filter(intf_fs)
 
@@ -621,15 +603,6 @@ Examples:
     if raw_stats:
         portstat.cnstat_print(cnstat_dict, ratestat_dict, intf_list, use_json, print_all, errors_only, rates_only)
         sys.exit(0)
-
-    # At this point, either we'll create a file or open an existing one.
-    if not os.path.exists(cnstat_dir):
-        try:
-            os.makedirs(cnstat_dir)
-        except IOError as e:
-            print(e.errno, e)
-            sys.exit(1)
-
 
     if save_fresh_stats:
         try:

--- a/scripts/queuestat
+++ b/scripts/queuestat
@@ -29,6 +29,7 @@ except KeyError:
     pass
 
 from swsscommon.swsscommon import SonicV2Connector
+from utilities_common.cli import UserCache
 
 QueueStats = namedtuple("QueueStats", "queueindex, queuetype, totalpacket, totalbytes, droppacket, dropbytes")
 header = ['Port', 'TxQ', 'Counter/pkts', 'Counter/bytes', 'Drop/pkts', 'Drop/bytes']
@@ -294,13 +295,6 @@ class Queuestat(object):
             print(json_dump(json_output))
 
     def save_fresh_stats(self):
-        if not os.path.exists(cnstat_dir):
-            try:
-                os.makedirs(cnstat_dir)
-            except IOError as e:
-                print(e.errno, e)
-                sys.exit(1)
-
         # Get stat for each port and save
         for port in natsorted(self.counter_port_name_map):
             cnstat_dict = self.get_cnstat(self.port_queues_map[port])
@@ -334,27 +328,18 @@ Examples:
     args = parser.parse_args()
 
     save_fresh_stats = args.clear
-    delete_all_stats = args.delete
+    delete_stats = args.delete
     json_opt = args.json_opt
 
     port_to_show_stats = args.port
 
-    uid = str(os.getuid())
-    cnstat_file = uid
+    cache = UserCache()
 
-    cnstat_dir = "/tmp/queuestat-" + uid
-    cnstat_fqn_file = cnstat_dir + "/" + cnstat_file
+    cnstat_dir = cache.get_directory()
+    cnstat_fqn_file = os.path.join(cnstat_dir, 'queuestat')
 
-    if delete_all_stats:
-        for file in os.listdir(cnstat_dir):
-            os.remove(cnstat_dir + "/" + file)
-
-        try:
-            os.rmdir(cnstat_dir)
-            sys.exit(0)
-        except IOError as e:
-            print(e.errno, e)
-            sys.exit(e)
+    if delete_stats:
+        cache.remove()
 
     queuestat = Queuestat()
 

--- a/scripts/tunnelstat
+++ b/scripts/tunnelstat
@@ -29,6 +29,7 @@ from collections import namedtuple, OrderedDict
 from natsort import natsorted
 from tabulate import tabulate
 from utilities_common.netstat import ns_diff, table_as_json, STATUS_NA, format_prate
+from utilities_common.cli import UserCache
 from swsscommon.swsscommon import SonicV2Connector
 
 
@@ -112,12 +113,12 @@ class Tunnelstat(object):
 
         if counter_tunnel_type_map is None:
             print("No %s in the DB!" % COUNTERS_TUNNEL_TYPE_MAP)
-            sys.exit(1)  
+            sys.exit(1)
 
         if tun_type and tun_type not in counter_types:
             print("Unknown tunnel type %s" % tun_type)
             sys.exit(1)
- 
+
         if tunnel and not tunnel in counter_tunnel_name_map:
             print("Interface %s missing from %s! Make sure it exists" % (tunnel, COUNTERS_TUNNEL_NAME_MAP))
             sys.exit(2)
@@ -250,55 +251,25 @@ def main():
     delete_all_stats = args.delete_all
     use_json = args.json
     tag_name = args.tag if args.tag else ""
-    uid = str(os.getuid())
     wait_time_in_seconds = args.period
     tunnel_name = args.tunnel if args.tunnel else ""
     tunnel_type = args.type if args.type else ""
 
-    # fancy filename with dashes: uid-tag-tunnel / uid-tunnel / uid-tag etc
-    filename_components = [uid, tag_name]
-    cnstat_file = "-".join(filter(None, filename_components))
+    cache = UserCache(tag=tag_name)
 
-    cnstat_dir = "/tmp/tunnelstat-" + uid
+    cnstat_file = "tunnelstat"
+
+    cnstat_dir = cache.get_directory()
     cnstat_fqn_file = cnstat_dir + "/" + cnstat_file
 
     if delete_all_stats:
-        # There is nothing to delete
-        if not os.path.isdir(cnstat_dir):
-            sys.exit(0)
-
-        for file in os.listdir(cnstat_dir):
-            os.remove(cnstat_dir + "/" + file)
-
-        try:
-            os.rmdir(cnstat_dir)
-            sys.exit(0)
-        except IOError as e:
-            print(e.errno, e)
-            sys.exit(e)
+        cache.remove_all()
 
     if delete_saved_stats:
-        try:
-            os.remove(cnstat_fqn_file)
-        except IOError as e:
-            if e.errno != ENOENT:
-                print(e.errno, e)
-                sys.exit(1)
-        finally:
-            if os.listdir(cnstat_dir) == []:
-                os.rmdir(cnstat_dir)
-            sys.exit(0)
+        cache.remove()
 
     tunnelstat = Tunnelstat()
     cnstat_dict,ratestat_dict = tunnelstat.get_cnstat(tunnel=tunnel_name, tun_type=tunnel_type)
-
-    # At this point, either we'll create a file or open an existing one.
-    if not os.path.exists(cnstat_dir):
-        try:
-            os.makedirs(cnstat_dir)
-        except IOError as e:
-            print(e.errno, e)
-            sys.exit(1)
 
     if save_fresh_stats:
         try:

--- a/show/plugins/pbh.py
+++ b/show/plugins/pbh.py
@@ -14,13 +14,13 @@ import json
 import utilities_common.cli as clicommon
 from swsscommon.swsscommon import SonicV2Connector
 
-PBH_COUNTERS_LOCATION = '/tmp/.pbh_counters.txt'
-
 COUNTER_PACKETS_ATTR = "SAI_ACL_COUNTER_ATTR_PACKETS"
 COUNTER_BYTES_ATTR = "SAI_ACL_COUNTER_ATTR_BYTES"
 
 COUNTERS = "COUNTERS"
 ACL_COUNTER_RULE_MAP = "ACL_COUNTER_RULE_MAP"
+
+PBH_COUNTERS_CACHE_FILENAME = "pbh-counters"
 
 pbh_hash_field_tbl_name = 'PBH_HASH_FIELD'
 pbh_hash_tbl_name = 'PBH_HASH'
@@ -428,15 +428,18 @@ def deserialize_pbh_counters():
             obj: counters dict.
     """
 
+    cache = clicommon.UserCache('pbh')
+    counters_cache_file = os.path.join(cache.get_directory(), PBH_COUNTERS_CACHE_FILENAME)
+
     def remap_keys(obj):
         res = {}
         for e in obj:
             res[e['key'][0], e['key'][1]] = e['value']
         return res
 
-    if os.path.isfile(PBH_COUNTERS_LOCATION):
+    if os.path.isfile(counters_cache_file):
         try:
-            with open(PBH_COUNTERS_LOCATION, 'r') as f:
+            with open(counters_cache_file, 'r') as f:
                 return remap_keys(json.load(f))
         except Exception as err:
             pass

--- a/tests/aclshow_test.py
+++ b/tests/aclshow_test.py
@@ -192,8 +192,8 @@ class Aclshow():
         This method is used to empty dumped counters
         if exist in /tmp/.counters_acl.p (by default).
         """
-        if os.path.isfile(aclshow.COUNTER_POSITION):
-            with open(aclshow.COUNTER_POSITION, 'w') as fp:
+        if os.path.isfile(aclshow.COUNTERS_CACHE):
+            with open(aclshow.COUNTERS_CACHE, 'w') as fp:
                 json.dump([], fp)
 
     def runTest(self):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -80,7 +80,6 @@ Please note loaded setting will be lost after system reboot. To preserve setting
 """
 
 RELOAD_CONFIG_DB_OUTPUT = """\
-Running command: rm -rf /tmp/dropstat-*
 Stopping SONiC target ...
 Running command: /usr/local/bin/sonic-cfggen  -j /tmp/config.json  --write-to-db
 Restarting SONiC target ...
@@ -88,7 +87,6 @@ Reloading Monit configuration ...
 """
 
 RELOAD_YANG_CFG_OUTPUT = """\
-Running command: rm -rf /tmp/dropstat-*
 Stopping SONiC target ...
 Running command: /usr/local/bin/sonic-cfggen  -Y /tmp/config.json  --write-to-db
 Restarting SONiC target ...
@@ -96,7 +94,6 @@ Reloading Monit configuration ...
 """
 
 RELOAD_MASIC_CONFIG_DB_OUTPUT = """\
-Running command: rm -rf /tmp/dropstat-*
 Stopping SONiC target ...
 Running command: /usr/local/bin/sonic-cfggen  -j /tmp/config.json  --write-to-db
 Running command: /usr/local/bin/sonic-cfggen  -j /tmp/config.json  -n asic0  --write-to-db
@@ -106,11 +103,9 @@ Reloading Monit configuration ...
 """
 
 reload_config_with_sys_info_command_output="""\
-Running command: rm -rf /tmp/dropstat-*
 Running command: /usr/local/bin/sonic-cfggen -H -k Seastone-DX010-25-50 --write-to-db"""
 
 reload_config_with_disabled_service_output="""\
-Running command: rm -rf /tmp/dropstat-*
 Stopping SONiC target ...
 Running command: /usr/local/bin/sonic-cfggen  -j /tmp/config.json  --write-to-db
 Restarting SONiC target ...
@@ -218,7 +213,7 @@ class TestConfigReload(object):
 
             assert result.exit_code == 0
 
-            assert "\n".join([l.rstrip() for l in result.output.split('\n')][:2]) == reload_config_with_sys_info_command_output
+            assert "\n".join([l.rstrip() for l in result.output.split('\n')][:1]) == reload_config_with_sys_info_command_output
 
     def test_config_reload_untriggered_timer(self, get_cmd_module, setup_single_broadcom_asic):
         with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect_untriggered_timer)) as mock_run_command:
@@ -276,9 +271,9 @@ class TestLoadMinigraph(object):
             traceback.print_tb(result.exc_info[2])
             assert result.exit_code == 0
             assert "\n".join([l.rstrip() for l in result.output.split('\n')]) == load_minigraph_command_output
-            # Verify "systemctl reset-failed" is called for services under sonic.target 
+            # Verify "systemctl reset-failed" is called for services under sonic.target
             mock_run_command.assert_any_call('systemctl reset-failed swss')
-            # Verify "systemctl reset-failed" is called for services under sonic-delayed.target 
+            # Verify "systemctl reset-failed" is called for services under sonic-delayed.target
             mock_run_command.assert_any_call('systemctl reset-failed snmp')
             assert mock_run_command.call_count == 11
 
@@ -493,7 +488,7 @@ class TestReloadConfig(object):
             runner = CliRunner()
             # 3 config files: 1 for host and 2 for asic
             cfg_files = "{},{},{}".format(
-                            self.dummy_cfg_file, 
+                            self.dummy_cfg_file,
                             self.dummy_cfg_file,
                             self.dummy_cfg_file)
             result = runner.invoke(
@@ -532,7 +527,7 @@ class TestReloadConfig(object):
         os.remove(cls.dummy_cfg_file)
         print("TEARDOWN")
 
- 
+
 class TestConfigCbf(object):
     @classmethod
     def setup_class(cls):

--- a/tests/pbh_test.py
+++ b/tests/pbh_test.py
@@ -10,6 +10,7 @@ import importlib
 
 from .pbh_input import assert_show_output
 from utilities_common.db import Db
+from utilities_common.cli import UserCache
 from click.testing import CliRunner
 from .mock_tables import dbconnector
 from .mock_tables import mock_single_asic
@@ -876,10 +877,7 @@ class TestPBH:
 
 
     def remove_pbh_counters_file(self):
-        SAVED_PBH_COUNTERS_FILE = '/tmp/.pbh_counters.txt'
-        if os.path.isfile(SAVED_PBH_COUNTERS_FILE):
-            os.remove(SAVED_PBH_COUNTERS_FILE)
-
+        UserCache('pbh').remove_all()
 
     def test_show_pbh_statistics_on_empty_config(self):
         dbconnector.dedicated_dbs['CONFIG_DB'] = None

--- a/tests/pfcstat_test.py
+++ b/tests/pfcstat_test.py
@@ -8,6 +8,7 @@ from click.testing import CliRunner
 import show.main as show
 
 from .utils import get_result_and_return_code
+from utilities_common.cli import UserCache
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
@@ -130,9 +131,8 @@ Ethernet-BP260       0       0       0       0       0       0       0       0
 
 
 def del_cached_stats():
-    uid = str(os.getuid())
-    cnstat_dir = os.path.join(os.sep, "tmp", "pfcstat-{}".format(uid))
-    shutil.rmtree(cnstat_dir, ignore_errors=True, onerror=None)
+    cache = UserCache("pfcstat")
+    cache.remove_all()
 
 
 def pfc_clear(expected_output):
@@ -142,17 +142,6 @@ def pfc_clear(expected_output):
     return_code, result = get_result_and_return_code(
         'pfcstat -c'
     )
-
-    # verify that files are created with stats
-    uid = str(os.getuid())
-    cnstat_dir = os.path.join(os.sep, "tmp", "pfcstat-{}".format(uid))
-    cnstat_fqn_file_rx = "{}rx".format(uid)
-    cnstat_fqn_file_tx = "{}tx".format(uid)
-    file_list = [cnstat_fqn_file_tx, cnstat_fqn_file_rx]
-    file_list.sort()
-    files = os.listdir(cnstat_dir)
-    files.sort()
-    assert files == file_list
 
     return_code, result = get_result_and_return_code(
         'pfcstat -s all'

--- a/tests/pgdropstat_test.py
+++ b/tests/pgdropstat_test.py
@@ -9,6 +9,8 @@ import config.main as config
 from click.testing import CliRunner
 from shutil import copyfile
 
+from utilities_common.cli import UserCache
+
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, "scripts")
@@ -88,25 +90,9 @@ class TestPgDropstat(object):
         assert result.exit_code == 0
         assert result.output == show_output
 
-    def test_show_pg_drop_config_reload(self):
-        runner = CliRunner()
-        self.test_show_pg_drop_clear()
-
-        # simulate 'config reload' to provoke counters recalculation (remove  backup from /tmp folder)
-        result = runner.invoke(config.config.commands["reload"], [ "--no_service_restart",  "-y"])
-
-        print(result.exit_code)
-        print(result.output)
-
-        assert result.exit_code == 0
-
-        self.test_show_pg_drop_show()
-
     @classmethod
     def teardown_class(cls):
         os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])
         os.environ['UTILITIES_UNIT_TESTING'] = "0"
-        dropstat_dir_prefix = '/tmp/dropstat'
-        dir_path = "{}-{}/".format(dropstat_dir_prefix, os.getuid())
-        os.system("rm -rf {}".format(dir_path))
+        UserCache('pg-drop').remove_all()
         print("TEARDOWN")

--- a/tests/portstat_test.py
+++ b/tests/portstat_test.py
@@ -6,6 +6,7 @@ from click.testing import CliRunner
 import clear.main as clear
 import show.main as show
 from .utils import get_result_and_return_code
+from utilities_common.cli import UserCache
 
 root_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(root_path)
@@ -191,9 +192,8 @@ TEST_PERIOD = 3
 
 def remove_tmp_cnstat_file():
     # remove the tmp portstat
-    uid = str(os.getuid())
-    cnstat_dir = os.path.join(os.sep, "tmp", "portstat-{}".format(uid))
-    shutil.rmtree(cnstat_dir, ignore_errors=True, onerror=None)
+    cache = UserCache("portstat")
+    cache.remove_all()
 
 
 def verify_after_clear(output, expected_out):

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -4,6 +4,7 @@ import os
 import re
 import subprocess
 import sys
+import shutil
 
 import click
 import json
@@ -662,3 +663,41 @@ def query_yes_no(question, default="yes"):
         else:
             sys.stdout.write("Please respond with 'yes' or 'no' "
                              "(or 'y' or 'n').\n")
+
+
+class UserCache:
+    """ General purpose cache directory created per user """
+
+    CACHE_DIR = "/tmp/cache/"
+
+    def __init__(self, app_name=None, tag=None):
+        """ Initialize UserCache and create a cache directory if it does not exist.
+
+        Args:
+            tag (str): Tag the user cache. Different tags correspond to different cache directories even for the same user.
+        """
+        self.uid = os.getuid()
+        self.app_name = os.path.basename(sys.argv[0]) if app_name is None else app_name
+        self.cache_directory_suffix = str(self.uid) if tag is None else f"{self.uid}-{tag}"
+        self.cache_directory_app = os.path.join(self.CACHE_DIR, self.app_name)
+
+        prev_umask = os.umask(0)
+        try:
+            os.makedirs(self.cache_directory_app, exist_ok=True)
+        finally:
+            os.umask(prev_umask)
+
+        self.cache_directory = os.path.join(self.cache_directory_app, self.cache_directory_suffix)
+        os.makedirs(self.cache_directory, exist_ok=True)
+
+    def get_directory(self):
+        """ Return the cache directory path """
+        return self.cache_directory
+
+    def remove(self):
+        """ Remove the content of the cache directory """
+        shutil.rmtree(self.cache_directory)
+
+    def remove_all(self):
+        """ Remove the content of the cache for all users """
+        shutil.rmtree(self.cache_directory_app)


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

- What I did
To fix Azure/sonic-buildimage#9817. Cache all counters in the same place. Created a UserCache helper class to access the cache directory.

- How I did it
Implemented UserCache class. Changed all stats commands to use new class. Adopted fast-reboot script.

- How to verify it
Run on the switch and verify counters stats command and clear commands work correctly. After config reload or cold/fast reboot counters cache is removed.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

